### PR TITLE
[FIX][I] Add session check when opening an editor

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorHandler.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorHandler.java
@@ -76,6 +76,10 @@ public class LocalEditorHandler {
         @NotNull
             VirtualFile virtualFile, boolean activate) {
 
+        if (!manager.hasSession()) {
+            return null;
+        }
+
         SPath path = virtualFileConverter.convertToPath(virtualFile);
 
         if (path == null) {
@@ -83,7 +87,6 @@ public class LocalEditorHandler {
                 " as it does not belong to a shared module");
 
             return null;
-
         }
 
         return openEditor(virtualFile,path,activate);


### PR DESCRIPTION
Adds a session check to LocalEditorManager#openEditor(...).
This allows us to avoid false log entries claiming that the open editors
belong to non-shared modules while there is no session.