### PR TITLE
[FIX][I] Also refresh content roots when refreshing the module object

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJProjectImplV2.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJProjectImplV2.java
@@ -51,7 +51,7 @@ public final class IntelliJProjectImplV2 extends IntelliJResourceImplV2
 
     private volatile Module module;
 
-    private final VirtualFile moduleRoot;
+    private volatile VirtualFile moduleRoot;
 
     /**
      * Creates a core compatible {@link IProject project} using the given
@@ -258,6 +258,10 @@ public final class IntelliJProjectImplV2 extends IntelliJResourceImplV2
             }
 
             module = newModule;
+
+            moduleRoot = getModuleContentRoot(module);
+            checkIfContentRootLocatedBelowProjectRoot(module, moduleRoot);
+            checkIfModuleFileLocatedInContentRoot(module, moduleRoot);
 
             return true;
         }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/ModuleInitialization.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/ModuleInitialization.java
@@ -149,7 +149,7 @@ public class ModuleInitialization implements Startable {
                         LOG.error("Failed to refresh the module object for " +
                             project + " as it it not disposed.");
                     }
-                } catch (ModuleNotFoundException e){
+                } catch (ModuleNotFoundException | IllegalArgumentException | IllegalStateException e) {
                     LOG.error("Failed to refresh the module object for " +
                         project, e);
                 }


### PR DESCRIPTION
The module object contained in an IntelliJProjectImplV2 can be refreshed
using the method #refreshModule(). To ensure that the state of the
IProject matches the loaded module, the contained content root is now
also reloaded and subsequently checked against our restrictions.