### PR TITLE
[FEATURE][CORE] Cancelable Input Streams

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/monitoring/CancelableInputStream.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/monitoring/CancelableInputStream.java
@@ -1,0 +1,47 @@
+package de.fu_berlin.inf.dpp.monitoring;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * This class wraps an <code>InputStream</code> to enable user canceling of long
+ * taking processings. This works best if consumers read streams in small
+ * buffers, like Eclipse does.
+ */
+public class CancelableInputStream extends InputStream {
+    /** the wrapped input stream */
+    private final InputStream in;
+
+    /** the monitor to check */
+    private final IProgressMonitor monitor;
+
+    /**
+     * Creates a new <code>CancelableInputStream</code> that wraps the given
+     * input and checks for a canceled monitor at every read call.
+     * 
+     * @param in
+     *            The wrapped input stream
+     * @param monitor
+     *            The checked monitor
+     */
+    public CancelableInputStream(InputStream in, IProgressMonitor monitor) {
+        this.in = in;
+        this.monitor = monitor;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (monitor.isCanceled())
+            throw new IOException("Processing was canceled!");
+
+        return super.read(b, off, len);
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (monitor.isCanceled())
+            throw new IOException("Processing was canceled!");
+
+        return in.read();
+    }
+}


### PR DESCRIPTION
This patch introduces a class, wrapping Input Streams, to check for user
cancellations at each read access and adds this behavior to the
DecompressArchiveTask.

It shortens the response time, till user cancelations are proceded,
while decompressing of large files and removes an old FIXME.