### PR TITLE
[I] Add xml file enabling google java style plugin by default

### DIFF
--- a/.idea/google-java-format.xml
+++ b/.idea/google-java-format.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GoogleJavaFormatSettings">
+    <option name="enabled" value="true" />
+  </component>
+</project>


### PR DESCRIPTION
Adds google-java-format.xml which enables the google java style
formatting plugin by default for this project if it is installed.