### PR TITLE
Pr/RefactoringSPath

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/activities/SPath.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/activities/SPath.java
@@ -7,7 +7,6 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
 import de.fu_berlin.inf.dpp.filesystem.IFolder;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.misc.xstream.SPathConverter;
@@ -137,13 +136,6 @@ public class SPath {
     public IFolder getFolder() {
         return referencePointManager.getFolder(referencePoint,
             relativePathFromReferencePoint);
-    }
-
-    /**
-     * Returns the project in which the referenced resource is located.
-     */
-    public IProject getProject() {
-        return referencePointManager.get(referencePoint);
     }
 
     /**

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/concurrent/management/JupiterServer.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/concurrent/management/JupiterServer.java
@@ -82,8 +82,8 @@ public class JupiterServer {
                  * resources in question. Other clients that haven't accepted
                  * the Project yet will be added later.
                  */
-                if (sarosSession.userHasReferencePoint(client, path
-                    .getProject().getReferencePoint())) {
+                if (sarosSession.userHasReferencePoint(client,
+                    path.getReferencePoint())) {
                     docServer.addProxyClient(client);
                 }
             }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/misc/xstream/SPathConverter.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/misc/xstream/SPathConverter.java
@@ -14,7 +14,6 @@ import de.fu_berlin.inf.dpp.annotations.Component;
 import de.fu_berlin.inf.dpp.communication.extensions.ActivitiesExtension;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IPathFactory;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
@@ -24,11 +23,11 @@ import de.fu_berlin.inf.dpp.session.ISarosSession;
  * representations, and vice versa.
  * <p>
  * <b>Example:</b> The XML representation of an {@link SPath} for a
- * {@linkplain IProject project} with id <code>"projA"</code> and a
+ * {@linkplain IReferencePoint referencePoint} with id <code>"refA"</code> and a
  * {@linkplain IPath relative path} <code>"src/Main.java"</code>:
  * 
  * <pre>
- * &lt;SPath i="projA" p="src/Main.java" /&gt;
+ * &lt;SPath i="refA" p="src/Main.java" /&gt;
  * </pre>
  */
 @Component
@@ -76,8 +75,7 @@ public class SPathConverter implements Converter, Startable {
         String i = session.getReferencePointID(spath.getReferencePoint());
         if (i == null) {
             LOG.error("Could not retrieve project id for project '"
-                + referencePointManager.get(spath.getReferencePoint())
-                    .getName()
+                + spath.getReferencePoint()
                 + "'. Make sure you don't create activities for non-shared projects");
             return;
         }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/misc/xstream/SPathConverter.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/misc/xstream/SPathConverter.java
@@ -15,6 +15,7 @@ import de.fu_berlin.inf.dpp.communication.extensions.ActivitiesExtension;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IPathFactory;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 
@@ -72,17 +73,17 @@ public class SPathConverter implements Converter, Startable {
 
         SPath spath = (SPath) value;
 
-        String i = session.getReferencePointID(spath.getProject()
-            .getReferencePoint());
+        String i = session.getReferencePointID(spath.getReferencePoint());
         if (i == null) {
             LOG.error("Could not retrieve project id for project '"
-                + spath.getProject().getName()
+                + referencePointManager.get(spath.getReferencePoint())
+                    .getName()
                 + "'. Make sure you don't create activities for non-shared projects");
             return;
         }
 
         String p = URLCodec.encode(pathFactory.fromPath(spath
-            .getProjectRelativePath()));
+            .getRelativePathFromReferencePoint()));
 
         writer.addAttribute(PROJECT_ID, i);
         writer.addAttribute(PATH, p);
@@ -95,16 +96,15 @@ public class SPathConverter implements Converter, Startable {
         String i = reader.getAttribute(PROJECT_ID);
         String p = URLCodec.decode(reader.getAttribute(PATH));
 
-        IProject project = referencePointManager.get(session
-            .getReferencePoint(i));
-        if (project == null) {
-            LOG.error("Could not create SPath because there is no shared project for id '"
+        IReferencePoint referencePoint = session.getReferencePoint(i);
+        if (referencePoint == null) {
+            LOG.error("Could not create SPath because there is no shared referencePoint for id '"
                 + i + "'");
             return null;
         }
 
         IPath path = pathFactory.fromString(p);
 
-        return new SPath(project, path);
+        return new SPath(referencePoint, path, referencePointManager);
     }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantOutgoingReferencePointNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantOutgoingReferencePointNegotiation.java
@@ -195,7 +195,7 @@ public class InstantOutgoingReferencePointNegotiation extends
                 .getReferencePointID());
             for (String file : list.getPaths()) {
                 files.add(new SPath(referencePointManager.get(referencePoint)
-                    .getFile(file)));
+                    .getFile(file), referencePointManager));
             }
         }
 
@@ -203,8 +203,8 @@ public class InstantOutgoingReferencePointNegotiation extends
         Collections.sort(files, new Comparator<SPath>() {
             @Override
             public int compare(SPath a, SPath b) {
-                int lenA = a.getProjectRelativePath().segmentCount();
-                int lenB = b.getProjectRelativePath().segmentCount();
+                int lenA = a.getRelativePathFromReferencePoint().segmentCount();
+                int lenB = b.getRelativePathFromReferencePoint().segmentCount();
                 return Integer.valueOf(lenA).compareTo(Integer.valueOf(lenB));
             }
         });
@@ -233,7 +233,7 @@ public class InstantOutgoingReferencePointNegotiation extends
         for (String string : eclipseProjFiles) {
             for (IReferencePoint referencePoint : referencePoints) {
                 SPath file = new SPath(referencePointManager
-                    .get(referencePoint).getFile(string));
+                    .get(referencePoint).getFile(string), referencePointManager);
                 sendIfRequired(osp, file);
             }
         }
@@ -245,8 +245,7 @@ public class InstantOutgoingReferencePointNegotiation extends
             while (!openedFiles.isEmpty()) {
                 SPath openFile = openedFiles.poll();
                 /* open files could be changed meanwhile */
-                editorManager.saveEditors(openFile.getProject()
-                    .getReferencePoint());
+                editorManager.saveEditors(openFile.getReferencePoint());
                 sendIfRequired(osp, openFile);
             }
 

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/stream/OutgoingStreamProtocol.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/stream/OutgoingStreamProtocol.java
@@ -82,9 +82,9 @@ public class OutgoingStreamProtocol extends AbstractStreamProtocol {
     }
 
     private void writeHeader(SPath file, long fileSize) throws IOException {
-        String projectID = session.getReferencePointID(file.getProject()
-            .getReferencePoint());
-        String fileName = file.getProjectRelativePath().toPortableString();
+        String projectID = session
+            .getReferencePointID(file.getReferencePoint());
+        String fileName = file.getRelativePathFromReferencePoint().toPortableString();
 
         out.writeUTF(projectID);
         out.writeUTF(fileName);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/ActivityHandler.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/ActivityHandler.java
@@ -197,7 +197,7 @@ public final class ActivityHandler implements Startable {
             } else {
                 for (User user : item.recipients) {
                     if (session.userHasReferencePoint(user, activity.getPath()
-                        .getProject().getReferencePoint())) {
+                        .getReferencePoint())) {
                         recipients.add(user);
                     }
                 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/ActivityQueuer.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/ActivityQueuer.java
@@ -160,9 +160,9 @@ public class ActivityQueuer {
                     // try to reuse the queue as lookup is O(n)
                     if (referencePointQueue == null
                         || !referencePointQueue.referencePoint.equals(path
-                            .getProject().getReferencePoint())) {
+                            .getReferencePoint())) {
                         referencePointQueue = getReferencePointQueue(path
-                            .getProject().getReferencePoint());
+                            .getReferencePoint());
                     }
 
                     if (referencePointQueue != null) {

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
@@ -49,7 +49,6 @@ import de.fu_berlin.inf.dpp.concurrent.management.ConcurrentDocumentServer;
 import de.fu_berlin.inf.dpp.context.IContainerContext;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
 import de.fu_berlin.inf.dpp.filesystem.IFolder;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.net.IConnectionManager;
@@ -804,7 +803,8 @@ public final class SarosSession implements ISarosSession {
     private boolean updatePartialSharedResources(
         final IFileSystemModificationActivity activity) {
 
-        final IProject project = activity.getPath().getProject();
+        final IReferencePoint referencePoint = activity.getPath()
+            .getReferencePoint();
 
         /*
          * The follow 'if check' assumes that move operations where at least one
@@ -812,8 +812,7 @@ public final class SarosSession implements ISarosSession {
          * activities.
          */
 
-        if (!referencePointMapper
-            .isPartiallyShared(project.getReferencePoint()))
+        if (!referencePointMapper.isPartiallyShared(referencePoint))
             return true;
 
         if (activity instanceof FileActivity) {
@@ -838,7 +837,7 @@ public final class SarosSession implements ISarosSession {
                     return false;
                 }
 
-                referencePointMapper.addResources(project.getReferencePoint(),
+                referencePointMapper.addResources(referencePoint,
                     Collections.singletonList(file));
 
                 break;
@@ -858,8 +857,7 @@ public final class SarosSession implements ISarosSession {
                     return false;
                 }
 
-                referencePointMapper.removeResources(
-                    project.getReferencePoint(),
+                referencePointMapper.removeResources(referencePoint,
                     Collections.singletonList(file));
 
                 break;
@@ -895,8 +893,7 @@ public final class SarosSession implements ISarosSession {
                     return false;
                 }
 
-                referencePointMapper.removeAndAddResources(
-                    project.getReferencePoint(),
+                referencePointMapper.removeAndAddResources(referencePoint,
                     Collections.singletonList(oldFile),
                     Collections.singletonList(file));
 
@@ -918,7 +915,7 @@ public final class SarosSession implements ISarosSession {
                 return false;
             }
 
-            referencePointMapper.addResources(project.getReferencePoint(),
+            referencePointMapper.addResources(referencePoint,
                 Collections.singletonList(folder));
 
         } else if (activity instanceof FolderDeletedActivity) {
@@ -937,7 +934,7 @@ public final class SarosSession implements ISarosSession {
                 return false;
             }
 
-            referencePointMapper.removeResources(project.getReferencePoint(),
+            referencePointMapper.removeResources(referencePoint,
                 Collections.singletonList(folder));
         }
 

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/activities/ActivityOptimizerTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/activities/ActivityOptimizerTest.java
@@ -11,7 +11,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import de.fu_berlin.inf.dpp.filesystem.IPath;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
 import de.fu_berlin.inf.dpp.session.IReferencePointManager;
@@ -26,8 +25,6 @@ public class ActivityOptimizerTest {
     private IPath fooPath;
     private IPath barPath;
 
-    private IProject fooProject;
-    private IProject barProject;
     private IReferencePoint referencePointOfFoo;
     private IReferencePoint referencePointOfBar;
     private IReferencePointManager referencePointManager;
@@ -36,9 +33,6 @@ public class ActivityOptimizerTest {
 
     @Before
     public void setup() {
-
-        fooProject = EasyMock.createNiceMock(IProject.class);
-        barProject = EasyMock.createNiceMock(IProject.class);
 
         referencePointOfFoo = EasyMock.createNiceMock(IReferencePoint.class);
         referencePointOfBar = EasyMock.createNiceMock(IReferencePoint.class);
@@ -49,8 +43,8 @@ public class ActivityOptimizerTest {
         fooPath = EasyMock.createNiceMock(IPath.class);
         barPath = EasyMock.createNiceMock(IPath.class);
 
-        EasyMock.replay(fooProject, barProject, fooPath, barPath,
-            referencePointOfFoo, referencePointOfBar, referencePointManager);
+        EasyMock.replay(fooPath, barPath, referencePointOfFoo,
+            referencePointOfBar, referencePointManager);
     }
 
     @Test

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/activities/ActivityOptimizerTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/activities/ActivityOptimizerTest.java
@@ -12,7 +12,9 @@ import org.junit.Test;
 
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.User;
 
 public class ActivityOptimizerTest {
@@ -26,6 +28,9 @@ public class ActivityOptimizerTest {
 
     private IProject fooProject;
     private IProject barProject;
+    private IReferencePoint referencePointOfFoo;
+    private IReferencePoint referencePointOfBar;
+    private IReferencePointManager referencePointManager;
 
     private final NOPActivity nop = new NOPActivity(alice, bob, 0);
 
@@ -35,22 +40,33 @@ public class ActivityOptimizerTest {
         fooProject = EasyMock.createNiceMock(IProject.class);
         barProject = EasyMock.createNiceMock(IProject.class);
 
+        referencePointOfFoo = EasyMock.createNiceMock(IReferencePoint.class);
+        referencePointOfBar = EasyMock.createNiceMock(IReferencePoint.class);
+
+        referencePointManager = EasyMock
+            .createNiceMock(IReferencePointManager.class);
+
         fooPath = EasyMock.createNiceMock(IPath.class);
         barPath = EasyMock.createNiceMock(IPath.class);
 
-        EasyMock.replay(fooProject, barProject, fooPath, barPath);
+        EasyMock.replay(fooProject, barProject, fooPath, barPath,
+            referencePointOfFoo, referencePointOfBar, referencePointManager);
     }
 
     @Test
     public void testOptimize() {
 
-        SPath foofooSPath = new SPath(fooProject, fooPath);
+        SPath foofooSPath = new SPath(referencePointOfFoo, fooPath,
+            referencePointManager);
 
-        SPath foobarSPath = new SPath(fooProject, barPath);
+        SPath foobarSPath = new SPath(referencePointOfFoo, barPath,
+            referencePointManager);
 
-        SPath barfooSPath = new SPath(barProject, fooPath);
+        SPath barfooSPath = new SPath(referencePointOfBar, fooPath,
+            referencePointManager);
 
-        SPath barbarSPath = new SPath(barProject, barPath);
+        SPath barbarSPath = new SPath(referencePointOfBar, barPath,
+            referencePointManager);
 
         TextSelectionActivity tsChange0 = new TextSelectionActivity(alice, 0,
             1, foofooSPath);

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/concurrent/SplitOperationTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/concurrent/SplitOperationTest.java
@@ -20,7 +20,8 @@ import de.fu_berlin.inf.dpp.concurrent.jupiter.internal.text.NoOperation;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.internal.text.SplitOperation;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.test.util.JupiterTestCase;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.test.util.PathFake;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.User;
 
 /**
@@ -28,7 +29,9 @@ import de.fu_berlin.inf.dpp.session.User;
  */
 public class SplitOperationTest {
 
-    protected IProject project;
+    // protected IProject project;
+    protected IReferencePoint referencePoint;
+    protected IReferencePointManager referencePointManager;
 
     protected SPath path;
     protected User source = JupiterTestCase.createUser("source");
@@ -51,9 +54,12 @@ public class SplitOperationTest {
 
     @Before
     public void setUp() {
-        project = createMock(IProject.class);
-        replay(project);
-        path = new SPath(project, new PathFake("path"));
+        // project = createMock(IProject.class);
+        referencePoint = createMock(IReferencePoint.class);
+        referencePointManager = createMock(IReferencePointManager.class);
+        replay(referencePoint, referencePointManager);
+        path = new SPath(referencePoint, new PathFake("path"),
+            referencePointManager);
     }
 
     @Test

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/concurrent/jupiter/test/puzzles/SimpleJupiterDocumentTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/concurrent/jupiter/test/puzzles/SimpleJupiterDocumentTest.java
@@ -20,7 +20,7 @@ import de.fu_berlin.inf.dpp.concurrent.jupiter.test.util.Document;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.test.util.JupiterTestCase;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.test.util.PathFake;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.session.User;
 
 public class SimpleJupiterDocumentTest extends JupiterTestCase {
@@ -32,12 +32,12 @@ public class SimpleJupiterDocumentTest extends JupiterTestCase {
     @Test
     public void testExecuteLocalOperations() {
         Algorithm algo = new Jupiter(true);
-        IProject project = createMock(IProject.class);
-        replay(project);
+        IReferencePoint referencePoint = createMock(IReferencePoint.class);
+        replay(referencePoint);
 
         IPath path = new PathFake("dummy");
 
-        Document doc = new Document("abc", project, path);
+        Document doc = new Document("abc", referencePoint, path);
         assertEquals("abc", doc.getDocument());
 
         /* insert one char. */

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/concurrent/jupiter/test/util/ClientSynchronizedDocument.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/concurrent/jupiter/test/util/ClientSynchronizedDocument.java
@@ -32,7 +32,7 @@ public class ClientSynchronizedDocument implements NetworkEventHandler,
     public ClientSynchronizedDocument(User server, String content,
         NetworkSimulator connection, User user) {
         this.server = server;
-        this.doc = new Document(content, connection.project, connection.path);
+        this.doc = new Document(content, connection.referencePoint, connection.path);
         this.algorithm = new Jupiter(true);
         this.connection = connection;
         this.user = user;

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/concurrent/jupiter/test/util/Document.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/concurrent/jupiter/test/util/Document.java
@@ -1,5 +1,8 @@
 package de.fu_berlin.inf.dpp.concurrent.jupiter.test.util;
 
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.replay;
+
 import java.util.List;
 
 import org.apache.log4j.Logger;
@@ -8,7 +11,8 @@ import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.activities.TextEditActivity;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.Operation;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.User;
 
 /**
@@ -40,7 +44,9 @@ public class Document {
 
     protected IPath path;
 
-    protected IProject project;
+    protected IReferencePoint referencePoint;
+
+    protected IReferencePointManager referencePointManager;
 
     /**
      * constructor to init doc.
@@ -48,10 +54,12 @@ public class Document {
      * @param initState
      *            start document state.
      */
-    public Document(String initState, IProject project, IPath path) {
+    public Document(String initState, IReferencePoint referencePoint, IPath path) {
         doc = new StringBuffer(initState);
-        this.project = project;
+        this.referencePoint = referencePoint;
         this.path = path;
+        this.referencePointManager = createMock(IReferencePointManager.class);
+        replay(referencePointManager);
     }
 
     /**
@@ -76,8 +84,8 @@ public class Document {
     public void execOperation(Operation op) {
         User dummy = JupiterTestCase.createUser("dummy");
 
-        List<TextEditActivity> activities = op.toTextEdit(
-            new SPath(project.getReferencePoint(), path, null), dummy);
+        List<TextEditActivity> activities = op.toTextEdit(new SPath(
+            referencePoint, path, referencePointManager), dummy);
 
         for (TextEditActivity activity : activities) {
 

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/concurrent/jupiter/test/util/Document.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/concurrent/jupiter/test/util/Document.java
@@ -76,8 +76,8 @@ public class Document {
     public void execOperation(Operation op) {
         User dummy = JupiterTestCase.createUser("dummy");
 
-        List<TextEditActivity> activities = op.toTextEdit(new SPath(project,
-            path), dummy);
+        List<TextEditActivity> activities = op.toTextEdit(
+            new SPath(project.getReferencePoint(), path, null), dummy);
 
         for (TextEditActivity activity : activities) {
 

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/concurrent/jupiter/test/util/JupiterSimulator.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/concurrent/jupiter/test/util/JupiterSimulator.java
@@ -17,7 +17,8 @@ import de.fu_berlin.inf.dpp.concurrent.jupiter.Operation;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.TransformationException;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.internal.Jupiter;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.User;
 
 public class JupiterSimulator {
@@ -31,12 +32,12 @@ public class JupiterSimulator {
 
     public JupiterSimulator(String document) {
 
-        IProject project = createMock(IProject.class);
-        replay(project);
+        IReferencePoint referencePoint = createMock(IReferencePoint.class);
+        replay(referencePoint);
         IPath path = new PathFake("test");
 
-        client = new Peer(new Jupiter(true), document, project, path);
-        server = new Peer(new Jupiter(false), document, project, path);
+        client = new Peer(new Jupiter(true), document, referencePoint, path);
+        server = new Peer(new Jupiter(false), document, referencePoint, path);
     }
 
     public class Peer {
@@ -49,13 +50,13 @@ public class JupiterSimulator {
 
         protected IPath path;
 
-        protected IProject project;
+        protected IReferencePoint referencePoint;
 
-        public Peer(Algorithm algorithm, String document, IProject project,
-            IPath path) {
+        public Peer(Algorithm algorithm, String document,
+            IReferencePoint referencePoint, IPath path) {
             this.algorithm = algorithm;
-            this.document = new Document(document, project, path);
-            this.project = project;
+            this.document = new Document(document, referencePoint, path);
+            this.referencePoint = referencePoint;
             this.path = path;
         }
 
@@ -65,10 +66,11 @@ public class JupiterSimulator {
             document.execOperation(operation);
 
             User user = JupiterTestCase.createUser("DUMMY");
-
+            IReferencePointManager referencePointManager = createMock(IReferencePointManager.class);
+            replay(referencePointManager);
             JupiterActivity jupiterActivity = algorithm
-                .generateJupiterActivity(operation, user,
-                    new SPath(project.getReferencePoint(), path, null));
+                .generateJupiterActivity(operation, user, new SPath(
+                    referencePoint, path, referencePointManager));
 
             if (this == client) {
                 server.inQueue.add(jupiterActivity);

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/concurrent/jupiter/test/util/JupiterSimulator.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/concurrent/jupiter/test/util/JupiterSimulator.java
@@ -67,8 +67,8 @@ public class JupiterSimulator {
             User user = JupiterTestCase.createUser("DUMMY");
 
             JupiterActivity jupiterActivity = algorithm
-                .generateJupiterActivity(operation, user, new SPath(project,
-                    path));
+                .generateJupiterActivity(operation, user,
+                    new SPath(project.getReferencePoint(), path, null));
 
             if (this == client) {
                 server.inQueue.add(jupiterActivity);

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/concurrent/jupiter/test/util/NetworkSimulator.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/concurrent/jupiter/test/util/NetworkSimulator.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.PriorityQueue;
 
 import de.fu_berlin.inf.dpp.filesystem.IPath;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.session.User;
 
 /**
@@ -19,7 +19,7 @@ public class NetworkSimulator {
 
     private HashMap<User, NetworkEventHandler> clients;
 
-    public IProject project;
+    public IReferencePoint referencePoint;
 
     public IPath path = new PathFake("dummy");
 
@@ -28,8 +28,8 @@ public class NetworkSimulator {
     protected int presentTime = -1;
 
     public NetworkSimulator() {
-        project = createMock(IProject.class);
-        replay(project);
+        referencePoint = createMock(IReferencePoint.class);
+        replay(referencePoint);
         clients = new HashMap<User, NetworkEventHandler>();
     }
 

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/concurrent/jupiter/test/util/TwoWayJupiterServerDocument.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/concurrent/jupiter/test/util/TwoWayJupiterServerDocument.java
@@ -27,7 +27,7 @@ public class TwoWayJupiterServerDocument implements NetworkEventHandler,
     private NetworkSimulator connection;
 
     public TwoWayJupiterServerDocument(String content, NetworkSimulator con) {
-        this.doc = new Document(content, con.project, con.path);
+        this.doc = new Document(content, con.referencePoint, con.path);
         this.algorithm = new Jupiter(false);
         this.connection = con;
     }

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/editor/remote/UserEditorStateTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/editor/remote/UserEditorStateTest.java
@@ -21,7 +21,8 @@ import de.fu_berlin.inf.dpp.editor.text.LineRange;
 import de.fu_berlin.inf.dpp.editor.text.TextSelection;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IPathFactory;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.User;
 
 public class UserEditorStateTest {
@@ -43,12 +44,16 @@ public class UserEditorStateTest {
         IPath pathMockA = mockPath("/foo/src/Main.java", pathFactory);
         IPath pathMockB = mockPath("/foo/src/Second.java", pathFactory);
 
-        IProject project = EasyMock.createNiceMock(IProject.class);
+        IReferencePoint referencePoint = EasyMock
+            .createNiceMock(IReferencePoint.class);
 
-        EasyMock.replay(pathFactory, project);
+        IReferencePointManager referencePointManager = EasyMock
+            .createNiceMock(IReferencePointManager.class);
 
-        pathA = new SPath(project, pathMockA);
-        pathB = new SPath(project, pathMockB);
+        EasyMock.replay(pathFactory, referencePoint);
+
+        pathA = new SPath(referencePoint, pathMockA, referencePointManager);
+        pathB = new SPath(referencePoint, pathMockB, referencePointManager);
 
         /***/
 

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/misc/xstream/SPathConverterTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/misc/xstream/SPathConverterTest.java
@@ -13,7 +13,6 @@ import com.thoughtworks.xstream.io.xml.DomDriver;
 import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IPathFactory;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
@@ -40,7 +39,6 @@ public class SPathConverterTest {
     private static IPath path;
     private static IReferencePoint referencePoint;
     private static IPathFactory pathFactory;
-    private static IProject project;
     private static IReferencePointManager referencePointManager;
 
     @BeforeClass
@@ -55,14 +53,10 @@ public class SPathConverterTest {
         expect(pathFactory.fromString("/foo/src/Main.java"))
             .andStubReturn(path);
 
-        project = EasyMock.createNiceMock(IProject.class);        
-        
         referencePoint = EasyMock.createNiceMock(IReferencePoint.class);
         referencePointManager = EasyMock
             .createNiceMock(IReferencePointManager.class);
-         expect(referencePointManager.get(referencePoint))
-         .andStubReturn(project);
-        EasyMock.replay(pathFactory, referencePoint, path, project,
+        EasyMock.replay(pathFactory, referencePoint, path,
             referencePointManager);
     }
 

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/misc/xstream/SPathConverterTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/misc/xstream/SPathConverterTest.java
@@ -38,9 +38,9 @@ public class SPathConverterTest {
     }
 
     private static IPath path;
-    private static IProject project;
     private static IReferencePoint referencePoint;
     private static IPathFactory pathFactory;
+    private static IProject project;
     private static IReferencePointManager referencePointManager;
 
     @BeforeClass
@@ -55,13 +55,13 @@ public class SPathConverterTest {
         expect(pathFactory.fromString("/foo/src/Main.java"))
             .andStubReturn(path);
 
+        project = EasyMock.createNiceMock(IProject.class);        
+        
         referencePoint = EasyMock.createNiceMock(IReferencePoint.class);
-        project = EasyMock.createNiceMock(IProject.class);
-        expect(project.getReferencePoint()).andStubReturn(referencePoint);
         referencePointManager = EasyMock
             .createNiceMock(IReferencePointManager.class);
-        expect(referencePointManager.get(referencePoint))
-            .andStubReturn(project);
+         expect(referencePointManager.get(referencePoint))
+         .andStubReturn(project);
         EasyMock.replay(pathFactory, referencePoint, path, project,
             referencePointManager);
     }
@@ -86,7 +86,7 @@ public class SPathConverterTest {
         receiver.registerConverter(new SPathConverter(session, pathFactory));
 
         /* Test */
-        SPath spath = new SPath(project, path);
+        SPath spath = new SPath(referencePoint, path, referencePointManager);
         SPath copy = (SPath) receiver.fromXML(sender.toXML(spath));
         assertEquals(spath, copy);
 
@@ -131,7 +131,7 @@ public class SPathConverterTest {
             pathFactory));
 
         /* Test */
-        SPath spath = new SPath(project, path);
+        SPath spath = new SPath(referencePoint, path, referencePointManager);
 
         // first call on running session on receiver side
         receiver.fromXML(sender.toXML(spath));
@@ -180,7 +180,8 @@ public class SPathConverterTest {
             pathFactory));
 
         /* Test */
-        Dummy dummy = new Dummy(new SPath(project, path));
+        Dummy dummy = new Dummy(new SPath(referencePoint, path,
+            referencePointManager));
         Dummy copy = (Dummy) receiver.fromXML(sender.toXML(dummy));
         assertEquals(dummy, copy);
 

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/internal/ActivityHandlerTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/internal/ActivityHandlerTest.java
@@ -409,7 +409,7 @@ public class ActivityHandlerTest {
         activities.add(EasyMock.createNiceMock(ChecksumActivity.class));
 
         path = EasyMock.createMock(SPath.class);
-        EasyMock.expect(path.getProject()).andStubReturn(project);
+        EasyMock.expect(path.getReferencePoint()).andStubReturn(referencePoint);
         EasyMock.replay(path);
 
         // Assign Targets and Source to activities

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/internal/ActivityQueuerTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/internal/ActivityQueuerTest.java
@@ -26,9 +26,9 @@ import de.fu_berlin.inf.dpp.activities.StartFollowingActivity;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.internal.JupiterVectorTime;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.internal.text.NoOperation;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.User;
 
 public class ActivityQueuerTest {
@@ -39,9 +39,7 @@ public class ActivityQueuerTest {
 
     private static IReferencePoint SHARED_REFERENCEPOINT;
     private static IReferencePoint NOT_SHARED_REFERENCEPOINT;
-
-    private static IProject SHARED_PROJECT;
-    private static IProject NOT_SHARED_PROJECT;
+    private static IReferencePointManager REFERENCEPOINT_MANAGER;
 
     private static SPath FOO_PATH_SHARED_PROJECT;
     private static SPath BAR_PATH_SHARED_PROJECT;
@@ -54,25 +52,20 @@ public class ActivityQueuerTest {
         SHARED_REFERENCEPOINT = EasyMock.createMock(IReferencePoint.class);
         NOT_SHARED_REFERENCEPOINT = EasyMock.createMock(IReferencePoint.class);
 
-        SHARED_PROJECT = EasyMock.createMock(IProject.class);
-        NOT_SHARED_PROJECT = EasyMock.createMock(IProject.class);
+        REFERENCEPOINT_MANAGER = EasyMock
+            .createMock(IReferencePointManager.class);
 
-        EasyMock.expect(SHARED_PROJECT.getReferencePoint()).andStubReturn(
-            SHARED_REFERENCEPOINT);
+        EasyMock.replay(SHARED_REFERENCEPOINT, NOT_SHARED_REFERENCEPOINT,
+            REFERENCEPOINT_MANAGER);
 
-        EasyMock.expect(NOT_SHARED_PROJECT.getReferencePoint()).andStubReturn(
-            NOT_SHARED_REFERENCEPOINT);
+        FOO_PATH_SHARED_PROJECT = new SPath(SHARED_REFERENCEPOINT,
+            EasyMock.createMock(IPath.class), REFERENCEPOINT_MANAGER);
 
-        EasyMock.replay(SHARED_PROJECT, NOT_SHARED_PROJECT);
+        BAR_PATH_SHARED_PROJECT = new SPath(SHARED_REFERENCEPOINT,
+            EasyMock.createMock(IPath.class), REFERENCEPOINT_MANAGER);
 
-        FOO_PATH_SHARED_PROJECT = new SPath(SHARED_PROJECT,
-            EasyMock.createMock(IPath.class));
-
-        BAR_PATH_SHARED_PROJECT = new SPath(SHARED_PROJECT,
-            EasyMock.createMock(IPath.class));
-
-        PATH_TO_NOT_SHARED_PROJECT = new SPath(NOT_SHARED_PROJECT,
-            EasyMock.createMock(IPath.class));
+        PATH_TO_NOT_SHARED_PROJECT = new SPath(NOT_SHARED_REFERENCEPOINT,
+            EasyMock.createMock(IPath.class), REFERENCEPOINT_MANAGER);
     }
 
     @Before

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
@@ -460,8 +460,11 @@ public class EditorManager extends AbstractActivityProducer
 
                 @Override
                 public String compute() {
-                    IntelliJProjectImplV2 module = (IntelliJProjectImplV2) path
-                        .getProject().getAdapter(IntelliJProjectImplV2.class);
+
+                    IReferencePoint referencePoint = path.getReferencePoint();
+
+                    IntelliJProjectImplV2 module = (IntelliJProjectImplV2) referencePointManager
+                        .get(referencePoint).getAdapter(IntelliJProjectImplV2.class);
 
                     VirtualFile virtualFile = module
                         .findVirtualFile(path.getRelativePathFromReferencePoint());
@@ -880,8 +883,7 @@ public class EditorManager extends AbstractActivityProducer
                 editorPaths.addAll(openEditorPaths);
 
                 for (final SPath path : editorPaths) {
-                    if (referencePoint == null || referencePoint.equals(path.getProject().
-                        getReferencePoint())) {
+                    if (referencePoint == null || referencePoint.equals(path.getReferencePoint())) {
                         saveFile(path);
                     }
                 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
@@ -464,7 +464,7 @@ public class EditorManager extends AbstractActivityProducer
                         .getProject().getAdapter(IntelliJProjectImplV2.class);
 
                     VirtualFile virtualFile = module
-                        .findVirtualFile(path.getProjectRelativePath());
+                        .findVirtualFile(path.getRelativePathFromReferencePoint());
 
                     if (virtualFile == null || !virtualFile.exists() ||
                         virtualFile.isDirectory()) {

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorHandler.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorHandler.java
@@ -103,7 +103,10 @@ public class LocalEditorHandler {
             return;
         }
 
-        openEditor(virtualFile, new SPath(resource), activate);
+        IReferencePointManager referencePointManager = manager.getSession().
+            getComponent(IReferencePointManager.class);
+        
+        openEditor(virtualFile, new SPath(resource, referencePointManager), activate);
     }
 
 
@@ -241,9 +244,9 @@ public class LocalEditorHandler {
             if(resource != null){
                 break;
             }
-        }
-
-        return resource == null ? null : new SPath(resource);
+        }        
+        
+        return resource == null ? null : new SPath(resource, referencePointManager);
     }
 
     /**

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorManipulator.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorManipulator.java
@@ -72,7 +72,7 @@ public class LocalEditorManipulator {
             path.getProject().getAdapter(IntelliJProjectImplV2.class);
 
         VirtualFile virtualFile = intelliJProject
-            .findVirtualFile(path.getProjectRelativePath());
+            .findVirtualFile(path.getRelativePathFromReferencePoint());
 
         if (virtualFile == null || !virtualFile.exists()) {
             LOG.warn("Could not open Editor for path " + path + " as a " +
@@ -106,7 +106,7 @@ public class LocalEditorManipulator {
             path.getProject().getAdapter(IntelliJProjectImplV2.class);
 
         VirtualFile virtualFile = intelliJProject
-            .findVirtualFile(path.getProjectRelativePath());
+            .findVirtualFile(path.getRelativePathFromReferencePoint());
 
         if (virtualFile == null || !virtualFile.exists()) {
             LOG.warn("Could not close Editor for path " + path + " as a " +
@@ -166,7 +166,7 @@ public class LocalEditorManipulator {
                 path.getProject().getAdapter(IntelliJProjectImplV2.class);
 
             VirtualFile virtualFile = module
-                .findVirtualFile(path.getProjectRelativePath());
+                .findVirtualFile(path.getRelativePathFromReferencePoint());
 
             if (virtualFile == null || !virtualFile.exists()) {
                 LOG.warn("Could not apply TextOperations " + operations

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorManipulator.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorManipulator.java
@@ -10,8 +10,10 @@ import de.fu_berlin.inf.dpp.concurrent.jupiter.internal.text.DeleteOperation;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.internal.text.ITextOperation;
 import de.fu_berlin.inf.dpp.editor.text.LineRange;
 import de.fu_berlin.inf.dpp.editor.text.TextSelection;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.intellij.editor.colorstorage.ColorModel;
 import de.fu_berlin.inf.dpp.intellij.filesystem.IntelliJProjectImplV2;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import org.apache.log4j.Logger;
 
 import java.awt.Color;
@@ -68,8 +70,14 @@ public class LocalEditorManipulator {
             return null;
         }
 
+        IReferencePointManager referencePointManager = manager.getSession()
+            .getComponent(IReferencePointManager.class);
+
+        IReferencePoint referencePoint = path.getReferencePoint();
+
         IntelliJProjectImplV2 intelliJProject = (IntelliJProjectImplV2)
-            path.getProject().getAdapter(IntelliJProjectImplV2.class);
+            referencePointManager.get(referencePoint).getAdapter(IntelliJProjectImplV2.class);
+
 
         VirtualFile virtualFile = intelliJProject
             .findVirtualFile(path.getRelativePathFromReferencePoint());
@@ -102,8 +110,13 @@ public class LocalEditorManipulator {
 
         LOG.debug("Removed editor for path " + path + " from EditorPool");
 
+        IReferencePointManager referencePointManager = manager.getSession()
+            .getComponent(IReferencePointManager.class);
+
+        IReferencePoint referencePoint = path.getReferencePoint();
+
         IntelliJProjectImplV2 intelliJProject = (IntelliJProjectImplV2)
-            path.getProject().getAdapter(IntelliJProjectImplV2.class);
+            referencePointManager.get(referencePoint).getAdapter(IntelliJProjectImplV2.class);
 
         VirtualFile virtualFile = intelliJProject
             .findVirtualFile(path.getRelativePathFromReferencePoint());
@@ -162,8 +175,13 @@ public class LocalEditorManipulator {
          * editorPool so we have to create it temporarily here.
          */
         if (doc == null) {
+            IReferencePointManager referencePointManager = manager.getSession()
+                .getComponent(IReferencePointManager.class);
+
+            IReferencePoint referencePoint = path.getReferencePoint();
+
             IntelliJProjectImplV2 module = (IntelliJProjectImplV2)
-                path.getProject().getAdapter(IntelliJProjectImplV2.class);
+                referencePointManager.get(referencePoint).getAdapter(IntelliJProjectImplV2.class);
 
             VirtualFile virtualFile = module
                 .findVirtualFile(path.getRelativePathFromReferencePoint());

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/FileSystemChangeListener.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/FileSystemChangeListener.java
@@ -67,8 +67,13 @@ public class FileSystemChangeListener extends AbstractStoppableListener
     private void generateFolderMove(SPath oldSPath, SPath newSPath,
         boolean before) {
         User user = resourceManager.getSession().getLocalUser();
-        IntelliJProjectImpl project = (IntelliJProjectImpl) oldSPath
-            .getProject();
+
+        IReferencePointManager referencePointManager = resourceManager.getSession()
+            .getComponent(IReferencePointManager.class);
+
+        IntelliJProjectImpl project = (IntelliJProjectImpl) referencePointManager.get(oldSPath
+            .getReferencePoint());
+
         IActivity createActivity = new FolderCreatedActivity(user, newSPath);
         resourceManager.internalFireActivity(createActivity);
 
@@ -86,8 +91,8 @@ public class FileSystemChangeListener extends AbstractStoppableListener
                 oldSPath.getFullPath().toOSString() + File.separator + resource
                     .getName())).getSPath();
             SPath newChildSPath = new IntelliJFileImpl(
-                (IntelliJProjectImpl) newSPath.getProject(), new File(
-                newSPath.getFullPath().toOSString() + File.separator + resource
+                (IntelliJProjectImpl) referencePointManager.get(newSPath.getReferencePoint()),
+                new File(newSPath.getFullPath().toOSString() + File.separator + resource
                     .getName())).getSPath();
             if (resource.getType() == IResource.FOLDER) {
                 generateFolderMove(oldChildSPath, newChildSPath, before);
@@ -106,10 +111,15 @@ public class FileSystemChangeListener extends AbstractStoppableListener
     private void generateFileMove(SPath oldSPath, SPath newSPath,
         boolean before) {
         User user = resourceManager.getSession().getLocalUser();
-        IntelliJProjectImpl project = (IntelliJProjectImpl) newSPath
-            .getProject();
-        IntelliJProjectImpl oldProject = (IntelliJProjectImpl) oldSPath
-            .getProject();
+
+        IReferencePointManager referencePointManager = resourceManager.getSession()
+            .getComponent(IReferencePointManager.class);
+
+        IntelliJProjectImpl project = (IntelliJProjectImpl) referencePointManager
+            .get(newSPath.getReferencePoint());
+
+        IntelliJProjectImpl oldProject = (IntelliJProjectImpl) referencePointManager
+            .get(oldSPath.getReferencePoint());
 
         IFile file;
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/FileSystemChangeListener.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/FileSystemChangeListener.java
@@ -100,7 +100,7 @@ public class FileSystemChangeListener extends AbstractStoppableListener
         resourceManager.internalFireActivity(removeActivity);
 
         project.addFile(newSPath.getFile().getLocation().toFile());
-        project.removeResource(oldSPath.getProjectRelativePath());
+        project.removeResource(oldSPath.getRelativePathFromReferencePoint());
     }
 
     private void generateFileMove(SPath oldSPath, SPath newSPath,
@@ -128,7 +128,7 @@ public class FileSystemChangeListener extends AbstractStoppableListener
             editorManager.saveFile(newSPath);
         }
 
-        oldProject.removeResource(oldSPath.getProjectRelativePath());
+        oldProject.removeResource(oldSPath.getRelativePathFromReferencePoint());
 
         byte[] bytes = FileUtils.getLocalFileContent(file);
         String charset = getEncoding(file);
@@ -168,7 +168,10 @@ public class FileSystemChangeListener extends AbstractStoppableListener
             return;
         }
 
-        SPath spath = new SPath(project, file.getProjectRelativePath());
+        IReferencePointManager referencePointManager = resourceManager.getSession().
+            getComponent(IReferencePointManager.class);
+
+        SPath spath = new SPath(project.getReferencePoint(), file.getProjectRelativePath(), referencePointManager);
 
         //FIXME does not work as it takes the file content, which has the wrong line separators
         //Files created from templates have initial content and are opened in
@@ -231,7 +234,10 @@ public class FileSystemChangeListener extends AbstractStoppableListener
 
         path = makeAbsolutePathProjectRelative(path, project);
 
-        SPath spath = new SPath(project, path);
+        IReferencePointManager referencePointManager = resourceManager.getSession().
+            getComponent(IReferencePointManager.class);
+
+        SPath spath = new SPath(project.getReferencePoint(), path, referencePointManager);
         User user = resourceManager.getSession().getLocalUser();
         IActivity activity;
 
@@ -277,7 +283,10 @@ public class FileSystemChangeListener extends AbstractStoppableListener
 
         path = makeAbsolutePathProjectRelative(path, project);
 
-        SPath spath = new SPath(project, path);
+        IReferencePointManager referencePointManager = resourceManager.getSession().
+            getComponent(IReferencePointManager.class);
+
+        SPath spath = new SPath(project.getReferencePoint(), path, referencePointManager);
         User user = resourceManager.getSession().getLocalUser();
 
         IActivity activity;
@@ -317,7 +326,10 @@ public class FileSystemChangeListener extends AbstractStoppableListener
 
         path = makeAbsolutePathProjectRelative(path, project);
 
-        SPath newSPath = new SPath(project, path);
+        IReferencePointManager referencePointManager = resourceManager.getSession().
+            getComponent(IReferencePointManager.class);
+
+        SPath newSPath = new SPath(project.getReferencePoint(), path, referencePointManager);
 
         IPath oldParent = IntelliJPathImpl
             .fromString(virtualFileMoveEvent.getOldParent().getPath());
@@ -325,7 +337,8 @@ public class FileSystemChangeListener extends AbstractStoppableListener
         IProject oldProject = getProjectForResource(oldPath);
 
         oldPath = makeAbsolutePathProjectRelative(oldPath, project);
-        SPath oldSPath = new SPath(oldProject, oldPath);
+
+        SPath oldSPath = new SPath(oldProject.getReferencePoint(), oldPath, referencePointManager);
 
         //FIXME: Handle cases where files are moved from outside the shared project
         //into the shared project
@@ -367,13 +380,16 @@ public class FileSystemChangeListener extends AbstractStoppableListener
             return;
         }
 
+        IReferencePointManager referencePointManager = resourceManager.getSession().
+            getComponent(IReferencePointManager.class);
+
         oldPath = makeAbsolutePathProjectRelative(oldPath, project);
-        SPath oldSPath = new SPath(project, oldPath);
+        SPath oldSPath = new SPath(project.getReferencePoint(), oldPath, referencePointManager);
 
         IPath newPath = IntelliJPathImpl.fromString(newFile.getPath());
         newPath = makeAbsolutePathProjectRelative(newPath, project);
 
-        SPath newSPath = new SPath(project, newPath);
+        SPath newSPath = new SPath(project.getReferencePoint(), newPath, referencePointManager);
         //we handle this as a move activity
         if (newFile.isFile()) {
             generateFileMove(oldSPath, newSPath, false);
@@ -407,7 +423,10 @@ public class FileSystemChangeListener extends AbstractStoppableListener
 
         path = makeAbsolutePathProjectRelative(path, project);
 
-        SPath spath = new SPath(project, path);
+        IReferencePointManager referencePointManager = resourceManager.getSession().
+            getComponent(IReferencePointManager.class);
+
+        SPath spath = new SPath(project.getReferencePoint(), path, referencePointManager);
 
         User user = resourceManager.getSession().getLocalUser();
         IActivity activity;

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/SharedResourcesManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/SharedResourcesManager.java
@@ -24,6 +24,7 @@ import de.fu_berlin.inf.dpp.session.AbstractActivityConsumer;
 import de.fu_berlin.inf.dpp.session.AbstractActivityProducer;
 import de.fu_berlin.inf.dpp.session.IActivityConsumer;
 import de.fu_berlin.inf.dpp.session.IActivityConsumer.Priority;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import org.apache.log4j.Logger;
 import org.picocontainer.Startable;
@@ -205,10 +206,13 @@ public class SharedResourcesManager extends AbstractActivityProducer
         SPath oldPath = activity.getOldPath();
         SPath newPath = activity.getPath();
 
+        IReferencePointManager referencePointManager = sarosSession.
+            getComponent(IReferencePointManager.class);
+
         IntelliJProjectImpl oldProject =
-            (IntelliJProjectImpl) oldPath.getProject();
+            (IntelliJProjectImpl) referencePointManager.get(oldPath.getReferencePoint());
         IntelliJProjectImpl newProject =
-            (IntelliJProjectImpl) newPath.getProject();
+            (IntelliJProjectImpl) referencePointManager.get(newPath.getReferencePoint());
 
         IPath newFilePath = newPath.getFullPath();
 
@@ -297,8 +301,7 @@ public class SharedResourcesManager extends AbstractActivityProducer
 
         SPath path = activity.getPath();
 
-        IFolder folder = path.getProject()
-            .getFolder(path.getRelativePathFromReferencePoint());
+        IFolder folder = path.getFolder();
         fileSystemListener.setEnabled(false);
         //HACK: It does not work to disable the fileSystemListener temporarly,
         //because a fileCreated event will be fired asynchronously,

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/SharedResourcesManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/SharedResourcesManager.java
@@ -219,7 +219,7 @@ public class SharedResourcesManager extends AbstractActivityProducer
         FileUtils.mkdirs(new IntelliJFileImpl(newProject,newFilePath.toFile()));
         FileUtils.move(newFilePath, oldPath.getResource());
 
-        oldProject.removeResource(oldPath.getProjectRelativePath());
+        oldProject.removeResource(oldPath.getRelativePathFromReferencePoint());
         newProject.addFile(newFilePath.toFile());
 
         localEditorManipulator.openEditor(newPath,false);
@@ -298,7 +298,7 @@ public class SharedResourcesManager extends AbstractActivityProducer
         SPath path = activity.getPath();
 
         IFolder folder = path.getProject()
-            .getFolder(path.getProjectRelativePath());
+            .getFolder(path.getRelativePathFromReferencePoint());
         fileSystemListener.setEnabled(false);
         //HACK: It does not work to disable the fileSystemListener temporarly,
         //because a fileCreated event will be fired asynchronously,

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJResourceImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJResourceImpl.java
@@ -82,7 +82,7 @@ public abstract class IntelliJResourceImpl implements IResource {
     }
 
     public SPath getSPath() {
-        return new SPath(project, getProjectRelativePath());
+        return null;//new SPath(project, getProjectRelativePath(), null);
     }
 
     @Override

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/views/buttons/ConsistencyButton.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/views/buttons/ConsistencyButton.java
@@ -222,7 +222,7 @@ public class ConsistencyButton extends ToolbarButton {
             sbInconsistentFiles.append(path.getProject().getName());
             sbInconsistentFiles.append(", file: ");
             sbInconsistentFiles
-                .append(path.getProjectRelativePath().toOSString());
+                .append(path.getRelativePathFromReferencePoint().toOSString());
             sbInconsistentFiles.append("\n");
 
         }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/views/buttons/ConsistencyButton.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/views/buttons/ConsistencyButton.java
@@ -219,7 +219,7 @@ public class ConsistencyButton extends ToolbarButton {
         StringBuilder sbInconsistentFiles = new StringBuilder();
         for (SPath path : paths) {
             sbInconsistentFiles.append("project: ");
-            sbInconsistentFiles.append(path.getProject().getName());
+            sbInconsistentFiles.append(path.getReferencePoint());
             sbInconsistentFiles.append(", file: ");
             sbInconsistentFiles
                 .append(path.getRelativePathFromReferencePoint().toOSString());

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/editor/DirtyStateListener.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/editor/DirtyStateListener.java
@@ -56,7 +56,7 @@ public class DirtyStateListener implements IElementStateListener {
         final IFile file = ((FileEditorInput) element).getFile();
 
         final IReferencePointManager referencePointManager = editorManager
-            .getSession().getComponent(IReferencePointManager.class);
+            .getReferencePointManager();
 
         /*
          * FIXME why must we sync on SWT ? This should only be called in SWT
@@ -78,7 +78,7 @@ public class DirtyStateListener implements IElementStateListener {
 
                 LOG.debug("Dirty state reset for: " + file);
                 editorManager.sendEditorActivitySaved(new SPath(
-                    ResourceAdapterFactory.create(file)));
+                    ResourceAdapterFactory.create(file), referencePointManager));
             }
         });
     }

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/editor/EditorManager.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/editor/EditorManager.java
@@ -141,6 +141,8 @@ public class EditorManager extends AbstractActivityProducer implements
 
     private LineRange localViewport;
 
+    private IReferencePointManager referencePointManager;
+
     /** all files that have connected document providers */
     private final Set<IFile> connectedFiles = new HashSet<IFile>();
 
@@ -1526,8 +1528,7 @@ public class EditorManager extends AbstractActivityProducer implements
 
                 for (final SPath path : editorPaths) {
                     if (referencePoint == null
-                        || referencePoint.equals(path.getProject()
-                            .getReferencePoint()))
+                        || referencePoint.equals(path.getReferencePoint()))
                         saveLazy(path);
                 }
             }
@@ -1772,7 +1773,6 @@ public class EditorManager extends AbstractActivityProducer implements
         assert editorPool.getAllEditors().size() == 0 : "EditorPool was not correctly reset!";
 
         session = newSession;
-
         session.getStopManager().addBlockable(stopManagerListener);
 
         hasWriteAccess = session.hasWriteAccess();
@@ -1803,6 +1803,9 @@ public class EditorManager extends AbstractActivityProducer implements
 
         if (window != null)
             window.getPartService().addPartListener(partListener);
+
+        referencePointManager = session
+            .getComponent(IReferencePointManager.class);
     }
 
     /**
@@ -1834,7 +1837,7 @@ public class EditorManager extends AbstractActivityProducer implements
             }
         });
 
-        editorPool.removeAllEditors();
+        editorPool.removeAllEditors(this.referencePointManager);
 
         customAnnotationManager.uninstallAllPainters(true);
 
@@ -1862,7 +1865,7 @@ public class EditorManager extends AbstractActivityProducer implements
             throw new IllegalStateException("method must be invoked from EDT");
     }
 
-    public ISarosSession getSession() {
-        return this.session;
+    public IReferencePointManager getReferencePointManager() {
+        return this.referencePointManager;
     }
 }

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/editor/EditorPool.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/editor/EditorPool.java
@@ -23,6 +23,7 @@ import org.eclipse.ui.texteditor.IElementStateListener;
 import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.editor.internal.EditorAPI;
 import de.fu_berlin.inf.dpp.filesystem.ResourceAdapterFactory;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.User.Permission;
 
 /**
@@ -154,7 +155,8 @@ final class EditorPool {
         documentProvider.getDocument(input).addDocumentListener(
             documentListener);
 
-        final SPath path = new SPath(ResourceAdapterFactory.create(file));
+        final SPath path = new SPath(ResourceAdapterFactory.create(file),
+            editorManager.getReferencePointManager());
 
         Set<IEditorPart> parts = editorParts.get(path);
 
@@ -260,7 +262,8 @@ final class EditorPool {
 
         editorManager.disconnect(file);
 
-        final SPath path = new SPath(ResourceAdapterFactory.create(file));
+        final SPath path = new SPath(ResourceAdapterFactory.create(file),
+            editorManager.getReferencePointManager());
 
         editorParts.get(path).remove(editorPart);
     }
@@ -301,8 +304,11 @@ final class EditorPool {
 
     /**
      * Removes all {@link IEditorPart} from the EditorPool.
+     * 
+     * @param referencePointManager
+     *            TODO
      */
-    public void removeAllEditors() {
+    public void removeAllEditors(IReferencePointManager referencePointManager) {
         LOG.trace("removing all editors");
 
         for (final IEditorPart part : new HashSet<IEditorPart>(getAllEditors()))

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/editor/internal/EditorAPI.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/editor/internal/EditorAPI.java
@@ -419,17 +419,16 @@ public class EditorAPI {
     }
 
     /**
-     * @param refernencePointManager
-     *            TODO
      * @return the path of the file the given editor is displaying or null if
      *         the given editor is not showing a file or the file is not
      *         referenced via a path in the project.
      */
     public static SPath getEditorPath(IEditorPart editorPart,
-        IReferencePointManager refernencePointManager) {
+        IReferencePointManager referencePointManager) {
         IResource resource = getEditorResource(editorPart);
+
         return (resource == null) ? null : new SPath(
-            ResourceAdapterFactory.create(resource));
+            ResourceAdapterFactory.create(resource), referencePointManager);
     }
 
     /**

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/project/FolderActivityConsumer.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/project/FolderActivityConsumer.java
@@ -62,9 +62,7 @@ public final class FolderActivityConsumer extends AbstractActivityConsumer
 
         SPath path = activity.getPath();
 
-        IFolder folder = ((EclipseFolderImpl) path.getProject().getFolder(
-            path.getProjectRelativePath())).getDelegate();
-
+        IFolder folder = ((EclipseFolderImpl) path.getFolder()).getDelegate();
         try {
             FileUtils.create(folder);
         } catch (CoreException e) {
@@ -77,8 +75,7 @@ public final class FolderActivityConsumer extends AbstractActivityConsumer
 
         SPath path = activity.getPath();
 
-        IFolder folder = ((EclipseFolderImpl) path.getProject().getFolder(
-            path.getProjectRelativePath())).getDelegate();
+        IFolder folder = ((EclipseFolderImpl) path.getFolder()).getDelegate();
 
         try {
             if (folder.exists())

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/project/ProjectDeltaVisitor.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/project/ProjectDeltaVisitor.java
@@ -21,6 +21,7 @@ import de.fu_berlin.inf.dpp.activities.IResourceActivity;
 import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.editor.EditorManager;
 import de.fu_berlin.inf.dpp.filesystem.ResourceAdapterFactory;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.User;
 import de.fu_berlin.inf.dpp.util.FileUtils;
@@ -178,8 +179,11 @@ final class ProjectDeltaVisitor implements IResourceDeltaVisitor {
     }
 
     private void generateCreated(IResource resource) {
+        IReferencePointManager referencePointManager = session
+            .getComponent(IReferencePointManager.class);
 
-        final SPath spath = new SPath(ResourceAdapterFactory.create(resource));
+        final SPath spath = new SPath(ResourceAdapterFactory.create(resource),
+            referencePointManager);
 
         if (isFile(resource)) {
             byte[] content = FileUtils.getLocalFileContent((IFile) resource
@@ -219,23 +223,30 @@ final class ProjectDeltaVisitor implements IResourceDeltaVisitor {
             }
         }
 
-        SPath newPath = new SPath(ResourceAdapterFactory.create(resource));
-        SPath oldPath = new SPath(ResourceAdapterFactory.create(oldProject),
-            ResourceAdapterFactory.create(oldFullPath.removeFirstSegments(1)));
+        IReferencePointManager referencePointManager = session
+            .getComponent(IReferencePointManager.class);
+
+        SPath newPath = new SPath(ResourceAdapterFactory.create(resource),
+            referencePointManager);
+        SPath oldPath = new SPath(ResourceAdapterFactory.create(oldProject)
+            .getReferencePoint(), ResourceAdapterFactory.create(oldFullPath
+            .removeFirstSegments(1)), referencePointManager);
         // TODO add encoding
         addActivity(new FileActivity(user, Type.MOVED, Purpose.ACTIVITY,
             newPath, oldPath, content, null));
     }
 
     private void generateRemoved(IResource resource) {
+        IReferencePointManager referencePointManager = session
+            .getComponent(IReferencePointManager.class);
 
         if (resource instanceof IFile) {
             addActivity(new FileActivity(user, Type.REMOVED, Purpose.ACTIVITY,
-                new SPath(ResourceAdapterFactory.create(resource)), null, null,
-                null));
+                new SPath(ResourceAdapterFactory.create(resource),
+                    referencePointManager), null, null, null));
         } else {
             addActivity(new FolderDeletedActivity(user, new SPath(
-                ResourceAdapterFactory.create(resource))));
+                ResourceAdapterFactory.create(resource), referencePointManager)));
         }
     }
 
@@ -252,7 +263,11 @@ final class ProjectDeltaVisitor implements IResourceDeltaVisitor {
 
         assert resource.getType() == IResource.FILE;
 
-        final SPath spath = new SPath(ResourceAdapterFactory.create(resource));
+        IReferencePointManager referencePointManager = session
+            .getComponent(IReferencePointManager.class);
+
+        final SPath spath = new SPath(ResourceAdapterFactory.create(resource),
+            referencePointManager);
 
         if (!session.isShared(ResourceAdapterFactory.create(resource)))
             return;

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/actions/ConsistencyAction.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/actions/ConsistencyAction.java
@@ -32,6 +32,7 @@ import de.fu_berlin.inf.dpp.concurrent.watchdog.ConsistencyWatchdogClient;
 import de.fu_berlin.inf.dpp.concurrent.watchdog.IsInconsistentObservable;
 import de.fu_berlin.inf.dpp.monitoring.ProgressMonitorAdapterFactory;
 import de.fu_berlin.inf.dpp.observables.ValueChangeListener;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
 import de.fu_berlin.inf.dpp.session.ISessionLifecycleListener;
@@ -279,10 +280,12 @@ public class ConsistencyAction extends Action implements Disposable {
                 + "The affected files and folders may be either modified, created, or deleted.\n\n"
                 + "Press 'Details' for the affected files and folders.", null);
 
+        IReferencePointManager referencePointManager = sarosSession
+            .getComponent(IReferencePointManager.class);
         for (SPath path : paths)
             multiStatus.add(new Status(IStatus.WARNING, pluginID, "project: "
-                + path.getProject().getName() + ", file:"
-                + path.getProjectRelativePath().toOSString()));
+                + referencePointManager.get(path.getReferencePoint()).getName()
+                + ", file:" + path.getRelativePathFromReferencePoint().toOSString()));
 
         class OkCancelErrorDialog extends ErrorDialog {
             public OkCancelErrorDialog(Shell parentShell, String dialogTitle,

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/model/session/AwarenessInformationTreeElement.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/model/session/AwarenessInformationTreeElement.java
@@ -116,7 +116,9 @@ public class AwarenessInformationTreeElement extends TreeElement {
              * 
              * TODO: make this configurable?
              */
-            details.add(activeFile.getProject().getName() + ": "
+            details.add(editorManager.getReferencePointManager()
+                .get(activeFile.getReferencePoint()).getName()
+                + ": "
                 + activeFile.getFile().getProjectRelativePath().toString());
         }
 

--- a/de.fu_berlin.inf.dpp/test/junit/de/fu_berlin/inf/dpp/concurrent/undo/UndoTest.java
+++ b/de.fu_berlin.inf.dpp/test/junit/de/fu_berlin/inf/dpp/concurrent/undo/UndoTest.java
@@ -15,8 +15,9 @@ import de.fu_berlin.inf.dpp.concurrent.jupiter.internal.text.InsertOperation;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.internal.text.NoOperation;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.internal.text.SplitOperation;
 import de.fu_berlin.inf.dpp.concurrent.undo.OperationHistory.Type;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.ResourceAdapterFactory;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 
 /**
  * testing TextOperationHistory and UndoManager
@@ -25,7 +26,9 @@ public class UndoTest {
 
     // private static final Logger log = Logger.getLogger(UndoTest.class);
 
-    protected IProject project;
+    protected IReferencePoint referencePoint;
+
+    protected IReferencePointManager referencePointManager;
 
     protected SPath path1;
     protected SPath path2;
@@ -35,14 +38,18 @@ public class UndoTest {
 
     @Before
     public void setUp() {
-        project = createMock(IProject.class);
-        replay(project);
+        referencePoint = createMock(IReferencePoint.class);
+        referencePointManager = createMock(IReferencePointManager.class);
+
+        replay(referencePoint, referencePointManager);
         undoManager = new UndoManager();
         history = undoManager.getHistory();
-        path1 = new SPath(project, ResourceAdapterFactory.create(new Path(
-            "path1")));
-        path2 = new SPath(project, ResourceAdapterFactory.create(new Path(
-            "path2")));
+        path1 = new SPath(referencePoint,
+            ResourceAdapterFactory.create(new Path("path1")),
+            referencePointManager);
+        path2 = new SPath(referencePoint,
+            ResourceAdapterFactory.create(new Path("path2")),
+            referencePointManager);
     }
 
     protected Operation nop() {


### PR DESCRIPTION
SPath doesn't contain core.IProject anymore. Now it either takes a resource, relativePathToReferencePoint and referencePointManager or the referencePoint, relativePathToReferencePoint and referencePointManager.

The funcionality doesn't changed. The difference is, that the SPath returns resources with the combination of the referencePoint and the relativePathToTheReferencePoint. This is the reason, that the SPath now needs the referencePointManager.

Because of refactoring SPath, some unit tests have to adjust to the new SPath class.