### PR TITLE
[FIX][CORE] #233 Correctly create ChecksumActivities for missing files

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/concurrent/watchdog/ConsistencyWatchdogClient.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/concurrent/watchdog/ConsistencyWatchdogClient.java
@@ -296,6 +296,14 @@ public class ConsistencyWatchdogClient extends AbstractActivityProducer
             return true;
         }
 
+        if (!checksum.existsFile() && !existsFileLocally) {
+            LOG.debug(
+                    "Ignoring checksum activity for file that does not exist on both sides: "
+                            + path);
+
+            return false;
+        }
+
         final String editorContent = editorManager.getContent(path);
 
         if (editorContent == null) {

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/concurrent/watchdog/ConsistencyWatchdogServer.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/concurrent/watchdog/ConsistencyWatchdogServer.java
@@ -257,8 +257,8 @@ public class ConsistencyWatchdogServer extends AbstractActivityProducer
          * Ensures that the watchdog server doesn't use outdated checksums for
          * files that no longer exist locally.
          */
-        if (!docPath.getFile().exists()
-                && checksum.getHash() != DocumentChecksum.NOT_AVAILABLE) {
+        if (checksum.getHash() != DocumentChecksum.NOT_AVAILABLE && !docPath
+                .getFile().exists()) {
 
             LOG.debug("Updating checksum for " + docPath + " to correctly "
                     + "represent that the file no longer exists locally: "

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/concurrent/watchdog/ConsistencyWatchdogServer.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/concurrent/watchdog/ConsistencyWatchdogServer.java
@@ -257,9 +257,11 @@ public class ConsistencyWatchdogServer extends AbstractActivityProducer
          * Ensures that the watchdog server doesn't use outdated checksums for
          * files that no longer exist locally.
          */
-        if (!docPath.getFile().exists()) {
-            LOG.debug("Marking checksum for " + docPath
-                    + " as dirty as the file no longer exists locally: "
+        if (!docPath.getFile().exists()
+                && checksum.getHash() != DocumentChecksum.NOT_AVAILABLE) {
+
+            LOG.debug("Updating checksum for " + docPath + " to correctly "
+                    + "represent that the file no longer exists locally: "
                     + checksum);
 
             checksum.markDirty();

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/concurrent/watchdog/ConsistencyWatchdogServer.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/concurrent/watchdog/ConsistencyWatchdogServer.java
@@ -253,8 +253,20 @@ public class ConsistencyWatchdogServer extends AbstractActivityProducer
             documentChecksums.put(docPath, checksum);
         }
 
-        if (!checksum.isDirty())
+        /*
+         * Ensures that the watchdog server doesn't use outdated checksums for
+         * files that no longer exist locally.
+         */
+        if (!docPath.getFile().exists()) {
+            checksum.markDirty();
+
+            LOG.debug("Marking checksum for " + docPath
+                    + " as dirty as the file no longer exists locally: "
+                    + checksum);
+
+        } else if (!checksum.isDirty()) {
             return;
+        }
 
         String content = editorManager.getContent(checksum.getPath());
 

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/concurrent/watchdog/ConsistencyWatchdogServer.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/concurrent/watchdog/ConsistencyWatchdogServer.java
@@ -258,11 +258,14 @@ public class ConsistencyWatchdogServer extends AbstractActivityProducer
          * files that no longer exist locally.
          */
         if (!docPath.getFile().exists()) {
-            checksum.markDirty();
-
             LOG.debug("Marking checksum for " + docPath
                     + " as dirty as the file no longer exists locally: "
                     + checksum);
+
+            checksum.markDirty();
+            checksum.update(null);
+
+            return;
 
         } else if (!checksum.isDirty()) {
             return;


### PR DESCRIPTION
Adds a check on the host side to ensure that existing checksums for
files are only used if the file still exists locally.

Adds a check on the client side to ensure that checksums for files
that don't exist on both sides don't trigger an inconsistency.