### PR TITLE
[FEATURE][CORE] Introduce Instant Session Start

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantIncomingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantIncomingProjectNegotiation.java
@@ -1,0 +1,127 @@
+package de.fu_berlin.inf.dpp.negotiation;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.log4j.Logger;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smackx.filetransfer.IncomingFileTransfer;
+
+import de.fu_berlin.inf.dpp.communication.extensions.StartActivityQueuingResponse;
+import de.fu_berlin.inf.dpp.exceptions.LocalCancellationException;
+import de.fu_berlin.inf.dpp.exceptions.SarosCancellationException;
+import de.fu_berlin.inf.dpp.filesystem.IChecksumCache;
+import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
+import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
+import de.fu_berlin.inf.dpp.negotiation.NegotiationTools.CancelOption;
+import de.fu_berlin.inf.dpp.negotiation.stream.IncomingStreamProtocol;
+import de.fu_berlin.inf.dpp.net.IReceiver;
+import de.fu_berlin.inf.dpp.net.ITransmitter;
+import de.fu_berlin.inf.dpp.net.xmpp.JID;
+import de.fu_berlin.inf.dpp.net.xmpp.XMPPConnectionService;
+import de.fu_berlin.inf.dpp.observables.FileReplacementInProgressObservable;
+import de.fu_berlin.inf.dpp.session.ISarosSession;
+import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
+
+/**
+ * Receive shared Projects and display them instant using a stream based
+ * solution.
+ */
+public class InstantIncomingProjectNegotiation extends
+    AbstractIncomingProjectNegotiation {
+
+    private static final Logger log = Logger
+        .getLogger(InstantIncomingProjectNegotiation.class);
+
+    public InstantIncomingProjectNegotiation(
+        final JID peer, //
+        final String negotiationID, //
+        final List<ProjectNegotiationData> projectNegotiationData, //
+        final ISarosSessionManager sessionManager, //
+        final ISarosSession session, //
+        final FileReplacementInProgressObservable fileReplacementInProgressObservable, //
+        final IWorkspace workspace, //
+        final IChecksumCache checksumCache, //
+        final XMPPConnectionService connectionService, //
+        final ITransmitter transmitter, //
+        final IReceiver receiver //
+    ) {
+        super(peer, TransferType.INSTANT, negotiationID,
+            projectNegotiationData, sessionManager, session,
+            fileReplacementInProgressObservable, workspace, checksumCache,
+            connectionService, transmitter, receiver);
+    }
+
+    @Override
+    protected void transfer(IProgressMonitor monitor,
+        Map<String, IProject> projectMapping, List<FileList> missingFiles)
+        throws IOException, SarosCancellationException {
+
+        awaitActivityQueueingActivation(monitor);
+
+        /*
+         * the user who sends this ProjectNegotiation is now responsible for the
+         * resources of the contained projects
+         */
+        for (Entry<String, IProject> entry : projectMapping.entrySet()) {
+            final String projectID = entry.getKey();
+            final IProject project = entry.getValue();
+
+            session.addProjectMapping(projectID, project);
+            /* TODO change queuing to resource based queuing */
+            session.enableQueuing(project);
+        }
+
+        transmitter.send(ISarosSession.SESSION_CONNECTION_ID, getPeer(), //
+            StartActivityQueuingResponse.PROVIDER //
+                .create( //
+                new StartActivityQueuingResponse(getSessionID(), getID())));
+
+        checkCancellation(CancelOption.NOTIFY_PEER);
+
+        /* only get files, if something is missing */
+        int filesMissing = 0;
+        for (FileList list : missingFiles)
+            filesMissing += list.getPaths().size();
+
+        if (filesMissing > 0)
+            receiveStream(monitor, filesMissing);
+    }
+
+    private void receiveStream(IProgressMonitor monitor, int fileCount)
+        throws SarosCancellationException, IOException {
+
+        String message = "Receiving files from " + getPeer().getName() + "...";
+        monitor.beginTask(message, fileCount);
+        monitor.subTask("Waiting for Host to start...");
+
+        awaitTransferRequest();
+
+        monitor.subTask("Host is starting to send...");
+        log.debug(this + ": Host is starting to send...");
+
+        IncomingFileTransfer transfer = transferListener.getRequest().accept();
+        InputStream in = null;
+        try {
+            in = transfer.recieveFile();
+
+            IncomingStreamProtocol isp;
+            isp = new IncomingStreamProtocol(in, session, monitor);
+            isp.receiveStream();
+        } catch (XMPPException e) {
+            throw new LocalCancellationException(e.getMessage(),
+                CancelOption.NOTIFY_PEER);
+        } finally {
+            IOUtils.closeQuietly(in);
+        }
+
+        log.debug(this + ": stream transmission done");
+        monitor.done();
+    }
+
+}

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantOutgoingProjectNegotiation.java
@@ -1,0 +1,273 @@
+package de.fu_berlin.inf.dpp.negotiation;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.LinkedBlockingDeque;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.log4j.Logger;
+import org.jivesoftware.smackx.filetransfer.FileTransfer;
+import org.jivesoftware.smackx.filetransfer.OutgoingFileTransfer;
+
+import de.fu_berlin.inf.dpp.activities.SPath;
+import de.fu_berlin.inf.dpp.editor.AbstractSharedEditorListener;
+import de.fu_berlin.inf.dpp.editor.IEditorManager;
+import de.fu_berlin.inf.dpp.editor.ISharedEditorListener;
+import de.fu_berlin.inf.dpp.editor.remote.UserEditorStateManager;
+import de.fu_berlin.inf.dpp.exceptions.LocalCancellationException;
+import de.fu_berlin.inf.dpp.exceptions.SarosCancellationException;
+import de.fu_berlin.inf.dpp.filesystem.IChecksumCache;
+import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
+import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
+import de.fu_berlin.inf.dpp.negotiation.NegotiationTools.CancelOption;
+import de.fu_berlin.inf.dpp.negotiation.stream.OutgoingStreamProtocol;
+import de.fu_berlin.inf.dpp.net.IReceiver;
+import de.fu_berlin.inf.dpp.net.ITransmitter;
+import de.fu_berlin.inf.dpp.net.xmpp.JID;
+import de.fu_berlin.inf.dpp.net.xmpp.XMPPConnectionService;
+import de.fu_berlin.inf.dpp.session.ISarosSession;
+import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
+import de.fu_berlin.inf.dpp.session.User;
+import de.fu_berlin.inf.dpp.synchronize.StartHandle;
+
+/**
+ * Share Projects to display them instant on client side using a stream based
+ * solution.
+ */
+public class InstantOutgoingProjectNegotiation extends
+    AbstractOutgoingProjectNegotiation {
+
+    private static final Logger log = Logger
+        .getLogger(InstantOutgoingProjectNegotiation.class);
+
+    /** used as LIFO queue **/
+    private final Deque<SPath> openedFiles = new LinkedBlockingDeque<SPath>();
+
+    private Set<SPath> transferList;
+    private Set<SPath> transmittedFiles;
+
+    /** receive open editors to prioritize these files **/
+    private final ISharedEditorListener listener = new AbstractSharedEditorListener() {
+        @Override
+        public void editorActivated(User user, SPath file) {
+            fileOpened(file);
+        }
+    };
+
+    private List<StartHandle> stoppedUsers = null;
+    private User remoteUser = null;
+
+    public InstantOutgoingProjectNegotiation(final JID peer, //
+        final List<IProject> projects, //
+        final ISarosSessionManager sessionManager, //
+        final ISarosSession session, //
+        final IEditorManager editorManager, //
+        final IWorkspace workspace, //
+        final IChecksumCache checksumCache, //
+        final XMPPConnectionService connectionService, //
+        final ITransmitter transmitter, //
+        final IReceiver receiver) //
+    {
+        super(peer, TransferType.INSTANT, projects, sessionManager, session,
+            editorManager, workspace, checksumCache, connectionService,
+            transmitter, receiver);
+    }
+
+    @Override
+    protected void setup(IProgressMonitor monitor) throws IOException,
+        LocalCancellationException {
+        if (fileTransferManager == null)
+            throw new LocalCancellationException(
+                "not connected to a XMPP server",
+                CancelOption.DO_NOT_NOTIFY_PEER);
+
+        /* get all opened editors */
+        editorManager.addSharedEditorListener(listener);
+        Set<SPath> openEditors = session.getComponent(
+            UserEditorStateManager.class).getOpenEditors();
+        for (SPath remoteOpenFile : openEditors)
+            fileOpened(remoteOpenFile);
+        for (SPath localOpenFile : editorManager.getOpenEditors())
+            fileOpened(localOpenFile);
+    }
+
+    @Override
+    protected void prepareTransfer(IProgressMonitor monitor,
+        List<FileList> fileLists) throws IOException,
+        SarosCancellationException {
+
+        /* until further patch, lock the complete session */
+        stoppedUsers = stopUsers(monitor);
+        sendAndAwaitActivityQueueingActivation(monitor);
+
+        remoteUser = session.getUser(getPeer());
+        if (remoteUser == null)
+            throw new LocalCancellationException(null,
+                CancelOption.DO_NOT_NOTIFY_PEER);
+
+        int fileCount = 0;
+        for (final FileList list : fileLists) {
+            fileCount += list.getPaths().size();
+
+            final String projectID = list.getProjectID();
+            final IProject project = session.getProject(projectID);
+
+            if (project == null)
+                throw new LocalCancellationException("project with id "
+                    + projectID + " was unshared during synchronization",
+                    CancelOption.NOTIFY_PEER);
+        }
+
+        createTransferList(fileLists, fileCount);
+        transmittedFiles = new HashSet<SPath>(fileCount * 2);
+    }
+
+    @Override
+    protected void transfer(IProgressMonitor monitor, List<FileList> fileLists)
+        throws SarosCancellationException, IOException {
+        if (transferList.isEmpty())
+            return;
+
+        log.debug(this + ": file transfer start");
+        assert fileTransferManager != null;
+
+        String message = "Sending files to " + getPeer().getName() + "...";
+        monitor.beginTask(message, transferList.size());
+
+        /* use piped stream to communicate with transfer thread */
+        PipedInputStream in = new PipedInputStream();
+        OutputStream out = new PipedOutputStream(in);
+
+        String userID = getPeer().toString();
+        OutgoingFileTransfer transfer;
+        transfer = fileTransferManager.createOutgoingFileTransfer(userID);
+
+        try {
+            OutgoingStreamProtocol osp;
+            osp = new OutgoingStreamProtocol(out, session, monitor);
+
+            /* id in description needed to bypass SendFileAction handler */
+            String streamName = TRANSFER_ID + getID();
+            transfer.sendStream(in, streamName, 0, streamName);
+
+            awaitNegotation(transfer, monitor);
+
+            sendProjectConfigFiles(osp);
+            sendRemainingPreferOpenedFirst(osp);
+
+            osp.close();
+        } finally {
+            IOUtils.closeQuietly(out);
+        }
+
+        monitor.done();
+        log.debug(this + ": file transfer done");
+    }
+
+    @Override
+    protected void cleanup(IProgressMonitor monitor) {
+        editorManager.removeSharedEditorListener(listener);
+        session.userStartedQueuing(remoteUser);
+
+        if (stoppedUsers != null)
+            startUsers(stoppedUsers);
+
+        super.cleanup(monitor);
+    }
+
+    private void createTransferList(List<FileList> fileLists, int fileCount) {
+        List<SPath> files = new ArrayList<SPath>(fileCount);
+        for (final FileList list : fileLists) {
+            IProject project = session.getProject(list.getProjectID());
+            for (String file : list.getPaths()) {
+                files.add(new SPath(project.getFile(file)));
+            }
+        }
+
+        /* sort hierarchy based, top files are seen first in project explorer */
+        Collections.sort(files, new Comparator<SPath>() {
+            @Override
+            public int compare(SPath a, SPath b) {
+                int lenA = a.getProjectRelativePath().segmentCount();
+                int lenB = b.getProjectRelativePath().segmentCount();
+                return Integer.valueOf(lenA).compareTo(Integer.valueOf(lenB));
+            }
+        });
+
+        /* LinkedHashSet for fast lookup while keeping sort order */
+        transferList = new LinkedHashSet<SPath>(files);
+    }
+
+    private void fileOpened(SPath file) {
+        if (file != null) {
+            openedFiles.addFirst(file);
+            log.debug(this + ": added " + file + " to open files queue");
+        }
+    }
+
+    private void sendProjectConfigFiles(OutgoingStreamProtocol osp)
+        throws IOException, LocalCancellationException {
+        /* TODO should be configurable in future */
+        String[] eclipseProjFiles = {
+            ".settings/org.eclipse.core.resources.prefs" /* for file encoding! */,
+            ".classpath", ".project",
+            ".settings/org.eclipse.core.runtime.prefs",
+            ".settings/org.eclipse.jdt.core.prefs",
+            ".settings/org.eclipse.jdt.ui.prefs" };
+
+        for (String string : eclipseProjFiles) {
+            for (IProject project : projects) {
+                SPath file = new SPath(project.getFile(string));
+                sendIfRequired(osp, file);
+            }
+        }
+    }
+
+    private void sendRemainingPreferOpenedFirst(OutgoingStreamProtocol osp)
+        throws IOException, LocalCancellationException {
+        for (SPath file : transferList) {
+            while (!openedFiles.isEmpty()) {
+                SPath openFile = openedFiles.poll();
+                /* open files could be changed meanwhile */
+                editorManager.saveEditors(openFile.getProject());
+                sendIfRequired(osp, openFile);
+            }
+
+            sendIfRequired(osp, file);
+        }
+    }
+
+    private void sendIfRequired(OutgoingStreamProtocol osp, SPath file)
+        throws IOException, LocalCancellationException {
+        if (transferList.contains(file) && !transmittedFiles.contains(file)) {
+            osp.streamFile(file);
+            transmittedFiles.add(file);
+        }
+    }
+
+    private void awaitNegotation(OutgoingFileTransfer transfer,
+        IProgressMonitor monitor) throws SarosCancellationException {
+        while (transfer.getStatus() != FileTransfer.Status.in_progress) {
+            monitor.subTask("waiting for client to accept file transfer");
+            try {
+                checkCancellation(CancelOption.NOTIFY_PEER);
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new LocalCancellationException();
+            }
+        }
+    }
+
+}

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/NegotiationFactory.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/NegotiationFactory.java
@@ -119,10 +119,13 @@ public final class NegotiationFactory {
         }
 
         switch (transferType) {
-        case INSTANT:
-            /* $FALL-THROUGH$ - implemented in follow-up patch */
         case ARCHIVE:
             return new ArchiveOutgoingProjectNegotiation(remoteAddress,
+                resources, sessionManager, session, /* editorManager */
+                context.getComponent(IEditorManager.class), workspace,
+                checksumCache, connectionService, transmitter, receiver);
+        case INSTANT:
+            return new InstantOutgoingProjectNegotiation(remoteAddress,
                 resources, sessionManager, session, /* editorManager */
                 context.getComponent(IEditorManager.class), workspace,
                 checksumCache, connectionService, transmitter, receiver);
@@ -143,10 +146,13 @@ public final class NegotiationFactory {
         }
 
         switch (transferType) {
-        case INSTANT:
-            /* $FALL-THROUGH$ - implemented in follow-up patch */
         case ARCHIVE:
             return new ArchiveIncomingProjectNegotiation(remoteAddress,
+                negotiationID, projectNegotiationData, sessionManager, session,
+                fileReplacementInProgressObservable, workspace, checksumCache,
+                connectionService, transmitter, receiver);
+        case INSTANT:
+            return new InstantIncomingProjectNegotiation(remoteAddress,
                 negotiationID, projectNegotiationData, sessionManager, session,
                 fileReplacementInProgressObservable, workspace, checksumCache,
                 connectionService, transmitter, receiver);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/stream/AbstractStreamProtocol.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/stream/AbstractStreamProtocol.java
@@ -1,0 +1,86 @@
+package de.fu_berlin.inf.dpp.negotiation.stream;
+
+import de.fu_berlin.inf.dpp.filesystem.IFile;
+import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
+import de.fu_berlin.inf.dpp.session.ISarosSession;
+
+/**
+ * Stream consists of infinite Stream entries. Stream end is signaled by empty
+ * <em>projectID</em>.
+ *
+ * <p>
+ * <b>Stream entry</b>
+ * <table>
+ * <tr>
+ * <th>byte count</th>
+ * <th>content</th>
+ * </tr>
+ * <tr>
+ * <td>varying</td>
+ * <td>{@code String} of <em>projectID</em> encoded via
+ * {@link java.io.DataOutputStream#writeUTF(String)}. If {@code String} is
+ * empty, signals stream end.</td>
+ * </tr>
+ * <tr>
+ * <td>varying</td>
+ * <td>{@code String} of <em>fileName</em> encoded via
+ * {@link java.io.DataOutputStream#writeUTF(String)}.</td>
+ * </tr>
+ * <tr>
+ * <td>{@code long}</td>
+ * <td>{@code long} of <em>fileSize</em></td>
+ * </tr>
+ * <tr>
+ * <td>defined by <em>fileSize</em></td>
+ * <td>{@code bytestream} of <em>fileContent</em></td>
+ * </tr>
+ * </table>
+ * </p>
+ *
+ * <b>Handle of Character Encoding</b>
+ * <p>
+ * The used Character Encoding for a file is an IDE/Editor handled setting.
+ * Eclipse is using <em>.settings/org.eclipse.core.resources.prefs</em> for
+ * this. Thats why it should be one of the first files transmitted in project
+ * sharing.
+ * </p>
+ * <p>
+ * Additionally, Eclipse handle rules like all <em>.properties</em> files till
+ * Java 9 use <em>ISO-8859-1</em> Encoding per default (see <a href=
+ * "https://docs.oracle.com/javase/9/intl/internationalization-enhancements-jdk-9.htm"
+ * >Internationalization Enhancements in JDK 9</a>), which by setting it
+ * explicitly would change a convention setting to a useless permanent
+ * configuration setting, with probably side effects.<br>
+ * In another case it leads to the Situation, that when one tries to set this
+ * explicit, it has to be set in the <em>pref</em> file and gets overwritten by
+ * the incoming <em>pref</em> file, if send later.
+ * </p>
+ * <p>
+ * Not forgetting to mention, this behavior is field tested in archive transfer
+ * mode.
+ * </p>
+ */
+abstract class AbstractStreamProtocol {
+
+    ISarosSession session;
+    IProgressMonitor monitor;
+
+    public AbstractStreamProtocol(ISarosSession session,
+        IProgressMonitor monitor) {
+        this.session = session;
+        this.monitor = monitor;
+    }
+
+    /**
+     * generates project and filename combination for user visualization
+     *
+     * @param file
+     * @return String of local project name and filename
+     */
+    String displayName(IFile file) {
+        String projectName = file.getProject().getName();
+        String fileName = file.getProjectRelativePath().toOSString();
+
+        return projectName + ": " + fileName;
+    }
+}

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/stream/IncomingStreamProtocol.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/stream/IncomingStreamProtocol.java
@@ -21,7 +21,7 @@ import de.fu_berlin.inf.dpp.session.ISarosSession;
 public class IncomingStreamProtocol extends AbstractStreamProtocol {
 
     private static final Logger log = Logger
-        .getLogger(OutgoingStreamProtocol.class);
+        .getLogger(IncomingStreamProtocol.class);
 
     private DataInputStream in;
 
@@ -34,7 +34,7 @@ public class IncomingStreamProtocol extends AbstractStreamProtocol {
     /**
      * Receive Files from {@code InputStream in} via in
      * {@link AbstractStreamProtocol} defined protocol.
-     *
+     * 
      * @throws IOException
      *             if any file or stream operation fails
      * @throws LocalCancellationException

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/stream/IncomingStreamProtocol.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/stream/IncomingStreamProtocol.java
@@ -1,0 +1,88 @@
+package de.fu_berlin.inf.dpp.negotiation.stream;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.BoundedInputStream;
+import org.apache.log4j.Logger;
+
+import de.fu_berlin.inf.dpp.exceptions.LocalCancellationException;
+import de.fu_berlin.inf.dpp.filesystem.FileSystem;
+import de.fu_berlin.inf.dpp.filesystem.IFile;
+import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
+import de.fu_berlin.inf.dpp.negotiation.NegotiationTools.CancelOption;
+import de.fu_berlin.inf.dpp.session.ISarosSession;
+
+/**
+ * Implements Stream processing in {@link AbstractStreamProtocol} format.
+ */
+public class IncomingStreamProtocol extends AbstractStreamProtocol {
+
+    private static final Logger log = Logger
+        .getLogger(OutgoingStreamProtocol.class);
+
+    private DataInputStream in;
+
+    public IncomingStreamProtocol(InputStream in, ISarosSession session,
+        IProgressMonitor monitor) {
+        super(session, monitor);
+        this.in = new DataInputStream(in);
+    }
+
+    /**
+     * Receive Files from {@code InputStream in} via in
+     * {@link AbstractStreamProtocol} defined protocol.
+     *
+     * @throws IOException
+     *             if any file or stream operation fails
+     * @throws LocalCancellationException
+     *             on local user cancellation
+     */
+    public void receiveStream() throws IOException, LocalCancellationException {
+        BoundedInputStream fileIn = null;
+        try {
+            while (true) {
+                String projectID = in.readUTF();
+
+                /* check stream end */
+                if (projectID.isEmpty())
+                    break;
+
+                String fileName = in.readUTF();
+                IFile file = session.getProject(projectID).getFile(fileName);
+
+                String message = "receiving " + displayName(file);
+                log.debug(message);
+                monitor.subTask(message);
+
+                /*
+                 * folder creation is already done after file exchange, but in
+                 * case of future changes
+                 */
+                FileSystem.createFolder(file);
+
+                long fileSize = in.readLong();
+                fileIn = new BoundedInputStream(in, fileSize);
+                fileIn.setPropagateClose(false);
+
+                if (file.exists())
+                    file.setContents(fileIn, false, true);
+                else
+                    file.create(fileIn, false);
+
+                if (monitor.isCanceled()) {
+                    throw new LocalCancellationException(
+                        "User canceled transmission", CancelOption.NOTIFY_PEER);
+                }
+
+                monitor.worked(1);
+            }
+        } finally {
+            IOUtils.closeQuietly(fileIn);
+            IOUtils.closeQuietly(in);
+        }
+    }
+
+}

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/stream/OutgoingStreamProtocol.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/stream/OutgoingStreamProtocol.java
@@ -1,0 +1,107 @@
+package de.fu_berlin.inf.dpp.negotiation.stream;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.log4j.Logger;
+
+import de.fu_berlin.inf.dpp.activities.SPath;
+import de.fu_berlin.inf.dpp.exceptions.LocalCancellationException;
+import de.fu_berlin.inf.dpp.filesystem.IFile;
+import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
+import de.fu_berlin.inf.dpp.negotiation.NegotiationTools.CancelOption;
+import de.fu_berlin.inf.dpp.session.ISarosSession;
+
+/**
+ * Implements Stream creation in {@link AbstractStreamProtocol} format.
+ */
+public class OutgoingStreamProtocol extends AbstractStreamProtocol {
+
+    private static final Logger log = Logger
+        .getLogger(OutgoingStreamProtocol.class);
+
+    private static final int BUFFER_SIZE = 8192;
+    /** used for copy operations between streams **/
+    private final byte[] buffer = new byte[BUFFER_SIZE];
+
+    private DataOutputStream out;
+
+    public OutgoingStreamProtocol(OutputStream out, ISarosSession session,
+        IProgressMonitor monitor) {
+        super(session, monitor);
+        this.out = new DataOutputStream(out);
+    }
+
+    /**
+     * Sends a File to {@code OutputStream out} via in
+     * {@link AbstractStreamProtocol} defined protocol.
+     * 
+     * @param file
+     *            the file to send
+     * @throws IOException
+     *             if any file or stream operation fails
+     * @throws LocalCancellationException
+     *             on local user cancellation
+     */
+    public void streamFile(SPath file) throws IOException,
+        LocalCancellationException {
+        String message = "sending " + displayName(file.getFile());
+        log.debug(message);
+        monitor.subTask(message);
+
+        IFile fileHandle = file.getFile();
+
+        writeHeader(file, fileHandle.getSize());
+
+        InputStream fileIn = null;
+        try {
+            fileIn = fileHandle.getContents();
+            int readBytes = 0;
+            /* buffer the file content and send to stream */
+            while (readBytes != -1) {
+                out.write(buffer, 0, readBytes);
+                readBytes = fileIn.read(buffer);
+
+                if (monitor.isCanceled())
+                    throw new LocalCancellationException(
+                        "transmission was canceled", CancelOption.NOTIFY_PEER);
+            }
+        } catch (IOException e) {
+            IOUtils.closeQuietly(out);
+            throw e;
+        } catch (LocalCancellationException e) {
+            IOUtils.closeQuietly(out);
+            throw e;
+        } finally {
+            IOUtils.closeQuietly(fileIn);
+        }
+        monitor.worked(1);
+    }
+
+    private void writeHeader(SPath file, long fileSize) throws IOException {
+        String projectID = session.getProjectID(file.getProject());
+        String fileName = file.getProjectRelativePath().toPortableString();
+
+        out.writeUTF(projectID);
+        out.writeUTF(fileName);
+        out.writeLong(fileSize);
+    }
+
+    /**
+     * Writes a end remark to notify stream endpoint about correct end of
+     * transmission and closes the stream correctly.
+     * 
+     * @throws IOException
+     *             if stream operation fails
+     */
+    public void close() throws IOException {
+        try {
+            out.writeUTF("");
+        } finally {
+            IOUtils.closeQuietly(out);
+        }
+    }
+}


### PR DESCRIPTION
This patch implements the core functionality of Instant Session Start,
which is optional selectable for Project Negotiation. The main scope of
this feature is to decrease the waiting time for users, till the first
files are provided and they can participate in a session.

Deviant to previous approaches, this one uses a file stream based
solution. Compared to using Activities, this provides increased
performance, because of small overheads and better compresion
possibilities, big files support and is for now, not interfering with
existing activity handling code.

This first Version implements a basic prioritisation, by first sending
important eclipse project files, afterwards allways opened files first
and remaining sorted by path hierarchy.

Following features are excluded, to limit this rather big patch or are
planned for the future:

 - Proper handling of Activities, to remove editor lock

 - Compression (using a libary like zstd)

 - Configurable File Prioritisations

 - More progress infos (bandwith, remaining file size, time...)

 - Performance optimizations, refactoring of ProjectNegotiation

 - User interface enhancements

 - Priority file sending, while active file transmission