### PR TITLE
[FIX][I] Correctly reset connection when unsubscribing editor listener

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/StoppableEditorFileListener.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/StoppableEditorFileListener.java
@@ -134,6 +134,8 @@ public class StoppableEditorFileListener extends AbstractStoppableListener
      */
     void unsubscribe(){
         messageBusConnection.disconnect();
+
+        messageBusConnection = null;
     }
 
     /**


### PR DESCRIPTION
StoppableEditorFileListener.unsubscribe() now correctly drops the held
MessageBusConnection object. If this object is not removed, subsequent
calls  to subscribe(Project) will fail as they think the listener is
already registered.