### PR TITLE
[FEATURE][CORE] Negotiate Transfer Type Instant

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/NegotiationFactory.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/NegotiationFactory.java
@@ -119,13 +119,16 @@ public final class NegotiationFactory {
         }
 
         switch (transferType) {
+        case INSTANT:
+            /* $FALL-THROUGH$ - implemented in follow-up patch */
         case ARCHIVE:
-            return new ArchiveOutgoingProjectNegotiation(remoteAddress, resources,
-                sessionManager, session, /* editorManager */
+            return new ArchiveOutgoingProjectNegotiation(remoteAddress,
+                resources, sessionManager, session, /* editorManager */
                 context.getComponent(IEditorManager.class), workspace,
                 checksumCache, connectionService, transmitter, receiver);
         default:
-            throw new UnsupportedOperationException("transferType not implemented");
+            throw new UnsupportedOperationException(
+                "transferType not implemented");
         }
     }
 
@@ -140,13 +143,16 @@ public final class NegotiationFactory {
         }
 
         switch (transferType) {
+        case INSTANT:
+            /* $FALL-THROUGH$ - implemented in follow-up patch */
         case ARCHIVE:
-            return new ArchiveIncomingProjectNegotiation(remoteAddress, negotiationID,
-                projectNegotiationData, sessionManager, session,
+            return new ArchiveIncomingProjectNegotiation(remoteAddress,
+                negotiationID, projectNegotiationData, sessionManager, session,
                 fileReplacementInProgressObservable, workspace, checksumCache,
                 connectionService, transmitter, receiver);
         default:
-            throw new UnsupportedOperationException("transferType not implemented");
+            throw new UnsupportedOperationException(
+                "transferType not implemented");
         }
     }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/TransferType.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/TransferType.java
@@ -7,5 +7,5 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  */
 @XStreamAlias("TT")
 public enum TransferType {
-    ARCHIVE
+    ARCHIVE, INSTANT
 }


### PR DESCRIPTION
In preparation for the new feature 'Instant Session Start', this patch
introduces a new Transfer Type INSTANT and extends the Project
Negotiation Type Hook to negotiate according to the User Preferences.

While users can already select the feature, it has no effect and Project
Negotiation defaults to ARCHIVE.