### PR TITLE
Clean up StoppableDocumentListener

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
@@ -413,7 +413,7 @@ public class EditorManager extends AbstractActivityProducer
             session.addActivityProducer(EditorManager.this);
             session.addActivityConsumer(consumer, Priority.ACTIVE);
 
-            documentListener.startListening();
+            documentListener.setEnabled(true);
 
             userEditorStateManager = session
                 .getComponent(UserEditorStateManager.class);
@@ -438,7 +438,7 @@ public class EditorManager extends AbstractActivityProducer
             session.removeActivityProducer(EditorManager.this);
             session.removeActivityConsumer(consumer);
 
-            documentListener.stopListening();
+            documentListener.setEnabled(false);
 
             session = null;
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/StoppableDocumentListener.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/StoppableDocumentListener.java
@@ -24,7 +24,7 @@ public class StoppableDocumentListener extends AbstractStoppableListener
 
     private final VirtualFileConverter virtualFileConverter;
 
-    public StoppableDocumentListener(EditorManager editorManager,
+    StoppableDocumentListener(EditorManager editorManager,
         VirtualFileConverter virtualFileConverter) {
 
         super(editorManager);
@@ -72,16 +72,6 @@ public class StoppableDocumentListener extends AbstractStoppableListener
 
         editorManager
             .generateTextEdit(event.getOffset(), newText, replacedText, path);
-    }
-
-    /**
-     * Does nothing.
-     *
-     * @param event
-     */
-    @Override
-    public void documentChanged(DocumentEvent event) {
-        // do nothing. We handled everything in documentAboutToBeChanged
     }
 
     @Override

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/StoppableDocumentListener.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/StoppableDocumentListener.java
@@ -86,36 +86,22 @@ public class StoppableDocumentListener extends AbstractStoppableListener
 
     @Override
     public void setEnabled(boolean enabled) {
-        if (enabled) {
-            startListening();
-        } else {
-            stopListening();
-        }
-    }
-
-    /**
-     * Stop listening for document modifications.
-     */
-    public void stopListening() {
-        if (enabled) {
-            EditorFactory.getInstance().getEventMulticaster()
-                .removeDocumentListener(this);
-            LOG.debug("Stopped listening for document events");
-        }
-
-        super.setEnabled(false);
-    }
-
-    /**
-     * Start listening for document modifications.
-     */
-    public void startListening() {
-        if (!enabled) {
-            EditorFactory.getInstance().getEventMulticaster()
-                .addDocumentListener(this);
+        if (!this.enabled && enabled) {
             LOG.debug("Started listening for document events");
-        }
 
-        super.setEnabled(true);
+            EditorFactory.getInstance().getEventMulticaster()
+                    .addDocumentListener(this);
+
+            this.enabled = true;
+
+        } else if (this.enabled && !enabled) {
+
+            LOG.debug("Stopped listening for document events");
+
+            EditorFactory.getInstance().getEventMulticaster()
+                    .removeDocumentListener(this);
+
+            this.enabled = false;
+        }
     }
 }

--- a/de.fu_berlin.inf.dpp.intellij/test/junit/de/fu_berlin/inf/dpp/intellij/editor/StoppableDocumentListenerTest.java
+++ b/de.fu_berlin.inf.dpp.intellij/test/junit/de/fu_berlin/inf/dpp/intellij/editor/StoppableDocumentListenerTest.java
@@ -32,21 +32,6 @@ public class StoppableDocumentListenerTest {
     }
 
     @Test
-    public void testStart() {
-        listener.startListening();
-
-        assertListening();
-    }
-
-    @Test
-    public void testStop() {
-        listener.startListening();
-        listener.stopListening();
-
-        assertNotListening();
-    }
-
-    @Test
     public void testEnable() {
         listener.setEnabled(true);
 
@@ -55,7 +40,7 @@ public class StoppableDocumentListenerTest {
 
     @Test
     public void testDisable() {
-        listener.startListening();
+        listener.setEnabled(true);
         listener.setEnabled(false);
 
         assertNotListening();


### PR DESCRIPTION
Moves the functionality of the classes startListening() and stopListening() into setEnabled(boolean).

Removes an empty implementation of an interface class that has become unnecessary with the introduction of the default modifier for interface methods.

Makes the class package-private as it is not accessed outside the package.