### PR TITLE
[INTERNAL][I] Add catch block for IllegalStateException

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/Messages.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/Messages.java
@@ -93,6 +93,8 @@ public class Messages {
     public static String ContactPopMenu_module_not_found_message_condition;
     public static String ContactPopMenu_invalid_module_title;
     public static String ContactPopMenu_invalid_module_message_condition;
+    public static String ContactPopMenu_error_creating_module_object_title;
+    public static String ContactPopMenu_error_creating_module_object_message;
 
     private Messages() {
     }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/messages.properties
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/messages.properties
@@ -77,3 +77,5 @@ ContactPopMenu_module_not_found_title=Module not found - Project sharing aborted
 ContactPopMenu_module_not_found_message_condition=Saros could not find the chosen module {0}. Please make sure that the module is correctly configured in the current project and exists on disk.\nIf there seems to be no problem with the module
 ContactPopMenu_invalid_module_title=Invalid modules not shown
 ContactPopMenu_invalid_module_message_condition=The module(s) {0} can not be shared through Saros and are therefore not shown. This is probably due to the modules not meeting the current restrictions. Modules should have exactly one content root that is located in the project root directory.\nIf these modules do meets the given restrictions
+ContactPopMenu_error_creating_module_object_title=Problem while handling the module "{0}"
+ContactPopMenu_error_creating_module_object_message=Saros ran into an exception while trying to handle the module "{0}". Please make sure that the module is configured correctly.\n{1}

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/tree/ContactPopMenu.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/tree/ContactPopMenu.java
@@ -95,6 +95,19 @@ class ContactPopMenu extends JPopupMenu {
                 nonCompliantModules.add(moduleName);
 
                 continue;
+
+            } catch (IllegalStateException exception) {
+                LOG.debug("Ignoring module " + moduleName + " as an error "
+                        + "occurred while trying to create an IProject object.",
+                        exception);
+
+                NotificationPanel.showWarning(MessageFormat
+                        .format(Messages.ContactPopMenu_error_creating_module_object_message,
+                                moduleName, exception), MessageFormat
+                        .format(Messages.ContactPopMenu_error_creating_module_object_title,
+                                moduleName));
+
+                continue;
             }
 
             JMenuItem moduleItem = new JMenuItem(moduleName);


### PR DESCRIPTION
Adds a catch block for IllegalStateExceptions in the ContactPopMenu.
IllegalStateExceptions can be thrown by the IntelliJProjectImplV2 CTOR
when the module structure checks can't find certain needed files. As
these exceptions point towards an error in the local module
configuration that is independent of Saros, a warning is shown to the
user for every module that failed with an IllegalStateException.

Beforehand, these exceptions were uncaught and stopped the contact pop
menu from opening if a faulty module existed.