### PR TITLE
[FEATURE][CORE] Replaceable Queue Mechanism

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractIncomingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractIncomingProjectNegotiation.java
@@ -213,13 +213,7 @@ public abstract class AbstractIncomingProjectNegotiation extends ProjectNegotiat
   protected void cleanup(IProgressMonitor monitor, Map<String, IProject> projectMapping) {
     fileReplacementInProgressObservable.replacementDone();
 
-    /*
-     * TODO Queuing responsibility should be moved to Project
-     * Negotiation, since its the only consumer of queuing
-     * functionality. This will enable a specific Queuing mechanism per
-     * TransferType (see github issue #137).
-     */
-    for (IProject project : projectMapping.values()) session.disableQueuing(project);
+    session.flushQueue();
 
     if (fileTransferManager != null)
       fileTransferManager.removeFileTransferListener(transferListener);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/IActivityQueuer.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/IActivityQueuer.java
@@ -1,0 +1,19 @@
+package de.fu_berlin.inf.dpp.session;
+
+import de.fu_berlin.inf.dpp.activities.IActivity;
+import de.fu_berlin.inf.dpp.activities.IResourceActivity;
+import java.util.List;
+
+/** Interface for queuing incoming {@linkplain IActivity activities}. */
+public interface IActivityQueuer {
+
+  /**
+   * Processes the incoming {@linkplain IActivity activities} and decides which {@linkplain
+   * IResourceActivity resource related activities} should be queued.
+   *
+   * @param activities
+   * @return dequeued {@linkplain IResourceActivity IResourceActivities} and not queued {@linkplain
+   *     IActivity IActivities} from input {@code activities} list
+   */
+  public List<IActivity> process(final List<IActivity> activities);
+}

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ISarosSession.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ISarosSession.java
@@ -387,26 +387,15 @@ public interface ISarosSession {
   public void changeColor(int colorID);
 
   /**
-   * FOR INTERNAL USE ONLY !
+   * Register a activity queuer. Effective only at first call as all following calls are ignored.
    *
-   * <p>Starts queuing of incoming {@linkplain IResourceActivity project-related activities}, since
-   * they cannot be applied before their corresponding project is received and extracted.
-   *
-   * <p>That queuing relies on an existing project-to-projectID mapping (see {@link
-   * #addProjectMapping(String, IProject)}), otherwise incoming activities cannot be queued and will
-   * be lost.
-   *
-   * @param project the project for which project-related activities should be queued
-   * @see #disableQueuing
+   * @param activityQueuer
+   * @return true if the activityQueuer was registered successfully
    */
-  public void enableQueuing(IProject project);
+  public boolean registerActivityQueuer(IActivityQueuer activityQueuer);
 
-  /**
-   * FOR INTERNAL USE ONLY !
-   *
-   * <p>Disables queuing for the given project and flushes all queued activities.
-   */
-  public void disableQueuing(IProject project);
+  /** Send a NOPActivity to trigger queue processing. */
+  public void flushQueue();
 
   /**
    * Returns the id of the current session.

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/ActivityQueuer.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/ActivityQueuer.java
@@ -7,14 +7,23 @@ import de.fu_berlin.inf.dpp.activities.IResourceActivity;
 import de.fu_berlin.inf.dpp.activities.JupiterActivity;
 import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.session.IActivityQueuer;
+import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.User;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/** This class enables the queuing of {@linkplain IActivity activities} for given projects. */
-public class ActivityQueuer {
+/**
+ * This class enables queuing of {@linkplain IActivity activities} for given {@link IProject
+ * IProjects}.
+ *
+ * <p>This Queuer relies on an existing project-to-projectID mapping in session (see {@link
+ * ISarosSession#addProjectMapping(String, IProject)}), otherwise incoming activities cannot be
+ * queued and will be lost.
+ */
+public class ActivityQueuer implements IActivityQueuer {
 
   private static class ProjectQueue {
     private final IProject project;
@@ -34,18 +43,7 @@ public class ActivityQueuer {
     projectQueues = new ArrayList<ProjectQueue>();
   }
 
-  /**
-   * Processes the incoming {@linkplain IActivity activities} and decides which activities should be
-   * queued. All {@linkplain IResourceActivity resource related activities} which relate to a
-   * project that is configured for queuing using {@link #enableQueuing} will be queued. The method
-   * returns all other activities which should not be queued.
-   *
-   * <p>If a flushing of the queue was previously requested by calling {@link #disableQueuing} than
-   * the method will return a list of all queued activities.
-   *
-   * @param activities
-   * @return the activities that are not queued
-   */
+  @Override
   public synchronized List<IActivity> process(final List<IActivity> activities) {
 
     if (projectQueues.isEmpty()) return activities;

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
@@ -46,6 +46,7 @@ import de.fu_berlin.inf.dpp.session.IActivityConsumer.Priority;
 import de.fu_berlin.inf.dpp.session.IActivityHandlerCallback;
 import de.fu_berlin.inf.dpp.session.IActivityListener;
 import de.fu_berlin.inf.dpp.session.IActivityProducer;
+import de.fu_berlin.inf.dpp.session.IActivityQueuer;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionContextFactory;
 import de.fu_berlin.inf.dpp.session.ISessionListener;
@@ -66,6 +67,7 @@ import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.picocontainer.MutablePicoContainer;
@@ -136,7 +138,9 @@ public final class SarosSession implements ISarosSession {
   private boolean started = false;
   private boolean stopped = false;
 
-  private final ActivityQueuer activityQueuer;
+  private IActivityQueuer activityQueuer;
+  private final AtomicBoolean activityQueuerChangeAllowed = new AtomicBoolean(true);
+
   private boolean starting = false;
   private boolean stopping = false;
 
@@ -1037,13 +1041,22 @@ public final class SarosSession implements ISarosSession {
   }
 
   @Override
-  public void enableQueuing(IProject project) {
-    activityQueuer.enableQueuing(project);
+  public boolean registerActivityQueuer(IActivityQueuer activityQueuer) {
+    if (activityQueuer == null || !activityQueuerChangeAllowed.get()) {
+      return false;
+    }
+
+    if (activityQueuerChangeAllowed.compareAndSet(true, false)) {
+      log.info("register a new Activity Queue Handler: " + activityQueuer);
+      this.activityQueuer = activityQueuer;
+      return true;
+    }
+
+    return false;
   }
 
   @Override
-  public void disableQueuing(IProject project) {
-    activityQueuer.disableQueuing(project);
+  public void flushQueue() {
     // send us a dummy activity to ensure the queues get flushed
     sendActivity(Collections.singletonList(localUser), new NOPActivity(localUser, localUser, 0));
   }
@@ -1059,7 +1072,14 @@ public final class SarosSession implements ISarosSession {
 
     this.sessionID = id;
     this.projectMapper = new SharedProjectMapper();
-    this.activityQueuer = new ActivityQueuer();
+    this.activityQueuer =
+        new IActivityQueuer() {
+          /* default handler to prevent NPEs / used by host */
+          @Override
+          public List<IActivity> process(List<IActivity> activities) {
+            return activities;
+          }
+        };
     this.containerContext = context;
 
     // FIXME that should be passed in !

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/test/stubs/SarosSessionStub.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/test/stubs/SarosSessionStub.java
@@ -10,6 +10,7 @@ import de.fu_berlin.inf.dpp.preferences.IPreferenceStore;
 import de.fu_berlin.inf.dpp.session.IActivityConsumer;
 import de.fu_berlin.inf.dpp.session.IActivityConsumer.Priority;
 import de.fu_berlin.inf.dpp.session.IActivityProducer;
+import de.fu_berlin.inf.dpp.session.IActivityQueuer;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISessionListener;
 import de.fu_berlin.inf.dpp.session.User;
@@ -196,16 +197,6 @@ public class SarosSessionStub implements ISarosSession {
   }
 
   @Override
-  public void enableQueuing(IProject project) {
-    throw new RuntimeException("Unexpected call to Stub");
-  }
-
-  @Override
-  public void disableQueuing(IProject project) {
-    throw new RuntimeException("Unexpected call to Stub");
-  }
-
-  @Override
   public void userStartedQueuing(User user) {
     throw new RuntimeException("Unexpected call to Stub");
   }
@@ -242,6 +233,16 @@ public class SarosSessionStub implements ISarosSession {
 
   @Override
   public void removeActivityConsumer(IActivityConsumer consumer) {
+    throw new RuntimeException("Unexpected call to Stub");
+  }
+
+  @Override
+  public boolean registerActivityQueuer(IActivityQueuer activityQueuer) {
+    throw new RuntimeException("Unexpected call to Stub");
+  }
+
+  @Override
+  public void flushQueue() {
     throw new RuntimeException("Unexpected call to Stub");
   }
 


### PR DESCRIPTION
This patch extracts a Interface out of the project based ActivityQueuer,
used on client-side, which handle activities in SarosSession, during the
project negotiation.
This moves the queuing responsibility into the transfer implementation
and is the preperation for a resource based queuing implementation.