### PR TITLE
[UI][I] Add user notification for session status changes

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/context/SarosIntellijContextFactory.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/context/SarosIntellijContextFactory.java
@@ -11,6 +11,7 @@ import de.fu_berlin.inf.dpp.core.awareness.AwarenessInformationCollector;
 import de.fu_berlin.inf.dpp.core.monitoring.remote.IntelliJRemoteProgressIndicatorFactoryImpl;
 import de.fu_berlin.inf.dpp.core.project.internal.SarosIntellijSessionContextFactory;
 import de.fu_berlin.inf.dpp.core.ui.eventhandler.NegotiationHandler;
+import de.fu_berlin.inf.dpp.intellij.ui.eventhandler.SessionStatusChangeHandler;
 import de.fu_berlin.inf.dpp.core.ui.eventhandler.UserStatusChangeHandler;
 import de.fu_berlin.inf.dpp.core.ui.eventhandler.XMPPAuthorizationHandler;
 import de.fu_berlin.inf.dpp.core.util.IntelliJCollaborationUtilsImpl;
@@ -86,6 +87,7 @@ public class SarosIntellijContextFactory extends AbstractContextFactory {
         Component.create(NegotiationHandler.class),
         Component.create(UserStatusChangeHandler.class),
         Component.create(XMPPAuthorizationHandler.class),
+        Component.create(SessionStatusChangeHandler.class),
 
         Component.create(IChecksumCache.class, NullChecksumCache.class),
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/Messages.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/Messages.java
@@ -98,6 +98,17 @@ public class Messages {
 
     public static String ShareWithUserAction_description;
 
+    public static String SessionStatusChangeHandler_session_started_title;
+    public static String SessionStatusChangeHandler_session_started_host_message;
+    public static String SessionStatusChangeHandler_session_started_host_empty_message;
+    public static String SessionStatusChangeHandler_session_started_client_message;
+    public static String SessionStatusChangeHandler_session_ended_title;
+    public static String SessionStatusChangeHandler_session_ended_message;
+    public static String SessionStatusChangeHandler_local_user_left;
+    public static String SessionStatusChangeHandler_host_left;
+    public static String SessionStatusChangeHandler_kicked;
+    public static String SessionStatusChangeHandler_connection_lost;
+
     private Messages() {
     }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/eventhandler/SessionStatusChangeHandler.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/eventhandler/SessionStatusChangeHandler.java
@@ -1,0 +1,118 @@
+package de.fu_berlin.inf.dpp.intellij.ui.eventhandler;
+
+import de.fu_berlin.inf.dpp.intellij.ui.Messages;
+import de.fu_berlin.inf.dpp.intellij.ui.util.NotificationPanel;
+import de.fu_berlin.inf.dpp.session.ISarosSession;
+import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
+import de.fu_berlin.inf.dpp.session.ISessionLifecycleListener;
+import de.fu_berlin.inf.dpp.session.NullSessionLifecycleListener;
+import de.fu_berlin.inf.dpp.session.SessionEndReason;
+import de.fu_berlin.inf.dpp.session.User;
+import org.jetbrains.annotations.NotNull;
+
+import java.text.MessageFormat;
+import java.util.List;
+
+/**
+ * Notifies the local user when a session is started or the current session
+ * ended.
+ */
+public class SessionStatusChangeHandler {
+
+    public SessionStatusChangeHandler(
+        @NotNull
+            ISarosSessionManager sarosSessionManager) {
+
+        ISessionLifecycleListener lifecycleListener = new NullSessionLifecycleListener() {
+
+            @Override
+            public void sessionStarted(ISarosSession session) {
+
+                notifySessionStart(session);
+            }
+
+            @Override
+            public void sessionEnded(ISarosSession session,
+                SessionEndReason reason) {
+
+                notifySessionEnd(reason);
+            }
+        };
+
+        sarosSessionManager.addSessionLifecycleListener(lifecycleListener);
+    }
+
+    /**
+     * Notifies the user that a new session has started. If the local user is the
+     * host, this message includes a list of the current participants in the
+     * session (if present). If the local user is a client, this message
+     * includes the host whose session the user joined.
+     *
+     * @param session the session that was started
+     */
+    private void notifySessionStart(
+        @NotNull
+            ISarosSession session) {
+
+        String sessionStartMessage;
+
+        if (session.isHost()) {
+            List<User> participants = session.getRemoteUsers();
+
+            if (participants.isEmpty()) {
+                sessionStartMessage = Messages.SessionStatusChangeHandler_session_started_host_empty_message;
+
+            } else {
+                sessionStartMessage = MessageFormat.format(
+                    Messages.SessionStatusChangeHandler_session_started_host_message,
+                    participants);
+            }
+
+        } else {
+            sessionStartMessage = MessageFormat.format(
+                Messages.SessionStatusChangeHandler_session_started_client_message,
+                session.getHost());
+        }
+
+        NotificationPanel.showInformation(sessionStartMessage,
+            Messages.SessionStatusChangeHandler_session_started_title);
+
+    }
+
+    /**
+     * Notifies the local user that the current session has ended. The displayed
+     * message is dependent on the reason the session ended.
+     *
+     * @param reason the reason the session ended
+     */
+    private void notifySessionEnd(
+        @NotNull
+            SessionEndReason reason) {
+
+        String sessionEndExplanation;
+
+        switch (reason) {
+        case LOCAL_USER_LEFT:
+            sessionEndExplanation = Messages.SessionStatusChangeHandler_local_user_left;
+            break;
+        case HOST_LEFT:
+            sessionEndExplanation = Messages.SessionStatusChangeHandler_host_left;
+            break;
+        case KICKED:
+            sessionEndExplanation = Messages.SessionStatusChangeHandler_kicked;
+            break;
+        case CONNECTION_LOST:
+            sessionEndExplanation = Messages.SessionStatusChangeHandler_connection_lost;
+            break;
+        default:
+            sessionEndExplanation = reason.name();
+        }
+
+        String message = MessageFormat
+            .format(Messages.SessionStatusChangeHandler_session_ended_message,
+                sessionEndExplanation);
+
+        NotificationPanel.showInformation(message,
+            Messages.SessionStatusChangeHandler_session_ended_title);
+    }
+}

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/messages.properties
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/messages.properties
@@ -81,3 +81,14 @@ ContactPopMenu_error_creating_module_object_title=Problem while handling the mod
 ContactPopMenu_error_creating_module_object_message=Saros ran into an exception while trying to handle the module "{0}". Please make sure that the module is configured correctly.\n{1}
 
 ShareWithUserAction_description=Share this module with {0}
+
+SessionStatusChangeHandler_session_started_title=Saros Session Started
+SessionStatusChangeHandler_session_started_host_message=You successfully started a session with {0}.
+SessionStatusChangeHandler_session_started_host_empty_message=You successfully started a session.
+SessionStatusChangeHandler_session_started_client_message=You successfully joined the session of {0}.
+SessionStatusChangeHandler_session_ended_title=Saros Session Ended
+SessionStatusChangeHandler_session_ended_message=The current Saros session has ended: {0}
+SessionStatusChangeHandler_local_user_left=You left the session.
+SessionStatusChangeHandler_host_left=The host left the session.
+SessionStatusChangeHandler_kicked=The host removed you from the session.
+SessionStatusChangeHandler_connection_lost=You lost the connection to the host.


### PR DESCRIPTION
Adds a notification that informs the user when a new session is started.
For the host, this contains all users that the session is started with
(usually nobody). For clients, this contains the host of the joined
session.

Adds a notification that informs the user when the current session ends.
This notification also includes the reason the session ended.