### PR TITLE
[INTERNAL] Added IReferencePoint and its implementation

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IReferencePoint.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IReferencePoint.java
@@ -1,0 +1,14 @@
+package de.fu_berlin.inf.dpp.filesystem;
+
+/**
+ * The IReferencePoint is an identical pointer to the root of the shared subtree of {@link
+ * IResource}s. For IDEs the root of the subtree is a container, on which {@link IResource}, like
+ * {@link IFolder} and {@link IFile}, is accessible via the relative path from IReferencePoint to
+ * {@link IResource}.
+ *
+ * <p>This interface is under development: The IReferencePoint is the absolute path of {@link
+ * IProject}
+ */
+public interface IReferencePoint {
+  /* Nothing here */
+}

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IResource.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IResource.java
@@ -50,4 +50,8 @@ public interface IResource {
   public IPath getLocation();
 
   public Object getAdapter(Class<? extends IResource> clazz);
+
+  /** Returns the {@link IReferencePoint} on which the resource is referenced to */
+  @Deprecated
+  public IReferencePoint getReferencePoint();
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/ReferencePointImpl.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/ReferencePointImpl.java
@@ -1,0 +1,30 @@
+package de.fu_berlin.inf.dpp.filesystem;
+
+public class ReferencePointImpl implements IReferencePoint {
+
+  private final IPath path;
+
+  public ReferencePointImpl(IPath path) {
+    this.path = path;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((path == null) ? 0 : path.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null) return false;
+    if (getClass() != obj.getClass()) return false;
+    ReferencePointImpl other = (ReferencePointImpl) obj;
+    if (path == null) {
+      if (other.path != null) return false;
+    } else if (!path.equals(other.path)) return false;
+    return true;
+  }
+}

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJFileImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJFileImpl.java
@@ -30,6 +30,8 @@ public final class IntelliJFileImpl extends IntelliJResourceImpl implements IFil
   public IntelliJFileImpl(@NotNull final IntelliJProjectImpl project, @NotNull final IPath path) {
     this.project = project;
     this.path = path;
+
+    this.referencePoint = project.getReferencePoint();
   }
 
   /**

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJFolderImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJFolderImpl.java
@@ -29,6 +29,8 @@ public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IF
   public IntelliJFolderImpl(@NotNull final IntelliJProjectImpl project, @NotNull final IPath path) {
     this.project = project;
     this.path = path;
+
+    this.referencePoint = project.getReferencePoint();
   }
 
   @Override

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJProjectImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJProjectImpl.java
@@ -14,6 +14,7 @@ import de.fu_berlin.inf.dpp.filesystem.IFolder;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
+import de.fu_berlin.inf.dpp.filesystem.ReferencePointImpl;
 import de.fu_berlin.inf.dpp.intellij.project.filesystem.IntelliJPathImpl;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -69,6 +70,8 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
     this.moduleName = module.getName();
 
     moduleRoot = getModuleContentRoot(module);
+
+    this.referencePoint = new ReferencePointImpl(getFullPath());
 
     checkIfContentRootLocatedBelowProjectRoot(module, moduleRoot);
     checkIfModuleFileLocatedInContentRoot(module, moduleRoot);

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJResourceImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJResourceImpl.java
@@ -1,14 +1,22 @@
 package de.fu_berlin.inf.dpp.intellij.filesystem;
 
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public abstract class IntelliJResourceImpl implements IResource {
 
+  protected IReferencePoint referencePoint;
+
   @Nullable
   @Override
   public Object getAdapter(@NotNull Class<? extends IResource> clazz) {
     return clazz.isInstance(this) ? this : null;
+  }
+
+  @Override
+  public IReferencePoint getReferencePoint() {
+    return referencePoint;
   }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJWorkspaceRootImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJWorkspaceRootImpl.java
@@ -3,6 +3,7 @@ package de.fu_berlin.inf.dpp.intellij.project.filesystem;
 import de.fu_berlin.inf.dpp.filesystem.IContainer;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspaceRoot;
 import java.io.IOException;
@@ -104,5 +105,10 @@ public class IntelliJWorkspaceRootImpl implements IWorkspaceRoot {
   @Override
   public Object getAdapter(Class<? extends IResource> clazz) {
     return null;
+  }
+
+  @Override
+  public IReferencePoint getReferencePoint() {
+    throw new UnsupportedOperationException();
   }
 }

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerResourceImpl.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerResourceImpl.java
@@ -3,8 +3,10 @@ package de.fu_berlin.inf.dpp.server.filesystem;
 import de.fu_berlin.inf.dpp.filesystem.IContainer;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
+import de.fu_berlin.inf.dpp.filesystem.ReferencePointImpl;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -16,6 +18,7 @@ public abstract class ServerResourceImpl implements IResource {
 
   private IWorkspace workspace;
   private IPath path;
+  private IReferencePoint referencePoint;
 
   /**
    * Creates a ServerResourceImpl.
@@ -26,6 +29,7 @@ public abstract class ServerResourceImpl implements IResource {
   public ServerResourceImpl(IWorkspace workspace, IPath path) {
     this.path = path;
     this.workspace = workspace;
+    this.referencePoint = new ReferencePointImpl(workspace.getLocation());
   }
 
   /**
@@ -122,5 +126,10 @@ public abstract class ServerResourceImpl implements IResource {
    */
   Path toNioPath() {
     return ((ServerPathImpl) getLocation()).getDelegate();
+  }
+
+  @Override
+  public IReferencePoint getReferencePoint() {
+    return referencePoint;
   }
 }

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/EclipseResourceImpl.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/EclipseResourceImpl.java
@@ -7,11 +7,15 @@ import org.eclipse.core.runtime.OperationCanceledException;
 public class EclipseResourceImpl implements IResource {
 
   protected final org.eclipse.core.resources.IResource delegate;
+  protected IReferencePoint referencePoint;
 
   EclipseResourceImpl(org.eclipse.core.resources.IResource delegate) {
     if (delegate == null) throw new NullPointerException("delegate is null");
 
     this.delegate = delegate;
+    if (delegate.getProject() != null)
+      this.referencePoint =
+          new ReferencePointImpl(new EclipsePathImpl(delegate.getProject().getFullPath()));
   }
 
   @Override
@@ -173,5 +177,10 @@ public class EclipseResourceImpl implements IResource {
   @Override
   public String toString() {
     return delegate.toString() + " (" + getClass().getSimpleName() + ")";
+  }
+
+  @Override
+  public IReferencePoint getReferencePoint() {
+    return referencePoint;
   }
 }

--- a/de.fu_berlin.inf.dpp/test/junit/de/fu_berlin/inf/dpp/filesystem/IResourceTest.java
+++ b/de.fu_berlin.inf.dpp/test/junit/de/fu_berlin/inf/dpp/filesystem/IResourceTest.java
@@ -13,6 +13,11 @@ public class IResourceTest {
     org.eclipse.core.resources.IFolder folder =
         EasyMock.createMock(org.eclipse.core.resources.IFolder.class);
 
+    org.eclipse.core.resources.IProject project =
+        EasyMock.createMock(org.eclipse.core.resources.IProject.class);
+
+    org.eclipse.core.runtime.IPath path = EasyMock.createMock(org.eclipse.core.runtime.IPath.class);
+
     Capture<Class<Object>> mappedAdapterClassCapture = new Capture<Class<Object>>();
 
     EasyMock.expect(folder.getAdapter(EasyMock.capture(mappedAdapterClassCapture)))
@@ -20,7 +25,11 @@ public class IResourceTest {
 
     EasyMock.expect(folder.getType()).andStubReturn(org.eclipse.core.resources.IResource.FOLDER);
 
-    EasyMock.replay(folder);
+    EasyMock.expect(folder.getProject()).andStubReturn(project);
+
+    EasyMock.expect(project.getFullPath()).andStubReturn(path);
+
+    EasyMock.replay(folder, project, path);
 
     final IFolder coreFolder = new EclipseFolderImpl(folder);
 

--- a/de.fu_berlin.inf.dpp/test/junit/de/fu_berlin/inf/dpp/project/FileActivityConsumerTest.java
+++ b/de.fu_berlin.inf.dpp/test/junit/de/fu_berlin/inf/dpp/project/FileActivityConsumerTest.java
@@ -20,7 +20,9 @@ import de.fu_berlin.inf.dpp.session.User;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.junit.After;
 import org.junit.Before;
@@ -39,6 +41,9 @@ public class FileActivityConsumerTest {
   /** Partial file mock in recording state, has to be replayed in every test before being used. */
   private IFile file;
 
+  private IProject project;
+  private IPath path;
+
   private SharedResourcesManager resourceChangeListener;
 
   @Before
@@ -56,6 +61,13 @@ public class FileActivityConsumerTest {
 
     consumer = new FileActivityConsumer(null, resourceChangeListener, null);
 
+    path = createMock(IPath.class);
+    replay(path);
+
+    project = createMock(IProject.class);
+    expect(project.getFullPath()).andStubReturn(path);
+    replay(project);
+
     file = createMock(IFile.class);
 
     expect(file.getContents()).andStubReturn(new ByteArrayInputStream(FILE_CONTENT));
@@ -63,6 +75,7 @@ public class FileActivityConsumerTest {
     expect(file.exists()).andStubReturn(Boolean.TRUE);
     expect(file.getType()).andStubReturn(IResource.FILE);
     expect(file.getAdapter(IFile.class)).andStubReturn(file);
+    expect(file.getProject()).andStubReturn(project);
   }
 
   @After


### PR DESCRIPTION
This PR is an updated version of the PR https://github.com/saros-project/saros/pull/227. The difference is that this PR is based on the new Saros enviroment...

The Saros filesystem gets a new component in its filesystem:
IReferencePoint. The first step of the refactoring that the
reference point of each files/folders points on the location
of the projects. So the IResource interface gets a new method
called getReferencePoint() and returns the reference point.
The IReferencePoint interface is empty. Its implementation
contains an IPath object from the location of the referenced
resource (project at first) and an IReferencePoint object is
comparable over the IPath object.

In issue https://github.com/saros-project/saros/issues/177 is a detailed description, what an IReferencePoint is, for what we need this and which steps planned for the future commits

EDIT: 
I reworked issue https://github.com/saros-project/saros/issues/177
and you can see the final state in PR https://github.com/saros-project/saros/pull/391