### PR TITLE
[FIX][SERVER] Do not assume projects are at the root of the workspace

### DIFF
--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerContainerImpl.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerContainerImpl.java
@@ -10,6 +10,7 @@ import org.apache.commons.io.FileUtils;
 
 import de.fu_berlin.inf.dpp.filesystem.IContainer;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
+import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 
@@ -25,11 +26,13 @@ public abstract class ServerContainerImpl extends ServerResourceImpl implements
      * 
      * @param workspace
      *            the containing workspace
+     * @param project
+     *            the containing project
      * @param path
      *            the container's path relative to the workspace's root
      */
-    public ServerContainerImpl(IWorkspace workspace, IPath path) {
-        super(workspace, path);
+    public ServerContainerImpl(IWorkspace workspace, IProject project, IPath path) {
+        super(workspace, project, path);
     }
 
     @Override
@@ -61,9 +64,9 @@ public abstract class ServerContainerImpl extends ServerResourceImpl implements
             IResource member;
 
             if (f.isDirectory()) {
-                member = new ServerFolderImpl(getWorkspace(), memberPath);
+                member = new ServerFolderImpl(getWorkspace(), getProject(), memberPath);
             } else {
-                member = new ServerFileImpl(getWorkspace(), memberPath);
+                member = new ServerFileImpl(getWorkspace(), getProject(), memberPath);
             }
 
             members.add(member);

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerFileImpl.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerFileImpl.java
@@ -8,6 +8,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 
+import de.fu_berlin.inf.dpp.filesystem.IProject;
 import org.apache.log4j.Logger;
 
 import de.fu_berlin.inf.dpp.filesystem.IFile;
@@ -28,11 +29,13 @@ public class ServerFileImpl extends ServerResourceImpl implements IFile {
      * 
      * @param workspace
      *            the containing workspace
+     * @param project
+     *            the containing project
      * @param path
      *            the file's path relative to the workspace's root
      */
-    public ServerFileImpl(IWorkspace workspace, IPath path) {
-        super(workspace, path);
+    public ServerFileImpl(IWorkspace workspace, IProject project, IPath path) {
+        super(workspace, project, path);
     }
 
     /**

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerFolderImpl.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerFolderImpl.java
@@ -7,6 +7,7 @@ import java.nio.file.Paths;
 
 import de.fu_berlin.inf.dpp.filesystem.IFolder;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
+import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 
@@ -20,11 +21,13 @@ public class ServerFolderImpl extends ServerContainerImpl implements IFolder {
      * 
      * @param workspace
      *            the containing workspace
+     * @param project
+     *            the containing project
      * @param path
      *            the folder's path relative to the workspace's root
      */
-    public ServerFolderImpl(IWorkspace workspace, IPath path) {
-        super(workspace, path);
+    public ServerFolderImpl(IWorkspace workspace, IProject project, IPath path) {
+        super(workspace, project, path);
     }
 
     @Override

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerPathImpl.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerPathImpl.java
@@ -19,7 +19,7 @@ public class ServerPathImpl implements IPath {
         return new ServerPathImpl(Paths.get(pathString));
     }
 
-    private ServerPathImpl(Path delegate) {
+    public ServerPathImpl(Path delegate) {
         /*
          * OpenJDK 7 on Linux has a bug which causes normalize() to throw an
          * ArrayIndexOutOfBoundsException if called on the empty path.

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerProjectImpl.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerProjectImpl.java
@@ -25,7 +25,7 @@ public class ServerProjectImpl extends ServerContainerImpl implements IProject {
      *            the project's name
      */
     public ServerProjectImpl(IWorkspace workspace, String name) {
-        super(workspace, ServerPathImpl.fromString(name));
+        super(workspace, null, ServerPathImpl.fromString(name));
     }
 
     @Override
@@ -49,9 +49,9 @@ public class ServerProjectImpl extends ServerContainerImpl implements IProject {
         File memberFile = memberLocation.toFile();
 
         if (memberFile.isFile()) {
-            return new ServerFileImpl(getWorkspace(), getFullMemberPath(path));
+            return new ServerFileImpl(getWorkspace(), getProject(), getFullMemberPath(path));
         } else if (memberFile.isDirectory()) {
-            return new ServerFolderImpl(getWorkspace(), getFullMemberPath(path));
+            return new ServerFolderImpl(getWorkspace(), getProject(), getFullMemberPath(path));
         } else {
             return null;
         }
@@ -59,7 +59,7 @@ public class ServerProjectImpl extends ServerContainerImpl implements IProject {
 
     @Override
     public IFile getFile(IPath path) {
-        return new ServerFileImpl(getWorkspace(), getFullMemberPath(path));
+        return new ServerFileImpl(getWorkspace(), getProject(), getFullMemberPath(path));
     }
 
     @Override
@@ -69,7 +69,7 @@ public class ServerProjectImpl extends ServerContainerImpl implements IProject {
 
     @Override
     public IFolder getFolder(IPath path) {
-        return new ServerFolderImpl(getWorkspace(), getFullMemberPath(path));
+        return new ServerFolderImpl(getWorkspace(), getProject(), getFullMemberPath(path));
     }
 
     @Override
@@ -79,5 +79,15 @@ public class ServerProjectImpl extends ServerContainerImpl implements IProject {
 
     private IPath getFullMemberPath(IPath memberPath) {
         return getFullPath().append(memberPath);
+    }
+
+    @Override
+    public IPath getProjectRelativePath() {
+        return ServerPathImpl.EMPTY;
+    }
+
+    @Override
+    public IProject getProject() {
+        return this;
     }
 }

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerResourceImpl.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerResourceImpl.java
@@ -16,6 +16,7 @@ import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 public abstract class ServerResourceImpl implements IResource {
 
     private IWorkspace workspace;
+    private IProject project;
     private IPath path;
 
     /**
@@ -23,11 +24,14 @@ public abstract class ServerResourceImpl implements IResource {
      * 
      * @param workspace
      *            the containing workspace
+     * @param project
+     *            the containing project
      * @param path
      *            the resource's path relative to the workspace's root
      */
-    public ServerResourceImpl(IWorkspace workspace, IPath path) {
+    public ServerResourceImpl(IWorkspace workspace, IProject project, IPath path) {
         this.path = path;
+        this.project = project;
         this.workspace = workspace;
     }
 
@@ -40,6 +44,16 @@ public abstract class ServerResourceImpl implements IResource {
         return workspace;
     }
 
+    /**
+     * Returns the project the resource belongs to.
+     *
+     * @return the containing project
+     */
+    @Override
+    public IProject getProject() {
+        return project;
+    }
+
     @Override
     public IPath getFullPath() {
         return path;
@@ -47,7 +61,9 @@ public abstract class ServerResourceImpl implements IResource {
 
     @Override
     public IPath getProjectRelativePath() {
-        return getFullPath().removeFirstSegments(1);
+        return new ServerPathImpl(
+            project.getLocation().toFile().toPath().relativize(getLocation().toFile().toPath())
+        );
     }
 
     @Override
@@ -66,12 +82,6 @@ public abstract class ServerResourceImpl implements IResource {
         IProject project = getProject();
         return parentPath.segmentCount() == 0 ? project : project
             .getFolder(parentPath);
-    }
-
-    @Override
-    public IProject getProject() {
-        String projectName = getFullPath().segment(0);
-        return workspace.getProject(projectName);
     }
 
     @Override

--- a/de.fu_berlin.inf.dpp.server/test/junit/de/fu_berlin/inf/dpp/server/filesystem/ServerContainerImplTest.java
+++ b/de.fu_berlin.inf.dpp.server/test/junit/de/fu_berlin/inf/dpp/server/filesystem/ServerContainerImplTest.java
@@ -34,8 +34,8 @@ public class ServerContainerImplTest extends EasyMockSupport {
 
     private static class ExampleContainer extends ServerContainerImpl {
 
-        public ExampleContainer(IPath path, IWorkspace workspace) {
-            super(workspace, path);
+        public ExampleContainer(IPath path, IProject project, IWorkspace workspace) {
+            super(workspace, project, path);
         }
 
         @Override
@@ -64,7 +64,7 @@ public class ServerContainerImplTest extends EasyMockSupport {
 
         replayAll();
 
-        container = new ExampleContainer(path(CONTAINER_PATH), workspace);
+        container = new ExampleContainer(path(CONTAINER_PATH), project, workspace);
     }
 
     @After

--- a/de.fu_berlin.inf.dpp.server/test/junit/de/fu_berlin/inf/dpp/server/filesystem/ServerFileImplTest.java
+++ b/de.fu_berlin.inf.dpp.server/test/junit/de/fu_berlin/inf/dpp/server/filesystem/ServerFileImplTest.java
@@ -47,7 +47,7 @@ public class ServerFileImplTest extends EasyMockSupport {
         expect(project.getDefaultCharset()).andStubReturn("UTF-8");
 
         replayAll();
-        file = new ServerFileImpl(workspace, path("project/file"));
+        file = new ServerFileImpl(workspace, project, path("project/file"));
 
     }
 

--- a/de.fu_berlin.inf.dpp.server/test/junit/de/fu_berlin/inf/dpp/server/filesystem/ServerFolderImplTest.java
+++ b/de.fu_berlin.inf.dpp.server/test/junit/de/fu_berlin/inf/dpp/server/filesystem/ServerFolderImplTest.java
@@ -11,6 +11,7 @@ import static org.easymock.EasyMock.expect;
 
 import java.io.IOException;
 
+import de.fu_berlin.inf.dpp.filesystem.IProject;
 import org.apache.commons.io.FileUtils;
 import org.easymock.EasyMockSupport;
 import org.junit.After;
@@ -29,15 +30,21 @@ public class ServerFolderImplTest extends EasyMockSupport {
 
     private IFolder folder;
     private IWorkspace workspace;
+    private IProject project;
 
     @Before
     public void setUp() throws Exception {
         workspace = createMock(IWorkspace.class);
+        project = createMock(IProject.class);
+
         expect(workspace.getLocation()).andStubReturn(createWorkspaceFolder());
+
+        expect(workspace.getProject("project")).andStubReturn(project);
+        expect(project.getDefaultCharset()).andStubReturn("UTF-8");
 
         replayAll();
 
-        folder = new ServerFolderImpl(workspace, path(FOLDER_PATH));
+        folder = new ServerFolderImpl(workspace, project, path(FOLDER_PATH));
     }
 
     @After

--- a/de.fu_berlin.inf.dpp.server/test/junit/de/fu_berlin/inf/dpp/server/filesystem/ServerResourceImplTest.java
+++ b/de.fu_berlin.inf.dpp.server/test/junit/de/fu_berlin/inf/dpp/server/filesystem/ServerResourceImplTest.java
@@ -29,8 +29,8 @@ public class ServerResourceImplTest extends EasyMockSupport {
 
     private static class ExampleResource extends ServerResourceImpl {
 
-        public ExampleResource(IPath path, IWorkspace workspace) {
-            super(workspace, path);
+        public ExampleResource(IPath path, IProject project, IWorkspace workspace) {
+            super(workspace, project, path);
         }
 
         @Override
@@ -67,7 +67,7 @@ public class ServerResourceImplTest extends EasyMockSupport {
 
         replayAll();
 
-        resource = new ExampleResource(path("project/folder/file"), workspace);
+        resource = new ExampleResource(path("project/folder/file"), project, workspace);
     }
 
     @After
@@ -108,7 +108,7 @@ public class ServerResourceImplTest extends EasyMockSupport {
 
     @Test
     public void getParentIfParentIsProject() {
-        resource = new ExampleResource(path("project/file"), workspace);
+        resource = new ExampleResource(path("project/file"), project, workspace);
         assertEquals(project, resource.getParent());
     }
 


### PR DESCRIPTION
The structure of the filesystem for the running server is not dictated
by any IDE. This lifts a limitation of the current implementation
forcing all projects to be in the workspace folder without any folders
in between.