### PR TITLE
[CORE] Successive and combined project negotiations

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ProjectNegotiationCollector.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ProjectNegotiationCollector.java
@@ -1,0 +1,58 @@
+package de.fu_berlin.inf.dpp.negotiation;
+
+import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IResource;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+/**
+ * This class collects resources that should be added to a session to add them at once in
+ * preparation of a new single project negotiation. The reason is to prevent multiple concurrent
+ * running project negotiations per user.
+ */
+public class ProjectNegotiationCollector {
+  private Map<IProject, List<IResource>> mapping = new HashMap<IProject, List<IResource>>();
+
+  /**
+   * Add project resource mappings for the next project negotiation.
+   *
+   * @param projectResourcesMapping project resource mappings to add
+   */
+  public synchronized void add(Map<IProject, List<IResource>> projectResourcesMapping) {
+    for (Entry<IProject, List<IResource>> mapEntry : projectResourcesMapping.entrySet()) {
+      final IProject project = mapEntry.getKey();
+      final List<IResource> resources = mapEntry.getValue();
+
+      boolean alreadyFullShared = mapping.containsKey(project) && mapping.get(project) == null;
+
+      /* full shared project */
+      if (resources == null || alreadyFullShared) {
+        mapping.put(project, null);
+        continue;
+      }
+
+      /* update partial shared project */
+      List<IResource> mappedResources = mapping.get(project);
+      if (mappedResources == null) {
+        mapping.put(project, new ArrayList<IResource>(resources));
+      } else {
+        mappedResources.addAll(resources);
+      }
+    }
+  }
+
+  /**
+   * Returns a list of project resource mappings that should be handled by a project negotiation.
+   * Resets the Collector for next additions.
+   *
+   * @return project resource mappings to add
+   */
+  public synchronized Map<IProject, List<IResource>> get() {
+    Map<IProject, List<IResource>> tmp = mapping;
+    mapping = new HashMap<IProject, List<IResource>>();
+    return tmp;
+  }
+}

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ProjectNegotiationObservable.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ProjectNegotiationObservable.java
@@ -106,4 +106,18 @@ final class ProjectNegotiationObservable {
 
     return currentNegotiations;
   }
+
+  /**
+   * Returns <tt>true</tt> if no running negotiations exist.
+   *
+   * @return <tt>true</tt> if no running negotiations exist
+   */
+  public synchronized boolean isEmpty() {
+    for (List<ProjectNegotiation> negotiationList : negotiations.values()) {
+      if (!negotiationList.isEmpty()) {
+        return false;
+      }
+    }
+    return true;
+  }
 }


### PR DESCRIPTION
Currently Saros creates a new project negotiation for every individually
added project resource. This leads to multiple concurrent negotiations
per user, which creates more overhead for transportation and user
interaction for every single negotiation. Additionally, it leads to
unexpected behavior because a new negotiation will transfer all files
currently not available on the remote machine, including files from
unfinished negotiation transfers.

This patch ensures that only one project negotiation per user is running
and all new shared resources are queued till all ongoing negotations
finished, before starting a new negotiation with all queued resources /
projects combined.