### PR TITLE
Fix context menu user name

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/META-INF/plugin.xml
+++ b/de.fu_berlin.inf.dpp.intellij/META-INF/plugin.xml
@@ -35,16 +35,17 @@
 
     <actions>
         <!-- Add your actions here -->
-        <group id="saros.MainMenu" text="Saros" description="Saros menu">
+        <group id="saros.MainMenu" text="S_aros" description="Saros menu">
             <add-to-group group-id="MainMenu" relative-to-action="HelpMenu" anchor="before"/>
             <action id="saros.about"
                     class="de.fu_berlin.inf.dpp.intellij.ui.menu.AboutSarosHandler"
-                    text="About Saros"/>
+                    text="_About Saros"/>
         </group>
 
         <group keep-content="true" compact="false" popup="true"
                id="saros.ShareWith"
-               icon="/icons/famfamfam/session_tsk.png" text="Share With..."
+               icon="/icons/famfamfam/session_tsk.png" text="_Share With..."
+               description="Share this module using Saros"
                class="de.fu_berlin.inf.dpp.intellij.ui.menu.SarosFileShareGroup">
             <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
         </group>

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/Messages.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/Messages.java
@@ -96,6 +96,8 @@ public class Messages {
     public static String ContactPopMenu_error_creating_module_object_title;
     public static String ContactPopMenu_error_creating_module_object_message;
 
+    public static String ShareWithUserAction_description;
+
     private Messages() {
     }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/menu/SarosFileShareGroup.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/menu/SarosFileShareGroup.java
@@ -68,12 +68,16 @@ public class SarosFileShareGroup extends ActionGroup {
             return new AnAction[0];
         }
 
+        int userCount = 1;
+
         List<AnAction> list = new ArrayList<>();
         for (RosterEntry rosterEntry : roster.getEntries()) {
             Presence presence = roster.getPresence(rosterEntry.getUser());
             if (presence.getType() == Presence.Type.available) {
-                list.add(
-                    new ShareWithUserAction(new JID(rosterEntry.getUser())));
+                list.add(new ShareWithUserAction(new JID(rosterEntry.getUser()),
+                    userCount));
+
+                userCount++;
             }
         }
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/menu/ShareWithUserAction.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/menu/ShareWithUserAction.java
@@ -10,10 +10,12 @@ import com.intellij.openapi.vfs.VirtualFile;
 import de.fu_berlin.inf.dpp.core.ui.util.CollaborationUtils;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.intellij.filesystem.IntelliJProjectImplV2;
+import de.fu_berlin.inf.dpp.intellij.ui.Messages;
 import de.fu_berlin.inf.dpp.intellij.ui.util.IconManager;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
 import org.apache.log4j.Logger;
 
+import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.List;
 
@@ -37,7 +39,8 @@ public class ShareWithUserAction extends AnAction {
     private final String title;
 
     ShareWithUserAction(JID user, int userCount) {
-        super("_" + userCount + ": " + user.getName(), null,
+        super("_" + userCount + ": " + user.getRAW(), MessageFormat
+                .format(Messages.ShareWithUserAction_description, user.getRAW()),
             IconManager.CONTACT_ONLINE_ICON);
         userJID = user;
         title = user.getName();

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/menu/ShareWithUserAction.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/menu/ShareWithUserAction.java
@@ -36,8 +36,9 @@ public class ShareWithUserAction extends AnAction {
     private final JID userJID;
     private final String title;
 
-    ShareWithUserAction(JID user) {
-        super(user.getName(), null, IconManager.CONTACT_ONLINE_ICON);
+    ShareWithUserAction(JID user, int userCount) {
+        super("_" + userCount + ": " + user.getName(), null,
+            IconManager.CONTACT_ONLINE_ICON);
         userJID = user;
         title = user.getName();
     }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/messages.properties
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/messages.properties
@@ -79,3 +79,5 @@ ContactPopMenu_invalid_module_title=Invalid modules not shown
 ContactPopMenu_invalid_module_message_condition=The module(s) {0} can not be shared through Saros and are therefore not shown. This is probably due to the modules not meeting the current restrictions. Modules should have exactly one content root that is located in the project root directory.\nIf these modules do meets the given restrictions
 ContactPopMenu_error_creating_module_object_title=Problem while handling the module "{0}"
 ContactPopMenu_error_creating_module_object_message=Saros ran into an exception while trying to handle the module "{0}". Please make sure that the module is configured correctly.\n{1}
+
+ShareWithUserAction_description=Share this module with {0}


### PR DESCRIPTION
Fixes the names being displayed incorrectly when sharing a module through the context menu. This is done by numbering the available users and using the number as the shortcut. More information can be found in the commit message of b7ad18b982e53584d76eeb2fa1c5779270df2e8b.

25235b28deb7767023c784e2592c3c8e258f0594 and 3493f1fc3c1484e032f1bd116a2a353461c52905 subsequently improve the message of the context menu entry and add shortcuts and descriptions to Saros menu entries.