### PR TITLE
[I] Add .gitignore entry for sonarlint directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bin_test/
 /.idea/inspectionProfiles/
 /.idea/copyright/
 /.idea/dictionaries/
+/.idea/sonarlint/
 /de.fu_berlin.inf.dpp.intellij/build.properties
 /de.fu_berlin.inf.dpp.server/lib/
 /de.fu_berlin.inf.dpp.server/instr/


### PR DESCRIPTION
Adds a .gitignore entry for the directory .idea/sonarlint/ as it is only
used to store results of the local sonar analysis.