### PR TITLE
Pr/adjusting shared project mapper v2

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/IReferencePointManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/IReferencePointManager.java
@@ -1,0 +1,33 @@
+package de.fu_berlin.inf.dpp.session;
+
+import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
+import java.util.Set;
+
+/** The IReferencePointManager maps an IReferencePoint to IProject */
+public interface IReferencePointManager {
+
+  /**
+   * Insert a pair of reference point and project
+   *
+   * @param referencePoint the key of the pair
+   * @param project the value of the pair
+   */
+  void put(IReferencePoint referencePoint, IProject project);
+
+  /**
+   * Returns the IProject given by the IReferencePoint
+   *
+   * @param referencePoint the key for which the IProject should be returned
+   * @return the IProject given by referencePoint
+   */
+  IProject get(IReferencePoint referencePoint);
+
+  /**
+   * Returns a set of IProjects given by a set of IReferencePoints
+   *
+   * @param referencePoints a set of referencePoints for which the set of IProjects should returned
+   * @return a set of IProject given by referencePoint
+   */
+  Set<IProject> getProjects(Set<IReferencePoint> referencePoints);
+}

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ReferencePointManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ReferencePointManager.java
@@ -1,0 +1,41 @@
+package de.fu_berlin.inf.dpp.session;
+
+import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+/** The implementation of {@link IReferencePointManager} */
+public class ReferencePointManager implements IReferencePointManager {
+
+  HashMap<IReferencePoint, IProject> referencePointToProjectMapper;
+
+  public ReferencePointManager() {
+    referencePointToProjectMapper = new HashMap<IReferencePoint, IProject>();
+  }
+
+  @Override
+  public synchronized void put(IReferencePoint referencePoint, IProject project) {
+    if (!referencePointToProjectMapper.containsKey(referencePoint)) {
+      referencePointToProjectMapper.put(referencePoint, project);
+    }
+  }
+
+  @Override
+  public synchronized IProject get(IReferencePoint referencePoint) {
+    return referencePointToProjectMapper.get(referencePoint);
+  }
+
+  @Override
+  public synchronized Set<IProject> getProjects(Set<IReferencePoint> referencePoints) {
+    Set<IProject> projectSet = new HashSet<IProject>();
+
+    for (IReferencePoint referencePoint : referencePoints) {
+      if (referencePointToProjectMapper.containsKey(referencePoint))
+        projectSet.add(get(referencePoint));
+    }
+
+    return projectSet;
+  }
+}

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
@@ -34,6 +34,7 @@ import de.fu_berlin.inf.dpp.context.IContainerContext;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
 import de.fu_berlin.inf.dpp.filesystem.IFolder;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.net.IConnectionManager;
 import de.fu_berlin.inf.dpp.net.ITransmitter;
@@ -46,9 +47,11 @@ import de.fu_berlin.inf.dpp.session.IActivityConsumer.Priority;
 import de.fu_berlin.inf.dpp.session.IActivityHandlerCallback;
 import de.fu_berlin.inf.dpp.session.IActivityListener;
 import de.fu_berlin.inf.dpp.session.IActivityProducer;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionContextFactory;
 import de.fu_berlin.inf.dpp.session.ISessionListener;
+import de.fu_berlin.inf.dpp.session.ReferencePointManager;
 import de.fu_berlin.inf.dpp.session.SessionEndReason;
 import de.fu_berlin.inf.dpp.session.User;
 import de.fu_berlin.inf.dpp.session.User.Permission;
@@ -59,6 +62,7 @@ import de.fu_berlin.inf.dpp.util.ThreadUtils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -88,6 +92,8 @@ public final class SarosSession implements ISarosSession {
   @Inject private XMPPConnectionService connectionService;
 
   @Inject private IConnectionManager connectionManager;
+
+  private IReferencePointManager referencePointManager;
 
   private final IContainerContext containerContext;
 
@@ -235,32 +241,34 @@ public final class SarosSession implements ISarosSession {
   public void addSharedResources(IProject project, String id, List<IResource> resources) {
 
     Set<IResource> allResources = null;
+    IReferencePoint referencePoint = project.getReferencePoint();
 
     if (resources != null) {
       allResources = new HashSet<IResource>();
       for (IResource resource : resources) allResources.addAll(getAllNonSharedChildren(resource));
     }
 
-    if (!projectMapper.isShared(project)) {
+    if (!projectMapper.isShared(referencePoint)) {
       // new project
       if (allResources == null) {
         // new fully shared project
-        projectMapper.addProject(id, project, false);
+        projectMapper.addReferencePoint(id, referencePoint, false);
       } else {
         // new partially shared project
-        projectMapper.addProject(id, project, true);
-        projectMapper.addResources(project, allResources);
+        projectMapper.addReferencePoint(id, referencePoint, true);
+        projectMapper.addResources(referencePoint, allResources);
       }
 
+      referencePointManager.put(referencePoint, project);
       listenerDispatch.projectAdded(project);
     } else {
       // existing project
       if (allResources == null) {
         // upgrade partially shared to fully shared project
-        projectMapper.addProject(id, project, false);
+        projectMapper.addReferencePoint(id, referencePoint, false);
       } else {
         // increase scope of partially shared project
-        projectMapper.addResources(project, allResources);
+        projectMapper.addResources(referencePoint, allResources);
       }
     }
 
@@ -308,7 +316,7 @@ public final class SarosSession implements ISarosSession {
 
   @Override
   public boolean userHasProject(User user, IProject project) {
-    return projectMapper.userHasProject(user, project);
+    return projectMapper.userHasReferencePoint(user, project.getReferencePoint());
   }
 
   @Override
@@ -427,7 +435,7 @@ public final class SarosSession implements ISarosSession {
      * Updates the projects for the given user, so that host knows that he can now send ever
      * Activity
      */
-    projectMapper.addMissingProjectsToUser(user);
+    projectMapper.addMissingReferencePointsToUser(user);
 
     synchronizer.syncExec(
         ThreadUtils.wrapSafe(
@@ -564,7 +572,7 @@ public final class SarosSession implements ISarosSession {
 
   @Override
   public Set<IProject> getProjects() {
-    return projectMapper.getProjects();
+    return referencePointManager.getProjects(projectMapper.getReferencePoints());
   }
 
   // FIXME synchronization
@@ -779,14 +787,14 @@ public final class SarosSession implements ISarosSession {
   private boolean updatePartialSharedResources(final IFileSystemModificationActivity activity) {
 
     final IProject project = activity.getPath().getProject();
-
+    final IReferencePoint referencePoint = project.getReferencePoint();
     /*
      * The follow 'if check' assumes that move operations where at least one
      * project is not part of the sharing is announced as create and delete
      * activities.
      */
 
-    if (!projectMapper.isPartiallyShared(project)) return true;
+    if (!projectMapper.isPartiallyShared(referencePoint)) return true;
 
     if (activity instanceof FileActivity) {
       FileActivity fileActivity = ((FileActivity) activity);
@@ -813,7 +821,7 @@ public final class SarosSession implements ISarosSession {
             return false;
           }
 
-          projectMapper.addResources(project, Collections.singletonList(file));
+          projectMapper.addResources(referencePoint, Collections.singletonList(file));
 
           break;
 
@@ -832,7 +840,7 @@ public final class SarosSession implements ISarosSession {
             return false;
           }
 
-          projectMapper.removeResources(project, Collections.singletonList(file));
+          projectMapper.removeResources(referencePoint, Collections.singletonList(file));
 
           break;
 
@@ -878,7 +886,7 @@ public final class SarosSession implements ISarosSession {
           }
 
           projectMapper.removeAndAddResources(
-              project, Collections.singletonList(oldFile), Collections.singletonList(file));
+              referencePoint, Collections.singletonList(oldFile), Collections.singletonList(file));
 
           break;
       }
@@ -898,7 +906,7 @@ public final class SarosSession implements ISarosSession {
         return false;
       }
 
-      projectMapper.addResources(project, Collections.singletonList(folder));
+      projectMapper.addResources(referencePoint, Collections.singletonList(folder));
 
     } else if (activity instanceof FolderDeletedActivity) {
       IFolder folder = activity.getPath().getFolder();
@@ -917,7 +925,7 @@ public final class SarosSession implements ISarosSession {
         return false;
       }
 
-      projectMapper.removeResources(project, Collections.singletonList(folder));
+      projectMapper.removeResources(referencePoint, Collections.singletonList(folder));
     }
 
     return true;
@@ -966,41 +974,53 @@ public final class SarosSession implements ISarosSession {
 
   @Override
   public String getProjectID(IProject project) {
-    return projectMapper.getID(project);
+    return projectMapper.getID(project.getReferencePoint());
   }
 
   @Override
   public IProject getProject(String projectID) {
-    return projectMapper.getProject(projectID);
+    return referencePointManager.get(projectMapper.getReferencePoint(projectID));
   }
 
   @Override
   public Map<IProject, List<IResource>> getProjectResourcesMapping() {
-    return projectMapper.getProjectResourceMapping();
+    Map<IReferencePoint, List<IResource>> referencePointResourceMap =
+        projectMapper.getReferencePointResourceMapping();
+
+    Map<IProject, List<IResource>> projectResourceMap = new HashMap<IProject, List<IResource>>();
+
+    for (Map.Entry<IReferencePoint, List<IResource>> entry : referencePointResourceMap.entrySet()) {
+      projectResourceMap.put(referencePointManager.get(entry.getKey()), entry.getValue());
+    }
+
+    return projectResourceMap;
   }
 
   @Override
   public List<IResource> getSharedResources(IProject project) {
-    return projectMapper.getProjectResourceMapping().get(project);
+    return projectMapper.getReferencePointResourceMapping().get(project.getReferencePoint());
   }
 
   @Override
   public boolean isCompletelyShared(IProject project) {
-    return projectMapper.isCompletelyShared(project);
+    return projectMapper.isCompletelyShared(project.getReferencePoint());
   }
 
   @Override
   public void addProjectMapping(String projectID, IProject project) {
-    if (projectMapper.getProject(projectID) == null) {
-      projectMapper.addProject(projectID, project, true);
+    if (projectMapper.getReferencePoint(projectID) == null) {
+      IReferencePoint referencePoint = project.getReferencePoint();
+
+      referencePointManager.put(referencePoint, project);
+      projectMapper.addReferencePoint(projectID, referencePoint, true);
       listenerDispatch.projectAdded(project);
     }
   }
 
   @Override
   public void removeProjectMapping(String projectID, IProject project) {
-    if (projectMapper.getProject(projectID) != null) {
-      projectMapper.removeProject(projectID);
+    if (projectMapper.getReferencePoint(projectID) != null) {
+      projectMapper.removeReferencePoint(projectID);
       listenerDispatch.projectRemoved(project);
     }
   }
@@ -1091,7 +1111,7 @@ public final class SarosSession implements ISarosSession {
     sessionContainer = context.createChildContainer();
     sessionContainer.addComponent(ISarosSession.class, this);
     sessionContainer.addComponent(IActivityHandlerCallback.class, activityCallback);
-
+    sessionContainer.addComponent(IReferencePointManager.class, new ReferencePointManager());
     ISarosSessionContextFactory factory = context.getComponent(ISarosSessionContextFactory.class);
     factory.createComponents(this, sessionContainer);
 
@@ -1113,6 +1133,8 @@ public final class SarosSession implements ISarosSession {
     activitySequencer = sessionContainer.getComponent(ActivitySequencer.class);
 
     userListHandler = sessionContainer.getComponent(UserInformationHandler.class);
+
+    referencePointManager = sessionContainer.getComponent(IReferencePointManager.class);
 
     // ensure that the container uses caching
     assert sessionContainer.getComponent(ActivityHandler.class)

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SharedProjectMapper.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SharedProjectMapper.java
@@ -1,6 +1,6 @@
 package de.fu_berlin.inf.dpp.session.internal;
 
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.session.User;
 import java.util.ArrayList;
@@ -14,126 +14,145 @@ import java.util.Set;
 import org.apache.log4j.Logger;
 
 /**
- * This class is responsible for mapping global project IDs to local {@linkplain IProject projects},
- * as well as storing which resources are shared from each project. On the host, it also tracks
- * which users have already received which shared projects.
+ * This class is responsible for mapping global reference point IDs to local {@linkplain
+ * IReferencePoint referencePoints}, as well as storing which resources are shared from each
+ * reference point. On the host, it also tracks which users have already received which shared
+ * reference point.
  *
- * <p>The project IDs are used to identify shared projects across the network, even when the local
- * names of shared projects are different. The ID is determined by the project/file-host.
+ * <p>The reference point IDs are used to identify shared reference point across the network, even
+ * when the local names of shared reference point are different. The ID is determined by the
+ * reference point/file-host.
  */
 class SharedProjectMapper {
 
   private static final Logger LOG = Logger.getLogger(SharedProjectMapper.class);
 
-  /** Mapping from project IDs to currently registered shared projects. */
-  private Map<String, IProject> idToProjectMapping = new HashMap<String, IProject>();
+  /** Mapping from reference point IDs to currently registered shared reference point. */
+  private Map<String, IReferencePoint> idToReferencePointMapping;
 
-  /** Mapping from currently registered shared projects to their id's. */
-  private Map<IProject, String> projectToIDMapping = new HashMap<IProject, String>();
+  /** Mapping from currently registered shared reference point to their id's. */
+  private Map<IReferencePoint, String> referencePointToIDMapping;
 
   /**
-   * Map for storing which clients have which projects. Used by the host to determine who can
-   * currently process an activity related to a particular project. (Non-hosts don't maintain this
-   * map.)
+   * Map for storing which clients have which reference point. Used by the host to determine who can
+   * currently process an activity related to a particular reference point. (Non-hosts don't
+   * maintain this map.)
    */
-  private Map<User, List<String>> projectsOfUsers = new HashMap<User, List<String>>();
+  private Map<User, List<String>> referencePointsOfUsers;
 
   /**
-   * Map for storing the set of resources shared for each shared project. Maps to <code>null</code>
-   * for completely shared projects.
+   * Map for storing the set of resources shared for each shared reference point. Maps to <code>null
+   * </code> for completely shared reference points.
    */
-  private Map<IProject, Set<IResource>> partiallySharedResourceMapping =
-      new HashMap<IProject, Set<IResource>>();
+  private Map<IReferencePoint, Set<IResource>> partiallySharedResourceMapping;
 
-  /** Set containing the currently completely shared projects. */
-  private Set<IProject> completelySharedProjects = new HashSet<IProject>();
+  /** Set containing the currently completely shared reference points. */
+  private Set<IReferencePoint> completelySharedReferencePoints;
 
-  /** Set containing the currently partially shared projects. */
-  private Set<IProject> partiallySharedProjects = new HashSet<IProject>();
+  /** Set containing the currently partially shared reference points. */
+  private Set<IReferencePoint> partiallySharedReferencePoints;
+
+  public SharedProjectMapper() {
+    idToReferencePointMapping = new HashMap<String, IReferencePoint>();
+    referencePointToIDMapping = new HashMap<IReferencePoint, String>();
+    referencePointsOfUsers = new HashMap<User, List<String>>();
+    partiallySharedResourceMapping = new HashMap<IReferencePoint, Set<IResource>>();
+    completelySharedReferencePoints = new HashSet<IReferencePoint>();
+    partiallySharedReferencePoints = new HashSet<IReferencePoint>();
+  }
 
   /**
-   * Adds a project to the set of currently shared projects.
+   * Adds a reference point to the set of currently shared reference points.
    *
-   * <p>It is possible to "upgrade" a partially shared project to a completely shared project by
-   * just adding the same project with the same ID again that must now marked as not partially
-   * shared.
+   * <p>It is possible to "upgrade" a partially shared reference point to a completely shared
+   * reference point by just adding the same reference point with the same ID again that must now
+   * marked as not partially shared.
    *
-   * @param id the ID for the project
-   * @param project the project to add
-   * @param isPartially <code>true</code> if the project should be treated as a partially shared
-   *     project, <code>false</code> if it should be treated as completely shared
-   * @throws NullPointerException if the ID or project is <code>null</code>
-   * @throws IllegalStateException if the ID is already in use or the project was already added
+   * @param id the ID for the reference points
+   * @param referencePoint the reference points to add
+   * @param isPartially <code>true</code> if the reference point should be treated as a partially
+   *     shared reference point, <code>false</code> if it should be treated as completely shared
+   * @throws NullPointerException if the ID or reference point is <code>null</code>
+   * @throws IllegalStateException if the ID is already in use or the reference point was already
+   *     added
    */
-  public synchronized void addProject(String id, IProject project, boolean isPartially) {
+  public synchronized void addReferencePoint(
+      String id, IReferencePoint referencePoint, boolean isPartially) {
     boolean upgrade = false;
 
     if (id == null) throw new NullPointerException("ID is null");
 
-    if (project == null) throw new NullPointerException("project is null");
+    if (referencePoint == null) throw new NullPointerException("referencePoint is null");
 
-    String currentProjectID = projectToIDMapping.get(project);
-    IProject currentProject = idToProjectMapping.get(id);
+    String currentReferencePointID = referencePointToIDMapping.get(referencePoint);
+    IReferencePoint currentReferencePoint = idToReferencePointMapping.get(id);
 
-    if (currentProjectID != null && !id.equals(currentProjectID)) {
+    if (currentReferencePointID != null && !id.equals(currentReferencePointID)) {
       throw new IllegalStateException(
           "cannot assign ID "
               + id
-              + " to project "
-              + project
+              + " to referencePoint "
+              + referencePoint
               + " because it is already registered with ID "
-              + currentProjectID);
+              + currentReferencePointID);
     }
 
-    if (currentProject != null && !project.equals(currentProject)) {
+    if (currentReferencePoint != null && !referencePoint.equals(currentReferencePoint)) {
       throw new IllegalStateException(
-          "ID " + id + " for project " + project + " is already used by project " + currentProject);
+          "ID "
+              + id
+              + " for referencePoint "
+              + referencePoint
+              + " is already used by referencePoint "
+              + currentReferencePoint);
     }
 
-    if (isPartially && partiallySharedProjects.contains(project))
-      throw new IllegalStateException("project " + project + " is already partially shared");
-
-    if (!isPartially && completelySharedProjects.contains(project))
-      throw new IllegalStateException("project " + project + " is already completely shared");
-
-    if (isPartially && completelySharedProjects.contains(project))
+    if (isPartially && partiallySharedReferencePoints.contains(referencePoint))
       throw new IllegalStateException(
-          "project "
-              + project
-              + " is already completely shared (cannot downgrade a completely shared project)");
+          "referencePoint " + referencePoint + " is already partially shared");
 
-    if (!isPartially && partiallySharedProjects.contains(project)) {
-      partiallySharedProjects.remove(project);
+    if (!isPartially && completelySharedReferencePoints.contains(referencePoint))
+      throw new IllegalStateException(
+          "referencePoint " + referencePoint + " is already completely shared");
+
+    if (isPartially && completelySharedReferencePoints.contains(referencePoint))
+      throw new IllegalStateException(
+          "referencePoint "
+              + referencePoint
+              + " is already completely shared (cannot downgrade a completely shared referencePoint)");
+
+    if (!isPartially && partiallySharedReferencePoints.contains(referencePoint)) {
+      partiallySharedReferencePoints.remove(referencePoint);
       upgrade = true;
     }
 
-    if (isPartially) partiallySharedProjects.add(project);
-    else completelySharedProjects.add(project);
+    if (isPartially) partiallySharedReferencePoints.add(referencePoint);
+    else completelySharedReferencePoints.add(referencePoint);
 
-    assert Collections.disjoint(completelySharedProjects, partiallySharedProjects);
+    assert Collections.disjoint(completelySharedReferencePoints, partiallySharedReferencePoints);
 
     if (upgrade) {
       // release resources
-      partiallySharedResourceMapping.put(project, null);
+      partiallySharedResourceMapping.put(referencePoint, null);
 
       LOG.debug(
-          "upgraded partially shared project "
-              + project
+          "upgraded partially shared referencePoint "
+              + referencePoint
               + " with ID "
               + id
-              + " to a completely shared project");
+              + " to a completely shared referencePoint");
       return;
     }
 
-    idToProjectMapping.put(id, project);
-    projectToIDMapping.put(project, id);
+    idToReferencePointMapping.put(id, referencePoint);
+    referencePointToIDMapping.put(referencePoint, id);
 
-    if (isPartially) partiallySharedResourceMapping.put(project, new HashSet<IResource>());
-    else partiallySharedResourceMapping.put(project, null);
+    if (isPartially) partiallySharedResourceMapping.put(referencePoint, new HashSet<IResource>());
+    else partiallySharedResourceMapping.put(referencePoint, null);
 
     LOG.debug(
-        "added project "
-            + project
+        "added referencePoint "
+            + referencePoint
             + " with ID "
             + id
             + " [completely shared:"
@@ -142,33 +161,34 @@ class SharedProjectMapper {
   }
 
   /**
-   * Removes a project from the set of currently shared projects. Does nothing if the project is not
-   * shared.
+   * Removes a reference point from the set of currently shared referencePoint. Does nothing if the
+   * referencePoint is not shared.
    *
-   * @param id the ID of the project to remove
+   * @param id the ID of the referencePoint to remove
    */
-  public synchronized void removeProject(String id) {
-    IProject project = idToProjectMapping.get(id);
+  public synchronized void removeReferencePoint(String id) {
+    IReferencePoint referencePoint = idToReferencePointMapping.get(id);
 
-    if (project == null) {
-      LOG.warn("could not remove project, no project is registerid with ID: " + id);
+    if (referencePoint == null) {
+      LOG.warn("could not remove referencePoint, no referencePoint is registerid with ID: " + id);
       return;
     }
 
-    if (partiallySharedProjects.contains(project)) partiallySharedProjects.remove(project);
-    else completelySharedProjects.remove(project);
+    if (partiallySharedReferencePoints.contains(referencePoint))
+      partiallySharedReferencePoints.remove(referencePoint);
+    else completelySharedReferencePoints.remove(referencePoint);
 
-    idToProjectMapping.remove(id);
-    projectToIDMapping.remove(project);
-    partiallySharedResourceMapping.remove(project);
+    idToReferencePointMapping.remove(id);
+    referencePointToIDMapping.remove(referencePoint);
+    partiallySharedResourceMapping.remove(referencePoint);
 
-    LOG.debug("removed project " + project + " with ID " + id);
+    LOG.debug("removed referencePoint " + referencePoint + " with ID " + id);
   }
 
   /**
-   * Adds the given resources to a <b>partially</b> shared project.
+   * Adds the given resources to a <b>partially</b> shared reference point.
    *
-   * @param project a project that was added as a partially shared project
+   * @param referencePoint a referencePoint that was added as a partially shared referencePoint
    * @param resources the resources to add
    */
   /*
@@ -178,66 +198,72 @@ class SharedProjectMapper {
    * at all
    */
   public synchronized void addResources(
-      IProject project, Collection<? extends IResource> resources) {
+      IReferencePoint referencePoint, Collection<? extends IResource> resources) {
 
-    if (projectToIDMapping.get(project) == null) {
-      LOG.warn("could not add resources to project " + project + " because it is not shared");
+    if (referencePointToIDMapping.get(referencePoint) == null) {
+      LOG.warn(
+          "could not add resources to referencePoint "
+              + referencePoint
+              + " because it is not shared");
       // throw new IllegalStateException(
       // "could not add resources to project " + project
       // + " because it is not shared");
       return;
     }
 
-    if (completelySharedProjects.contains(project)) {
-      LOG.warn("cannot add resources to completely shared project: " + project);
+    if (completelySharedReferencePoints.contains(referencePoint)) {
+      LOG.warn("cannot add resources to completely shared referencePoint: " + referencePoint);
       // throw new IllegalStateException(
       // "cannot add resources to completely shared project: " + project);
       return;
     }
 
-    Set<IResource> partiallySharedResources = partiallySharedResourceMapping.get(project);
+    Set<IResource> partiallySharedResources = partiallySharedResourceMapping.get(referencePoint);
 
     if (partiallySharedResources.isEmpty()) {
       partiallySharedResources = new HashSet<IResource>(Math.max(1024, (resources.size() * 3) / 2));
 
-      partiallySharedResourceMapping.put(project, partiallySharedResources);
+      partiallySharedResourceMapping.put(referencePoint, partiallySharedResources);
     }
 
     partiallySharedResources.addAll(resources);
   }
 
   /**
-   * Removes the given resources from a <b>partially</b> shared project.
+   * Removes the given resources from a <b>partially</b> shared reference point.
    *
-   * @param project a project that was added as a partially shared project
+   * @param referencePoint a reference point that was added as a partially shared reference point
    * @param resources the resources to remove
    */
   /*
    * TODO needs proper sync. in the SarosSession class
    *
-   * @throws IllegalStateException if the project is completely or not shared
-   * at all
+   * @throws IllegalStateException if the referencePoint is completely or not
+   * shared at all
    */
   public synchronized void removeResources(
-      IProject project, Collection<? extends IResource> resources) {
+      IReferencePoint referencePoint, Collection<? extends IResource> resources) {
 
-    if (projectToIDMapping.get(project) == null) {
-      LOG.warn("could not remove resources from project " + project + " because it is not shared");
+    if (referencePointToIDMapping.get(referencePoint) == null) {
+      LOG.warn(
+          "could not remove resources from referencePoint "
+              + referencePoint
+              + " because it is not shared");
       // throw new IllegalStateException(
       // "could not remove resources from project " + project
       // + " because it is not shared");
       return;
     }
 
-    if (completelySharedProjects.contains(project)) {
-      LOG.warn("cannot remove resources from completely shared project: " + project);
+    if (completelySharedReferencePoints.contains(referencePoint)) {
+      LOG.warn("cannot remove resources from completely shared reference point: " + referencePoint);
       // throw new IllegalStateException(
       // "cannot remove resources from completely shared project: " +
       // project);
       return;
     }
 
-    Set<IResource> partiallySharedResources = partiallySharedResourceMapping.get(project);
+    Set<IResource> partiallySharedResources = partiallySharedResourceMapping.get(referencePoint);
 
     partiallySharedResources.removeAll(resources);
   }
@@ -246,48 +272,49 @@ class SharedProjectMapper {
    * Atomically removes and adds resources. The resources to remove will be removed first before the
    * resources to add will be added.
    *
-   * @param project a project that was added as a partially shared project
+   * @param referencePoint a reference point that was added as a partially shared reference point
    * @param resourcesToRemove the resources to remove
    * @param resourcesToAdd the resources to add
    */
   /*
    * TODO needs proper sync. in the SarosSession class
    *
-   * @throws IllegalStateException if the project is completely or not shared
-   * at all
+   * @throws IllegalStateException if the referencePoint is completely or not
+   * shared at all
    */
   public synchronized void removeAndAddResources(
-      IProject project,
+      IReferencePoint referencePoint,
       Collection<? extends IResource> resourcesToRemove,
       Collection<? extends IResource> resourcesToAdd) {
 
-    removeResources(project, resourcesToRemove);
-    addResources(project, resourcesToAdd);
+    removeResources(referencePoint, resourcesToRemove);
+    addResources(referencePoint, resourcesToAdd);
   }
 
   /**
-   * Returns the ID assigned to the given shared project.
+   * Returns the ID assigned to the given shared reference point.
    *
-   * @param project the project to look up the ID for
-   * @return the shared project's ID or <code>null</code> if the project is not shared
+   * @param referencePoint the reference point to look up the ID for
+   * @return the shared reference point's ID or <code>null</code> if the reference point is not
+   *     shared
    */
-  public synchronized String getID(IProject project) {
-    return projectToIDMapping.get(project);
+  public synchronized String getID(IReferencePoint referencePoint) {
+    return referencePointToIDMapping.get(referencePoint);
   }
 
   /**
-   * Returns the shared project with the given ID.
+   * Returns the shared reference point with the given ID.
    *
-   * @param id the ID to look up the project for
-   * @return the shared project for the given ID or <code>null</code> if no shared project is
-   *     registered with this ID
+   * @param id the ID to look up the reference point for
+   * @return the shared reference point for the given ID or <code>null</code> if no shared reference
+   *     point is registered with this ID
    */
-  public synchronized IProject getProject(String id) {
-    return idToProjectMapping.get(id);
+  public synchronized IReferencePoint getReferencePoint(String id) {
+    return idToReferencePointMapping.get(id);
   }
 
   /**
-   * Returns whether the given resource is included in one of the currently shared projects.
+   * Returns whether the given resource is included in one of the currently shared reference points.
    *
    * @param resource the resource to check for
    * @return <code>true</code> if the resource is shared, <code>false</code> otherwise
@@ -295,31 +322,38 @@ class SharedProjectMapper {
   public synchronized boolean isShared(IResource resource) {
     if (resource == null) return false;
 
-    if (resource.getType() == IResource.PROJECT) return idToProjectMapping.containsValue(resource);
+    if (resource.getType() == IResource.PROJECT) {
+      return isShared(resource.getReferencePoint());
+    }
 
-    IProject project = resource.getProject();
+    IReferencePoint referencePoint = resource.getReferencePoint();
 
-    if (!idToProjectMapping.containsValue(project)) return false;
+    if (!idToReferencePointMapping.containsValue(referencePoint)) return false;
 
-    if (isCompletelyShared(project))
+    if (isCompletelyShared(referencePoint))
       // TODO how should partial sharing handle this case ?
       return !resource.isDerived(true);
-    else return partiallySharedResourceMapping.get(project).contains(resource);
+    else return partiallySharedResourceMapping.get(referencePoint).contains(resource);
+  }
+
+  public synchronized boolean isShared(IReferencePoint referencePoint) {
+    return idToReferencePointMapping.containsValue(referencePoint);
   }
 
   /**
-   * Returns the currently shared projects.
+   * Returns the currently shared reference points.
    *
-   * @return a newly created {@link Set} with the shared projects
+   * @return a newly created {@link Set} with the shared reference points
    */
-  public synchronized Set<IProject> getProjects() {
-    return new HashSet<IProject>(idToProjectMapping.values());
+  public synchronized Set<IReferencePoint> getReferencePoints() {
+    return new HashSet<IReferencePoint>(idToReferencePointMapping.values());
   }
 
   /**
-   * Returns all resources from all partially shared projects.
+   * Returns all resources from all partially shared reference points.
    *
-   * @return a newly created {@link List} with all of the partially shared projects' resources
+   * @return a newly created {@link List} with all of the partially shared reference points'
+   *     resources
    */
   public synchronized List<IResource> getPartiallySharedResources() {
 
@@ -337,26 +371,27 @@ class SharedProjectMapper {
   }
 
   /**
-   * Returns the current number of shared projects.
+   * Returns the current number of shared reference points.
    *
-   * @return number of shared projects
+   * @return number of shared reference points
    */
   public synchronized int size() {
-    return idToProjectMapping.size();
+    return idToReferencePointMapping.size();
   }
 
   /**
-   * Returns a mapping for each shared project and its containing resources. The resource list is
-   * <b>always</b> <code>null</code> for completely shared projects.
+   * Returns a mapping for each shared reference point and its containing resources. The resource
+   * list is <b>always</b> <code>null</code> for completely shared reference points.
    *
-   * @return a map from project to resource list (partially shared) or <code>null</code> (completely
-   *     shared)
+   * @return a map from reference point to resource list (partially shared) or <code>null</code>
+   *     (completely shared)
    */
-  public synchronized Map<IProject, List<IResource>> getProjectResourceMapping() {
+  public synchronized Map<IReferencePoint, List<IResource>> getReferencePointResourceMapping() {
 
-    Map<IProject, List<IResource>> result = new HashMap<IProject, List<IResource>>();
+    Map<IReferencePoint, List<IResource>> result = new HashMap<IReferencePoint, List<IResource>>();
 
-    for (Map.Entry<IProject, Set<IResource>> entry : partiallySharedResourceMapping.entrySet()) {
+    for (Map.Entry<IReferencePoint, Set<IResource>> entry :
+        partiallySharedResourceMapping.entrySet()) {
 
       List<IResource> partiallySharedResources = null;
 
@@ -370,70 +405,71 @@ class SharedProjectMapper {
   }
 
   /**
-   * Checks whether a project is completely shared.
+   * Checks whether a reference point is completely shared.
    *
-   * @param project the project to check for
-   * @return <code>true</code> if the project is completely shared, <code>false</code> if the
-   *     project is not or partially shared
+   * @param referencePoint the referencePoint to check for
+   * @return <code>true</code> if the reference point is completely shared, <code>false</code> if
+   *     the reference point is not or partially shared
    */
-  public synchronized boolean isCompletelyShared(IProject project) {
-    return completelySharedProjects.contains(project);
+  public synchronized boolean isCompletelyShared(IReferencePoint referencePoint) {
+    return completelySharedReferencePoints.contains(referencePoint);
   }
 
   /**
-   * Checks if a project is partially shared.
+   * Checks if a reference point is partially shared.
    *
-   * @param project the project to check
-   * @return <code>true</code> if the project is partially shared, <code>false</code> if the project
-   *     is not or completely shared
+   * @param referencePoint the reference point to check
+   * @return <code>true</code> if the reference point is partially shared, <code>false</code> if the
+   *     reference point is not or completely shared
    */
-  public synchronized boolean isPartiallyShared(IProject project) {
-    return partiallySharedProjects.contains(project);
+  public synchronized boolean isPartiallyShared(IReferencePoint referencePoint) {
+    return partiallySharedReferencePoints.contains(referencePoint);
   }
 
   /**
-   * Checks if the given user already has the given project, and can thus process activities related
-   * to that project.
+   * Checks if the given user already has the given reference point, and can thus process activities
+   * related to that reference point.
    *
    * <p>This method should only be called by the session's host.
    *
    * @param user The user to be checked
-   * @param project The project to be checked
-   * @return <code>true</code> if the user currently has the project, <code>false</code> if not
+   * @param referencePoint The reference point to be checked
+   * @return <code>true</code> if the user currently has the reference point, <code>false</code> if
+   *     not
    */
-  public synchronized boolean userHasProject(User user, IProject project) {
-    if (projectsOfUsers.containsKey(user)) {
-      return projectsOfUsers.get(user).contains(getID(project));
+  public synchronized boolean userHasReferencePoint(User user, IReferencePoint referencePoint) {
+    if (referencePointsOfUsers.containsKey(user)) {
+      return referencePointsOfUsers.get(user).contains(getID(referencePoint));
     }
     return false;
   }
 
   /**
-   * Tells the mapper that the given user now has all currently shared projects.
+   * Tells the mapper that the given user now has all currently shared reference point.
    *
    * <p>This method should only be called by the session's host.
    *
-   * @param user user who now has all projects
-   * @see #userHasProject(User, IProject)
+   * @param user user who now has all reference points
+   * @see #userHasReferencePoint(User, IReferencePoint)
    */
-  public synchronized void addMissingProjectsToUser(User user) {
-    List<String> projects = new ArrayList<String>();
-    for (String project : idToProjectMapping.keySet()) {
-      projects.add(project);
+  public synchronized void addMissingReferencePointsToUser(User user) {
+    List<String> referencePoints = new ArrayList<String>();
+    for (String referencePoint : idToReferencePointMapping.keySet()) {
+      referencePoints.add(referencePoint);
     }
 
-    this.projectsOfUsers.put(user, projects);
+    this.referencePointsOfUsers.put(user, referencePoints);
   }
 
   /**
-   * Removes the user-project mapping of the user that left the session.
+   * Removes the user-referencePoint mapping of the user that left the session.
    *
    * <p>This method should only be called by the session's host.
    *
    * @param user user who left the session
-   * @see #userHasProject(User, IProject)
+   * @see #userHasReferencePoint(User, IReferencePoint)
    */
   public void userLeft(User user) {
-    projectsOfUsers.remove(user);
+    referencePointsOfUsers.remove(user);
   }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SharedReferencePointMapper.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SharedReferencePointMapper.java
@@ -23,9 +23,9 @@ import org.apache.log4j.Logger;
  * when the local names of shared reference point are different. The ID is determined by the
  * reference point/file-host.
  */
-class SharedProjectMapper {
+class SharedReferencePointMapper {
 
-  private static final Logger LOG = Logger.getLogger(SharedProjectMapper.class);
+  private static final Logger LOG = Logger.getLogger(SharedReferencePointMapper.class);
 
   /** Mapping from reference point IDs to currently registered shared reference point. */
   private Map<String, IReferencePoint> idToReferencePointMapping;
@@ -52,7 +52,7 @@ class SharedProjectMapper {
   /** Set containing the currently partially shared reference points. */
   private Set<IReferencePoint> partiallySharedReferencePoints;
 
-  public SharedProjectMapper() {
+  public SharedReferencePointMapper() {
     idToReferencePointMapping = new HashMap<String, IReferencePoint>();
     referencePointToIDMapping = new HashMap<IReferencePoint, String>();
     referencePointsOfUsers = new HashMap<User, List<String>>();

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/internal/SharedProjectMapperTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/internal/SharedProjectMapperTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import java.util.Collections;
 import java.util.List;
@@ -27,211 +27,220 @@ public class SharedProjectMapperTest {
   }
 
   @Test(expected = NullPointerException.class)
-  public void testAddNullProject() {
-    mapper.addProject("0", null, false);
+  public void testAddNullReferencePoint() {
+    mapper.addReferencePoint("0", null, false);
   }
 
   @Test(expected = NullPointerException.class)
-  public void testAddProjectWithNullID() {
-    mapper.addProject(null, createProjectMock(), false);
+  public void testAddReferencePointWithNullID() {
+    mapper.addReferencePoint(null, createReferencePointMock(), false);
   }
 
   @Test
-  public void testAddCompletelySharedProject() {
-    IProject projectMock = createProjectMock();
+  public void testAddCompletelySharedReferencePoint() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
-    mapper.addProject("0", projectMock, false);
+    mapper.addReferencePoint("0", referencePointMock, false);
 
-    assertTrue("project is not shared at all", mapper.isShared(projectMock));
+    assertTrue("referencePoint is not shared at all", mapper.isShared(referencePointMock));
 
-    assertFalse("project is partially shared", mapper.isPartiallyShared(projectMock));
+    assertFalse("referencePoint is partially shared", mapper.isPartiallyShared(referencePointMock));
 
-    assertTrue("project is not completely shared", mapper.isCompletelyShared(projectMock));
+    assertTrue(
+        "referencePoint is not completely shared", mapper.isCompletelyShared(referencePointMock));
   }
 
   @Test
-  public void testAddPartiallySharedProject() {
-    IProject projectMock = createProjectMock();
+  public void testAddPartiallySharedReferencePoint() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
-    mapper.addProject("0", projectMock, true);
+    mapper.addReferencePoint("0", referencePointMock, true);
 
-    assertTrue("project is not shared at all", mapper.isShared(projectMock));
+    assertTrue("referencePoint is not shared at all", mapper.isShared(referencePointMock));
 
-    assertFalse("project is completely shared", mapper.isCompletelyShared(projectMock));
+    assertFalse(
+        "referencePoint is completely shared", mapper.isCompletelyShared(referencePointMock));
 
-    assertTrue("project is not partially shared", mapper.isPartiallyShared(projectMock));
+    assertTrue(
+        "referencePoint is not partially shared", mapper.isPartiallyShared(referencePointMock));
   }
 
   @Test(expected = IllegalStateException.class)
-  public void testAddCompletelySharedProjectTwice() {
-    IProject projectMock = createProjectMock();
+  public void testAddCompletelySharedReferencePointTwice() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
     try {
-      mapper.addProject("0", projectMock, false);
+      mapper.addReferencePoint("0", referencePointMock, false);
     } catch (RuntimeException e) {
       e.printStackTrace();
       fail(e.getMessage());
     }
-    mapper.addProject("0", projectMock, false);
+    mapper.addReferencePoint("0", referencePointMock, false);
   }
 
   @Test(expected = IllegalStateException.class)
-  public void testAddPartiallySharedProjectTwice() {
-    IProject projectMock = createProjectMock();
+  public void testAddPartiallySharedReferencePointTwice() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
     try {
-      mapper.addProject("0", projectMock, true);
+      mapper.addReferencePoint("0", referencePointMock, true);
     } catch (RuntimeException e) {
       e.printStackTrace();
       fail(e.getMessage());
     }
-    mapper.addProject("0", projectMock, true);
+    mapper.addReferencePoint("0", referencePointMock, true);
   }
 
   @Test(expected = IllegalStateException.class)
-  public void testAddSameProjectWithDifferentID() {
-    IProject projectMock = createProjectMock();
+  public void testAddSameReferencePointWithDifferentID() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
     try {
-      mapper.addProject("0", projectMock, true);
-    } catch (RuntimeException e) {
-      e.printStackTrace();
-      fail(e.getMessage());
-    }
-
-    mapper.addProject("1", projectMock, true);
-  }
-
-  @Test(expected = IllegalStateException.class)
-  public void testAddNewProjectWithIDAlreadyInUse() {
-    IProject projectMockA = createProjectMock();
-    IProject projectMockB = createProjectMock();
-
-    try {
-      mapper.addProject("0", projectMockA, true);
+      mapper.addReferencePoint("0", referencePointMock, true);
     } catch (RuntimeException e) {
       e.printStackTrace();
       fail(e.getMessage());
     }
 
-    mapper.addProject("0", projectMockB, true);
+    mapper.addReferencePoint("1", referencePointMock, true);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testAddNewReferencePointWithIDAlreadyInUse() {
+    IReferencePoint referencePointMockA = createReferencePointMock();
+    IReferencePoint referencePointMockB = createReferencePointMock();
+
+    try {
+      mapper.addReferencePoint("0", referencePointMockA, true);
+    } catch (RuntimeException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+
+    mapper.addReferencePoint("0", referencePointMockB, true);
   }
 
   @Test
-  public void testPartiallySharedProjectUpgrade() {
-    IProject projectMock = createProjectMock();
+  public void testPartiallySharedReferencePointUpgrade() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
-    mapper.addProject("0", projectMock, true);
-    assertTrue("project is not partially shared", mapper.isPartiallyShared(projectMock));
+    mapper.addReferencePoint("0", referencePointMock, true);
+    assertTrue(
+        "referencePoint is not partially shared", mapper.isPartiallyShared(referencePointMock));
 
-    assertFalse("project is completely shared", mapper.isCompletelyShared(projectMock));
+    assertFalse(
+        "referencePoint is completely shared", mapper.isCompletelyShared(referencePointMock));
 
-    mapper.addProject("0", projectMock, false);
-    assertFalse("project is partially shared", mapper.isPartiallyShared(projectMock));
+    mapper.addReferencePoint("0", referencePointMock, false);
+    assertFalse("referencePoint is partially shared", mapper.isPartiallyShared(referencePointMock));
 
-    assertTrue("project is not completely shared", mapper.isCompletelyShared(projectMock));
+    assertTrue(
+        "referencePoint is not completely shared", mapper.isCompletelyShared(referencePointMock));
   }
 
   @Test(expected = IllegalStateException.class)
-  public void testCompletelySharedProjectDowngrade() {
-    IProject projectMock = createProjectMock();
+  public void testCompletelySharedReferencePointDowngrade() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
     try {
-      mapper.addProject("0", projectMock, false);
+      mapper.addReferencePoint("0", referencePointMock, false);
     } catch (RuntimeException e) {
       e.printStackTrace();
       fail(e.getMessage());
     }
 
-    mapper.addProject("0", projectMock, true);
+    mapper.addReferencePoint("0", referencePointMock, true);
   }
 
   @Test
-  public void testRemoveProjects() {
-    IProject projectMockA = createProjectMock();
-    IProject projectMockB = createProjectMock();
+  public void testRemoveReferencePoints() {
+    IReferencePoint referencePointMockA = createReferencePointMock();
+    IReferencePoint referencePointMockB = createReferencePointMock();
 
-    mapper.addProject("0", projectMockA, false);
-    mapper.addProject("1", projectMockB, true);
+    mapper.addReferencePoint("0", referencePointMockA, false);
+    mapper.addReferencePoint("1", referencePointMockB, true);
 
-    mapper.removeProject("0");
-    mapper.removeProject("1");
+    mapper.removeReferencePoint("0");
+    mapper.removeReferencePoint("1");
 
-    assertFalse("project is still shared", mapper.isShared(projectMockA));
-    assertFalse("project is still shared", mapper.isShared(projectMockB));
+    assertFalse("referencePoint is still shared", mapper.isShared(referencePointMockA));
+    assertFalse("referencePoint is still shared", mapper.isShared(referencePointMockB));
 
-    assertFalse("project is still completely shared", mapper.isCompletelyShared(projectMockA));
-    assertFalse("project is still partially shared", mapper.isPartiallyShared(projectMockB));
+    assertFalse(
+        "referencePoint is still completely shared",
+        mapper.isCompletelyShared(referencePointMockA));
+    assertFalse(
+        "referencePoint is still partially shared", mapper.isPartiallyShared(referencePointMockB));
   }
 
   @Test(expected = IllegalStateException.class)
   @Ignore(
       "logic is currently not performed - should be enabled after the SarosSession is properly synchronized")
-  public void testAddResourcesToCompletelySharedProject() {
-    IProject projectMock = createProjectMock();
-    mapper.addProject("0", projectMock, false);
+  public void testAddResourcesToCompletelySharedReferencePoint() {
+    IReferencePoint referencePointMock = createReferencePointMock();
+    mapper.addReferencePoint("0", referencePointMock, false);
     List<IResource> emptyList = Collections.emptyList();
-    mapper.addResources(projectMock, emptyList);
+    mapper.addResources(referencePointMock, emptyList);
   }
 
   @Test(expected = IllegalStateException.class)
   @Ignore(
       "logic is currently not performed - should be enabled after the SarosSession is properly synchronized")
-  public void testAddResourcesToNonSharedProject() {
-    IProject projectMock = createProjectMock();
+  public void testAddResourcesToNonSharedReferencePoint() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
     List<IResource> emptyList = Collections.emptyList();
-    mapper.addResources(projectMock, emptyList);
+    mapper.addResources(referencePointMock, emptyList);
   }
 
   @Test(expected = IllegalStateException.class)
   @Ignore(
       "logic is currently not performed - should be enabled after the SarosSession is properly synchronized")
-  public void testRemoveResourcesFromCompletelySharedProject() {
-    IProject projectMock = createProjectMock();
+  public void testRemoveResourcesFromCompletelySharedReferencePoint() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
-    mapper.addProject("0", projectMock, false);
+    mapper.addReferencePoint("0", referencePointMock, false);
 
     List<IResource> emptyList = Collections.emptyList();
-    mapper.removeResources(projectMock, emptyList);
+    mapper.removeResources(referencePointMock, emptyList);
   }
 
   @Test(expected = IllegalStateException.class)
   @Ignore(
       "logic is currently not performed - should be enabled after the SarosSession is properly synchronized")
-  public void testRemoveResourcesFromNonSharedProject() {
-    IProject projectMock = createProjectMock();
+  public void testRemoveResourcesFromNonSharedReferencePoint() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
     List<IResource> emptyList = Collections.emptyList();
-    mapper.removeResources(projectMock, emptyList);
+    mapper.removeResources(referencePointMock, emptyList);
   }
 
   @Test
-  public void testAddRemoveResourcesOfPartiallySharedProject() {
+  public void testAddRemoveResourcesOfPartiallySharedReferencePoint() {
 
-    IProject projectMock = createProjectMock();
+    IReferencePoint referencePointMock = createReferencePointMock();
 
     IResource resourceMockA = EasyMock.createNiceMock(IResource.class);
-    EasyMock.expect(resourceMockA.getProject()).andStubReturn(projectMock);
+    EasyMock.expect(resourceMockA.getReferencePoint()).andStubReturn(referencePointMock);
     IResource resourceMockB = EasyMock.createNiceMock(IResource.class);
-    EasyMock.expect(resourceMockB.getProject()).andStubReturn(projectMock);
+    EasyMock.expect(resourceMockB.getReferencePoint()).andStubReturn(referencePointMock);
     EasyMock.replay(resourceMockA, resourceMockB);
 
-    mapper.addProject("0", projectMock, true);
-    mapper.addResources(projectMock, Collections.singletonList(resourceMockA));
+    mapper.addReferencePoint("0", referencePointMock, true);
+    mapper.addResources(referencePointMock, Collections.singletonList(resourceMockA));
 
     assertTrue("resource is not shared", mapper.isShared(resourceMockA));
     assertEquals(1, mapper.getPartiallySharedResources().size());
 
-    mapper.removeResources(projectMock, Collections.singletonList(resourceMockA));
+    mapper.removeResources(referencePointMock, Collections.singletonList(resourceMockA));
 
     assertFalse("resource is still shared", mapper.isShared(resourceMockA));
     assertEquals(0, mapper.getPartiallySharedResources().size());
 
-    mapper.addResources(projectMock, Collections.singletonList(resourceMockA));
+    mapper.addResources(referencePointMock, Collections.singletonList(resourceMockA));
 
     mapper.removeAndAddResources(
-        projectMock,
+        referencePointMock,
         Collections.singletonList(resourceMockA),
         Collections.singletonList(resourceMockB));
 
@@ -241,16 +250,16 @@ public class SharedProjectMapperTest {
   }
 
   @Test
-  public void testDerivedResourcesOnCompletelySharedProject() {
-    IProject projectMock = createProjectMock();
+  public void testDerivedResourcesOnCompletelySharedReferencePoint() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
     IResource resourceMock = EasyMock.createNiceMock(IResource.class);
-    EasyMock.expect(resourceMock.getProject()).andStubReturn(projectMock);
+    EasyMock.expect(resourceMock.getReferencePoint()).andStubReturn(referencePointMock);
     EasyMock.expect(resourceMock.isDerived(true)).andReturn(true);
 
     EasyMock.replay(resourceMock);
 
-    mapper.addProject("0", projectMock, false);
+    mapper.addReferencePoint("0", referencePointMock, false);
 
     assertFalse("derived resource is marked as shared", mapper.isShared(resourceMock));
 
@@ -260,14 +269,14 @@ public class SharedProjectMapperTest {
   @Test
   public void testIsShared() {
 
-    IProject projectMockA = createProjectMock();
-    IProject projectMockB = createProjectMock();
+    IReferencePoint referencePointMockA = createReferencePointMock();
+    IReferencePoint referencePointMockB = createReferencePointMock();
 
     IResource resourceMockA = EasyMock.createNiceMock(IResource.class);
-    EasyMock.expect(resourceMockA.getProject()).andStubReturn(projectMockA);
+    EasyMock.expect(resourceMockA.getReferencePoint()).andStubReturn(referencePointMockA);
 
     IResource resourceMockB = EasyMock.createNiceMock(IResource.class);
-    EasyMock.expect(resourceMockB.getProject()).andStubReturn(projectMockB);
+    EasyMock.expect(resourceMockB.getReferencePoint()).andStubReturn(referencePointMockB);
 
     EasyMock.replay(resourceMockA, resourceMockB);
 
@@ -275,61 +284,66 @@ public class SharedProjectMapperTest {
 
     assertFalse("resource should not be marked as shared", mapper.isShared(resourceMockB));
 
-    mapper.addProject("0", projectMockA, false);
-    mapper.addProject("1", projectMockB, true);
+    mapper.addReferencePoint("0", referencePointMockA, false);
+    mapper.addReferencePoint("1", referencePointMockB, true);
 
     assertTrue("resource is not marked as shared", mapper.isShared(resourceMockA));
 
     assertFalse("resource should not be marked as shared", mapper.isShared(resourceMockB));
 
-    mapper.addResources(projectMockB, Collections.singletonList(resourceMockB));
+    mapper.addResources(referencePointMockB, Collections.singletonList(resourceMockB));
 
     assertTrue("resource is not marked as shared", mapper.isShared(resourceMockB));
   }
 
   @Test
-  public void testGetProjectResourceMapping() {
-    IProject projectMockA = createProjectMock();
-    IProject projectMockB = createProjectMock();
+  public void testGetReferencePointResourceMapping() {
+    IReferencePoint referencePointMockA = createReferencePointMock();
+    IReferencePoint referencePointMockB = createReferencePointMock();
 
     IResource resourceMockB = EasyMock.createNiceMock(IResource.class);
-    EasyMock.expect(resourceMockB.getProject()).andStubReturn(projectMockB);
+    EasyMock.expect(resourceMockB.getReferencePoint()).andStubReturn(referencePointMockB);
 
     EasyMock.replay(resourceMockB);
 
-    mapper.addProject("0", projectMockA, false);
-    mapper.addProject("1", projectMockB, true);
+    mapper.addReferencePoint("0", referencePointMockA, false);
+    mapper.addReferencePoint("1", referencePointMockB, true);
 
-    mapper.addResources(projectMockB, Collections.singletonList(resourceMockB));
+    mapper.addResources(referencePointMockB, Collections.singletonList(resourceMockB));
 
-    Map<IProject, List<IResource>> mapping = mapper.getProjectResourceMapping();
+    Map<IReferencePoint, List<IResource>> mapping = mapper.getReferencePointResourceMapping();
 
-    assertNull("completely shared projects have no resource list", mapping.get(projectMockA));
+    assertNull(
+        "completely shared referencePoint have no resource list", mapping.get(referencePointMockA));
 
-    assertNotNull("partially shared projects must have a resource list", mapping.get(projectMockB));
+    assertNotNull(
+        "partially shared referencePoint must have a resource list",
+        mapping.get(referencePointMockB));
 
     assertEquals(
-        "resource list does not contain the shared resource", 1, mapping.get(projectMockB).size());
+        "resource list does not contain the shared resource",
+        1,
+        mapping.get(referencePointMockB).size());
   }
 
   @Test
-  public void testGetProjects() {
-    IProject projectMockA = createProjectMock();
-    IProject projectMockB = createProjectMock();
+  public void testGetReferencePoints() {
+    IReferencePoint referencePointMockA = createReferencePointMock();
+    IReferencePoint referencePointMockB = createReferencePointMock();
 
-    mapper.addProject("0", projectMockA, false);
-    mapper.addProject("1", projectMockB, false);
+    mapper.addReferencePoint("0", referencePointMockA, false);
+    mapper.addReferencePoint("1", referencePointMockB, false);
 
-    assertEquals(2, mapper.getProjects().size());
+    assertEquals(2, mapper.getReferencePoints().size());
     assertEquals(2, mapper.size());
   }
 
   @Test
-  public void testIDToProjectMapping() {
-    IProject projectMock = createProjectMock();
-    mapper.addProject("0", projectMock, false);
-    assertEquals("0", mapper.getID(projectMock));
-    assertEquals(projectMock, mapper.getProject("0"));
+  public void testIDToReferencePointMapping() {
+    IReferencePoint referencePointMock = createReferencePointMock();
+    mapper.addReferencePoint("0", referencePointMock, false);
+    assertEquals("0", mapper.getID(referencePointMock));
+    assertEquals(referencePointMock, mapper.getReferencePoint("0"));
   }
 
   /*
@@ -337,10 +351,9 @@ public class SharedProjectMapperTest {
    * IllegalArgumentExceptions as well which may lead to false positive
    * (passed) test cases
    */
-  private IProject createProjectMock() {
-    IProject projectMock = EasyMock.createNiceMock(IProject.class);
-    EasyMock.expect(projectMock.getType()).andStubReturn(IResource.PROJECT);
-    EasyMock.replay(projectMock);
-    return projectMock;
+  private IReferencePoint createReferencePointMock() {
+    IReferencePoint referencePointMock = EasyMock.createNiceMock(IReferencePoint.class);
+    EasyMock.replay(referencePointMock);
+    return referencePointMock;
   }
 }

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/internal/SharedReferencePointMapperTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/internal/SharedReferencePointMapperTest.java
@@ -17,13 +17,13 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-public class SharedProjectMapperTest {
+public class SharedReferencePointMapperTest {
 
-  private SharedProjectMapper mapper;
+  private SharedReferencePointMapper mapper;
 
   @Before
   public void setUp() {
-    mapper = new SharedProjectMapper();
+    mapper = new SharedReferencePointMapper();
   }
 
   @Test(expected = NullPointerException.class)

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/internal/TestSuite.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/internal/TestSuite.java
@@ -8,7 +8,7 @@ import org.junit.runners.Suite;
   ActivityHandlerTest.class,
   ActivityQueuerTest.class,
   ActivitySequencerTest.class,
-  SharedProjectMapperTest.class,
+  SharedReferencePointMapperTest.class,
   UserInformationHandlerTest.class
 })
 public class TestSuite {


### PR DESCRIPTION
This PR is an updated version of the PR https://github.com/saros-project/saros/pull/257. The difference is that this PR is based on the new Saros enviroment...

In Saros Core the IReferencePointManager was introduced. As described on https://github.com/saros-project/saros/issues/177, The IReferencePointManager is needed in Saros Core during adapting step by step. 
The IReferencePointManager maps an IReferencePoint to an core.IProject and returns either an core.IProject given by an IReferencePoint or a set of core.IProject given by a set of IReferencePoint. The ReferencePointManager is an implementation of the IReferencePointManager.

SharedProjectMapper/-test:
The SharedProjectMapper now works with IReferencePoints. The logic itself did'nt changed. The unit tests had to be adjusted. The SharedProjectMapper was renamend to SharedReferencePointMapper in a seperate commit.

IReferencePointManager/ReferencePointManager:
The IReferencePointManager maps an IReferencePoint to an core.IProject.
Because not all classes will not adapted at the same time, the IReferencePointManager
is needed for classes, who still works core.IProjects. The ReferencePointManager
is an implementation of IReferencePointManager.

SarosSession:
After the SharedProjectManager works with reference points, the SarosSession needs
the ÍReferencePointManager for getting IProjects given by IReferencePoints.
The IReferencePointManager will instantiated in SarosSession and kept in
the core session container. The IReferencePointManager will needed only if a session is
running, so that the reason, that the IReferencePointManager is in the core session
container. Currently the SarosSession is responsible for putting the pairs IReferencePoints
and core.IProjects, which should to be shared.

EDIT: 
I reworked issue https://github.com/saros-project/saros/issues/177
and you can see the final state in PR https://github.com/saros-project/saros/pull/391