### PR TITLE
[FEATURE][CORE][E] Toggle Instant Session Start

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/preferences/PreferenceConstants.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/preferences/PreferenceConstants.java
@@ -45,5 +45,5 @@ public class PreferenceConstants {
 
     public static final String SESSION_NICKNAME = "session.nickname";
 
-    public static final String INSTANT_SESSION_START_PREFERED = "instant_session_start_prefered";
+    public static final String INSTANT_SESSION_START_PREFERRED = "instant_session_start_preferred";
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/preferences/PreferenceConstants.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/preferences/PreferenceConstants.java
@@ -44,4 +44,6 @@ public class PreferenceConstants {
     public static final String FAVORITE_SESSION_COLOR_ID = "favorite.session.color.id";
 
     public static final String SESSION_NICKNAME = "session.nickname";
+
+    public static final String INSTANT_SESSION_START_PREFERED = "instant_session_start_prefered";
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/preferences/PreferenceInitializer.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/preferences/PreferenceInitializer.java
@@ -42,7 +42,7 @@ public class PreferenceInitializer {
             UserColorID.UNKNOWN);
 
         store.setDefault(PreferenceConstants.SESSION_NICKNAME, "");
-        store.setDefault(PreferenceConstants.INSTANT_SESSION_START_PREFERED,
+        store.setDefault(PreferenceConstants.INSTANT_SESSION_START_PREFERRED,
             false);
     }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/preferences/PreferenceInitializer.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/preferences/PreferenceInitializer.java
@@ -42,5 +42,7 @@ public class PreferenceInitializer {
             UserColorID.UNKNOWN);
 
         store.setDefault(PreferenceConstants.SESSION_NICKNAME, "");
+        store.setDefault(PreferenceConstants.INSTANT_SESSION_START_PREFERED,
+            false);
     }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/preferences/Preferences.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/preferences/Preferences.java
@@ -202,6 +202,6 @@ public abstract class Preferences {
      */
     public boolean isInstantSessionStartPreferred() {
         return store
-            .getBoolean(PreferenceConstants.INSTANT_SESSION_START_PREFERED);
+            .getBoolean(PreferenceConstants.INSTANT_SESSION_START_PREFERRED);
     }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/preferences/Preferences.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/preferences/Preferences.java
@@ -195,4 +195,13 @@ public abstract class Preferences {
         return store.getInt(PreferenceConstants.FAVORITE_SESSION_COLOR_ID);
     }
 
+    /**
+     * Returns the preference for instant session start feature.
+     * 
+     * @return true if instant session start is preferred
+     */
+    public boolean isInstantSessionStartPreferred() {
+        return store
+            .getBoolean(PreferenceConstants.INSTANT_SESSION_START_PREFERED);
+    }
 }

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/Messages.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/Messages.java
@@ -36,6 +36,7 @@ public class Messages extends NLS {
     public static String AdvancedPreferencePage_description;
     public static String AdvancedPreferencePage_show_xmpp_debug;
     public static String AdvancedPreferencePage_activate_server;
+    public static String AdvancedPreferencePage_instant_session_start_preferred;
 
     public static String ChangeColorAction_message_text;
     public static String ChangeColorAction_message_title;

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/messages.properties
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/messages.properties
@@ -188,6 +188,7 @@ AddXMPPAccountWizard_account_created=Account Created
 AdvancedPreferencePage_description=Advanced settings geared toward developers and power users.
 AdvancedPreferencePage_show_xmpp_debug=Show SMACK debug window (needs restart).
 AdvancedPreferencePage_activate_server=Activate Server [experimental] (requires reconnect)
+AdvancedPreferencePage_instant_session_start_preferred=Prefer Instant Session Start [experimental].
 
 ChangeColorWizard_title=Change Session Color
 ChangeColorWizardPage_title=Change Session Color

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/preferencePages/AdvancedPreferencePage.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/preferencePages/AdvancedPreferencePage.java
@@ -71,6 +71,11 @@ public class AdvancedPreferencePage extends FieldEditorPreferencePage implements
                 Messages.AdvancedPreferencePage_activate_server,
                 getFieldEditorParent()));
         }
+
+        addField(new BooleanFieldEditor(
+            PreferenceConstants.INSTANT_SESSION_START_PREFERED,
+            Messages.AdvancedPreferencePage_instant_session_start_preferred,
+            getFieldEditorParent()));
     }
 
     @Override

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/preferencePages/AdvancedPreferencePage.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/preferencePages/AdvancedPreferencePage.java
@@ -73,7 +73,7 @@ public class AdvancedPreferencePage extends FieldEditorPreferencePage implements
         }
 
         addField(new BooleanFieldEditor(
-            PreferenceConstants.INSTANT_SESSION_START_PREFERED,
+            PreferenceConstants.INSTANT_SESSION_START_PREFERRED,
             Messages.AdvancedPreferencePage_instant_session_start_preferred,
             getFieldEditorParent()));
     }


### PR DESCRIPTION
In preparation for the new feature 'Instant Session Start', this patch
introduces a feature toggle, configurable via the user preference store.

While users can already select the feature in Eclipse, via
Preferences -> Saros -> Advanced, it has no effect.

This Patch is a adapted version of parts of the work from
[Patrick Fehling] and [Victor Brekenfeld].

[Patrick Fehling]: https://saros-build.imp.fu-berlin.de/gerrit/#/c/3067/
[Victor Brekenfeld]: https://saros-build.imp.fu-berlin.de/gerrit/#/c/3498/