### PR TITLE
[INTERNAL][I] Make injection in SelectedEditorState static

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/SelectedEditorState.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/SelectedEditorState.java
@@ -30,19 +30,21 @@ public class SelectedEditorState {
     private boolean hasCapturedState;
 
     @Inject
-    private ProjectAPI projectAPI;
+    private static ProjectAPI projectAPI;
 
     @Inject
-    private EditorManager editorManager;
+    private static EditorManager editorManager;
 
     @Inject
-    private Project project;
+    private static Project project;
+
+    static {
+        SarosPluginContext.initComponent(new SelectedEditorState());
+    }
 
     public SelectedEditorState() {
         this.selectedEditors = new ArrayList<>();
         this.hasCapturedState = false;
-
-        SarosPluginContext.initComponent(this);
     }
 
     /**


### PR DESCRIPTION
Makes the dependency injection in SelectedEditorState static as the
injected objects never change. This avoids additional injections with
every instantiation of SelectedEditorState.

This can help to alleviate potential problems when using annotation injection (too often) as mentioned in #275.