### PR TITLE
[INTERNAL][I] Make VirtualFileConverter static and session independent

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/context/SarosIntellijContextFactory.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/context/SarosIntellijContextFactory.java
@@ -26,7 +26,6 @@ import de.fu_berlin.inf.dpp.intellij.editor.EditorManager;
 import de.fu_berlin.inf.dpp.intellij.editor.LocalEditorHandler;
 import de.fu_berlin.inf.dpp.intellij.editor.LocalEditorManipulator;
 import de.fu_berlin.inf.dpp.intellij.editor.ProjectAPI;
-import de.fu_berlin.inf.dpp.intellij.editor.VirtualFileConverter;
 import de.fu_berlin.inf.dpp.intellij.editor.annotations.AnnotationManager;
 import de.fu_berlin.inf.dpp.intellij.negotiation.hooks.ModuleTypeNegotiationHook;
 import de.fu_berlin.inf.dpp.intellij.preferences.IntelliJPreferences;
@@ -76,9 +75,6 @@ public class SarosIntellijContextFactory extends AbstractContextFactory {
 
         Component.create(ISarosSessionContextFactory.class,
             SarosIntellijSessionContextFactory.class),
-
-        // Utility to create Saros resources from a VirtualFile
-        Component.create(VirtualFileConverter.class),
 
         // Annotation utility to create, remove, and manage annotations
         Component.create(AnnotationManager.class),

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
@@ -480,7 +480,6 @@ public class EditorManager extends AbstractActivityProducer
     public EditorManager(ISarosSessionManager sessionManager,
         LocalEditorHandler localEditorHandler,
         LocalEditorManipulator localEditorManipulator, ProjectAPI projectAPI,
-        VirtualFileConverter virtualFileConverter,
         AnnotationManager annotationManager,
         FileReplacementInProgressObservable fileReplacementInProgressObservable) {
 
@@ -490,10 +489,8 @@ public class EditorManager extends AbstractActivityProducer
         this.annotationManager = annotationManager;
         this.fileReplacementInProgressObservable = fileReplacementInProgressObservable;
 
-        documentListener = new StoppableDocumentListener(this,
-                virtualFileConverter);
-        fileListener = new StoppableEditorFileListener(this,
-                virtualFileConverter, annotationManager);
+        documentListener = new StoppableDocumentListener(this);
+        fileListener = new StoppableEditorFileListener(this, annotationManager);
 
         selectionListener = new StoppableSelectionListener(this);
         viewportListener = new StoppableViewPortListener(this);

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
@@ -31,6 +31,7 @@ import de.fu_berlin.inf.dpp.filesystem.IFile;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.intellij.editor.annotations.AnnotationManager;
 import de.fu_berlin.inf.dpp.intellij.filesystem.Filesystem;
+import de.fu_berlin.inf.dpp.intellij.filesystem.VirtualFileConverter;
 import de.fu_berlin.inf.dpp.intellij.ui.util.NotificationPanel;
 import de.fu_berlin.inf.dpp.observables.FileReplacementInProgressObservable;
 import de.fu_berlin.inf.dpp.session.AbstractActivityConsumer;

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
@@ -31,7 +31,6 @@ import de.fu_berlin.inf.dpp.filesystem.IFile;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.intellij.editor.annotations.AnnotationManager;
 import de.fu_berlin.inf.dpp.intellij.filesystem.Filesystem;
-import de.fu_berlin.inf.dpp.intellij.filesystem.IntelliJProjectImplV2;
 import de.fu_berlin.inf.dpp.intellij.ui.util.NotificationPanel;
 import de.fu_berlin.inf.dpp.observables.FileReplacementInProgressObservable;
 import de.fu_berlin.inf.dpp.session.AbstractActivityConsumer;
@@ -512,11 +511,8 @@ public class EditorManager extends AbstractActivityProducer
 
                 @Override
                 public String compute() {
-                    IntelliJProjectImplV2 module = (IntelliJProjectImplV2) path
-                        .getProject().getAdapter(IntelliJProjectImplV2.class);
-
-                    VirtualFile virtualFile = module
-                        .findVirtualFile(path.getProjectRelativePath());
+                    VirtualFile virtualFile = VirtualFileConverter
+                        .convertToVirtualFile(path);
 
                     if (virtualFile == null || !virtualFile.exists() ||
                         virtualFile.isDirectory()) {

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorHandler.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorHandler.java
@@ -25,7 +25,6 @@ public class LocalEditorHandler {
         .getLogger(LocalEditorHandler.class);
 
     private final ProjectAPI projectAPI;
-    private final VirtualFileConverter virtualFileConverter;
 
     /**
      * This is just a reference to {@link EditorManager}'s editorPool and not a
@@ -35,11 +34,9 @@ public class LocalEditorHandler {
 
     private EditorManager manager;
 
-    public LocalEditorHandler(ProjectAPI projectAPI,
-        VirtualFileConverter virtualFileConverter) {
+    public LocalEditorHandler(ProjectAPI projectAPI) {
 
         this.projectAPI = projectAPI;
-        this.virtualFileConverter = virtualFileConverter;
     }
 
     /**
@@ -82,9 +79,9 @@ public class LocalEditorHandler {
             return null;
         }
 
-        SPath path = virtualFileConverter.convertToPath(virtualFile);
+        SPath path = VirtualFileConverter.convertToSPath(virtualFile);
 
-        if (path == null) {
+        if (path == null || !SessionUtils.isShared(path)) {
             LOG.debug("Ignored open editor request for file " + virtualFile +
                 " as it does not belong to a shared module");
 
@@ -116,10 +113,10 @@ public class LocalEditorHandler {
         @NotNull
             IProject project, boolean activate) {
 
-        IResource resource = virtualFileConverter
+        IResource resource = VirtualFileConverter
             .getResource(virtualFile, project);
 
-        if (resource == null) {
+        if (resource == null || !SessionUtils.isShared(resource)) {
             LOG.debug("Could not open Editor for file " + virtualFile +
                 " as it does not belong to the given module " + project);
 
@@ -181,8 +178,9 @@ public class LocalEditorHandler {
      * @param virtualFile
      */
     public void closeEditor(@NotNull VirtualFile virtualFile) {
-        SPath path = virtualFileConverter.convertToPath(virtualFile);
-        if (path != null) {
+        SPath path = VirtualFileConverter.convertToSPath(virtualFile);
+
+        if (path != null && SessionUtils.isShared(path)) {
             editorPool.removeEditor(path);
             manager.generateEditorClosed(path);
         }
@@ -242,8 +240,9 @@ public class LocalEditorHandler {
      * @param file
      */
     public void activateEditor(@NotNull VirtualFile file) {
-        SPath path = virtualFileConverter.convertToPath(file);
-        if (path != null) {
+        SPath path = VirtualFileConverter.convertToSPath(file);
+
+        if (path != null && SessionUtils.isShared(path)) {
             manager.generateEditorActivated(path);
         }
     }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorHandler.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorHandler.java
@@ -7,7 +7,6 @@ import com.intellij.openapi.vfs.VirtualFile;
 import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
-import de.fu_berlin.inf.dpp.intellij.filesystem.IntelliJProjectImplV2;
 import de.fu_berlin.inf.dpp.intellij.session.SessionUtils;
 
 import org.apache.log4j.Logger;
@@ -208,11 +207,7 @@ public class LocalEditorHandler {
         Document document = editorPool.getDocument(path);
 
         if (document == null) {
-            IntelliJProjectImplV2 project = (IntelliJProjectImplV2) path
-                .getProject().getAdapter(IntelliJProjectImplV2.class);
-
-            VirtualFile file = project
-                .findVirtualFile(path.getProjectRelativePath());
+            VirtualFile file = VirtualFileConverter.convertToVirtualFile(path);
 
             if (file == null || !file.exists()) {
                 LOG.warn("Failed to save document for " + path

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorHandler.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorHandler.java
@@ -113,7 +113,7 @@ public class LocalEditorHandler {
             IProject project, boolean activate) {
 
         IResource resource = VirtualFileConverter
-            .getResource(virtualFile, project);
+            .convertToResource(virtualFile, project);
 
         if (resource == null || !SessionUtils.isShared(resource)) {
             LOG.debug("Could not open Editor for file " + virtualFile +

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorHandler.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorHandler.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
+import de.fu_berlin.inf.dpp.intellij.filesystem.VirtualFileConverter;
 import de.fu_berlin.inf.dpp.intellij.session.SessionUtils;
 
 import org.apache.log4j.Logger;

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorManipulator.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorManipulator.java
@@ -10,6 +10,7 @@ import de.fu_berlin.inf.dpp.concurrent.jupiter.internal.text.DeleteOperation;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.internal.text.ITextOperation;
 import de.fu_berlin.inf.dpp.editor.text.LineRange;
 import de.fu_berlin.inf.dpp.editor.text.TextSelection;
+import de.fu_berlin.inf.dpp.intellij.filesystem.VirtualFileConverter;
 import de.fu_berlin.inf.dpp.intellij.session.SessionUtils;
 
 import org.apache.log4j.Logger;

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorManipulator.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorManipulator.java
@@ -10,7 +10,6 @@ import de.fu_berlin.inf.dpp.concurrent.jupiter.internal.text.DeleteOperation;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.internal.text.ITextOperation;
 import de.fu_berlin.inf.dpp.editor.text.LineRange;
 import de.fu_berlin.inf.dpp.editor.text.TextSelection;
-import de.fu_berlin.inf.dpp.intellij.filesystem.IntelliJProjectImplV2;
 import de.fu_berlin.inf.dpp.intellij.session.SessionUtils;
 
 import org.apache.log4j.Logger;
@@ -67,11 +66,8 @@ public class LocalEditorManipulator {
             return null;
         }
 
-        IntelliJProjectImplV2 intelliJProject = (IntelliJProjectImplV2)
-            path.getProject().getAdapter(IntelliJProjectImplV2.class);
-
-        VirtualFile virtualFile = intelliJProject
-            .findVirtualFile(path.getProjectRelativePath());
+        VirtualFile virtualFile = VirtualFileConverter
+            .convertToVirtualFile(path);
 
         if (virtualFile == null || !virtualFile.exists()) {
             LOG.warn("Could not open Editor for path " + path + " as a " +
@@ -101,11 +97,8 @@ public class LocalEditorManipulator {
 
         LOG.debug("Removed editor for path " + path + " from EditorPool");
 
-        IntelliJProjectImplV2 intelliJProject = (IntelliJProjectImplV2)
-            path.getProject().getAdapter(IntelliJProjectImplV2.class);
-
-        VirtualFile virtualFile = intelliJProject
-            .findVirtualFile(path.getProjectRelativePath());
+        VirtualFile virtualFile = VirtualFileConverter
+            .convertToVirtualFile(path);
 
         if (virtualFile == null || !virtualFile.exists()) {
             LOG.warn("Could not close Editor for path " + path + " as a " +
@@ -159,11 +152,8 @@ public class LocalEditorManipulator {
          * editorPool so we have to create it temporarily here.
          */
         if (doc == null) {
-            IntelliJProjectImplV2 module = (IntelliJProjectImplV2)
-                path.getProject().getAdapter(IntelliJProjectImplV2.class);
-
-            VirtualFile virtualFile = module
-                .findVirtualFile(path.getProjectRelativePath());
+            VirtualFile virtualFile = VirtualFileConverter
+                .convertToVirtualFile(path);
 
             if (virtualFile == null || !virtualFile.exists()) {
                 LOG.warn("Could not apply TextOperations " + operations

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/SelectedEditorState.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/SelectedEditorState.java
@@ -5,7 +5,6 @@ import com.intellij.openapi.vfs.VirtualFile;
 
 import de.fu_berlin.inf.dpp.SarosPluginContext;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
-import de.fu_berlin.inf.dpp.intellij.filesystem.IntelliJProjectImplV2;
 
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -140,13 +139,11 @@ public class SelectedEditorState {
         @NotNull
             IFile newFile) {
 
-        VirtualFile oldVirtualFile = ((IntelliJProjectImplV2) oldFile
-            .getProject().getAdapter(IntelliJProjectImplV2.class))
-            .findVirtualFile(oldFile.getProjectRelativePath());
+        VirtualFile oldVirtualFile = VirtualFileConverter
+            .convertToVirtualFile(oldFile);
 
-        VirtualFile newVirtualFile = ((IntelliJProjectImplV2) newFile
-            .getProject().getAdapter(IntelliJProjectImplV2.class))
-            .findVirtualFile(newFile.getProjectRelativePath());
+        VirtualFile newVirtualFile = VirtualFileConverter
+            .convertToVirtualFile(newFile);
 
         if (oldVirtualFile == null) {
             throw new IllegalStateException(

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/SelectedEditorState.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/SelectedEditorState.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import de.fu_berlin.inf.dpp.SarosPluginContext;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
 
+import de.fu_berlin.inf.dpp.intellij.filesystem.VirtualFileConverter;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.picocontainer.annotations.Inject;

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/StoppableDocumentListener.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/StoppableDocumentListener.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.editor.event.DocumentListener;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import de.fu_berlin.inf.dpp.activities.SPath;
+import de.fu_berlin.inf.dpp.intellij.session.SessionUtils;
 import org.apache.log4j.Logger;
 
 /**
@@ -22,15 +23,10 @@ public class StoppableDocumentListener extends AbstractStoppableListener
     private static final Logger LOG = Logger
         .getLogger(StoppableDocumentListener.class);
 
-    private final VirtualFileConverter virtualFileConverter;
-
-    StoppableDocumentListener(EditorManager editorManager,
-        VirtualFileConverter virtualFileConverter) {
+    StoppableDocumentListener(EditorManager editorManager) {
 
         super(editorManager);
         super.setEnabled(false);
-
-        this.virtualFileConverter = virtualFileConverter;
     }
 
     /**
@@ -57,9 +53,10 @@ public class StoppableDocumentListener extends AbstractStoppableListener
                 return;
             }
 
-            path = virtualFileConverter.convertToPath(virtualFile);
+            path = VirtualFileConverter.convertToSPath(virtualFile);
 
-            if (path == null) {
+            if (path == null || !SessionUtils.isShared(path)) {
+
                 LOG.trace("Ignoring Event for document " + document
                         + " - document is not shared");
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/StoppableDocumentListener.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/StoppableDocumentListener.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.editor.event.DocumentListener;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import de.fu_berlin.inf.dpp.activities.SPath;
+import de.fu_berlin.inf.dpp.intellij.filesystem.VirtualFileConverter;
 import de.fu_berlin.inf.dpp.intellij.session.SessionUtils;
 import org.apache.log4j.Logger;
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/StoppableEditorFileListener.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/StoppableEditorFileListener.java
@@ -10,6 +10,7 @@ import com.intellij.util.messages.MessageBusConnection;
 import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
 import de.fu_berlin.inf.dpp.intellij.editor.annotations.AnnotationManager;
+import de.fu_berlin.inf.dpp.intellij.filesystem.VirtualFileConverter;
 import de.fu_berlin.inf.dpp.intellij.session.SessionUtils;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/StoppableEditorFileListener.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/StoppableEditorFileListener.java
@@ -10,6 +10,7 @@ import com.intellij.util.messages.MessageBusConnection;
 import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
 import de.fu_berlin.inf.dpp.intellij.editor.annotations.AnnotationManager;
+import de.fu_berlin.inf.dpp.intellij.session.SessionUtils;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
@@ -24,18 +25,15 @@ public class StoppableEditorFileListener extends AbstractStoppableListener
 
     private final BeforeEditorActionListener beforeEditorActionListener;
 
-    private final VirtualFileConverter virtualFileConverter;
     private final AnnotationManager annotationManager;
 
     private MessageBusConnection messageBusConnection;
 
     StoppableEditorFileListener(EditorManager manager,
-        VirtualFileConverter virtualFileConverter,
         AnnotationManager annotationManager) {
 
         super(manager);
 
-        this.virtualFileConverter = virtualFileConverter;
         this.annotationManager = annotationManager;
 
         this.beforeEditorActionListener = new BeforeEditorActionListener();
@@ -60,9 +58,9 @@ public class StoppableEditorFileListener extends AbstractStoppableListener
         Editor editor = editorManager.getLocalEditorHandler()
             .openEditor(virtualFile, false);
 
-        SPath sPath = virtualFileConverter.convertToPath(virtualFile);
+        SPath sPath = VirtualFileConverter.convertToSPath(virtualFile);
 
-        if (sPath != null && editor != null) {
+        if (sPath != null && SessionUtils.isShared(sPath) && editor != null) {
             annotationManager.applyStoredAnnotations(sPath.getFile(), editor);
         }
     }
@@ -152,9 +150,9 @@ public class StoppableEditorFileListener extends AbstractStoppableListener
             @NotNull
                 VirtualFile virtualFile) {
 
-            SPath sPath = virtualFileConverter.convertToPath(virtualFile);
+            SPath sPath = VirtualFileConverter.convertToSPath(virtualFile);
 
-            if (sPath != null) {
+            if (sPath != null && SessionUtils.isShared(sPath)) {
                 IFile file = sPath.getFile();
 
                 annotationManager.updateAnnotationStore(file);

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/VirtualFileConverter.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/VirtualFileConverter.java
@@ -97,24 +97,27 @@ public class VirtualFileConverter {
     }
 
     /**
-     * Returns an <code>IResource</code> for the passed VirtualFile and module.
+     * Returns an <code>IResource</code> representing the given
+     * <code>VirtualFile</code>.
      *
      * @param virtualFile file to get the <code>IResource</code> for
      * @param project     module the file belongs to
-     * @return an <code>IResource</code> for the passed file or
-     * <code>null</code> it does not belong to the passed module.
+     * @return an <code>IResource</code> for the given file or
+     * <code>null</code> if the given file does not exist, does not belong to
+     * the passed module, or the relative path path between the module root and
+     * the file could not be constructed
      */
     @Nullable
-    public static IResource getResource(
+    public static IResource convertToResource(
         @NotNull
             VirtualFile virtualFile,
         @NotNull
             IProject project) {
 
-        IntelliJProjectImplV2 module = (IntelliJProjectImplV2) project
+        IntelliJProjectImplV2 wrappedModule = (IntelliJProjectImplV2) project
             .getAdapter(IntelliJProjectImplV2.class);
 
-        return module.getResource(virtualFile);
+        return wrappedModule.getResource(virtualFile);
     }
 
     /**

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/VirtualFileConverter.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/VirtualFileConverter.java
@@ -17,7 +17,8 @@ import org.jetbrains.annotations.Nullable;
 import org.picocontainer.annotations.Inject;
 
 /**
- * Provides static methods to convert VirtualFiles to Saros resource objects.
+ * Provides static methods to convert VirtualFiles to Saros resource objects
+ * or Saros resources objects to VirtualFiles.
  */
 public class VirtualFileConverter {
 
@@ -114,5 +115,52 @@ public class VirtualFileConverter {
             .getAdapter(IntelliJProjectImplV2.class);
 
         return module.getResource(virtualFile);
+    }
+
+    /**
+     * Returns a <code>VirtualFile</code> for the given resource.
+     *
+     * @param path the SPath representing the resource to get a VirtualFile for
+     * @return a VirtualFile for the given resource or <code>null</code> if the
+     * given resource does not exists in the VFS snapshot, is derived, or
+     * belongs to a sub-module
+     */
+    @Nullable
+    public static VirtualFile convertToVirtualFile(
+        @NotNull
+            SPath path) {
+
+        IResource resource = path.getResource();
+
+        if (resource == null) {
+            return null;
+        }
+
+        return convertToVirtualFile(resource);
+    }
+
+    /**
+     * Returns a <code>VirtualFile</code> for the given resource.
+     *
+     * @param resource the resource to get a VirtualFile for
+     * @return a VirtualFile for the given resource or <code>null</code> if the
+     * given resource does not exists in the VFS snapshot, is derived, or
+     * belongs to a sub-module
+     */
+    @Nullable
+    public static VirtualFile convertToVirtualFile(
+        @NotNull
+            IResource resource) {
+
+        if (resource instanceof IProject) {
+            throw new IllegalArgumentException(
+                "The given resource must be a file or a folder. resource: "
+                    + resource);
+        }
+
+        IntelliJProjectImplV2 wrappedModule = (IntelliJProjectImplV2) resource
+            .getProject().getAdapter(IntelliJProjectImplV2.class);
+
+        return wrappedModule.findVirtualFile(resource.getProjectRelativePath());
     }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/VirtualFileConverter.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/VirtualFileConverter.java
@@ -1,4 +1,4 @@
-package de.fu_berlin.inf.dpp.intellij.editor;
+package de.fu_berlin.inf.dpp.intellij.filesystem;
 
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtil;
@@ -9,7 +9,6 @@ import de.fu_berlin.inf.dpp.SarosPluginContext;
 import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
-import de.fu_berlin.inf.dpp.intellij.filesystem.IntelliJProjectImplV2;
 
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;

--- a/de.fu_berlin.inf.dpp.intellij/test/junit/de/fu_berlin/inf/dpp/intellij/editor/StoppableDocumentListenerTest.java
+++ b/de.fu_berlin.inf.dpp.intellij/test/junit/de/fu_berlin/inf/dpp/intellij/editor/StoppableDocumentListenerTest.java
@@ -27,7 +27,7 @@ public class StoppableDocumentListenerTest {
     @Before
     public void before() {
         mockEditorFactory();
-        listener = new StoppableDocumentListener(dummyEditorManager(), null);
+        listener = new StoppableDocumentListener(dummyEditorManager());
         listening = false;
     }
 


### PR DESCRIPTION
Makes the VirtualFileConverter session independent. The new
implementation now uses the IntelliJ API to get the module objects
needed to convert the VirtualFile.

As a consequence to being independent of the session, the
VirtualFileConverter can now also return resource objects for resources
that are not shared. This means any class using the converter now has to
check whether the returned resource is shared itself.
Adjustments for preexisting usages of the VirtualFileConverter are
included in this commit.

Subsequently makes the VirtualFileListener static for better usability.

Adds utility methods to VirtualFileConverter to convert Saros resources
to VirtualFiles and replaces the existing logic in multiple classes with a
call to the VirtualFileConverter.