### PR TITLE
[I] Add exception for PicoContainer Inject annotation to code analyzer

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <writeAnnotations>
+      <writeAnnotation name="org.picocontainer.annotations.Inject" />
+    </writeAnnotations>
+  </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />


### PR DESCRIPTION
Adds a setting that tells the IntelliJ code analyzer to ignore that
instance variables are never assigned if they are tagged with the
PicoContainer "Inject" annotation. This prevents the IntelliJ code
analyzer from incorrectly warning that a injected variable is never
set.

The added section to the misc.xml was created automatically by
IntelliJ.