### PR TITLE
[INTERNAL][I] Use a singleton list in #addSelectionAnnotation(...)

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/annotations/AnnotationManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/annotations/AnnotationManager.java
@@ -16,6 +16,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.awt.Color;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -84,7 +85,6 @@ public class AnnotationManager {
             return;
         }
 
-        List<AnnotationRange> annotationRanges = new ArrayList<>();
         AnnotationRange annotationRange;
 
         if (editor != null) {
@@ -97,10 +97,8 @@ public class AnnotationManager {
             annotationRange = new AnnotationRange(start, end);
         }
 
-        annotationRanges.add(annotationRange);
-
         SelectionAnnotation selectionAnnotation = new SelectionAnnotation(user,
-            file, editor, annotationRanges);
+            file, editor, Collections.singletonList(annotationRange));
 
         selectionAnnotationStore.addAnnotation(selectionAnnotation);
     }


### PR DESCRIPTION
Use Collections#singletonList(...) in for the list of annotation ranges
in AnnotationManager#addSelectionAnnotation(...). This improves the
performance of the method as #singletonList(...) only creates a wrapper
for the given element instead of a new list object.

The list contained in the created selection annotation is still mutable
since the general annotation CTOR in AbstractEditorAnnotation copies the
given list of range highlighters instead of using the given list
directly.