### PR TITLE
[UI][I] Remove contact form address from messages

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/Messages.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/Messages.java
@@ -85,8 +85,6 @@ public class Messages {
     public static String ConnectButton_connect_to_new_account_title;
     public static String ConnectButton_connect_to_new_account_message;
 
-    public static String Contact_option_mailing_list_devel;
-    public static String Contact_option_website_feedback;
     public static String Contact_saros_message_conditional;
 
     public static String ContactPopMenu_unsupported_ide_title;

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/messages.properties
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/messages.properties
@@ -69,9 +69,7 @@ SubscriptionManager_incoming_subscription_request_message={0} wants to add you t
 ConnectButton_connect_to_new_account_title=Connect to new Account?
 ConnectButton_connect_to_new_account_message=Connect to the created Account?\nNOTE: This will remove you from any sessions that are currently running without correctly informing the other participants.
 
-Contact_option_mailing_list_devel=saros-devel@googlegroups.com
-Contact_option_website_feedback=https://www.saros-project.org/contact/Website%20feedback
-Contact_saros_message_conditional={0}, please contact the Saros development team. You can reach us by writing to our mailing list (<a href=\"https://groups.google.com/forum/#!forum/saros-devel\">forum</a>, <a href=\"mailto:saros-devel@googlegroups.com\">mailto</a>) or by using our <a href=\"https://www.saros-project.org/contact/Website%20feedback\">contact form</a>.
+Contact_saros_message_conditional={0}, please contact the Saros development team. You can reach us by writing to our mailing list (<a href=\"https://groups.google.com/forum/#!forum/saros-devel\">forum</a>, <a href=\"mailto:saros-devel@googlegroups.com\">mailto</a>).
 
 ContactPopMenu_unsupported_ide_title=Unsupported IDE
 ContactPopMenu_unsupported_ide_message_condition=The local module manager could not be found. This most likely means that you are not using IntelliJ IDEA or are using an unsupported version. If you are using a supported version of IntelliJ IDEA


### PR DESCRIPTION
The contact form on out website saros-project.org is no longer
activated. Add contact should be done through our mailing lists.

Also removes the separate devel mailing list address as it is currently
not used.