### PR TITLE
[FIX] #168 Add hook method to set the initial host preferences

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/hooks/ISessionNegotiationHook.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/hooks/ISessionNegotiationHook.java
@@ -32,17 +32,18 @@ public interface ISessionNegotiationHook {
     public String getIdentifier();
 
     /**
-     * Receives the host's fixed preferences.
+     * Sets the host preferences that are needed before the session negotiation
+     * is started.
      * <p>
-     * During the session creation this method will be called on the <b>host</b>
-     * side (see {@link SarosSessionManager#startSession(Map)}).
+     * This method will be called on the <b>host</b> side during the session
+     * creation as part of {@link SarosSessionManager#startSession(Map)}).
      * 
-     * @return The settings in form of [Key, Value] pairs. The settings should
-     *         in general look the same as those returned by
-     *         {@link #considerClientPreferences(JID, Map)} as both will be
-     *         passed to {@link #applyActualParameters(Map, IPreferenceStore)}.
+     * @param hostPreferences
+     *            The session preference store that corresponds to the host. May
+     *            be used to store the initial host properties so they can be
+     *            accessed by other components.
      */
-    public Map<String, String> tellHostPreferences();
+    public void setInitialHostPreferences(IPreferenceStore hostPreferences);
 
     /**
      * Receive the client's preferences for later consideration.
@@ -76,10 +77,7 @@ public interface ISessionNegotiationHook {
      * @return The settings determined by the host which -- if not
      *         <code>null</code> -- will be sent back to the client. It's up to
      *         the specific hook to which extent the host considers the wishes
-     *         of the client. The settings should in general look the same as
-     *         those returned by {@link #tellHostPreferences()} as both will be
-     *         passed into {@link #applyActualParameters(Map, IPreferenceStore)}
-     *         .
+     *         of the client.
      */
     public Map<String, String> considerClientPreferences(JID client,
         Map<String, String> input);
@@ -98,26 +96,20 @@ public interface ISessionNegotiationHook {
      * @param input
      *            The parameters concerning the hook at hand, which were
      *            determined by the host during his
-     *            {@link OutgoingSessionNegotiation}. On the host this is the
-     *            result of {@link #tellHostPreferences()} for the first call
-     *            and the result of {@link #considerClientPreferences(JID, Map),
-     *            for subsequent calls. On the client the received result of
+     *            {@link OutgoingSessionNegotiation} through
      *            {@link #considerClientPreferences(JID, Map)}. Might be
      *            <code>null</code>, if the host has no counterpart for this
      *            hook.
      * 
      * @param hostPreferences
-     *            The session preference store that corresponds to the host.
-     *            May be used to store the final properties so they can be
-     *            accessed by other components.
+     *            The session preference store that corresponds to the host. May
+     *            be used to store the final properties so they can be accessed
+     *            by other components.
      * 
      * @param clientPreferences
      *            The session preference store that corresponds to the client.
      *            May be used to store the final properties so they can be
-     *            accessed by other components. The IPreferenceStore may be
-     *            <code>null</code> if the host is currently the only member
-     *            of the session.
-     * 
+     *            accessed by other components.
      */
     public void applyActualParameters(Map<String, String> input,
         IPreferenceStore hostPreferences, IPreferenceStore clientPreferences);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ColorNegotiationHook.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ColorNegotiationHook.java
@@ -33,15 +33,11 @@ public class ColorNegotiationHook implements ISessionNegotiationHook {
     }
 
     @Override
-    public Map<String, String> tellHostPreferences() {
-        String favoriteColor = Integer.toString(preferences
-            .getFavoriteColorID());
-
-        Map<String, String> colorSettings = new HashMap<String, String>();
-        colorSettings.put(KEY_HOST_COLOR, favoriteColor);
-        colorSettings.put(KEY_HOST_FAV_COLOR, favoriteColor);
-
-        return colorSettings;
+    public void setInitialHostPreferences(IPreferenceStore hostPreferences) {
+        hostPreferences.setValue(KEY_INITIAL_COLOR,
+            preferences.getFavoriteColorID());
+        hostPreferences.setValue(KEY_FAV_COLOR,
+            preferences.getFavoriteColorID());
     }
 
     @Override
@@ -86,12 +82,11 @@ public class ColorNegotiationHook implements ISessionNegotiationHook {
             Integer.parseInt(input.get(KEY_HOST_COLOR)));
         hostPreferences.setValue(KEY_FAV_COLOR,
             Integer.parseInt(input.get(KEY_HOST_FAV_COLOR)));
-        if (clientPreferences != null) {
-            clientPreferences.setValue(KEY_INITIAL_COLOR,
-                Integer.parseInt(input.get(KEY_CLIENT_COLOR)));
-            clientPreferences.setValue(KEY_FAV_COLOR,
-                Integer.parseInt(input.get(KEY_CLIENT_FAV_COLOR)));
-        }
+
+        clientPreferences.setValue(KEY_INITIAL_COLOR,
+            Integer.parseInt(input.get(KEY_CLIENT_COLOR)));
+        clientPreferences.setValue(KEY_FAV_COLOR,
+            Integer.parseInt(input.get(KEY_CLIENT_FAV_COLOR)));
     }
 
     @Override

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ProjectNegotiationTypeHook.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ProjectNegotiationTypeHook.java
@@ -49,8 +49,8 @@ public class ProjectNegotiationTypeHook implements ISessionNegotiationHook {
     }
 
     @Override
-    public Map<String, String> tellHostPreferences() {
-        return getLocalPreference();
+    public void setInitialHostPreferences(IPreferenceStore hostPreferences) {
+        // NOP
     }
 
     @Override
@@ -70,7 +70,7 @@ public class ProjectNegotiationTypeHook implements ISessionNegotiationHook {
 
         /* if both prefer the same type, set it */
         String inputType = input.get(KEY_PREFERRED_TYPE);
-        if (inputType.equals(tellHostPreferences().get(KEY_PREFERRED_TYPE))) {
+        if (inputType.equals(getLocalPreference().get(KEY_PREFERRED_TYPE))) {
             return Collections.singletonMap(KEY_TYPE, inputType);
         }
 
@@ -101,9 +101,8 @@ public class ProjectNegotiationTypeHook implements ISessionNegotiationHook {
         }
 
         hostPreferences.setValue(KEY_TYPE, type.name());
-        if (clientPreferences != null) {
-            clientPreferences.setValue(KEY_TYPE, type.name());
-        }
+
+        clientPreferences.setValue(KEY_TYPE, type.name());
     }
 
     private Map<String, String> getLocalPreference() {

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/SarosSessionManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/SarosSessionManager.java
@@ -244,8 +244,7 @@ public class SarosSessionManager implements ISarosSessionManager {
             IPreferenceStore hostProperties = new PreferenceStore();
             if (hookManager != null) {
                 for (ISessionNegotiationHook hook : hookManager.getHooks()) {
-                    hook.applyActualParameters(hook.tellHostPreferences(),
-                        hostProperties, null);
+                    hook.setInitialHostPreferences(hostProperties);
                 }
             }
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/negotiation/hooks/ModuleTypeNegotiationHook.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/negotiation/hooks/ModuleTypeNegotiationHook.java
@@ -72,10 +72,9 @@ public class ModuleTypeNegotiationHook implements ISessionNegotiationHook {
     }
 
     @Override
-    public Map<String, String> tellHostPreferences() {
-        return null;
+    public void setInitialHostPreferences(IPreferenceStore hostPreferences) {
+        //NOP
     }
-
 
     @Override
     public Map<String, String> tellClientPreferences() {
@@ -144,12 +143,8 @@ public class ModuleTypeNegotiationHook implements ISessionNegotiationHook {
     }
 
     @Override
-    public void applyActualParameters(Map<String, String> input, IPreferenceStore hostPreferences,
-        IPreferenceStore clientPreferences) {
-        if (clientPreferences == null) {
-           //there is not client yet, nothing to do
-           return;
-        }
+    public void applyActualParameters(Map<String, String> input,
+        IPreferenceStore hostPreferences, IPreferenceStore clientPreferences) {
 
         if (input == null) {
             LOG.warn("The client did not indicate any module type " +

--- a/de.fu_berlin.inf.dpp.whiteboard/src/de/fu_berlin/inf/dpp/whiteboard/net/WhiteboardManager.java
+++ b/de.fu_berlin.inf.dpp.whiteboard/src/de/fu_berlin/inf/dpp/whiteboard/net/WhiteboardManager.java
@@ -146,8 +146,8 @@ public class WhiteboardManager {
         }
 
         @Override
-        public Map<String, String> tellHostPreferences() {
-            return null;
+        public void setInitialHostPreferences(IPreferenceStore hostPreferences) {
+            // NOP
         }
 
         @Override
@@ -179,9 +179,6 @@ public class WhiteboardManager {
         @Override
         public void applyActualParameters(Map<String, String> input,
             IPreferenceStore hostPreferences, IPreferenceStore clientPreferences) {
-
-            if (clientPreferences == null)
-                return; // no client yet
 
             hostHasWhiteboard = (input != null && USE_VAL.equals(input
                 .get(USE_KEY)));

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/communication/chat/muc/negotiation/MUCNegotiationManager.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/communication/chat/muc/negotiation/MUCNegotiationManager.java
@@ -65,9 +65,9 @@ public class MUCNegotiationManager {
         }
 
         @Override
-        public Map<String, String> tellHostPreferences() {
-            // Nothing to do
-            return null;
+        public void setInitialHostPreferences(
+            de.fu_berlin.inf.dpp.preferences.IPreferenceStore hostPreferences) {
+            // NOP
         }
 
         @Override


### PR DESCRIPTION
Adds the method ISessionNegotiationHook#setInitialHostPreferences(...).
This method can be used to set initial preferences before the session
negotiation is started. This method is now used in
SarosSessionManager#startSession() to set the initial host preferences
for each hook.

Subsequently removes #tellHostPreferences() as it is no longer needed.