### PR TITLE
[I] Add needed codestyle settings

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,26 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <option name="RIGHT_MARGIN" value="100" />
+    <JavaCodeStyleSettings>
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+      <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+        <value />
+      </option>
+      <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+          <package name="" withSubpackages="true" static="true" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="false" />
+        </value>
+      </option>
+    </JavaCodeStyleSettings>
+    <codeStyleSettings language="JAVA">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/context/SarosIntellijContextFactory.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/context/SarosIntellijContextFactory.java
@@ -4,7 +4,6 @@ import com.intellij.openapi.project.Project;
 import de.fu_berlin.inf.dpp.communication.connection.IProxyResolver;
 import de.fu_berlin.inf.dpp.communication.connection.NullProxyResolver;
 import de.fu_berlin.inf.dpp.context.AbstractContextFactory;
-import de.fu_berlin.inf.dpp.context.AbstractContextFactory.Component;
 import de.fu_berlin.inf.dpp.context.IContextKeyBindings;
 import de.fu_berlin.inf.dpp.core.awareness.AwarenessInformationCollector;
 import de.fu_berlin.inf.dpp.core.monitoring.remote.IntelliJRemoteProgressIndicatorFactoryImpl;


### PR DESCRIPTION
Adds some basic codestyle settings for Intellij which are still needed
with the google java style plugin.

Adds import settings to match the google java style:
 - Don't use wildcards for normal imports.
 - Don't use wildcards for static imports.
 - Order imports correctly.
Setting this manually in the Intellij settings is currently needed as
imports are not correctly handled by the google java style plugin.
For more details, see the following issues.
 - google/google-java-format#94
 - google/google-java-format#236
The used formatting rules were suggested in 263.

Sets the right margin to 100 characters so that it is displayed
correctly in the editor.

Sets indentation and tab size to two spaces as well as the
continuation indentation size to 4 spaces to match the google style.
Otherwise, the Intellij format analyzer complains that the used
indentation size does not match the settings.