### PR TITLE
[STF] Add ContactListItem accessible and complete the test

### DIFF
--- a/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/IRemoteHTMLButton.java
+++ b/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/IRemoteHTMLButton.java
@@ -12,4 +12,9 @@ public interface IRemoteHTMLButton extends Remote {
      * Click on the button.
      */
     public void click() throws RemoteException;
+
+    /**
+     * Get the displayed text of the button.
+     */
+    public String text() throws RemoteException;
 }

--- a/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/IRemoteHTMLView.java
+++ b/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/IRemoteHTMLView.java
@@ -69,6 +69,21 @@ public interface IRemoteHTMLView extends Remote {
     IRemoteHTMLButton button(String id) throws RemoteException;
 
     /**
+     * Gets a remote representation of the contact-list item with the given JID
+     * from within this view. The item is used as a button.
+     * 
+     * @param jid
+     *            the value of the JID of the contact
+     * 
+     * @return an instance of {@link IRemoteHTMLButton}, if such a item exists
+     *         in this view
+     * 
+     * @throws RemoteException
+     *             e.g. if no such item exist in this view
+     */
+    IRemoteHTMLButton contactListItem(String jid) throws RemoteException;
+
+    /**
      * Gets a remote representation of the HTML input field with the given name
      * from within this view.
      *
@@ -180,8 +195,8 @@ public interface IRemoteHTMLView extends Remote {
      * @param className
      *            the value of the identifying class of the element
      * 
-     * @return an instance of {@link IRemoteHTMLTree}, if such a element
-     *         exists in this view
+     * @return an instance of {@link IRemoteHTMLTree}, if such a element exists
+     *         in this view
      * 
      * @throws RemoteException
      *             e.g. if no such element exist in this view

--- a/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/impl/RemoteHTMLButton.java
+++ b/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/impl/RemoteHTMLButton.java
@@ -18,4 +18,11 @@ public final class RemoteHTMLButton extends HTMLSTFRemoteObject implements
     public void click() throws RemoteException {
         browser.run(String.format("%s[0].click();", selector.getStatement()));
     }
+
+    @Override
+    public String text() throws RemoteException {
+        return (String) browser.syncRun("return " + selector.getStatement()
+            + ".text();");
+    }
+
 }

--- a/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/impl/RemoteHTMLView.java
+++ b/de.fu_berlin.inf.dpp.ui/test/framework/stf/src/de/fu_berlin/inf/dpp/stf/server/rmi/htmlbot/widget/impl/RemoteHTMLView.java
@@ -78,6 +78,14 @@ public class RemoteHTMLView extends HTMLSTFRemoteObject implements
     }
 
     @Override
+    public IRemoteHTMLButton contactListItem(String jid) throws RemoteException {
+        Selector selector = new Selector("li[data-jid=\"" + jid + "\"]");
+        button.setSelector(selector);
+        ensureExistence(selector);
+        return button;
+    }
+
+    @Override
     public IRemoteHTMLInputField inputField(String name) throws RemoteException {
         NameSelector selector = new NameSelector(name);
         inputField.setSelector(selector);
@@ -137,7 +145,7 @@ public class RemoteHTMLView extends HTMLSTFRemoteObject implements
 
     @Override
     public IRemoteHTMLTree tree(String className) throws RemoteException {
-        Selector selector = new Selector("ul." + className + "[role=tree]");
+        Selector selector = new Selector("ul." + className);
         tree.setSelector(selector);
         ensureExistence(selector);
         return tree;

--- a/de.fu_berlin.inf.dpp/test/framework/stf/test/de/fu_berlin/inf/dpp/stf/test/stf/view/html/HtmlBasicWidgetTest.java
+++ b/de.fu_berlin.inf.dpp/test/framework/stf/test/de/fu_berlin/inf/dpp/stf/test/stf/view/html/HtmlBasicWidgetTest.java
@@ -206,5 +206,7 @@ public class HtmlBasicWidgetTest extends StfHtmlTestCase {
         assertTrue(view.textElement("button-display-text").getText()
             .equals("key-split-3"));
 
+        assertTrue(view.button("button").text().equals("Button"));
+
     }
 }

--- a/de.fu_berlin.inf.dpp/test/stf/de/fu_berlin/inf/dpp/stf/test/html/StartSessionWizardTest.java
+++ b/de.fu_berlin.inf.dpp/test/stf/de/fu_berlin/inf/dpp/stf/test/html/StartSessionWizardTest.java
@@ -55,6 +55,7 @@ public class StartSessionWizardTest extends StfHtmlTestCase {
             .getText().equals("Choose Contacts"));
     }
 
+    // TODO: fix the HTML StartSessionWizard to success this test
     @Test
     public void shouldStartSession() throws Exception {
         assertTrue(ALICE.superBot().views().packageExplorerView()
@@ -82,9 +83,11 @@ public class StartSessionWizardTest extends StfHtmlTestCase {
             SESSION_WIZARD);
         assertTrue(contactList.contains(BOB.getBaseJid()));
 
-        // TODO click on user in list
-        // TODO click on Finish button
-        // TODO assert that dialog is closed
-
+        ALICE.htmlBot().view(SESSION_WIZARD).contactListItem(BOB.getBaseJid())
+            .click();
+        assertTrue(ALICE.htmlBot().view(SESSION_WIZARD).button("next-button")
+            .text().equals("Finish"));
+        ALICE.htmlBot().view(SESSION_WIZARD).button("next-button").click();
+        assertFalse(ALICE.htmlBot().view(SESSION_WIZARD).isOpen());
     }
 }


### PR DESCRIPTION
I reused the RemoteHTMLButton to make the ContactListItem clickable. So
now the STF can click on list items in the contact-list. But the wizard
has some more bugs so the test fails until someone fix the issues in the
wizard.