### PR TITLE
[STF] Add RemoteHTMLTree and use it in StartSessionWizardTest

### DIFF
--- a/de.fu_berlin.inf.dpp.ui.frontend/html/src/components/App.jsx
+++ b/de.fu_berlin.inf.dpp.ui.frontend/html/src/components/App.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import $ from 'jquery'
 import { inject, observer } from 'mobx-react'
 import { views } from 'Constants'
 import MainView from './MainView'
@@ -12,13 +13,14 @@ const viewComponents = {
   [views.ADD_CONTACT]: AddContactView,
   [views.START_SESSION_WIZARD]: StartSessionWizardView,
   [views.CONFIGURATION_WIZARD]: ConfigurationWizardView,
-    [views.BASIC_WIDGET_TEST]: BasicWidgetTestView
+  [views.BASIC_WIDGET_TEST]: BasicWidgetTestView
 }
 
 @inject('view')
 @observer
 class App extends React.Component {
   render () {
+    window.$ = $
     const View = viewComponents[this.props.view.currentView]
     if (!View) {
       return null

--- a/de.fu_berlin.inf.dpp.ui.frontend/html/src/components/BasicWidgetTestView/index.jsx
+++ b/de.fu_berlin.inf.dpp.ui.frontend/html/src/components/BasicWidgetTestView/index.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import $ from 'jquery'
 import { observable, action } from 'mobx'
 import { observer, inject } from 'mobx-react'
 import { Grid, Row, Col, Form, FormGroup, FormControl, ControlLabel, Button, DropdownButton, SplitButton, MenuItem, Checkbox, Radio, ProgressBar } from 'react-bootstrap'
@@ -21,7 +20,7 @@ export default class BasicWidgetTestView extends React.Component {
     radioGroup: '1',
     select: 'option1', // Default value
     multiSelect: [],
-    progressBar: 50
+    progressBar: 50,
   }
 
   @action setFieldValue = (field, value) => {

--- a/de.fu_berlin.inf.dpp.ui.frontend/html/src/components/StartSessionWizardView/ChooseFilesStep.jsx
+++ b/de.fu_berlin.inf.dpp.ui.frontend/html/src/components/StartSessionWizardView/ChooseFilesStep.jsx
@@ -25,6 +25,7 @@ export default class ChooseFilesStep extends React.Component {
     if (!initialProjectTrees) return null
     return (
       <Tree
+        className='project-tree'
         showLine checkable defaultExpandAll
         selectable={false}
         checkedKeys={Array.from(checkedKeys)}

--- a/de.fu_berlin.inf.dpp.ui.frontend/html/src/components/Wizard/Step.jsx
+++ b/de.fu_berlin.inf.dpp.ui.frontend/html/src/components/Wizard/Step.jsx
@@ -75,7 +75,7 @@ export default class Step extends React.Component {
           <button disabled={!hasPrev} className={cn('btn', 'btn-default', !hasPrev && 'disabled')} onClick={wizard.onClickBack}>
             <Text message='action.back' />
           </button>
-          <button className={cn('wizard-next-btn', 'btn', hasNext ? 'btn-default' : 'btn-primary')} onClick={this.onClickNext}>
+          <button id='next-button' className={cn('wizard-next-btn', 'btn', hasNext ? 'btn-default' : 'btn-primary')} onClick={this.onClickNext}>
             <Text message={hasNext ? 'action.next' : 'action.finish'} />
           </button>
         </nav>

--- a/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/IHTMLBot.java
+++ b/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/IHTMLBot.java
@@ -34,9 +34,11 @@ public interface IHTMLBot extends Remote {
     /**
      * Returns the currently displayed list of contacts.
      * 
+     * @param view
+     *            The part of the Saros GUI on which the contact list is
+     *            displayed.
      * @return a list of diplayNames of contacts
      * @throws RemoteException
      */
-    List<String> getContactList() throws RemoteException;
-
+    List<String> getContactList(View view) throws RemoteException;
 }

--- a/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/impl/HTMLBotImpl.java
+++ b/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/impl/HTMLBotImpl.java
@@ -12,6 +12,7 @@ import de.fu_berlin.inf.dpp.stf.server.rmi.htmlbot.IHTMLBot;
 import de.fu_berlin.inf.dpp.stf.server.rmi.htmlbot.widget.IRemoteHTMLView;
 import de.fu_berlin.inf.dpp.stf.server.rmi.htmlbot.widget.impl.RemoteHTMLView;
 import de.fu_berlin.inf.dpp.ui.View;
+import de.fu_berlin.inf.dpp.ui.pages.IBrowserPage;
 import de.fu_berlin.inf.dpp.ui.pages.MainPage;
 
 public class HTMLBotImpl extends HTMLSTFRemoteObject implements IHTMLBot {
@@ -37,17 +38,19 @@ public class HTMLBotImpl extends HTMLSTFRemoteObject implements IHTMLBot {
 
     @Override
     public List<String> getAccountList() throws RemoteException {
-        return BotUtils.getListItemsText(getBrowser(), SELECTOR_ACCOUNT_ENTRY);
+        return BotUtils.getListItemsText(getBrowser(MainPage.class),
+            SELECTOR_ACCOUNT_ENTRY);
     }
 
     @Override
-    public List<String> getContactList() throws RemoteException {
-        return BotUtils.getListItemsText(getBrowser(),
+    public List<String> getContactList(View view) throws RemoteException {
+        return BotUtils.getListItemsText(getBrowser(view.getPageClass()),
             SELECTOR_CONTACT_ITEM_DISPLAY_NAME);
     }
 
-    private IJQueryBrowser getBrowser() {
-        return getBrowserManager().getBrowser(MainPage.class);
+    private IJQueryBrowser getBrowser(
+        Class<? extends IBrowserPage> browserPageClass) {
+        return getBrowserManager().getBrowser(browserPageClass);
     }
 
     public static IHTMLBot getInstance() {

--- a/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/IRemoteHTMLTree.java
+++ b/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/IRemoteHTMLTree.java
@@ -1,0 +1,25 @@
+package de.fu_berlin.inf.dpp.stf.server.rmi.htmlbot.widget;
+
+import java.rmi.Remote;
+import java.rmi.RemoteException;
+
+/**
+ * Represent an React Tree Element and makes it controllable via RMI..
+ */
+public interface IRemoteHTMLTree extends Remote {
+
+    /**
+     * Check the node of the tree with the given title
+     */
+    public void check(String title) throws RemoteException;
+
+    /**
+     * Uncheck the node of the tree with the given title
+     */
+    public void uncheck(String title) throws RemoteException;
+
+    /**
+     * Get the node state of the tree with the given title
+     */
+    public boolean isChecked(String title) throws RemoteException;
+}

--- a/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/IRemoteHTMLView.java
+++ b/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/IRemoteHTMLView.java
@@ -173,4 +173,19 @@ public interface IRemoteHTMLView extends Remote {
      */
     IRemoteHTMLTextElement textElement(String id) throws RemoteException;
 
+    /**
+     * Gets a remote representation of the React Tree Element with the given
+     * className from within this view.
+     * 
+     * @param className
+     *            the value of the identifying class of the element
+     * 
+     * @return an instance of {@link IRemoteHTMLTree}, if such a element
+     *         exists in this view
+     * 
+     * @throws RemoteException
+     *             e.g. if no such element exist in this view
+     */
+    IRemoteHTMLTree tree(String className) throws RemoteException;
+
 }

--- a/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/impl/RemoteHTMLButton.java
+++ b/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/impl/RemoteHTMLButton.java
@@ -16,6 +16,6 @@ public final class RemoteHTMLButton extends HTMLSTFRemoteObject implements
 
     @Override
     public void click() throws RemoteException {
-        browser.run(selector.getStatement() + "[0].click();");
+        browser.run(String.format("%s[0].click();", selector.getStatement()));
     }
 }

--- a/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/impl/RemoteHTMLTree.java
+++ b/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/impl/RemoteHTMLTree.java
@@ -20,7 +20,8 @@ public final class RemoteHTMLTree extends HTMLSTFRemoteObject implements
         if (isChecked(title) == false) {
             Selector nodeSelector = new Selector("span[title=\"" + title
                 + "\"]");
-            browser.run(nodeSelector.getStatement() + "[0].click();");
+            browser.run(String.format("%s[0].click();",
+                nodeSelector.getStatement()));
         }
     }
 
@@ -29,16 +30,17 @@ public final class RemoteHTMLTree extends HTMLSTFRemoteObject implements
         if (isChecked(title)) {
             Selector nodeSelector = new Selector("span[title=\"" + title
                 + "\"]");
-            browser.run(nodeSelector.getStatement() + "[0].click();");
+            browser.run(String.format("%s[0].click();",
+                nodeSelector.getStatement()));
         }
     }
 
     @Override
     public boolean isChecked(String title) throws RemoteException {
         Selector nodeSelector = new Selector("span[title=\"" + title + "\"]");
-        Object checked = browser.syncRun("return "
-            + nodeSelector.getStatement()
-            + ".prev().hasClass('rc-tree-checkbox-checked')");
+        Object checked = browser.syncRun(String.format(
+            "return %s.prev().hasClass('rc-tree-checkbox-checked')",
+            nodeSelector.getStatement()));
         return checked != null ? (Boolean) checked : null;
     }
 }

--- a/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/impl/RemoteHTMLTree.java
+++ b/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/impl/RemoteHTMLTree.java
@@ -1,0 +1,43 @@
+package de.fu_berlin.inf.dpp.stf.server.rmi.htmlbot.widget.impl;
+
+import java.rmi.RemoteException;
+
+import de.fu_berlin.inf.ag_se.browser.html.ISelector.Selector;
+import de.fu_berlin.inf.dpp.stf.server.HTMLSTFRemoteObject;
+import de.fu_berlin.inf.dpp.stf.server.rmi.htmlbot.widget.IRemoteHTMLTree;
+
+public final class RemoteHTMLTree extends HTMLSTFRemoteObject implements
+    IRemoteHTMLTree {
+
+    private static final RemoteHTMLTree INSTANCE = new RemoteHTMLTree();
+
+    public static RemoteHTMLTree getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public void check(String title) throws RemoteException {
+        // if (isChecked(title) == false) {
+        Selector nodeSelector = new Selector("span[title=\"" + title + "\"]");
+        browser.run(nodeSelector.getStatement() + ".click();");
+        // }
+    }
+
+    @Override
+    public void uncheck(String title) throws RemoteException {
+        if (isChecked(title)) {
+            Selector nodeSelector = new Selector("span[title=\"" + title
+                + "\"]");
+            browser.run(nodeSelector.getStatement() + "[0].click();");
+        }
+    }
+
+    @Override
+    public boolean isChecked(String title) throws RemoteException {
+        Selector nodeSelector = new Selector("span[title=\"" + title + "\"]");
+        Object checked = browser.syncRun("return "
+            + nodeSelector.getStatement()
+            + ".prev().hasClass('rc-tree-checkbox-checked')");
+        return checked != null ? (Boolean) checked : null;
+    }
+}

--- a/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/impl/RemoteHTMLTree.java
+++ b/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/impl/RemoteHTMLTree.java
@@ -17,10 +17,11 @@ public final class RemoteHTMLTree extends HTMLSTFRemoteObject implements
 
     @Override
     public void check(String title) throws RemoteException {
-        // if (isChecked(title) == false) {
-        Selector nodeSelector = new Selector("span[title=\"" + title + "\"]");
-        browser.run(nodeSelector.getStatement() + ".click();");
-        // }
+        if (isChecked(title) == false) {
+            Selector nodeSelector = new Selector("span[title=\"" + title
+                + "\"]");
+            browser.run(nodeSelector.getStatement() + "[0].click();");
+        }
     }
 
     @Override

--- a/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/impl/RemoteHTMLView.java
+++ b/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/impl/RemoteHTMLView.java
@@ -11,6 +11,7 @@ import de.fu_berlin.inf.ag_se.browser.extensions.IJQueryBrowser;
 import de.fu_berlin.inf.ag_se.browser.html.ISelector;
 import de.fu_berlin.inf.ag_se.browser.html.ISelector.IdSelector;
 import de.fu_berlin.inf.ag_se.browser.html.ISelector.NameSelector;
+import de.fu_berlin.inf.ag_se.browser.html.ISelector.Selector;
 import de.fu_berlin.inf.dpp.stf.server.HTMLSTFRemoteObject;
 import de.fu_berlin.inf.dpp.stf.server.bot.BotPreferences;
 import de.fu_berlin.inf.dpp.stf.server.rmi.htmlbot.widget.IRemoteHTMLButton;
@@ -21,6 +22,7 @@ import de.fu_berlin.inf.dpp.stf.server.rmi.htmlbot.widget.IRemoteHTMLProgressBar
 import de.fu_berlin.inf.dpp.stf.server.rmi.htmlbot.widget.IRemoteHTMLRadioGroup;
 import de.fu_berlin.inf.dpp.stf.server.rmi.htmlbot.widget.IRemoteHTMLSelect;
 import de.fu_berlin.inf.dpp.stf.server.rmi.htmlbot.widget.IRemoteHTMLTextElement;
+import de.fu_berlin.inf.dpp.stf.server.rmi.htmlbot.widget.IRemoteHTMLTree;
 import de.fu_berlin.inf.dpp.stf.server.rmi.htmlbot.widget.IRemoteHTMLView;
 import de.fu_berlin.inf.dpp.ui.View;
 
@@ -43,6 +45,7 @@ public class RemoteHTMLView extends HTMLSTFRemoteObject implements
     private RemoteHTMLMultiSelect multiSelect;
     private RemoteHTMLProgressBar progressBar;
     private RemoteHTMLTextElement textElement;
+    private RemoteHTMLTree tree;
 
     public RemoteHTMLView() {
         button = RemoteHTMLButton.getInstance();
@@ -53,6 +56,7 @@ public class RemoteHTMLView extends HTMLSTFRemoteObject implements
         multiSelect = RemoteHTMLMultiSelect.getInstance();
         progressBar = RemoteHTMLProgressBar.getInstance();
         textElement = RemoteHTMLTextElement.getInstance();
+        tree = RemoteHTMLTree.getInstance();
     }
 
     @Override
@@ -132,6 +136,14 @@ public class RemoteHTMLView extends HTMLSTFRemoteObject implements
     }
 
     @Override
+    public IRemoteHTMLTree tree(String className) throws RemoteException {
+        Selector selector = new Selector("ul." + className + "[role=tree]");
+        tree.setSelector(selector);
+        ensureExistence(selector);
+        return tree;
+    }
+
+    @Override
     public boolean isOpen() {
         return exists(new IdSelector(view.getRootId()));
     }
@@ -153,6 +165,7 @@ public class RemoteHTMLView extends HTMLSTFRemoteObject implements
         this.multiSelect.setBrowser(getBrowser());
         this.progressBar.setBrowser(getBrowser());
         this.textElement.setBrowser(getBrowser());
+        this.tree.setBrowser(getBrowser());
     }
 
     private IJQueryBrowser getBrowser() {

--- a/de.fu_berlin.inf.dpp/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/STFController.java
+++ b/de.fu_berlin.inf.dpp/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/STFController.java
@@ -40,6 +40,7 @@ import de.fu_berlin.inf.dpp.stf.server.rmi.htmlbot.widget.impl.RemoteHTMLProgres
 import de.fu_berlin.inf.dpp.stf.server.rmi.htmlbot.widget.impl.RemoteHTMLRadioGroup;
 import de.fu_berlin.inf.dpp.stf.server.rmi.htmlbot.widget.impl.RemoteHTMLSelect;
 import de.fu_berlin.inf.dpp.stf.server.rmi.htmlbot.widget.impl.RemoteHTMLTextElement;
+import de.fu_berlin.inf.dpp.stf.server.rmi.htmlbot.widget.impl.RemoteHTMLTree;
 import de.fu_berlin.inf.dpp.stf.server.rmi.htmlbot.widget.impl.RemoteHTMLView;
 import de.fu_berlin.inf.dpp.stf.server.rmi.remotebot.impl.RemoteWorkbenchBot;
 import de.fu_berlin.inf.dpp.stf.server.rmi.remotebot.widget.impl.RemoteBotButton;
@@ -211,6 +212,7 @@ public class STFController {
             exportObject(RemoteHTMLMultiSelect.getInstance(), "htmlMultiSelect");
             exportObject(RemoteHTMLProgressBar.getInstance(), "htmlProgressBar");
             exportObject(RemoteHTMLTextElement.getInstance(), "htmlTextElement");
+            exportObject(RemoteHTMLTree.getInstance(), "htmlTree");
         }
 
         /*

--- a/de.fu_berlin.inf.dpp/test/stf/de/fu_berlin/inf/dpp/stf/test/html/AddContactTest.java
+++ b/de.fu_berlin.inf.dpp/test/stf/de/fu_berlin/inf/dpp/stf/test/html/AddContactTest.java
@@ -30,8 +30,9 @@ public class AddContactTest extends StfHtmlTestCase {
     @Test
     public void addBobAsContact() throws Exception {
         // Precondition
-        List<String> aliceContactList = ALICE.htmlBot().getContactList();
-        List<String> bobContactList = BOB.htmlBot().getContactList();
+        List<String> aliceContactList = ALICE.htmlBot().getContactList(
+            MAIN_VIEW);
+        List<String> bobContactList = BOB.htmlBot().getContactList(MAIN_VIEW);
         assertFalse("Alice still has Bob as contact",
             aliceContactList.contains(BOB.getBaseJid()));
         assertFalse("Bob still has Alice as contact",
@@ -53,8 +54,8 @@ public class AddContactTest extends StfHtmlTestCase {
         ALICE.superBot().confirmShellRequestOfSubscriptionReceived();
 
         // check new contact
-        aliceContactList = ALICE.htmlBot().getContactList();
-        bobContactList = BOB.htmlBot().getContactList();
+        aliceContactList = ALICE.htmlBot().getContactList(MAIN_VIEW);
+        bobContactList = BOB.htmlBot().getContactList(MAIN_VIEW);
         assertTrue("Alice has Bob not as contact",
             aliceContactList.contains(BOB.getBaseJid()));
         assertTrue("Bob has Alice not as contact",

--- a/de.fu_berlin.inf.dpp/test/stf/de/fu_berlin/inf/dpp/stf/test/html/StartSessionWizardTest.java
+++ b/de.fu_berlin.inf.dpp/test/stf/de/fu_berlin/inf/dpp/stf/test/html/StartSessionWizardTest.java
@@ -4,6 +4,7 @@ import static de.fu_berlin.inf.dpp.stf.client.tester.SarosTester.ALICE;
 import static de.fu_berlin.inf.dpp.stf.client.tester.SarosTester.BOB;
 import static de.fu_berlin.inf.dpp.ui.View.MAIN_VIEW;
 import static de.fu_berlin.inf.dpp.ui.View.SESSION_WIZARD;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.rmi.RemoteException;
@@ -69,6 +70,11 @@ public class StartSessionWizardTest extends StfHtmlTestCase {
         ALICE.htmlBot().view(SESSION_WIZARD).tree("project-tree")
             .check(Constants.PROJECT1);
         assertTrue(ALICE.htmlBot().view(SESSION_WIZARD).tree("project-tree")
+            .isChecked(Constants.PROJECT1));
+
+        ALICE.htmlBot().view(SESSION_WIZARD).tree("project-tree")
+            .uncheck(".classpath");
+        assertFalse(ALICE.htmlBot().view(SESSION_WIZARD).tree("project-tree")
             .isChecked(Constants.PROJECT1));
 
         ALICE.htmlBot().view(SESSION_WIZARD).button("next-button").click();

--- a/de.fu_berlin.inf.dpp/test/stf/de/fu_berlin/inf/dpp/stf/test/html/StartSessionWizardTest.java
+++ b/de.fu_berlin.inf.dpp/test/stf/de/fu_berlin/inf/dpp/stf/test/html/StartSessionWizardTest.java
@@ -1,20 +1,39 @@
 package de.fu_berlin.inf.dpp.stf.test.html;
 
 import static de.fu_berlin.inf.dpp.stf.client.tester.SarosTester.ALICE;
+import static de.fu_berlin.inf.dpp.stf.client.tester.SarosTester.BOB;
 import static de.fu_berlin.inf.dpp.ui.View.MAIN_VIEW;
 import static de.fu_berlin.inf.dpp.ui.View.SESSION_WIZARD;
 import static org.junit.Assert.assertTrue;
 
+import java.rmi.RemoteException;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import de.fu_berlin.inf.dpp.stf.client.StfHtmlTestCase;
+import de.fu_berlin.inf.dpp.stf.test.Constants;
 
 public class StartSessionWizardTest extends StfHtmlTestCase {
 
     @BeforeClass
     public static void selectTesters() throws Exception {
-        select(ALICE);
+        select(ALICE, BOB);
+    }
+
+    @Before
+    public void initProject() throws RemoteException {
+        ALICE
+            .superBot()
+            .views()
+            .packageExplorerView()
+            .tree()
+            .newC()
+            .javaProjectWithClasses(Constants.PROJECT1, Constants.PKG1,
+                Constants.CLS1);
     }
 
     @Test
@@ -33,6 +52,33 @@ public class StartSessionWizardTest extends StfHtmlTestCase {
         ALICE.htmlBot().view(SESSION_WIZARD).button("next-button").click();
         assertTrue(ALICE.htmlBot().view(SESSION_WIZARD).textElement("header")
             .getText().equals("Choose Contacts"));
+    }
+
+    @Test
+    public void shouldStartSession() throws Exception {
+        assertTrue(ALICE.superBot().views().packageExplorerView()
+            .selectPkg(Constants.PROJECT1, Constants.PKG1)
+            .existsWithRegex(Pattern.quote(Constants.CLS1) + ".*"));
+
+        assertTrue("Main view did not load", ALICE.htmlBot().view(MAIN_VIEW)
+            .isOpen());
+
+        ALICE.htmlBot().view(MAIN_VIEW).button("start-session").click();
+        assertTrue(ALICE.htmlBot().view(SESSION_WIZARD).isOpen());
+
+        ALICE.htmlBot().view(SESSION_WIZARD).tree("project-tree")
+            .check(Constants.PROJECT1);
+        assertTrue(ALICE.htmlBot().view(SESSION_WIZARD).tree("project-tree")
+            .isChecked(Constants.PROJECT1));
+
+        ALICE.htmlBot().view(SESSION_WIZARD).button("next-button").click();
+        List<String> contactList = ALICE.htmlBot().getContactList(
+            SESSION_WIZARD);
+        assertTrue(contactList.contains(BOB.getBaseJid()));
+
+        // TODO click on user in list
+        // TODO click on Finish button
+        // TODO assert that dialog is closed
 
     }
 }


### PR DESCRIPTION
To interact with the project file tree in the session dialog I wrote a
RemoteHTMLTree class. In this patch I didn't complete the
StartSessionWizardTest, interaction with the user list is missing for
now.

Change-Id: I6f0aeab9788de999486596a4e6a0b571b709c306