### PR TITLE
[FIX][I] Fix memory leak in EditorPool

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
@@ -557,11 +557,11 @@ public class EditorManager extends AbstractActivityProducer
     }
 
     public void removeAllEditorsForPath(SPath path) {
-        editorPool.removeAll(path);
+        editorPool.removeEditor(path);
     }
 
     public void replaceAllEditorsForPath(SPath oldPath, SPath newPath) {
-        editorPool.replaceAll(oldPath, newPath);
+        editorPool.replacePath(oldPath, newPath);
     }
 
     /**

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorHandler.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorHandler.java
@@ -189,7 +189,7 @@ public class LocalEditorHandler {
      * @param path path
      */
     public void removeEditor(@NotNull SPath path){
-        editorPool.removeAll(path);
+        editorPool.removeEditor(path);
     }
 
     /**


### PR DESCRIPTION
The EditorPool was storing Document objects. This is strongly
discouraged by the IntelliJ api documentation as it can lead to memory
leaks. This is explained in more detail in IntelliJ Platform SDK
DevGuide for Documents in the section ["How long does a document
persist?"](http://www.jetbrains.org/intellij/sdk/docs/basics/architectural_overview/documents.html#how-long-does-a-document-persist).
This problem is easily solved by not holding the document objects
persistently but rather creating them from the stored Editor objects
when they are needed.

Subsequently cleans up the EditorPool, adds more documentation to the
editor pool methods and introduces the usage of NotNull and Nullable
annotations.