### PR TITLE
[INTERNAL][I] Adjust module structure check

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJProjectImplV2.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJProjectImplV2.java
@@ -69,7 +69,14 @@ public final class IntelliJProjectImplV2 extends IntelliJResourceImplV2
      * @param module
      *            an IntelliJ <i>module</i>
      * @throws IllegalArgumentException if the given module does not have
-     *                                  exactly one content root
+     *                                  exactly one content root, the content
+     *                                  root is not located under the project
+     *                                  root or the module file is not located
+     *                                  in the base directory of the content
+     *                                  root
+     * @throws IllegalStateException    if the project base dir, the module file
+     *                                  or the directory containing the module
+     *                                  file could not be found
      */
     public IntelliJProjectImplV2(@NotNull final Module module) {
         this.module = module;
@@ -77,20 +84,8 @@ public final class IntelliJProjectImplV2 extends IntelliJResourceImplV2
 
         moduleRoot = getModuleContentRoot(module);
 
-        VirtualFile moduleRootParent = moduleRoot.getParent();
-        VirtualFile projectRoot = module.getProject().getBaseDir();
-
-        if (projectRoot == null) {
-            throw new IllegalStateException("Project " + module.getProject() +
-                " has no base dir (null).");
-        }
-
-        if (moduleRootParent == null || !moduleRootParent.equals(projectRoot)) {
-
-            throw new IllegalArgumentException("content root " + moduleRoot +
-                " of module " + module + " is not located in the project " +
-                "root " + projectRoot);
-        }
+        checkIfContentRootLocatedBelowProjectRoot(module, moduleRoot);
+        checkIfModuleFileLocatedInContentRoot(module, moduleRoot);
     }
 
     /**
@@ -126,6 +121,97 @@ public final class IntelliJProjectImplV2 extends IntelliJResourceImplV2
         }
 
         return contentRoots[0];
+    }
+
+    /**
+     * Checks whether the given content root is located under the project root.
+     *
+     * <p>
+     * This method is used to enforce the current restriction concerning the
+     * module structure.
+     * </p>
+     *
+     * @param module     the module to check the structure for
+     * @param moduleRoot the content root of the given module
+     * @throws IllegalArgumentException if the given content root is not located
+     *                                  under the project root
+     * @throws IllegalStateException    if the project basedir could not be
+     *                                  found
+     */
+    private static void checkIfContentRootLocatedBelowProjectRoot(
+        @NotNull
+            Module module,
+        @NotNull
+            VirtualFile moduleRoot) {
+
+        Project project = module.getProject();
+
+        VirtualFile projectRoot = project.getBaseDir();
+
+        if (projectRoot == null) {
+            throw new IllegalStateException(
+                "The base dir for the project " + project
+                    + " could not be found.");
+        }
+
+        Path moduleRootPath = Paths.get(moduleRoot.getPath());
+        Path projectRootPath = Paths.get(projectRoot.getPath());
+
+        if (moduleRoot.equals(projectRoot) || !moduleRootPath
+            .startsWith(projectRootPath)) {
+
+            throw new IllegalArgumentException(
+                "The content root " + moduleRoot + " of the module " + module
+                    + " is not located under the project root " + projectRoot
+                    + ".");
+        }
+    }
+
+    /**
+     * Checks whether the module file is located in the base directory of the
+     * given content root.
+     *
+     * <p>
+     * This method is used to enforce the current restriction concerning the
+     * module structure.
+     * </p>
+     *
+     * @param module     the module to check the structure for
+     * @param moduleRoot the content root of the given module
+     * @throws IllegalArgumentException if the module file is not located in the
+     *                                  base directory of given content root
+     * @throws IllegalStateException    if the module file or the directory
+     *                                  containing the module file could not be
+     *                                  found
+     */
+    private static void checkIfModuleFileLocatedInContentRoot(
+        @NotNull
+            Module module,
+        @NotNull
+            VirtualFile moduleRoot) {
+
+        VirtualFile moduleFile = module.getModuleFile();
+
+        if (moduleFile == null) {
+            throw new IllegalStateException(
+                "The module file for the module " + module
+                    + " could not be found.");
+        }
+
+        VirtualFile moduleFileParent = moduleFile.getParent();
+
+        if (moduleFileParent == null) {
+            throw new IllegalStateException(
+                "The parent directory of the module file for the module "
+                    + module + " could not be found.");
+        }
+
+        if (!moduleRoot.equals(moduleFileParent)) {
+            throw new IllegalArgumentException(
+                "The module file " + moduleFile + " for the module " + module
+                    + " is not located in the base directory of the content"
+                    + " root " + moduleRoot + ".");
+        }
     }
 
     /**


### PR DESCRIPTION
Adjusts the module structure check in IntelliJProjectImplV2 to allow
more cases that actually work with the current implementation.
Subsequently moves the checks to separate methods to clean up the CTOR
and adds @throws tags for the exceptions to the CTOR javadoc.

Previously, the restrictions were that the content root of all shareable
modules needed to be located in the project root directory. There were
no restrictions concerning the location of the module file. However, if
the module file is not located in the base directory of the content
root, the creation of the new module as part of the project negotiation
fails on the client side.

The new restrictions for shareable modules are now that
 - the content root needs to be located below the project root.
 - the module file needs to be located in the base directory of the
   content root.

The first restriction was added to ensure that shared modules only
contain paths relative to the project root. Otherwise the module file
could contain absolute paths, which would be problematic when trying to
load it on the client side.