### PR TITLE
[STF] Add RemoteHTMLTextElement to test functionality of buttons

### DIFF
--- a/de.fu_berlin.inf.dpp.ui.frontend/html/package.json
+++ b/de.fu_berlin.inf.dpp.ui.frontend/html/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "babel-polyfill": "^6.23.0",
     "bootstrap": "^3.3.7",
+    "jquery": "^3.3.1",
     "mobx": "^3.1.9",
     "mobx-react": "^4.1.8",
     "prop-types": "^15.5.8",

--- a/de.fu_berlin.inf.dpp.ui.frontend/html/src/components/ComponentTestView/index.jsx
+++ b/de.fu_berlin.inf.dpp.ui.frontend/html/src/components/ComponentTestView/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import $ from 'jquery'
 import { observable, action } from 'mobx'
 import { observer, inject } from 'mobx-react'
 import { Grid, Row, Col, Form, FormGroup, FormControl, ControlLabel, Button, DropdownButton, SplitButton, MenuItem, Checkbox, Radio, ProgressBar } from 'react-bootstrap'
@@ -51,8 +52,14 @@ export default class ComponentTestView extends React.Component {
   }
 
   @action onClickButton = (e) => {
-    // TODO: do something with this click or display a message
-    console.log(e.target.id)
+    var value
+    if (e.target === undefined) {
+      value = e // key
+    } else {
+      value = e.target.id
+    }
+    $('#button-display-text').html(value)
+    console.log(value)
   }
 
   render () {
@@ -148,17 +155,20 @@ export default class ComponentTestView extends React.Component {
 
                 <FormGroup>
                   <Col smOffset={2} sm={10}>
+                    <div>
+                      <span>Pressed Button: </span><span id='button-display-text'>none</span>
+                    </div>
                     <div className='btn-toolbar'>
                       <Button type='button' id='button' onClick={this.onClickButton} >Button</Button>
                       <DropdownButton title='DropdownButton' id='button-dropdown'>
-                        <MenuItem eventKey='1' id='button-dropdown-1' onClick={this.onClickButton}>Dropdown link 1</MenuItem>
-                        <MenuItem eventKey='2' id='button-dropdown-2' onClick={this.onClickButton}>Dropdown link 2</MenuItem>
-                        <MenuItem eventKey='3' id='button-dropdown-3' onClick={this.onClickButton}>Dropdown link 3</MenuItem>
+                        <MenuItem eventKey='key-dropdown-1' id='button-dropdown-1' onSelect={this.onClickButton}>Dropdown link 1</MenuItem>
+                        <MenuItem eventKey='key-dropdown-2' id='button-dropdown-2' onSelect={this.onClickButton}>Dropdown link 2</MenuItem>
+                        <MenuItem eventKey='key-dropdown-3' id='button-dropdown-3' onSelect={this.onClickButton}>Dropdown link 3</MenuItem>
                       </DropdownButton>
                       <SplitButton title='SplitButton' id='split-button' onClick={this.onClickButton}>
-                        <MenuItem eventKey='1' id='split-button-1' onClick={this.onClickButton}>Dropdown link 1</MenuItem>
-                        <MenuItem eventKey='2' id='split-button-2' onClick={this.onClickButton}>Dropdown link 2</MenuItem>
-                        <MenuItem eventKey='3' id='split-button-3' onClick={this.onClickButton}>Dropdown link 3</MenuItem>
+                        <MenuItem eventKey='key-split-1' id='split-button-1' onSelect={this.onClickButton}>SplitButton link 1</MenuItem>
+                        <MenuItem eventKey='key-split-2' id='split-button-2' onSelect={this.onClickButton}>SplitButton link 2</MenuItem>
+                        <MenuItem eventKey='key-split-3' id='split-button-3' onSelect={this.onClickButton}>SplitButton link 3</MenuItem>
                       </SplitButton>
                     </div>
                   </Col>

--- a/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/remotebot/widget/IRemoteHTMLTextElement.java
+++ b/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/remotebot/widget/IRemoteHTMLTextElement.java
@@ -1,0 +1,21 @@
+package de.fu_berlin.inf.dpp.stf.server.rmi.remotebot.widget;
+
+import java.rmi.Remote;
+import java.rmi.RemoteException;
+
+/**
+ * This interface represent an HTML Element which contains simple text (div,
+ * span, ...) and makes it controllable via RMI.
+ */
+public interface IRemoteHTMLTextElement extends Remote {
+
+    /**
+     * Get the innerHTML of the element
+     */
+    public String getText() throws RemoteException;
+
+    /**
+     * Set the innerHTML of the element
+     */
+    public void setText(String text) throws RemoteException;
+}

--- a/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/remotebot/widget/IRemoteHTMLView.java
+++ b/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/remotebot/widget/IRemoteHTMLView.java
@@ -53,6 +53,30 @@ public interface IRemoteHTMLView extends Remote {
     void open() throws RemoteException;
 
     /**
+     * Checks whether this view contains a button with the given ID.
+     * 
+     * @param id
+     *            the value of the ID attribute of the button
+     * @return <code>true</code> if a button with the given id exists,
+     *         <code>false</code> if not
+     * @throws RemoteException
+     *             if the presence could not be determined
+     */
+    boolean hasElementWithId(String id) throws RemoteException;
+
+    /**
+     * Checks whether this view contains a element with the given name.
+     * 
+     * @param name
+     *            the value of the name attribute of the element
+     * @return <code>true</code> if a element with the given name exists,
+     *         <code>false</code> if not
+     * @throws RemoteException
+     *             if the presence could not be determined
+     */
+    boolean hasElementWithName(String name) throws RemoteException;
+
+    /**
      * Gets a remote representation of the HTML button with the given ID from
      * within this view.
      * 
@@ -66,30 +90,6 @@ public interface IRemoteHTMLView extends Remote {
      *             e.g. if no such button exist in this view
      */
     IRemoteHTMLButton button(String id) throws RemoteException;
-
-    /**
-     * Checks whether this view contains a button with the given ID.
-     * 
-     * @param id
-     *            the value of the ID attribute of the button
-     * @return <code>true</code> if a button with the given id exists,
-     *         <code>false</code> if not
-     * @throws RemoteException
-     *             if the presence could not be determined
-     */
-    boolean hasButton(String id) throws RemoteException;
-
-    /**
-     * Checks whether this view contains a element with the given name.
-     * 
-     * @param name
-     *            the value of the name attribute of the element
-     * @return <code>true</code> if a element with the given name exists,
-     *         <code>false</code> if not
-     * @throws RemoteException
-     *             if the presence could not be determined
-     */
-    boolean hasElementWithName(String name) throws RemoteException;
 
     /**
      * Gets a remote representation of the HTML input field with the given name
@@ -180,5 +180,20 @@ public interface IRemoteHTMLView extends Remote {
      *             e.g. if no such progressbar exist in this view
      */
     IRemoteHTMLProgressBar progressBar(String name) throws RemoteException;
+
+    /**
+     * Gets a remote representation of the HTML Element (div, span, ... ) with
+     * the given id from within this view.
+     * 
+     * @param id
+     *            the value of the id of the element
+     * 
+     * @return an instance of {@link IRemoteHTMLTextElement}, if such a element
+     *         exists in this view
+     * 
+     * @throws RemoteException
+     *             e.g. if no such element exist in this view
+     */
+    IRemoteHTMLTextElement textElement(String id) throws RemoteException;
 
 }

--- a/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/remotebot/widget/impl/RemoteHTMLButton.java
+++ b/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/remotebot/widget/impl/RemoteHTMLButton.java
@@ -21,7 +21,7 @@ public final class RemoteHTMLButton extends HTMLSTFRemoteObject implements
 
     @Override
     public void click() throws RemoteException {
-        browser.run(selector.getStatement() + ".click();");
+        browser.run(selector.getStatement() + "[0].click();");
     }
 
     void setBrowser(IJQueryBrowser browser) {

--- a/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/remotebot/widget/impl/RemoteHTMLTextElement.java
+++ b/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/remotebot/widget/impl/RemoteHTMLTextElement.java
@@ -1,0 +1,44 @@
+package de.fu_berlin.inf.dpp.stf.server.rmi.remotebot.widget.impl;
+
+import java.rmi.RemoteException;
+
+import de.fu_berlin.inf.ag_se.browser.extensions.IJQueryBrowser;
+import de.fu_berlin.inf.ag_se.browser.html.ISelector;
+import de.fu_berlin.inf.dpp.stf.server.HTMLSTFRemoteObject;
+import de.fu_berlin.inf.dpp.stf.server.rmi.remotebot.widget.IRemoteHTMLTextElement;
+
+public final class RemoteHTMLTextElement extends HTMLSTFRemoteObject implements
+    IRemoteHTMLTextElement {
+
+    private static final RemoteHTMLTextElement INSTANCE = new RemoteHTMLTextElement();
+
+    private IJQueryBrowser browser;
+    private ISelector selector;
+
+    public static RemoteHTMLTextElement getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public String getText() throws RemoteException {
+
+        Object text = browser.syncRun(String.format("return %s.text()",
+            selector.getStatement()));
+        return text != null ? text.toString() : null;
+    }
+
+    @Override
+    public void setText(String text) throws RemoteException {
+        browser.run(String.format("%s.text('%s')", selector.getStatement(),
+            text));
+    }
+
+    void setBrowser(IJQueryBrowser browser) {
+        this.browser = browser;
+    }
+
+    void setSelector(ISelector selector) {
+        this.selector = selector;
+    }
+
+}

--- a/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/remotebot/widget/impl/RemoteHTMLView.java
+++ b/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/remotebot/widget/impl/RemoteHTMLView.java
@@ -22,6 +22,7 @@ import de.fu_berlin.inf.dpp.stf.server.rmi.remotebot.widget.IRemoteHTMLMultiSele
 import de.fu_berlin.inf.dpp.stf.server.rmi.remotebot.widget.IRemoteHTMLProgressBar;
 import de.fu_berlin.inf.dpp.stf.server.rmi.remotebot.widget.IRemoteHTMLRadioGroup;
 import de.fu_berlin.inf.dpp.stf.server.rmi.remotebot.widget.IRemoteHTMLSelect;
+import de.fu_berlin.inf.dpp.stf.server.rmi.remotebot.widget.IRemoteHTMLTextElement;
 import de.fu_berlin.inf.dpp.stf.server.rmi.remotebot.widget.IRemoteHTMLView;
 import de.fu_berlin.inf.dpp.ui.pages.AbstractBrowserPage;
 import de.fu_berlin.inf.dpp.ui.pages.MainPage;
@@ -83,6 +84,7 @@ public class RemoteHTMLView extends HTMLSTFRemoteObject implements
     private RemoteHTMLSelect select;
     private RemoteHTMLMultiSelect multiSelect;
     private RemoteHTMLProgressBar progressBar;
+    private RemoteHTMLTextElement textElement;
 
     public RemoteHTMLView() {
         button = RemoteHTMLButton.getInstance();
@@ -92,11 +94,17 @@ public class RemoteHTMLView extends HTMLSTFRemoteObject implements
         select = RemoteHTMLSelect.getInstance();
         multiSelect = RemoteHTMLMultiSelect.getInstance();
         progressBar = RemoteHTMLProgressBar.getInstance();
+        textElement = RemoteHTMLTextElement.getInstance();
     }
 
     @Override
-    public boolean hasButton(String id) throws RemoteException {
+    public boolean hasElementWithId(String id) throws RemoteException {
         return exists(new IdSelector(id));
+    }
+
+    @Override
+    public boolean hasElementWithName(String name) throws RemoteException {
+        return exists(new NameSelector(name));
     }
 
     @Override
@@ -105,11 +113,6 @@ public class RemoteHTMLView extends HTMLSTFRemoteObject implements
         button.setSelector(selector);
         ensureExistence(selector);
         return button;
-    }
-
-    @Override
-    public boolean hasElementWithName(String name) throws RemoteException {
-        return exists(new NameSelector(name));
     }
 
     @Override
@@ -163,6 +166,14 @@ public class RemoteHTMLView extends HTMLSTFRemoteObject implements
     }
 
     @Override
+    public IRemoteHTMLTextElement textElement(String id) throws RemoteException {
+        IdSelector selector = new IdSelector(id);
+        textElement.setSelector(selector);
+        ensureExistence(selector);
+        return textElement;
+    }
+
+    @Override
     public boolean isOpen() {
         String id = map.get(view).id;
         return exists(new IdSelector(id));
@@ -184,6 +195,7 @@ public class RemoteHTMLView extends HTMLSTFRemoteObject implements
         this.select.setBrowser(getBrowser());
         this.multiSelect.setBrowser(getBrowser());
         this.progressBar.setBrowser(getBrowser());
+        this.textElement.setBrowser(getBrowser());
 
     }
 

--- a/de.fu_berlin.inf.dpp/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/STFController.java
+++ b/de.fu_berlin.inf.dpp/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/STFController.java
@@ -68,6 +68,7 @@ import de.fu_berlin.inf.dpp.stf.server.rmi.remotebot.widget.impl.RemoteHTMLMulti
 import de.fu_berlin.inf.dpp.stf.server.rmi.remotebot.widget.impl.RemoteHTMLProgressBar;
 import de.fu_berlin.inf.dpp.stf.server.rmi.remotebot.widget.impl.RemoteHTMLRadioGroup;
 import de.fu_berlin.inf.dpp.stf.server.rmi.remotebot.widget.impl.RemoteHTMLSelect;
+import de.fu_berlin.inf.dpp.stf.server.rmi.remotebot.widget.impl.RemoteHTMLTextElement;
 import de.fu_berlin.inf.dpp.stf.server.rmi.remotebot.widget.impl.RemoteHTMLView;
 import de.fu_berlin.inf.dpp.stf.server.rmi.superbot.component.contextmenu.peview.impl.ContextMenusInPEView;
 import de.fu_berlin.inf.dpp.stf.server.rmi.superbot.component.contextmenu.peview.submenu.impl.NewC;
@@ -209,6 +210,7 @@ public class STFController {
             exportObject(RemoteHTMLSelect.getInstance(), "htmlSelect");
             exportObject(RemoteHTMLMultiSelect.getInstance(), "htmlMultiSelect");
             exportObject(RemoteHTMLProgressBar.getInstance(), "htmlProgressBar");
+            exportObject(RemoteHTMLTextElement.getInstance(), "htmlTextElement");
         }
 
         /*

--- a/de.fu_berlin.inf.dpp/test/stf/de/fu_berlin/inf/dpp/stf/test/html/ComponentViewTest.java
+++ b/de.fu_berlin.inf.dpp/test/stf/de/fu_berlin/inf/dpp/stf/test/html/ComponentViewTest.java
@@ -152,4 +152,59 @@ public class ComponentViewTest extends StfHtmlTestCase {
         view.progressBar("progressBar").setValue(42);
         assertTrue(view.progressBar("progressBar").getValue() == 42);
     }
+
+    @Test
+    public void shouldTestTextElement() throws Exception {
+        IRemoteHTMLView view = ALICE.htmlBot().view(View.COMPONENT_TEST);
+
+        assertTrue(view.hasElementWithId("button-display-text"));
+        assertTrue(view.textElement("button-display-text").getText()
+            .equals("none"));
+
+        view.textElement("button-display-text").setText("Some other content");
+        assertTrue(view.textElement("button-display-text").getText()
+            .equals("Some other content"));
+
+    }
+
+    @Test
+    public void shouldTestButton() throws Exception {
+        IRemoteHTMLView view = ALICE.htmlBot().view(View.COMPONENT_TEST);
+
+        assertTrue(view.hasElementWithId("button"));
+        view.button("button").click();
+        assertTrue(view.textElement("button-display-text").getText()
+            .equals("button"));
+
+        assertTrue(view.hasElementWithId("button-dropdown-1"));
+        view.button("button-dropdown-1").click();
+        assertTrue(view.textElement("button-display-text").getText()
+            .equals("key-dropdown-1"));
+
+        assertTrue(view.hasElementWithId("button-dropdown-2"));
+        view.button("button-dropdown-2").click();
+        assertTrue(view.textElement("button-display-text").getText()
+            .equals("key-dropdown-2"));
+
+        assertTrue(view.hasElementWithId("button-dropdown-3"));
+        view.button("button-dropdown-3").click();
+        assertTrue(view.textElement("button-display-text").getText()
+            .equals("key-dropdown-3"));
+
+        assertTrue(view.hasElementWithId("split-button-1"));
+        view.button("split-button-1").click();
+        assertTrue(view.textElement("button-display-text").getText()
+            .equals("key-split-1"));
+
+        assertTrue(view.hasElementWithId("split-button-2"));
+        view.button("split-button-2").click();
+        assertTrue(view.textElement("button-display-text").getText()
+            .equals("key-split-2"));
+
+        assertTrue(view.hasElementWithId("split-button-3"));
+        view.button("split-button-3").click();
+        assertTrue(view.textElement("button-display-text").getText()
+            .equals("key-split-3"));
+
+    }
 }

--- a/de.fu_berlin.inf.dpp/test/stf/de/fu_berlin/inf/dpp/stf/test/html/MainViewTest.java
+++ b/de.fu_berlin.inf.dpp/test/stf/de/fu_berlin/inf/dpp/stf/test/html/MainViewTest.java
@@ -21,8 +21,8 @@ public class MainViewTest extends StfHtmlTestCase {
             .isOpen());
 
         assertTrue("No 'Add Contact' button", ALICE.htmlBot().view(MAIN_VIEW)
-            .hasButton("add-contact"));
+            .hasElementWithId("add-contact"));
         assertTrue("No 'Start Session' button", ALICE.htmlBot().view(MAIN_VIEW)
-            .hasButton("start-session"));
+            .hasElementWithId("start-session"));
     }
 }


### PR DESCRIPTION
I introduced a RemoteHTMLTextElement which simply contains text and has
getter and setter for the content. I needed this new Element to test if
a simple click on button, dropdown-button and split-button is working.
So when you click on a button in the ComponentTestView the specified
eventkey will be displayed in a span above the ButtonToolbar whereupon
the assertion takes place.

To dev and debug easier I added jQuery to the ComponentTestView

Change-Id: Id8591a0975973a767ff0d754b5b90055fe3053d6