### PR TITLE
[INTERNAL] Move Transfer Listener Logic

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveIncomingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveIncomingProjectNegotiation.java
@@ -9,8 +9,6 @@ import java.util.Map.Entry;
 
 import org.apache.log4j.Logger;
 import org.jivesoftware.smack.XMPPException;
-import org.jivesoftware.smackx.filetransfer.FileTransferListener;
-import org.jivesoftware.smackx.filetransfer.FileTransferRequest;
 import org.jivesoftware.smackx.filetransfer.IncomingFileTransfer;
 
 import de.fu_berlin.inf.dpp.communication.extensions.StartActivityQueuingResponse;
@@ -41,7 +39,6 @@ public class ArchiveIncomingProjectNegotiation extends
 
     private static final Logger LOG = Logger
         .getLogger(ArchiveIncomingProjectNegotiation.class);
-    private ArchiveTransferListener archiveTransferListener = null;
 
     public ArchiveIncomingProjectNegotiation(
         final JID peer, //
@@ -65,19 +62,6 @@ public class ArchiveIncomingProjectNegotiation extends
     }
 
     @Override
-    protected void setup(IProgressMonitor monitor)
-        throws IOException {
-        archiveTransferListener = new ArchiveTransferListener(
-            ARCHIVE_TRANSFER_ID + getID());
-
-        if (fileTransferManager == null)
-            // FIXME: the logic will try to send this to the remote contact
-            throw new IOException("not connected to a XMPP server");
-
-        fileTransferManager.addFileTransferListener(archiveTransferListener);
-    }
-
-    @Override
     protected void transfer(IProgressMonitor monitor,
         Map<String, IProject> projectMapping, List<FileList> missingFiles)
         throws IOException, SarosCancellationException {
@@ -97,7 +81,7 @@ public class ArchiveIncomingProjectNegotiation extends
              * TODO Move enable (and disable) queuing responsibility to
              * SarosSession, since the second call relies on the first one, and
              * the first one is never done without the second. (see also TODO in
-             * {@link cleanup}).
+             * {@link AbstractIncomingProjectNegotiation#cleanup}).
              */
             session.addProjectMapping(projectID, project);
             session.enableQueuing(project);
@@ -117,26 +101,8 @@ public class ArchiveIncomingProjectNegotiation extends
 
         // the host do not send an archive if we do not need any files
         if (filesMissing) {
-            receiveAndUnpackArchive(projectMapping, archiveTransferListener,
-                monitor);
+            receiveAndUnpackArchive(projectMapping, transferListener, monitor);
         }
-    }
-
-    @Override
-    protected void cleanup(IProgressMonitor monitor,
-        Map<String, IProject> projectMapping) {
-        /*
-         * TODO Move disable queuing responsibility to SarosSession (see todo
-         * above in {@link transfer}).
-         */
-        for (IProject project : projectMapping.values())
-            session.disableQueuing(project);
-
-        if (fileTransferManager != null)
-            fileTransferManager
-                .removeFileTransferListener(archiveTransferListener);
-
-        super.cleanup(monitor, projectMapping);
     }
 
     /**
@@ -144,7 +110,7 @@ public class ArchiveIncomingProjectNegotiation extends
      */
     private void receiveAndUnpackArchive(
         final Map<String, IProject> localProjectMapping,
-        final ArchiveTransferListener archiveTransferListener,
+        final TransferListener archiveTransferListener,
         final IProgressMonitor monitor) throws IOException,
         SarosCancellationException {
 
@@ -166,7 +132,8 @@ public class ArchiveIncomingProjectNegotiation extends
             monitor.done();
         } finally {
             if (archiveFile != null && !archiveFile.delete()) {
-                LOG.warn("Could not clean up archive file "+archiveFile.getAbsolutePath());
+                LOG.warn("Could not clean up archive file "
+                    + archiveFile.getAbsolutePath());
             }
         }
     }
@@ -211,8 +178,7 @@ public class ArchiveIncomingProjectNegotiation extends
         // TODO: now add the checksums into the cache
     }
 
-    private File receiveArchive(
-        ArchiveTransferListener archiveTransferListener,
+    private File receiveArchive(TransferListener archiveTransferListener,
         IProgressMonitor monitor) throws IOException,
         SarosCancellationException {
 
@@ -222,15 +188,7 @@ public class ArchiveIncomingProjectNegotiation extends
         monitor
             .subTask("Host is compressing project files. Waiting for the archive file...");
 
-        try {
-            while (!archiveTransferListener.hasReceived()) {
-                checkCancellation(CancelOption.NOTIFY_PEER);
-                Thread.sleep(200);
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new LocalCancellationException();
-        }
+        awaitTransferRequest();
 
         monitor.subTask("Receiving archive file...");
 
@@ -253,7 +211,8 @@ public class ArchiveIncomingProjectNegotiation extends
             throw new IOException(e.getMessage(), e.getCause());
         } finally {
             if (transferFailed && !archiveFile.delete()) {
-                LOG.warn("Could not clean up archive file "+archiveFile.getAbsolutePath());
+                LOG.warn("Could not clean up archive file "
+                    + archiveFile.getAbsolutePath());
             }
         }
 
@@ -266,28 +225,4 @@ public class ArchiveIncomingProjectNegotiation extends
         return archiveFile;
     }
 
-    private static class ArchiveTransferListener implements
-        FileTransferListener {
-        private String description;
-        private volatile FileTransferRequest request;
-
-        public ArchiveTransferListener(String description) {
-            this.description = description;
-        }
-
-        @Override
-        public void fileTransferRequest(FileTransferRequest request) {
-            if (request.getDescription().equals(description)) {
-                this.request = request;
-            }
-        }
-
-        public boolean hasReceived() {
-            return this.request != null;
-        }
-
-        public FileTransferRequest getRequest() {
-            return this.request;
-        }
-    }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveOutgoingProjectNegotiation.java
@@ -111,8 +111,7 @@ public class ArchiveOutgoingProjectNegotiation extends
     protected void transfer(IProgressMonitor monitor, List<FileList> fileLists)
         throws SarosCancellationException, IOException {
         if (zipArchive != null)
-            sendArchive(zipArchive, getPeer(), ARCHIVE_TRANSFER_ID + getID(),
-                monitor);
+            sendArchive(zipArchive, getPeer(), TRANSFER_ID + getID(), monitor);
     }
 
     @Override

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ProjectNegotiation.java
@@ -37,7 +37,7 @@ public abstract class ProjectNegotiation extends Negotiation {
     /**
      * Prefix part of the id used in the SMACK XMPP file transfer protocol.
      */
-    public static final String ARCHIVE_TRANSFER_ID = "saros-dpp-pn-server-client-archive/";
+    public static final String TRANSFER_ID = "saros-dpp-pn-server-client-archive/";
 
     /**
      * Delimiter for every Zip entry to delimit the project id from the path

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/actions/SendFileAction.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/actions/SendFileAction.java
@@ -77,7 +77,7 @@ public class SendFileAction extends Action implements Disposable {
 
             if (description != null
                 && description
-                    .startsWith(ProjectNegotiation.ARCHIVE_TRANSFER_ID))
+                    .startsWith(ProjectNegotiation.TRANSFER_ID))
                 return;
 
             SWTUtils.runSafeSWTAsync(LOG, new Runnable() {


### PR DESCRIPTION
In preparation for the new feature 'Instant Session Start', this patch
move parts of the Archive Type to the Abstract class and prevent code
duplication.

This PR is the same as #127, which was reverted in #160, because I dismissed @srossbach Review.
More infos in the conversations of #127.