### PR TITLE
[INTERNAL][WB] Added IWhiteboardBrowser and its Eclipse implementation

### DIFF
--- a/de.fu_berlin.inf.dpp.whiteboard/src/de/fu_berlin/inf/dpp/whiteboard/ui/browser/BrowserRunnable.java
+++ b/de.fu_berlin.inf.dpp.whiteboard/src/de/fu_berlin/inf/dpp/whiteboard/ui/browser/BrowserRunnable.java
@@ -1,0 +1,19 @@
+package de.fu_berlin.inf.dpp.whiteboard.ui.browser;
+
+/**
+ * Contains the code that will be run when a browser function is called.
+ * <p>
+ * is used to overcome the problem that the {@link Runnable} interface doesn't
+ * accept parameters in its {@link Runnable#run()} method.
+ */
+public interface BrowserRunnable {
+    /**
+     * runs the java code when the JavaScript function is called.
+     * 
+     * @param arguments
+     *            the parameters which have been given in browser while calling
+     *            the function
+     * @return result of the executed code
+     */
+    Object run(Object[] arguments);
+}

--- a/de.fu_berlin.inf.dpp.whiteboard/src/de/fu_berlin/inf/dpp/whiteboard/ui/browser/EclipseWhiteboardBrowser.java
+++ b/de.fu_berlin.inf.dpp.whiteboard/src/de/fu_berlin/inf/dpp/whiteboard/ui/browser/EclipseWhiteboardBrowser.java
@@ -1,0 +1,52 @@
+package de.fu_berlin.inf.dpp.whiteboard.ui.browser;
+
+import org.apache.log4j.Logger;
+import org.eclipse.swt.browser.Browser;
+import org.eclipse.swt.browser.BrowserFunction;
+
+import de.fu_berlin.inf.dpp.ui.util.SWTUtils;
+import de.fu_berlin.inf.dpp.whiteboard.ui.HTMLWhiteboardView;
+
+/**
+ * the eclipse implementation of the IWhiteboardBrowser, this implementation
+ * uses the SWT browser to transfer events and commands between java and
+ * javascript
+ */
+public class EclipseWhiteboardBrowser implements IWhiteboardBrowser {
+
+    private static final Logger LOG = Logger
+        .getLogger(EclipseWhiteboardBrowser.class);
+
+    private final Browser browser;
+
+    /**
+     * this browser will be initialised in the {@link HTMLWhiteboardView}
+     * 
+     * @param browser
+     *            a SWT browser instance which displays the whiteboard
+     */
+    public EclipseWhiteboardBrowser(Browser browser) {
+        this.browser = browser;
+    }
+
+    @Override
+    public void asyncRun(final String script) {
+        SWTUtils.runSafeSWTAsync(LOG, new Runnable() {
+            @Override
+            public void run() {
+                browser.evaluate(script);
+            }
+        });
+    }
+
+    @Override
+    public void createBrowserFunction(String functionName,
+        final BrowserRunnable runnable) {
+        new BrowserFunction(browser, functionName) {
+            @Override
+            public Object function(Object[] arguments) {
+                return runnable.run(arguments);
+            }
+        };
+    }
+}

--- a/de.fu_berlin.inf.dpp.whiteboard/src/de/fu_berlin/inf/dpp/whiteboard/ui/browser/IWhiteboardBrowser.java
+++ b/de.fu_berlin.inf.dpp.whiteboard/src/de/fu_berlin/inf/dpp/whiteboard/ui/browser/IWhiteboardBrowser.java
@@ -1,0 +1,35 @@
+package de.fu_berlin.inf.dpp.whiteboard.ui.browser;
+
+/**
+ * Describes the functionality of the browser used to display the
+ * HTMLWhiteboard, this allows for an IDE-independent implementation of the
+ * Whiteboard.
+ * <p>
+ * Any browser displaying the whiteboard must implement this interface.
+ */
+public interface IWhiteboardBrowser {
+
+    /**
+     * Runs the script in browser <b>asynchronously</b> and ignores returned
+     * values.
+     * <p>
+     * this function can be called from the UI thread.
+     * 
+     * @param script
+     *            String that will be called as Javascript code in browser
+     */
+    void asyncRun(String script);
+
+    /**
+     * Creates a function that is callable from Javascript from within the
+     * browser.
+     * 
+     * @param functionName
+     *            the name of the function that will be globally registered in
+     *            the Javascript runtime environment
+     * @param runnable
+     *            the java code to be executed when the function is called from
+     *            Javascript
+     */
+    void createBrowserFunction(String functionName, BrowserRunnable runnable);
+}


### PR DESCRIPTION
this implementation will be later used in the bridge between the sxe controller of the whiteboard and the browser.
this interface should allow for an eclipse independent implementation of the whiteboard, if for example the whiteboard would be ported to intellij, only the view and an instance of the IWhiteboardbrowser would be needed.

original Gerrit commit: 
[https://saros-build.imp.fu-berlin.de/gerrit/#/c/3550/](https://saros-build.imp.fu-berlin.de/gerrit/#/c/3550/)