### PR TITLE
[FEATURE][CORE] No Session Lock for existing User

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/concurrent/management/ConcurrentDocumentServer.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/concurrent/management/ConcurrentDocumentServer.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import org.apache.log4j.Logger;
 import org.picocontainer.Startable;
 
@@ -41,8 +42,8 @@ public class ConcurrentDocumentServer implements Startable {
       new ISessionListener() {
 
         @Override
-        public void userStartedQueuing(final User user) {
-          server.addUser(user);
+        public void userStartedQueuing(User user, Set<SPath> resourcesUnavailable) {
+          server.addUser(user, resourcesUnavailable);
         }
 
         @Override
@@ -189,5 +190,16 @@ public class ConcurrentDocumentServer implements Startable {
       result.add(new QueueItem(user, transformed));
     }
     return result;
+  }
+
+  /**
+   * Set a user resource available for activity processing and add to existing Jupiter documents.
+   *
+   * @host
+   * @param user
+   * @param resource
+   */
+  public synchronized void setResourceAvailable(User user, SPath resource) {
+    server.setResourceAvailable(user, resource);
   }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractOutgoingProjectNegotiation.java
@@ -104,11 +104,6 @@ public abstract class AbstractOutgoingProjectNegotiation extends ProjectNegotiat
       checkCancellation(CancelOption.NOTIFY_PEER);
 
       transfer(monitor, fileLists);
-
-      User user = session.getUser(getPeer());
-      if (user == null) throw new LocalCancellationException(null, CancelOption.DO_NOT_NOTIFY_PEER);
-
-      session.userFinishedProjectNegotiation(user);
     } catch (Exception e) {
       exception = e;
     } finally {
@@ -274,6 +269,19 @@ public abstract class AbstractOutgoingProjectNegotiation extends ProjectNegotiat
       LOG.debug(this + " : restarting user " + startHandle.getUser());
       startHandle.start();
     }
+  }
+
+  /**
+   * TODO rename userFinishedProjectNegotiation saros wide, because its actually telling if a user
+   * is (partially) processing activities
+   */
+  protected void userFinishedProjectNegotiation() throws LocalCancellationException {
+    User user = session.getUser(getPeer());
+    if (user == null) {
+      throw new LocalCancellationException(null, CancelOption.DO_NOT_NOTIFY_PEER);
+    }
+
+    session.userFinishedProjectNegotiation(user);
   }
 
   protected void createCollectors() {

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveOutgoingProjectNegotiation.java
@@ -94,7 +94,7 @@ public class ArchiveOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
        * this time. Maybe change the description of the listener interface
        * ?
        */
-      session.userStartedQueuing(user);
+      session.userStartedQueuing(user, null);
 
       zipArchive = createProjectArchive(fileLists, monitor);
       monitor.subTask("");
@@ -108,6 +108,8 @@ public class ArchiveOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
       throws SarosCancellationException, IOException {
     if (zipArchive != null)
       sendArchive(zipArchive, getPeer(), TRANSFER_ID_PREFIX + getID(), monitor);
+
+    userFinishedProjectNegotiation();
   }
 
   @Override

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/stream/OutgoingStreamProtocol.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/stream/OutgoingStreamProtocol.java
@@ -6,6 +6,7 @@ import de.fu_berlin.inf.dpp.filesystem.IFile;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
 import de.fu_berlin.inf.dpp.negotiation.NegotiationTools.CancelOption;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
+import de.fu_berlin.inf.dpp.session.User;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -23,10 +24,13 @@ public class OutgoingStreamProtocol extends AbstractStreamProtocol {
   private final byte[] buffer = new byte[BUFFER_SIZE];
 
   private DataOutputStream out;
+  private User remoteUser;
 
-  public OutgoingStreamProtocol(OutputStream out, ISarosSession session, IProgressMonitor monitor) {
+  public OutgoingStreamProtocol(
+      OutputStream out, ISarosSession session, User remoteUser, IProgressMonitor monitor) {
     super(session, monitor);
     this.out = new DataOutputStream(out);
+    this.remoteUser = remoteUser;
   }
 
   /**
@@ -49,6 +53,7 @@ public class OutgoingStreamProtocol extends AbstractStreamProtocol {
     InputStream fileIn = null;
     try {
       fileIn = fileHandle.getContents();
+      session.getConcurrentDocumentServer().setResourceAvailable(remoteUser, file);
       int readBytes = 0;
       /* buffer the file content and send to stream */
       while (readBytes != -1) {

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ISarosSession.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ISarosSession.java
@@ -21,6 +21,7 @@ package de.fu_berlin.inf.dpp.session;
 
 import de.fu_berlin.inf.dpp.activities.IActivity;
 import de.fu_berlin.inf.dpp.activities.IResourceActivity;
+import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.concurrent.management.ConcurrentDocumentClient;
 import de.fu_berlin.inf.dpp.concurrent.management.ConcurrentDocumentServer;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
@@ -111,8 +112,10 @@ public interface ISarosSession {
    *
    * @host This method may only called by the host.
    * @param user
+   * @param resourcesUnavailable Set of resources the user is currently not able to process
+   *     activities for
    */
-  public void userStartedQueuing(final User user);
+  public void userStartedQueuing(User user, Set<SPath> resourcesUnavailable);
 
   /**
    * Informs all participants and listeners that a user now has finished the Project Negotiation.

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ISessionListener.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ISessionListener.java
@@ -19,8 +19,10 @@
  */
 package de.fu_berlin.inf.dpp.session;
 
+import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.session.User.Permission;
+import java.util.Set;
 
 /**
  * Listens for events that can happen during a {@link ISarosSession session}. For life-cycle events
@@ -57,7 +59,7 @@ public interface ISessionListener {
    *
    * @param user the user that has joined.
    */
-  public default void userStartedQueuing(User user) {
+  public default void userStartedQueuing(User user, Set<SPath> resourcesUnavailable) {
     // NOP
   }
 

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
@@ -26,6 +26,7 @@ import de.fu_berlin.inf.dpp.activities.IActivity;
 import de.fu_berlin.inf.dpp.activities.IFileSystemModificationActivity;
 import de.fu_berlin.inf.dpp.activities.IResourceActivity;
 import de.fu_berlin.inf.dpp.activities.NOPActivity;
+import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.communication.extensions.KickUserExtension;
 import de.fu_berlin.inf.dpp.communication.extensions.LeaveSessionExtension;
 import de.fu_berlin.inf.dpp.concurrent.management.ConcurrentDocumentClient;
@@ -422,7 +423,7 @@ public final class SarosSession implements ISarosSession {
   }
 
   @Override
-  public void userStartedQueuing(final User user) {
+  public void userStartedQueuing(final User user, Set<SPath> resourcesUnavailable) {
 
     log.info("user " + user + " started queuing projects and can receive IResourceActivities");
 
@@ -438,7 +439,7 @@ public final class SarosSession implements ISarosSession {
             new Runnable() {
               @Override
               public void run() {
-                listenerDispatch.userStartedQueuing(user);
+                listenerDispatch.userStartedQueuing(user, resourcesUnavailable);
               }
             }));
   }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SessionListenerDispatch.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SessionListenerDispatch.java
@@ -1,8 +1,10 @@
 package de.fu_berlin.inf.dpp.session.internal;
 
+import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.session.ISessionListener;
 import de.fu_berlin.inf.dpp.session.User;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /** {@link ISessionListener} implementation which can dispatch events to multiple listeners. */
@@ -22,8 +24,9 @@ public class SessionListenerDispatch implements ISessionListener {
   }
 
   @Override
-  public void userStartedQueuing(User user) {
-    for (ISessionListener listener : listeners) listener.userStartedQueuing(user);
+  public void userStartedQueuing(User user, Set<SPath> resourcesUnavailable) {
+    for (ISessionListener listener : listeners)
+      listener.userStartedQueuing(user, resourcesUnavailable);
   }
 
   @Override

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/test/stubs/SarosSessionStub.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/test/stubs/SarosSessionStub.java
@@ -1,6 +1,7 @@
 package de.fu_berlin.inf.dpp.test.stubs;
 
 import de.fu_berlin.inf.dpp.activities.IActivity;
+import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.concurrent.management.ConcurrentDocumentClient;
 import de.fu_berlin.inf.dpp.concurrent.management.ConcurrentDocumentServer;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
@@ -197,7 +198,7 @@ public class SarosSessionStub implements ISarosSession {
   }
 
   @Override
-  public void userStartedQueuing(User user) {
+  public void userStartedQueuing(User user, Set<SPath> resourcesUnavailable) {
     throw new RuntimeException("Unexpected call to Stub");
   }
 


### PR DESCRIPTION
This patch allows to only send Jupiter Activities for Files, a User can
already process. This enables to remove the session lock for existing
session participants.

The invited User stays in read-only mode, till the end of the
negotiation, but can already view activities for received files.

extends #157 