### PR TITLE
 [INTERNAL][I] Add session utilities

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorHandler.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorHandler.java
@@ -8,6 +8,7 @@ import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.intellij.filesystem.IntelliJProjectImplV2;
+import de.fu_berlin.inf.dpp.intellij.session.SessionUtils;
 
 import org.apache.log4j.Logger;
 
@@ -156,7 +157,7 @@ public class LocalEditorHandler {
 
             return null;
 
-        }else if (!manager.getSession().isShared(path.getResource())) {
+        }else if (!SessionUtils.isShared(path)) {
             LOG.debug("Ignored open editor request for file " + virtualFile +
                 " as it is not shared");
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorManipulator.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorManipulator.java
@@ -3,6 +3,7 @@ package de.fu_berlin.inf.dpp.intellij.editor;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.vfs.VirtualFile;
+
 import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.Operation;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.internal.text.DeleteOperation;
@@ -10,6 +11,8 @@ import de.fu_berlin.inf.dpp.concurrent.jupiter.internal.text.ITextOperation;
 import de.fu_berlin.inf.dpp.editor.text.LineRange;
 import de.fu_berlin.inf.dpp.editor.text.TextSelection;
 import de.fu_berlin.inf.dpp.intellij.filesystem.IntelliJProjectImplV2;
+import de.fu_berlin.inf.dpp.intellij.session.SessionUtils;
+
 import org.apache.log4j.Logger;
 
 /**
@@ -57,7 +60,7 @@ public class LocalEditorManipulator {
      * or <code>null</code> if the file does not exist or is not shared
      */
     public Editor openEditor(SPath path, boolean activate) {
-        if (!manager.getSession().isShared(path.getResource())) {
+        if (!SessionUtils.isShared(path.getResource())) {
             LOG.warn("Ignored open editor request for path " + path +
                 " as it is not shared");
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/session/SessionUtils.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/session/SessionUtils.java
@@ -1,0 +1,93 @@
+package de.fu_berlin.inf.dpp.intellij.session;
+
+import de.fu_berlin.inf.dpp.SarosPluginContext;
+import de.fu_berlin.inf.dpp.activities.SPath;
+import de.fu_berlin.inf.dpp.filesystem.IResource;
+import de.fu_berlin.inf.dpp.session.ISarosSession;
+import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
+import de.fu_berlin.inf.dpp.session.NullSessionLifecycleListener;
+import de.fu_berlin.inf.dpp.session.SessionEndReason;
+
+import org.jetbrains.annotations.NotNull;
+import org.picocontainer.annotations.Inject;
+
+/**
+ * A utility class to provide easy access to functionality needing a session
+ * object.
+ * <p>
+ * <b>NOTE:</b> It should be carefully considered when to use this class as it
+ * generally is an indicator that the calling class should belong to the session
+ * context (which would make the usage of this class unnecessary).
+ * </p>
+ *
+ * @deprecated Consider whether your class actually belongs inside the session
+ * context and use the session container instead in such cases.
+ */
+//TODO consider to remove this class after the session & plugin context have been correctly separated
+@Deprecated
+public class SessionUtils {
+    private static volatile ISarosSession currentSarosSession;
+
+    @Inject
+    private static ISarosSessionManager sarosSessionManager;
+
+    static {
+        SarosPluginContext.initComponent(new SessionUtils());
+
+        sarosSessionManager
+            .addSessionLifecycleListener(new NullSessionLifecycleListener() {
+                @Override
+                public void sessionStarted(ISarosSession session) {
+
+                    currentSarosSession = session;
+                }
+
+                @Override
+                public void sessionEnded(ISarosSession session,
+                    SessionEndReason reason) {
+
+                    currentSarosSession = null;
+                }
+            });
+    }
+
+    private SessionUtils() {
+        //NOP
+    }
+
+    /**
+     * Returns whether the resource represented by the given SPath is shared.
+     *
+     * @param resource the resource to check
+     * @return <code>true</code> if a session is currently running and the given
+     * resource exists and is shared, <code>false</code> otherwise
+     */
+    public static boolean isShared(
+        @NotNull
+            IResource resource) {
+
+        ISarosSession session = currentSarosSession;
+
+        return session != null && session.isShared(resource);
+    }
+
+    /**
+     * Returns whether the resource represented by the given SPath is shared.
+     *
+     * @param path the SPath representing the resource to check
+     * @return <code>true</code> if a session is currently running and the
+     * resource represented by the given resource exists and is shared,
+     * <code>false</code> otherwise
+     */
+    public static boolean isShared(
+        @NotNull
+            SPath path) {
+
+        IResource resource = path.getResource();
+
+        ISarosSession session = currentSarosSession;
+
+        return resource != null && session != null && session
+            .isShared(resource);
+    }
+}


### PR DESCRIPTION
Adds a class containing static session utilities. The main benefit of
this utility class is that it can provide certain useful interactions
with the session without requiring the caller to have access to a
session object.

Currently, this class only provides methods to check whether a given
resource is shared or not.

[EDIT: This point is no longer applicable. The need for this utility class stems from the poor separation of which classes should belong to the session context and which to the plugin context. See discussion below.]
This class is currently only used in the IntelliJ part. But as it does not contains any functionality specific to IntelliJ and because it might be useful for other implementations, I added it to the core.
If there are other useful applications for such a static class holding a session object, the methods offered by this utility class can be expanded later on.

The class FileSystemChangeListener was explicitly not adjusted as it will be completely re-written in an upcoming PR anyway.