### PR TITLE
[FIX][I] Ensure that document listener is enabled after text operations

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorManipulator.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorManipulator.java
@@ -181,28 +181,32 @@ public class LocalEditorManipulator {
             }
         }
 
-         /*
-         * Disable documentListener temporarily to avoid being notified of the
-         * change
-         */
-        manager.disableDocumentListener();
-        for (ITextOperation op : operations.getTextOperations()) {
-            if (op instanceof DeleteOperation) {
-                editorAPI.deleteText(doc, op.getPosition(),
-                    op.getPosition() + op.getTextLength());
-            } else {
-                boolean writePermission = doc.isWritable();
-                if (!writePermission) {
-                    doc.setReadOnly(false);
-                }
-                editorAPI.insertText(doc, op.getPosition(), op.getText());
-                if (!writePermission) {
-                    doc.setReadOnly(true);
+        try {
+            /*
+             * Disable documentListener temporarily to avoid being notified of
+             * the change
+             */
+            manager.disableDocumentListener();
+
+            for (ITextOperation op : operations.getTextOperations()) {
+                if (op instanceof DeleteOperation) {
+                    editorAPI.deleteText(doc, op.getPosition(),
+                        op.getPosition() + op.getTextLength());
+                } else {
+                    boolean writePermission = doc.isWritable();
+                    if (!writePermission) {
+                        doc.setReadOnly(false);
+                    }
+                    editorAPI.insertText(doc, op.getPosition(), op.getText());
+                    if (!writePermission) {
+                        doc.setReadOnly(true);
+                    }
                 }
             }
-        }
 
-        manager.enableDocumentListener();
+        } finally {
+            manager.enableDocumentListener();
+        }
     }
 
     /**


### PR DESCRIPTION
Moves re-enabling the document listener after applying a text operation
into a finally block to ensure that the listener is always enabled, even
if applying the text operation fails with an uncaught exception.