### PR TITLE
Adjust SarosSessionManager and IWorkspace/-Runnable to ReferencePoints

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IWorkspace.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IWorkspace.java
@@ -3,6 +3,7 @@ package de.fu_berlin.inf.dpp.filesystem;
 import java.io.IOException;
 
 import de.fu_berlin.inf.dpp.exceptions.OperationCanceledException;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 
 /**
  * This interface is under development. It currently equals its Eclipse
@@ -33,11 +34,12 @@ public interface IWorkspace {
      * {@linkplain #run(IWorkspaceRunnable)}.
      * 
      * @param runnable
-     * @param resources
+     * @param referencePoints
+     * @param referencePointManager TODO
      * @throws IOException
      * @throws OperationCanceledException
      */
-    public void run(IWorkspaceRunnable runnable, IResource[] resources)
+    public void run(IWorkspaceRunnable runnable, IReferencePoint[] referencePoints, IReferencePointManager referencePointManager)
         throws IOException, OperationCanceledException;
 
     public IProject getProject(String project);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveIncomingReferencePointNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveIncomingReferencePointNegotiation.java
@@ -15,9 +15,7 @@ import de.fu_berlin.inf.dpp.communication.extensions.StartActivityQueuingRespons
 import de.fu_berlin.inf.dpp.exceptions.LocalCancellationException;
 import de.fu_berlin.inf.dpp.exceptions.SarosCancellationException;
 import de.fu_berlin.inf.dpp.filesystem.IChecksumCache;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
-import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
 import de.fu_berlin.inf.dpp.monitoring.SubProgressMonitor;
@@ -27,13 +25,15 @@ import de.fu_berlin.inf.dpp.net.ITransmitter;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
 import de.fu_berlin.inf.dpp.net.xmpp.XMPPConnectionService;
 import de.fu_berlin.inf.dpp.observables.FileReplacementInProgressObservable;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
 import de.fu_berlin.inf.dpp.util.CoreUtils;
 
 /**
  * Implementation of {@link AbstractIncomingReferencePointNegotiation} utilizing
- * a transferred zip archive to exchange differences in the project files.
+ * a transferred zip archive to exchange differences in the files from reference
+ * points
  */
 public class ArchiveIncomingReferencePointNegotiation extends
     AbstractIncomingReferencePointNegotiation {
@@ -44,7 +44,7 @@ public class ArchiveIncomingReferencePointNegotiation extends
     public ArchiveIncomingReferencePointNegotiation(
         final JID peer, //
         final String negotiationID, //
-        final List<ReferencePointNegotiationData> projectNegotiationData, //
+        final List<ReferencePointNegotiationData> referencePointNegotiationData, //
 
         final ISarosSessionManager sessionManager, //
         final ISarosSession session, //
@@ -58,7 +58,7 @@ public class ArchiveIncomingReferencePointNegotiation extends
         final IReceiver receiver //
     ) {
         super(peer, TransferType.ARCHIVE, negotiationID,
-            projectNegotiationData, sessionManager, session,
+            referencePointNegotiationData, sessionManager, session,
             fileReplacementInProgressObservable, workspace, checksumCache,
             connectionService, transmitter, receiver);
     }
@@ -150,15 +150,17 @@ public class ArchiveIncomingReferencePointNegotiation extends
         final File archiveFile, final IProgressMonitor monitor)
         throws LocalCancellationException, IOException {
 
-        final Map<String, IProject> projectMapping = new HashMap<String, IProject>();
+        final Map<String, IReferencePoint> referencePointMapping = new HashMap<String, IReferencePoint>();
 
         for (Entry<String, IReferencePoint> entry : localReferencePointMapping
             .entrySet())
-            projectMapping.put(entry.getKey(),
-                referencePointManager.get(entry.getValue()));
+            referencePointMapping.put(entry.getKey(), entry.getValue());
 
+        IReferencePointManager referencePointManager = session
+            .getComponent(IReferencePointManager.class);
         final DecompressArchiveTask decompressTask = new DecompressArchiveTask(
-            archiveFile, projectMapping, PATH_DELIMITER, monitor);
+            archiveFile, referencePointMapping, PATH_DELIMITER, monitor,
+            referencePointManager);
 
         long startTime = System.currentTimeMillis();
 
@@ -173,8 +175,8 @@ public class ArchiveIncomingReferencePointNegotiation extends
          */
 
         try {
-            workspace.run(decompressTask,
-                projectMapping.values().toArray(new IResource[0]));
+            workspace.run(decompressTask, referencePointMapping.values()
+                .toArray(new IReferencePoint[0]), referencePointManager);
         } catch (de.fu_berlin.inf.dpp.exceptions.OperationCanceledException e) {
             LocalCancellationException canceled = new LocalCancellationException(
                 null, CancelOption.DO_NOT_NOTIFY_PEER);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/DecompressArchiveTask.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/DecompressArchiveTask.java
@@ -14,10 +14,12 @@ import de.fu_berlin.inf.dpp.exceptions.OperationCanceledException;
 import de.fu_berlin.inf.dpp.filesystem.FileSystem;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspaceRunnable;
 import de.fu_berlin.inf.dpp.monitoring.CancelableInputStream;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 
 public class DecompressArchiveTask implements IWorkspaceRunnable {
@@ -27,8 +29,9 @@ public class DecompressArchiveTask implements IWorkspaceRunnable {
 
     private final File file;
     private final IProgressMonitor monitor;
-    private final Map<String, IProject> idToProjectMapping;
+    private final Map<String, IReferencePoint> idToReferencePointMapping;
     private final String delimiter;
+    private final IReferencePointManager referencePointManager;
 
     /**
      * Creates a decompress task for an archive file that can be executed by
@@ -38,22 +41,25 @@ public class DecompressArchiveTask implements IWorkspaceRunnable {
      * 
      * @param file
      *            Zip file containing the compressed data
-     * @param idToProjectMapping
-     *            map containing the id to project mapping (see also
-     *            {@link ISarosSession#getProjectID(de.fu_berlin.inf.dpp.filesystem.IProject)}
-     * 
+     * @param idToReferencePointMapping
+     *            map containing the id to referencePoint mapping (see also
+     *            {@link ISarosSession#getReferencePointID(de.fu_berlin.inf.dpp.filesystem.IReferencePoint)}
      * @param monitor
      *            monitor that is used for progress report and cancellation or
      *            <code>null</code> to use the monitor provided by the
      *            {@link #run(IProgressMonitor)} method
+     * @param referencePointManager
+     *            returns the container resource given by a referencePoint
      */
     public DecompressArchiveTask(final File file,
-        final Map<String, IProject> idToProjectMapping, final String delimiter,
-        final IProgressMonitor monitor) {
+        final Map<String, IReferencePoint> idToReferencePointMapping,
+        final String delimiter, final IProgressMonitor monitor,
+        IReferencePointManager referencePointManager) {
         this.file = file;
-        this.idToProjectMapping = idToProjectMapping;
+        this.idToReferencePointMapping = idToReferencePointMapping;
         this.delimiter = delimiter;
         this.monitor = monitor;
+        this.referencePointManager = referencePointManager;
     }
 
     // TODO extract as much as possible even on some failures
@@ -101,15 +107,18 @@ public class DecompressArchiveTask implements IWorkspaceRunnable {
                 final String path = entryName.substring(delimiterIdx + 1,
                     entryName.length());
 
-                final IProject project = idToProjectMapping.get(id);
+                final IReferencePoint referencePoint = idToReferencePointMapping
+                    .get(id);
 
-                if (project == null) {
+                if (referencePoint == null) {
                     LOG.warn("skipping zip entry " + entryName
-                        + ", unknown project id: " + id);
+                        + ", unknown referencePoint id: " + id);
 
                     monitor.worked(1);
                     continue;
                 }
+
+                IProject project = referencePointManager.get(referencePoint);
 
                 final IFile decompressedFile = project.getFile(path);
 

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/stream/IncomingStreamProtocol.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/stream/IncomingStreamProtocol.java
@@ -11,7 +11,7 @@ import org.apache.log4j.Logger;
 import de.fu_berlin.inf.dpp.exceptions.LocalCancellationException;
 import de.fu_berlin.inf.dpp.filesystem.FileSystem;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
 import de.fu_berlin.inf.dpp.negotiation.NegotiationTools.CancelOption;
 import de.fu_berlin.inf.dpp.session.IReferencePointManager;
@@ -49,16 +49,17 @@ public class IncomingStreamProtocol extends AbstractStreamProtocol {
         BoundedInputStream fileIn = null;
         try {
             while (true) {
-                String projectID = in.readUTF();
+                String referencePointID = in.readUTF();
 
                 /* check stream end */
-                if (projectID.isEmpty())
+                if (referencePointID.isEmpty())
                     break;
 
                 String fileName = in.readUTF();
-                IProject project = referencePointManager.get(session
-                    .getReferencePoint(projectID));
-                IFile file = project.getFile(fileName);
+                IReferencePoint referencePoint = session
+                    .getReferencePoint(referencePointID);
+                IFile file = referencePointManager.get(referencePoint).getFile(
+                    fileName);
 
                 String message = "receiving " + displayName(file);
                 log.debug(message);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ISarosSessionManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ISarosSessionManager.java
@@ -4,7 +4,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
@@ -25,10 +25,13 @@ public interface ISarosSessionManager {
     /**
      * Starts a new DPP session with the local user as only participant.
      * 
-     * @param projectResources
-     *            the local project resources which should be shared.
+     * @param referencePointResources
+     *            the local resources from referencePoint which should be
+     *            shared.
      */
-    public void startSession(Map<IProject, List<IResource>> projectResources);
+    public void startSession(
+        Map<IReferencePoint, List<IResource>> referencePointResources,
+        IReferencePointManager referencePointManager);
 
     // FIXME this method is error prone and only used by the IPN, find a better
     // abstraction
@@ -70,13 +73,14 @@ public interface ISarosSessionManager {
         ISessionLifecycleListener listener);
 
     /**
-     * Starts sharing all projects of the current session with the given session
-     * user. This should be called after the user joined the current session.
+     * Starts sharing all resources with referencePoints of the current session
+     * with the given session user. This should be called after the user joined
+     * the current session.
      * 
      * @param user
      *            JID of the user to share projects with
      */
-    public void startSharingProjects(JID user);
+    public void startSharingReferencePoint(JID user);
 
     /**
      * Invites a user to a running session. Does nothing if no session is
@@ -97,13 +101,13 @@ public interface ISarosSessionManager {
     public void invite(Collection<JID> jidsToInvite, String description);
 
     /**
-     * Adds project resources to an existing session.
+     * Adds resources from referencePoint to an existing session.
      * 
-     * @param projectResourcesMapping
+     * @param referencePointResourcesMapping
      * 
      */
     public void addResourcesToSession(
-        Map<IProject, List<IResource>> projectResourcesMapping);
+        Map<IReferencePoint, List<IResource>> referencePointResourcesMapping);
 
     /**
      * Call this before a ISarosSession is started.

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/NegotiationPacketListener.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/NegotiationPacketListener.java
@@ -140,7 +140,7 @@ final class NegotiationPacketListener {
                 return;
             }
 
-            projectNegotiationRequest(new JID(packet.getFrom()),
+            referencePointNegotiationRequest(new JID(packet.getFrom()),
                 extension.getNegotiationID(), extension.getTransferType(),
                 extension.getProjectNegotiationData());
         }
@@ -279,14 +279,14 @@ final class NegotiationPacketListener {
         }
     }
 
-    private void projectNegotiationRequest(final JID sender,
+    private void referencePointNegotiationRequest(final JID sender,
         final String negotiationID, final TransferType transferType,
         final List<ReferencePointNegotiationData> projectNegotiationData) {
 
         LOG.info("received project negotiation from " + sender
             + " with negotiation id: " + negotiationID);
 
-        sessionManager.projectNegotiationRequestReceived(sender, transferType,
+        sessionManager.referencePointpointNegotiationRequestReceived(sender, transferType,
             projectNegotiationData, negotiationID);
     }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
@@ -222,9 +222,10 @@ public final class SarosSession implements ISarosSession {
      * Constructor for host.
      */
     public SarosSession(final String id, IPreferenceStore properties,
-        IContainerContext containerContext) {
+        IContainerContext containerContext,
+        IReferencePointManager referencePointManager) {
         this(id, containerContext, properties, /* unused */
-        null, /* unused */null);
+        null, /* unused */null, referencePointManager);
     }
 
     /**
@@ -233,7 +234,8 @@ public final class SarosSession implements ISarosSession {
     public SarosSession(final String id, JID hostJID,
         IPreferenceStore localProperties, IPreferenceStore hostProperties,
         IContainerContext containerContext) {
-        this(id, containerContext, localProperties, hostJID, hostProperties);
+        this(id, containerContext, localProperties, hostJID, hostProperties,
+            new ReferencePointManager());
     }
 
     @Override
@@ -1090,7 +1092,8 @@ public final class SarosSession implements ISarosSession {
 
     private SarosSession(final String id, IContainerContext context,
         IPreferenceStore localProperties, JID host,
-        IPreferenceStore hostProperties) {
+        IPreferenceStore hostProperties,
+        IReferencePointManager referencePointManager) {
 
         context.initComponent(this);
 
@@ -1136,7 +1139,7 @@ public final class SarosSession implements ISarosSession {
         sessionContainer.addComponent(IActivityHandlerCallback.class,
             activityCallback);
         sessionContainer.addComponent(IReferencePointManager.class,
-            new ReferencePointManager());
+            referencePointManager);
         ISarosSessionContextFactory factory = context
             .getComponent(ISarosSessionContextFactory.class);
         factory.createComponents(this, sessionContainer);

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/SarosSessionManagerTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/SarosSessionManagerTest.java
@@ -16,7 +16,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import de.fu_berlin.inf.dpp.context.IContainerContext;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.net.IReceiver;
 import de.fu_berlin.inf.dpp.net.ITransmitter;
@@ -89,6 +89,8 @@ public class SarosSessionManagerTest {
 
     private SarosSessionManager manager;
 
+    private IReferencePointManager referencePointManager;
+
     @Before
     public void setUp() throws Exception {
         SarosSession session = PowerMock.createNiceMock(SarosSession.class);
@@ -105,6 +107,7 @@ public class SarosSessionManagerTest {
         PowerMock.expectNew(SarosSession.class,
             EasyMock.anyObject(String.class),
             EasyMock.anyObject(IPreferenceStore.class),
+            EasyMock.anyObject(IReferencePointManager.class),
             EasyMock.anyObject(IContainerContext.class)).andStubReturn(session);
 
         PowerMock.replayAll();
@@ -116,22 +119,26 @@ public class SarosSessionManagerTest {
     @Test
     public void testStartStopListenerCallback() {
         manager.addSessionLifecycleListener(new StateVerifyListener());
-        manager.startSession(new HashMap<IProject, List<IResource>>());
+        manager.startSession(new HashMap<IReferencePoint, List<IResource>>(),
+            referencePointManager);
         manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
     }
 
     @Test
     public void testMultipleStarts() {
         manager.addSessionLifecycleListener(new StateVerifyListener());
-        manager.startSession(new HashMap<IProject, List<IResource>>());
-        manager.startSession(new HashMap<IProject, List<IResource>>());
+        manager.startSession(new HashMap<IReferencePoint, List<IResource>>(),
+            referencePointManager);
+        manager.startSession(new HashMap<IReferencePoint, List<IResource>>(),
+            referencePointManager);
         manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
     }
 
     @Test
     public void testMultipleStops() {
         manager.addSessionLifecycleListener(new StateVerifyListener());
-        manager.startSession(new HashMap<IProject, List<IResource>>());
+        manager.startSession(new HashMap<IReferencePoint, List<IResource>>(),
+            referencePointManager);
         manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
         manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
     }
@@ -139,7 +146,8 @@ public class SarosSessionManagerTest {
     @Test(expected = DummyError.class)
     public void testListenerDispatchIsNotCatchingErrors() {
         manager.addSessionLifecycleListener(new ErrorThrowingListener());
-        manager.startSession(new HashMap<IProject, List<IResource>>());
+        manager.startSession(new HashMap<IReferencePoint, List<IResource>>(),
+            referencePointManager);
         manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
     }
 
@@ -157,7 +165,8 @@ public class SarosSessionManagerTest {
 
         };
         manager.addSessionLifecycleListener(listener);
-        manager.startSession(new HashMap<IProject, List<IResource>>());
+        manager.startSession(new HashMap<IReferencePoint, List<IResource>>(),
+            referencePointManager);
         manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
     }
 
@@ -170,12 +179,15 @@ public class SarosSessionManagerTest {
             public void sessionStarting(ISarosSession oldSarosSession) {
                 assertTrue("startSession is executed recusive", count == 0);
                 count++;
-                manager.startSession(new HashMap<IProject, List<IResource>>());
+                manager.startSession(
+                    new HashMap<IReferencePoint, List<IResource>>(),
+                    referencePointManager);
             }
 
         };
         manager.addSessionLifecycleListener(listener);
-        manager.startSession(new HashMap<IProject, List<IResource>>());
+        manager.startSession(new HashMap<IReferencePoint, List<IResource>>(),
+            referencePointManager);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -195,7 +207,8 @@ public class SarosSessionManagerTest {
 
         };
         manager.addSessionLifecycleListener(listener);
-        manager.startSession(new HashMap<IProject, List<IResource>>());
+        manager.startSession(new HashMap<IReferencePoint, List<IResource>>(),
+            referencePointManager);
 
         RuntimeException rte = exception.get();
 
@@ -212,8 +225,9 @@ public class SarosSessionManagerTest {
             @Override
             public void sessionEnding(ISarosSession oldSarosSession) {
                 try {
-                    manager
-                        .startSession(new HashMap<IProject, List<IResource>>());
+                    manager.startSession(
+                        new HashMap<IReferencePoint, List<IResource>>(),
+                        referencePointManager);
                 } catch (RuntimeException e) {
                     exception.set(e);
                 }
@@ -221,7 +235,8 @@ public class SarosSessionManagerTest {
 
         };
         manager.addSessionLifecycleListener(listener);
-        manager.startSession(new HashMap<IProject, List<IResource>>());
+        manager.startSession(new HashMap<IReferencePoint, List<IResource>>(),
+            referencePointManager);
         manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
 
         RuntimeException rte = exception.get();

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/core/ui/eventhandler/NegotiationHandler.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/core/ui/eventhandler/NegotiationHandler.java
@@ -182,7 +182,7 @@ public class NegotiationHandler implements INegotiationHandler {
 
             }
 
-            sessionManager.startSharingProjects(negotiation.getPeer());
+            sessionManager.startSharingReferencePoint(negotiation.getPeer());
 
             return Status.OK_STATUS;
         }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJWorkspaceImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJWorkspaceImpl.java
@@ -9,13 +9,14 @@ import com.intellij.openapi.vfs.LocalFileSystem;
 import de.fu_berlin.inf.dpp.exceptions.OperationCanceledException;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
-import de.fu_berlin.inf.dpp.filesystem.IResource;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspaceRunnable;
 import de.fu_berlin.inf.dpp.intellij.filesystem.Filesystem;
 import de.fu_berlin.inf.dpp.intellij.filesystem.IntelliJProjectImplV2;
 import de.fu_berlin.inf.dpp.intellij.project.FileSystemChangeListener;
 import de.fu_berlin.inf.dpp.monitoring.NullProgressMonitor;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 
 import org.apache.log4j.Logger;
 
@@ -42,7 +43,7 @@ public class IntelliJWorkspaceImpl implements IWorkspace {
     }
 
     @Override
-    public void run(IWorkspaceRunnable runnable, IResource[] resources)
+    public void run(IWorkspaceRunnable runnable, IReferencePoint[] referencePoints, IReferencePointManager referencePointManager)
         throws IOException, OperationCanceledException {
         run(runnable);
     }

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerWorkspaceImpl.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerWorkspaceImpl.java
@@ -5,10 +5,11 @@ import java.io.IOException;
 import de.fu_berlin.inf.dpp.exceptions.OperationCanceledException;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
-import de.fu_berlin.inf.dpp.filesystem.IResource;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspaceRunnable;
 import de.fu_berlin.inf.dpp.monitoring.NullProgressMonitor;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 
 /**
  * Server implementation of the {@link IWorkspace} interface.
@@ -41,11 +42,11 @@ public class ServerWorkspaceImpl implements IWorkspace {
     public void run(IWorkspaceRunnable runnable) throws IOException,
         OperationCanceledException {
 
-        run(runnable, null);
+        run(runnable, null, null);
     }
 
     @Override
-    public void run(IWorkspaceRunnable runnable, IResource[] resources)
+    public void run(IWorkspaceRunnable runnable, IReferencePoint[] referencePoints, IReferencePointManager referencePointManager)
         throws IOException, OperationCanceledException {
 
         /*

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/session/NegotiationHandler.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/session/NegotiationHandler.java
@@ -57,7 +57,8 @@ public class NegotiationHandler implements INegotiationHandler {
 
                 switch (status) {
                 case OK:
-                    sessionManager.startSharingProjects(negotiation.getPeer());
+                    sessionManager.startSharingReferencePoint(negotiation
+                        .getPeer());
                     break;
                 case ERROR:
                     log.error("ERROR running session negotiation: "

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/EclipseWorkspaceImpl.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/EclipseWorkspaceImpl.java
@@ -2,6 +2,7 @@ package de.fu_berlin.inf.dpp.filesystem;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 import org.eclipse.core.runtime.CoreException;
@@ -14,6 +15,7 @@ import de.fu_berlin.inf.dpp.Saros;
 import de.fu_berlin.inf.dpp.exceptions.OperationCanceledException;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
 import de.fu_berlin.inf.dpp.monitoring.ProgressMonitorAdapterFactory;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 
 /**
  * Eclipse implementation of {@link IWorkspace}. Lets you execute
@@ -79,12 +81,14 @@ public class EclipseWorkspaceImpl implements IWorkspace {
     @Override
     public void run(final IWorkspaceRunnable runnable) throws IOException,
         OperationCanceledException {
-        run(runnable, null);
+        run(runnable, null, null);
     }
 
     @Override
-    public void run(IWorkspaceRunnable runnable, IResource[] resources)
-        throws IOException, OperationCanceledException {
+    public void run(IWorkspaceRunnable runnable,
+        IReferencePoint[] referencePoints,
+        IReferencePointManager referencePointManager) throws IOException,
+        OperationCanceledException {
 
         final org.eclipse.core.resources.IWorkspaceRunnable eclipseRunnable;
 
@@ -98,6 +102,11 @@ public class EclipseWorkspaceImpl implements IWorkspace {
         } else {
             eclipseRunnable = new EclipseRunnableAdapter(runnable);
         }
+
+        IResource[] resources = referencePoints == null ? null
+            : referencePointManager.getProjects(
+                new HashSet<IReferencePoint>(Arrays.asList(referencePoints)))
+                .toArray(new IResource[0]);
 
         final List<org.eclipse.core.resources.IResource> eclipseResources = ResourceAdapterFactory
             .convertBack(resources != null ? Arrays.asList(resources) : null);

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/eventhandler/NegotiationHandler.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/eventhandler/NegotiationHandler.java
@@ -132,7 +132,7 @@ public class NegotiationHandler implements INegotiationHandler {
 
             }
 
-            sessionManager.startSharingProjects(negotiation.getPeer());
+            sessionManager.startSharingReferencePoint(negotiation.getPeer());
 
             return Status.OK_STATUS;
         }

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/util/CollaborationUtils.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/util/CollaborationUtils.java
@@ -29,12 +29,15 @@ import org.picocontainer.annotations.Inject;
 
 import de.fu_berlin.inf.dpp.Saros;
 import de.fu_berlin.inf.dpp.SarosPluginContext;
+import de.fu_berlin.inf.dpp.filesystem.EclipsePathImpl;
 import de.fu_berlin.inf.dpp.filesystem.EclipseProjectImpl;
+import de.fu_berlin.inf.dpp.filesystem.EclipseReferencePointImpl;
 import de.fu_berlin.inf.dpp.filesystem.ResourceAdapterFactory;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
 import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
+import de.fu_berlin.inf.dpp.session.ReferencePointManager;
 import de.fu_berlin.inf.dpp.session.SessionEndReason;
 import de.fu_berlin.inf.dpp.session.User;
 import de.fu_berlin.inf.dpp.session.internal.SarosSession;
@@ -92,7 +95,14 @@ public class CollaborationUtils {
 
                 try {
                     refreshProjects(newResources.keySet(), null);
-                    sessionManager.startSession(convert(newResources));
+
+                    if (referencePointManager == null)
+                        referencePointManager = new ReferencePointManager();
+
+                    fillReferencePointManager(newResources.keySet(),
+                        referencePointManager);
+                    sessionManager.startSession(convert(newResources),
+                        referencePointManager);
                     Set<JID> participantsToAdd = new HashSet<JID>(contacts);
 
                     ISarosSession session = sessionManager.getSession();
@@ -217,7 +227,8 @@ public class CollaborationUtils {
                      * execption handling !
                      */
                 }
-
+                fillReferencePointManager(projectResources.keySet(),
+                    referencePointManager);
                 sessionManager.addResourcesToSession(convert(projectResources));
             }
         });
@@ -455,14 +466,15 @@ public class CollaborationUtils {
             / (1000F * 1000F * 1000F));
     }
 
-    private static Map<de.fu_berlin.inf.dpp.filesystem.IProject, List<de.fu_berlin.inf.dpp.filesystem.IResource>> convert(
+    private static Map<de.fu_berlin.inf.dpp.filesystem.IReferencePoint, List<de.fu_berlin.inf.dpp.filesystem.IResource>> convert(
         Map<IProject, List<IResource>> data) {
 
-        Map<de.fu_berlin.inf.dpp.filesystem.IProject, List<de.fu_berlin.inf.dpp.filesystem.IResource>> result = new HashMap<de.fu_berlin.inf.dpp.filesystem.IProject, List<de.fu_berlin.inf.dpp.filesystem.IResource>>();
+        Map<de.fu_berlin.inf.dpp.filesystem.IReferencePoint, List<de.fu_berlin.inf.dpp.filesystem.IResource>> result = new HashMap<de.fu_berlin.inf.dpp.filesystem.IReferencePoint, List<de.fu_berlin.inf.dpp.filesystem.IResource>>();
 
         for (Entry<IProject, List<IResource>> entry : data.entrySet())
-            result.put(ResourceAdapterFactory.create(entry.getKey()),
-                ResourceAdapterFactory.convertTo(entry.getValue()));
+            result.put(ResourceAdapterFactory.create(entry.getKey())
+                .getReferencePoint(), ResourceAdapterFactory.convertTo(entry
+                .getValue()));
 
         return result;
     }
@@ -482,5 +494,21 @@ public class CollaborationUtils {
         }
 
         progress.done();
+    }
+
+    private static void fillReferencePointManager(
+        Set<IProject> eclipseProjects,
+        IReferencePointManager referencePointManager) {
+
+        for (IProject eclipseProject : eclipseProjects) {
+            de.fu_berlin.inf.dpp.filesystem.IPath path = ResourceAdapterFactory
+                .create(eclipseProject.getLocation());
+
+            de.fu_berlin.inf.dpp.filesystem.IReferencePoint referencePoint = new EclipseReferencePointImpl(
+                (EclipsePathImpl) path);
+
+            referencePointManager.put(referencePoint,
+                ResourceAdapterFactory.create(eclipseProject));
+        }
     }
 }

--- a/de.fu_berlin.inf.dpp/test/junit/de/fu_berlin/inf/dpp/session/internal/SarosSessionTest.java
+++ b/de.fu_berlin.inf.dpp/test/junit/de/fu_berlin/inf/dpp/session/internal/SarosSessionTest.java
@@ -64,6 +64,7 @@ import de.fu_berlin.inf.dpp.net.xmpp.XMPPConnectionService;
 import de.fu_berlin.inf.dpp.preferences.EclipsePreferences;
 import de.fu_berlin.inf.dpp.preferences.PreferenceStore;
 import de.fu_berlin.inf.dpp.project.internal.SarosEclipseSessionContextFactory;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSessionContextFactory;
 import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
 import de.fu_berlin.inf.dpp.session.SessionEndReason;
@@ -234,6 +235,15 @@ public class SarosSessionTest {
         return receiver;
     }
 
+    private IReferencePointManager createReferencePointManagerMock() {
+        IReferencePointManager referencePointManager;
+
+        referencePointManager = createMock(IReferencePointManager.class);
+        replay(referencePointManager);
+
+        return referencePointManager;
+    }
+
     private void addMockedComponent(Class<?> clazz) {
         Object mock = createNiceMock(clazz);
         replay(mock);
@@ -327,10 +337,11 @@ public class SarosSessionTest {
         createWorkspaceMock(workspaceListeners);
 
         final IContainerContext context = createContextMock(container);
+        final IReferencePointManager referencePointManager = createReferencePointManagerMock();
 
         // Test creating, starting and stopping the session.
         SarosSession session = new SarosSession(SAROS_SESSION_ID,
-            new PreferenceStore(), context);
+            new PreferenceStore(), context, referencePointManager);
 
         assertFalse(session.hasActivityConsumers());
         assertFalse(session.hasActivityProducers());


### PR DESCRIPTION
The ISarosSessionManager was adjusted to reference points and
works only with reference points and its resources now. So the
IReferencePointManager can not be filled with reference points and projects.
So IReferencePointManager will be filled in the CollaborationUtils class,
before the reference points and the ressources will be added to the
saros session.

IWorkspace:
the run method does'nt get core.IResources anymore because there
are only core.IProject. So the run method get IReferencePoints
and the IReferencePointManager. The implementations of IWorkspace
can get the IDE-dependent resource with the help of the referece
points and the IReferencePoints.

DecompressArchiveTask:
this task was refactored and works with IReferencePoints now.

ArchiveOutgoing/-IncommingReferencePoint Negotation:
Some parts were adjust for DecompressArchiveTask (giving the
IReferencePointManager as parameter)

TODO:
ArchiveOutoingReferencePointNegotiation and DecompressArchiveTask
still use an IProject object for ex. getting saros file object,
which should be compress. This will be solves in a later commit

For more details for the idea of adjusting to reference points: https://github.com/saros-project/saros/issues/177