### PR TITLE
[INTERNAL][I] Add methods to handle annotations for moved/deleted files

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/annotations/AbstractEditorAnnotation.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/annotations/AbstractEditorAnnotation.java
@@ -28,7 +28,7 @@ import java.util.List;
  */
 abstract class AbstractEditorAnnotation {
     private final User user;
-    private final IFile file;
+    private IFile file;
     private final List<AnnotationRange> annotationRanges;
 
     private Editor editor;
@@ -221,6 +221,18 @@ abstract class AbstractEditorAnnotation {
             AnnotationRange annotationRange) {
 
         annotationRanges.remove(annotationRange);
+    }
+
+    /**
+     * Changes the file the annotation belongs to.
+     *
+     * @param newFile the new file of the annotation
+     */
+    void updateFile(
+        @NotNull
+            IFile newFile) {
+
+        file = newFile;
     }
 
     @NotNull

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/annotations/AnnotationManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/annotations/AnnotationManager.java
@@ -582,6 +582,35 @@ public class AnnotationManager {
     }
 
     /**
+     * Removes all annotations belonging to the given file from all annotation
+     * stores and from the editor for the file.
+     * <p></p>
+     * This method should be used when a file is deleted or removed from the
+     * session scope.
+     *
+     * @param file the file to remove from the annotation store
+     */
+    public void removeAnnotations(
+        @NotNull
+            IFile file) {
+
+        for (SelectionAnnotation selectionAnnotation : selectionAnnotationStore
+            .getAnnotations(file)) {
+
+            removeRangeHighlighter(selectionAnnotation);
+            selectionAnnotationStore.removeAnnotation(selectionAnnotation);
+        }
+
+        for (ContributionAnnotation contributionAnnotation : contributionAnnotationQueue
+            .getAnnotations(file)) {
+
+            removeRangeHighlighter(contributionAnnotation);
+            contributionAnnotationQueue
+                .removeAnnotation(contributionAnnotation);
+        }
+    }
+
+    /**
      * Removes all annotations from all open editors and removes all the stored
      * annotations from all annotation stores.
      */
@@ -591,6 +620,73 @@ public class AnnotationManager {
 
         contributionAnnotationQueue.removeAllAnnotations()
             .forEach(this::removeRangeHighlighter);
+    }
+
+    /**
+     * Sets the given new file as the file for all annotations belonging to the
+     * given old file and updates the mapping of all annotation stores.
+     * <p></p>
+     * This method should be used when a file is moved.
+     * <p>
+     * Whether or not the move was caused locally should be specified using the
+     * boolean <code>causedLocally</code>.
+     * If the move was caused by a local action, the editor and range
+     * highlighters contained in the stored annotations can still be used as
+     * they will get updated by the internal Intellij logic. If the move was
+     * caused by a received Saros activity, the local representation has to be
+     * removed. It will be re-created once an editor for the new file is opened.
+     * </p>
+     *
+     * @param oldFile       the old file of the annotations
+     * @param newFile       the new file of the annotations
+     * @param causedLocally whether the file move was caused locally or received
+     *                      from another participant
+     */
+    public void updateAnnotationPath(
+        @NotNull
+            IFile oldFile,
+        @NotNull
+            IFile newFile, boolean causedLocally) {
+
+        updateAnnotationPath(newFile,
+            selectionAnnotationStore.getAnnotations(oldFile), causedLocally);
+
+        selectionAnnotationStore.updateAnnotationPath(oldFile, newFile);
+
+        updateAnnotationPath(newFile,
+            contributionAnnotationQueue.getAnnotations(oldFile), causedLocally);
+
+        contributionAnnotationQueue.updateAnnotationPath(oldFile, newFile);
+    }
+
+    /**
+     * Sets the given file as the new file for the given annotations to
+     * correctly store the new path of a moved file. If the move was not
+     * triggered locally, also removes the local representation of the given
+     * annotations.
+     *
+     * @param newFile        the new file of the annotations
+     * @param oldAnnotations the annotations for the old file
+     * @param causedLocally  whether the file move was caused locally or
+     *                       received from another participant
+     * @param <E>            the type of annotations stored in the given
+     *                       annotation store
+     */
+    private <E extends AbstractEditorAnnotation> void updateAnnotationPath(
+        @NotNull
+            IFile newFile,
+        @NotNull
+            List<E> oldAnnotations, boolean causedLocally) {
+
+        for (E oldAnnotation : oldAnnotations) {
+            oldAnnotation.updateFile(newFile);
+
+            if (!causedLocally) {
+                removeRangeHighlighter(oldAnnotation);
+
+                oldAnnotation.removeLocalRepresentation();
+            }
+        }
     }
 
     /**

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/annotations/AnnotationManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/annotations/AnnotationManager.java
@@ -628,47 +628,49 @@ public class AnnotationManager {
      * <p></p>
      * This method should be used when a file is moved.
      * <p>
-     * Whether or not the move was caused locally should be specified using the
-     * boolean <code>causedLocally</code>.
+     * <b>NOTE:</b> If the move was caused by a received Saros activity, the
+     * local representation has to be removed from the corresponding
+     * annotations. This method assumes that such local representations were
+     * already removed if necessary. This can be done by closing the old editor
+     * before calling this method. The local representation for all annotations
+     * will then be re-created once an editor for the new file is opened.
+     * </p>
      * If the move was caused by a local action, the editor and range
      * highlighters contained in the stored annotations can still be used as
-     * they will get updated by the internal Intellij logic. If the move was
-     * caused by a received Saros activity, the local representation has to be
-     * removed. It will be re-created once an editor for the new file is opened.
-     * </p>
+     * they will get updated by the internal Intellij logic.
      *
-     * @param oldFile       the old file of the annotations
-     * @param newFile       the new file of the annotations
-     * @param causedLocally whether the file move was caused locally or received
-     *                      from another participant
+     * @param oldFile the old file of the annotations
+     * @param newFile the new file of the annotations
      */
     public void updateAnnotationPath(
         @NotNull
             IFile oldFile,
         @NotNull
-            IFile newFile, boolean causedLocally) {
+            IFile newFile) {
 
         updateAnnotationPath(newFile,
-            selectionAnnotationStore.getAnnotations(oldFile), causedLocally);
+            selectionAnnotationStore.getAnnotations(oldFile));
 
         selectionAnnotationStore.updateAnnotationPath(oldFile, newFile);
 
         updateAnnotationPath(newFile,
-            contributionAnnotationQueue.getAnnotations(oldFile), causedLocally);
+            contributionAnnotationQueue.getAnnotations(oldFile));
 
         contributionAnnotationQueue.updateAnnotationPath(oldFile, newFile);
     }
 
     /**
      * Sets the given file as the new file for the given annotations to
-     * correctly store the new path of a moved file. If the move was not
-     * triggered locally, also removes the local representation of the given
-     * annotations.
+     * correctly store the new path of a moved file.
+     * <p>
+     * <b>NOTE:</b> If the move was caused by a received Saros activity, the
+     * local representation has to be removed from the corresponding
+     * annotations. This method assumes that such local representations were
+     * already removed if necessary.
+     * </p>
      *
      * @param newFile        the new file of the annotations
      * @param oldAnnotations the annotations for the old file
-     * @param causedLocally  whether the file move was caused locally or
-     *                       received from another participant
      * @param <E>            the type of annotations stored in the given
      *                       annotation store
      */
@@ -676,16 +678,10 @@ public class AnnotationManager {
         @NotNull
             IFile newFile,
         @NotNull
-            List<E> oldAnnotations, boolean causedLocally) {
+            List<E> oldAnnotations) {
 
         for (E oldAnnotation : oldAnnotations) {
             oldAnnotation.updateFile(newFile);
-
-            if (!causedLocally) {
-                removeRangeHighlighter(oldAnnotation);
-
-                oldAnnotation.removeLocalRepresentation();
-            }
         }
     }
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/annotations/AnnotationStore.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/annotations/AnnotationStore.java
@@ -214,4 +214,27 @@ class AnnotationStore<E extends AbstractEditorAnnotation> {
 
         return removedAnnotations;
     }
+
+    /**
+     * Sets the given new file as the file for all annotations belonging to the
+     * given old file.
+     * <p></p>
+     * This method should be used to update the annotation store when a file is
+     * moved.
+     *
+     * @param oldFile the old file of the annotations
+     * @param newFile the new file of the annotations
+     */
+    void updateAnnotationPath(
+        @NotNull
+            IFile oldFile,
+        @NotNull
+            IFile newFile) {
+
+        Map<User, List<E>> oldMapping = annotationMap.remove(oldFile);
+
+        if (oldMapping != null) {
+            annotationMap.put(newFile, oldMapping);
+        }
+    }
 }


### PR DESCRIPTION
Adds methods that can be used to clean up the annotation store when
files are moved or deleted. These methods are needed in the upcoming
patches introducing the new logic handling file creations, deletions,
moves and renamings.