### PR TITLE
[DO NOT MERGE] Add SonarCloud projectKey to sonar configuration

### DIFF
--- a/de.fu_berlin.inf.dpp.core/sonar-project.properties
+++ b/de.fu_berlin.inf.dpp.core/sonar-project.properties
@@ -1,4 +1,5 @@
 sonar.projectName        = Saros/Core
+sonar.projectKey         = saros_core
 sonar.projectDescription = Saros core business logic and utilities
 sonar.projectVersion     = 0.1.0.DEVEL
 

--- a/de.fu_berlin.inf.dpp.intellij/sonar-project.properties
+++ b/de.fu_berlin.inf.dpp.intellij/sonar-project.properties
@@ -1,4 +1,5 @@
-sonar.projectName        = Saros/I
+sonar.projectName        = Saros/Intellij
+sonar.projectKey         = saros_intellij
 sonar.projectDescription = Saros plugin for IntelliJ IDEA
 sonar.projectVersion     = 0.1.0.DEVEL
 

--- a/de.fu_berlin.inf.dpp.server/sonar-project.properties
+++ b/de.fu_berlin.inf.dpp.server/sonar-project.properties
@@ -1,4 +1,5 @@
 sonar.projectName        = Saros/Server
+sonar.projectKey         = saros_server
 sonar.projectDescription = Standalone Saros Server
 sonar.projectVersion     = 0.1.0.DEVEL
 

--- a/de.fu_berlin.inf.dpp.ui.frontend/sonar-project.properties
+++ b/de.fu_berlin.inf.dpp.ui.frontend/sonar-project.properties
@@ -1,4 +1,5 @@
 sonar.projectName        = Saros/UI.Frontend
+sonar.projectKey         = saros_ui_frontend
 sonar.projectDescription = Common Saros User Interface (HTML/JS part)
 sonar.projectVersion     = 0.1.0.DEVEL
 

--- a/de.fu_berlin.inf.dpp.ui/sonar-project.properties
+++ b/de.fu_berlin.inf.dpp.ui/sonar-project.properties
@@ -1,4 +1,5 @@
 sonar.projectName        = Saros/UI
+sonar.projectKey         = saros_ui
 sonar.projectDescription = Common Saros User Interface (Java part)
 sonar.projectVersion     = 0.1.0.DEVEL
 

--- a/de.fu_berlin.inf.dpp.whiteboard/sonar-project.properties
+++ b/de.fu_berlin.inf.dpp.whiteboard/sonar-project.properties
@@ -1,4 +1,5 @@
 sonar.projectName        = Saros/Whiteboard
+sonar.projectKey         = saros_whiteboard
 sonar.projectDescription = Saros Whiteboard plugin for Eclipse IDE
 sonar.projectVersion     = 14.11.28.DEVEL
 

--- a/de.fu_berlin.inf.dpp/sonar-project.properties
+++ b/de.fu_berlin.inf.dpp/sonar-project.properties
@@ -1,4 +1,5 @@
-sonar.projectName        = Saros/E
+sonar.projectName        = Saros/Eclipse
+sonar.projectKey         = saros_eclipse
 sonar.projectDescription = Saros plugin for the Eclipse IDE
 sonar.projectVersion     = 14.11.28.DEVEL
 

--- a/de.fu_berlin.inf.dpp/test/framework/stf/sonar-project.properties
+++ b/de.fu_berlin.inf.dpp/test/framework/stf/sonar-project.properties
@@ -1,4 +1,5 @@
-sonar.projectName        = STF
+sonar.projectName        = Saros/STF
+sonar.projectKey         = saros_stf
 sonar.projectDescription = Saros Test Framework
 sonar.projectVersion     = 14.11.28.DEVEL
 


### PR DESCRIPTION
#######
THIS PR IS JUST FOR TESTING THE SONARSOURCE GITHUB PLUGIN
#######
In order to use the sonarcloud service the
subprojects have to be assigned to a sonarcloud
project via a projectKey