### PR TITLE
[INTERNAL] Added IReferencePoint and its implementation

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IReferencePoint.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IReferencePoint.java
@@ -1,0 +1,19 @@
+package de.fu_berlin.inf.dpp.filesystem;
+
+/**
+ * The IReferencePoint represents the absolute path of the root of the shared
+ * subtree of {@link IResource}s. For IDEs the root of the subtree is a
+ * container, on which {@link IResource}, like {@link IFolder} and {@link IFile}
+ * , is accessible via the relative path from IReferencePoint to
+ * {@link IResource}.
+ * 
+ * This interface is under development: The IReferencePoint is the absolute path
+ * of {@link IProject}
+ * 
+ */
+public interface IReferencePoint {
+
+    /*
+     * Nothing here
+     */
+}

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IResource.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IResource.java
@@ -58,4 +58,11 @@ public interface IResource {
 
     public Object getAdapter(Class<? extends IResource> clazz);
 
+    /**
+     * Returns the {@link IReferencePoint} on which the resource referenced to
+     * 
+     * @return
+     */
+    public IReferencePoint getReferencePoint();
+
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJFileImplV2.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJFileImplV2.java
@@ -35,7 +35,7 @@ public final class IntelliJFileImplV2 extends IntelliJResourceImplV2 implements
         @NotNull final IPath path) {
         this.project = project;
         this.path = path;
-
+        this.referencePoint = project.getReferencePoint();
     }
 
     /**

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJFolderImplV2.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJFolderImplV2.java
@@ -34,6 +34,7 @@ public final class IntelliJFolderImplV2 extends IntelliJResourceImplV2
         @NotNull final IPath path) {
         this.project = project;
         this.path = path;
+        this.referencePoint = project.getReferencePoint();
     }
 
     @Override

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJProjectImplV2.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJProjectImplV2.java
@@ -81,6 +81,8 @@ public final class IntelliJProjectImplV2 extends IntelliJResourceImplV2
     public IntelliJProjectImplV2(@NotNull final Module module) {
         this.module = module;
         this.moduleName = module.getName();
+        this.referencePoint = new IntelliJReferencePointImpl((IntelliJPathImpl)
+            this.getLocation());
 
         moduleRoot = getModuleContentRoot(module);
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJReferencePointImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJReferencePointImpl.java
@@ -1,0 +1,38 @@
+package de.fu_berlin.inf.dpp.intellij.filesystem;
+
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
+import de.fu_berlin.inf.dpp.intellij.project.filesystem.IntelliJPathImpl;
+
+public class IntelliJReferencePointImpl implements IReferencePoint {
+
+    private final IntelliJPathImpl path;
+
+    public IntelliJReferencePointImpl(IntelliJPathImpl path) {
+        this.path = path;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((path == null) ? 0 : path.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        IntelliJReferencePointImpl other = (IntelliJReferencePointImpl) obj;
+        if (path == null) {
+            if (other.path != null)
+                return false;
+        } else if (!path.equals(other.path))
+            return false;
+        return true;
+    }
+}

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJResourceImplV2.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJResourceImplV2.java
@@ -1,5 +1,6 @@
 package de.fu_berlin.inf.dpp.intellij.filesystem;
 
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -7,9 +8,17 @@ import de.fu_berlin.inf.dpp.filesystem.IResource;
 
 public abstract class IntelliJResourceImplV2 implements IResource {
 
+    protected IReferencePoint referencePoint;
+
     @Nullable
     @Override
     public Object getAdapter(@NotNull Class<? extends IResource> clazz) {
         return clazz.isInstance(this) ? this : null;
+    }
+
+    @Override
+    public IReferencePoint getReferencePoint()
+    {
+        return referencePoint;
     }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJFolderImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJFolderImpl.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import de.fu_berlin.inf.dpp.filesystem.IFolder;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 
 import java.io.File;
@@ -94,6 +95,12 @@ public class IntelliJFolderImpl extends IntelliJResourceImpl
             return this;
         }
 
+        return null;
+    }
+
+    @Override
+    public IReferencePoint getReferencePoint()
+    {
         return null;
     }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJProjectImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJProjectImpl.java
@@ -7,6 +7,7 @@ import de.fu_berlin.inf.dpp.filesystem.IFile;
 import de.fu_berlin.inf.dpp.filesystem.IFolder;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
@@ -419,5 +420,11 @@ public class IntelliJProjectImpl implements IProject {
         }
 
         return getClass().getName() + sb;
+    }
+
+    @Override
+    public IReferencePoint getReferencePoint()
+    {
+        return null;
     }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJResourceImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJResourceImpl.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import org.jetbrains.annotations.NotNull;
 
@@ -224,5 +225,11 @@ public abstract class IntelliJResourceImpl implements IResource {
 
         return getType() == other.getType() && getLocation()
                 .equals(other.getLocation());
+    }
+
+    @Override
+    public IReferencePoint getReferencePoint()
+    {
+        return null;
     }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJWorkspaceRootImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJWorkspaceRootImpl.java
@@ -3,6 +3,7 @@ package de.fu_berlin.inf.dpp.intellij.project.filesystem;
 import de.fu_berlin.inf.dpp.filesystem.IContainer;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspaceRoot;
 
@@ -106,6 +107,12 @@ public class IntelliJWorkspaceRootImpl implements IWorkspaceRoot {
 
     @Override
     public Object getAdapter(Class<? extends IResource> clazz) {
+        return null;
+    }
+
+    @Override
+    public IReferencePoint getReferencePoint()
+    {
         return null;
     }
 }

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerReferencePointImpl.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerReferencePointImpl.java
@@ -1,0 +1,37 @@
+package de.fu_berlin.inf.dpp.server.filesystem;
+
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
+
+public class ServerReferencePointImpl implements IReferencePoint {
+
+    private final ServerPathImpl path;
+
+    public ServerReferencePointImpl(ServerPathImpl path) {
+        this.path = path;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((path == null) ? 0 : path.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ServerReferencePointImpl other = (ServerReferencePointImpl) obj;
+        if (path == null) {
+            if (other.path != null)
+                return false;
+        } else if (!path.equals(other.path))
+            return false;
+        return true;
+    }
+}

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerResourceImpl.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerResourceImpl.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import de.fu_berlin.inf.dpp.filesystem.IContainer;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 
@@ -17,6 +18,7 @@ public abstract class ServerResourceImpl implements IResource {
 
     private IWorkspace workspace;
     private IPath path;
+    protected IReferencePoint referencePoint;
 
     /**
      * Creates a ServerResourceImpl.
@@ -29,6 +31,8 @@ public abstract class ServerResourceImpl implements IResource {
     public ServerResourceImpl(IWorkspace workspace, IPath path) {
         this.path = path;
         this.workspace = workspace;
+        this.referencePoint = new ServerReferencePointImpl(
+            (ServerPathImpl) workspace.getLocation().append(path.segment(0)));
     }
 
     /**
@@ -129,5 +133,10 @@ public abstract class ServerResourceImpl implements IResource {
      */
     Path toNioPath() {
         return ((ServerPathImpl) getLocation()).getDelegate();
+    }
+
+    @Override
+    public IReferencePoint getReferencePoint() {
+        return referencePoint;
     }
 }

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/EclipseProjectImpl.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/EclipseProjectImpl.java
@@ -5,6 +5,9 @@ public class EclipseProjectImpl extends EclipseContainerImpl implements
 
     EclipseProjectImpl(org.eclipse.core.resources.IProject delegate) {
         super(delegate);
+
+        referencePoint = new EclipseReferencePointImpl(new EclipsePathImpl(
+            delegate.getLocation()));
     }
 
     @Override

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/EclipseReferencePointImpl.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/EclipseReferencePointImpl.java
@@ -1,0 +1,35 @@
+package de.fu_berlin.inf.dpp.filesystem;
+
+public class EclipseReferencePointImpl implements IReferencePoint {
+
+    private final EclipsePathImpl path;
+
+    public EclipseReferencePointImpl(EclipsePathImpl path) {
+        this.path = path;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((path == null) ? 0 : path.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        EclipseReferencePointImpl other = (EclipseReferencePointImpl) obj;
+        if (path == null) {
+            if (other.path != null)
+                return false;
+        } else if (!path.equals(other.path))
+            return false;
+        return true;
+    }
+}

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/EclipseResourceImpl.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/EclipseResourceImpl.java
@@ -8,12 +8,17 @@ import org.eclipse.core.runtime.OperationCanceledException;
 public class EclipseResourceImpl implements IResource {
 
     protected final org.eclipse.core.resources.IResource delegate;
+    protected IReferencePoint referencePoint;
 
     EclipseResourceImpl(org.eclipse.core.resources.IResource delegate) {
         if (delegate == null)
             throw new NullPointerException("delegate is null");
 
         this.delegate = delegate;
+
+        if (delegate.getProject() != null)
+            referencePoint = new EclipseReferencePointImpl(new EclipsePathImpl(
+                delegate.getProject().getLocation()));
     }
 
     @Override
@@ -191,5 +196,10 @@ public class EclipseResourceImpl implements IResource {
     @Override
     public String toString() {
         return delegate.toString() + " (" + getClass().getSimpleName() + ")";
+    }
+
+    @Override
+    public IReferencePoint getReferencePoint() {
+        return referencePoint;
     }
 }

--- a/de.fu_berlin.inf.dpp/test/junit/de/fu_berlin/inf/dpp/filesystem/IResourceTest.java
+++ b/de.fu_berlin.inf.dpp/test/junit/de/fu_berlin/inf/dpp/filesystem/IResourceTest.java
@@ -13,6 +13,12 @@ public class IResourceTest {
         org.eclipse.core.resources.IFolder folder = EasyMock
             .createMock(org.eclipse.core.resources.IFolder.class);
 
+        org.eclipse.core.resources.IProject project = EasyMock
+            .createMock(org.eclipse.core.resources.IProject.class);
+
+        org.eclipse.core.runtime.IPath path = EasyMock
+            .createMock(org.eclipse.core.runtime.IPath.class);
+
         Capture<Class<?>> mappedAdapterClassCapture = new Capture<Class<?>>();
 
         EasyMock.expect(
@@ -22,7 +28,11 @@ public class IResourceTest {
         EasyMock.expect(folder.getType()).andStubReturn(
             org.eclipse.core.resources.IResource.FOLDER);
 
-        EasyMock.replay(folder);
+        EasyMock.expect(folder.getProject()).andStubReturn(project);
+
+        EasyMock.expect(project.getLocation()).andStubReturn(path);
+
+        EasyMock.replay(folder, project, path);
 
         final IFolder coreFolder = new EclipseFolderImpl(folder);
 

--- a/de.fu_berlin.inf.dpp/test/junit/de/fu_berlin/inf/dpp/project/FileActivityConsumerTest.java
+++ b/de.fu_berlin.inf.dpp/test/junit/de/fu_berlin/inf/dpp/project/FileActivityConsumerTest.java
@@ -13,7 +13,9 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.junit.After;
 import org.junit.Before;
@@ -44,6 +46,8 @@ public class FileActivityConsumerTest {
      * before being used.
      */
     private IFile file;
+    private IProject project;
+    private IPath path;
 
     private SharedResourcesManager resourceChangeListener;
 
@@ -62,6 +66,13 @@ public class FileActivityConsumerTest {
 
         consumer = new FileActivityConsumer(null, resourceChangeListener, null);
 
+        path = createMock(IPath.class);
+        replay(path);
+
+        project = createMock(IProject.class);
+        expect(project.getLocation()).andStubReturn(path);
+        replay(project);
+
         file = createMock(IFile.class);
 
         expect(file.getContents()).andStubReturn(
@@ -71,6 +82,7 @@ public class FileActivityConsumerTest {
         expect(file.getType()).andStubReturn(IResource.FILE);
         expect(file.getAdapter(IFile.class)).andStubReturn(file);
 
+        expect(file.getProject()).andStubReturn(project);
     }
 
     @After


### PR DESCRIPTION
The Saros filesystem gets a new component in its filesystem:
IReferencePoint. The first step of the refactoring that the
reference point of each files/folders points on the location
of the projects. So the IResource interface gets a new method
called getReferencePoint() and returns the reference point.
The IReferencePoint interface is empty. Its implementation
contains an IPath object from the location of the referenced
resource (project at first) and an IReferencePoint object is
comparable over the IPath object.

In issue https://github.com/saros-project/saros/issues/177 is a detailed description, what an IReferencePoint is, for what we need this and which steps planned for the future commits