### PR TITLE
[FIX][I] #285 Introduce logic to handle content recovery

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/resources/saros.properties
+++ b/de.fu_berlin.inf.dpp.intellij/resources/saros.properties
@@ -45,7 +45,6 @@ saros.intellij.MAX_CONTRIBUTION_ANNOTATIONS = 50
 
 # feature flag for functionality not fully working in current release, can be removed when features are fully implemented
 # If true, features are enabled
-saros.intellij.ENABLE_RECOVERY = true
 saros.intellij.ENABLE_FOLLOW_MODE = false
 saros.intellij.ENABLE_ADD_CONTACT = false
 saros.intellij.ENABLE_PREFERENCES = false

--- a/de.fu_berlin.inf.dpp.intellij/resources/saros.properties
+++ b/de.fu_berlin.inf.dpp.intellij/resources/saros.properties
@@ -45,7 +45,7 @@ saros.intellij.MAX_CONTRIBUTION_ANNOTATIONS = 50
 
 # feature flag for functionality not fully working in current release, can be removed when features are fully implemented
 # If true, features are enabled
-saros.intellij.ENABLE_RECOVERY = false
+saros.intellij.ENABLE_RECOVERY = true
 saros.intellij.ENABLE_FOLLOW_MODE = false
 saros.intellij.ENABLE_ADD_CONTACT = false
 saros.intellij.ENABLE_PREFERENCES = false

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorAPI.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorAPI.java
@@ -88,36 +88,6 @@ public class EditorAPI {
   }
 
   /**
-   * Overwrites the content of the document with text inside the UI thread.
-   *
-   * @param doc
-   * @param text
-   */
-  public void setText(final Document doc, final String text) {
-    Runnable action =
-        new Runnable() {
-          @Override
-          public void run() {
-            commandProcessor.executeCommand(
-                project,
-                new Runnable() {
-
-                  @Override
-                  public void run() {
-                    doc.setText(text);
-                  }
-                },
-                "Saros text set to \"" + text + "\"",
-                commandProcessor.getCurrentCommandGroupId(),
-                UndoConfirmationPolicy.REQUEST_CONFIRMATION,
-                doc);
-          }
-        };
-
-    Filesystem.runWriteAction(action, ModalityState.defaultModalityState());
-  }
-
-  /**
    * Deletes text in document in the specified range in the UI thread.
    *
    * @param doc

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
@@ -830,6 +830,10 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
     return session.isShared(editorFilePath.getResource());
   }
 
+  boolean isDocumentListenerEnabled() {
+    return documentListener.enabled;
+  }
+
   void enableDocumentListener() {
     documentListener.setEnabled(true);
     annotationDocumentListener.setEnabled(true);

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorManipulator.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorManipulator.java
@@ -120,30 +120,6 @@ public class LocalEditorManipulator {
   }
 
   /**
-   * Replaces the content of the document at the given path. The text is only replaced, if the
-   * editor is writable.
-   *
-   * @param path path of the editor
-   * @param text text to set the document's content to
-   * @return Returns <code>true</code> if replacement was successful, <code>false</code> if the path
-   *     was <code>null></code>, if the path points to a non-existing document or the document was
-   *     not writable.
-   */
-  public boolean replaceText(SPath path, String text) {
-    Document doc = editorPool.getDocument(path);
-    if (doc == null) {
-      return false;
-    }
-    if (!doc.isWritable()) {
-      LOG.error("File to replace text in is not writeable: " + path);
-      return false;
-    }
-
-    editorAPI.setText(doc, text);
-    return true;
-  }
-
-  /**
    * Applies the text operations on the path and marks them in color.
    *
    * @param path

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorManipulator.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorManipulator.java
@@ -3,14 +3,23 @@ package de.fu_berlin.inf.dpp.intellij.editor;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.vfs.VirtualFile;
+import de.fu_berlin.inf.dpp.activities.FileActivity;
 import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.Operation;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.internal.text.DeleteOperation;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.internal.text.ITextOperation;
 import de.fu_berlin.inf.dpp.editor.text.LineRange;
 import de.fu_berlin.inf.dpp.editor.text.TextSelection;
+import de.fu_berlin.inf.dpp.filesystem.IFile;
+import de.fu_berlin.inf.dpp.intellij.editor.annotations.AnnotationManager;
 import de.fu_berlin.inf.dpp.intellij.filesystem.VirtualFileConverter;
+import de.fu_berlin.inf.dpp.intellij.project.SharedResourcesManager;
 import de.fu_berlin.inf.dpp.intellij.session.SessionUtils;
+import de.fu_berlin.inf.dpp.intellij.ui.Messages;
+import de.fu_berlin.inf.dpp.intellij.ui.util.NotificationPanel;
+import de.fu_berlin.inf.dpp.session.User;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import org.apache.log4j.Logger;
 
 /** This class applies the logic for activities that were received from remote. */
@@ -20,15 +29,18 @@ public class LocalEditorManipulator {
 
   private final ProjectAPI projectAPI;
   private final EditorAPI editorAPI;
+  private final AnnotationManager annotationManager;
 
   /** This is just a reference to {@link EditorManager}'s editorPool and not a separate pool. */
   private EditorPool editorPool;
 
   private EditorManager manager;
 
-  public LocalEditorManipulator(ProjectAPI projectAPI, EditorAPI editorAPI) {
+  public LocalEditorManipulator(
+      ProjectAPI projectAPI, EditorAPI editorAPI, AnnotationManager annotationManager) {
     this.projectAPI = projectAPI;
     this.editorAPI = editorAPI;
+    this.annotationManager = annotationManager;
   }
 
   /** Initializes all fields that require an EditorManager. */
@@ -232,5 +244,96 @@ public class LocalEditorManipulator {
         editor, range.getStartLine(), range.getStartLine() + range.getNumberOfLines());
 
     // todo: implement actual viewport adjustment logic
+  }
+
+  /**
+   * Replaces the content of the given file with the given content. This is done on the Document
+   * level.
+   *
+   * <p><b>NOTE:</b> This method should only be used as part of the recovery process.
+   *
+   * @param path the path of the file to recover
+   * @param content the new content of the file
+   * @param encoding the encoding of the content
+   * @param source the user that send the recovery action
+   * @see Document
+   * @see SharedResourcesManager#handleFileRecovery(FileActivity)
+   */
+  public void handleContentRecovery(SPath path, byte[] content, String encoding, User source) {
+    VirtualFile virtualFile = VirtualFileConverter.convertToVirtualFile(path);
+    if (virtualFile == null) {
+      LOG.warn(
+          "Could not recover file content of "
+              + path
+              + " as it could not be converted to a VirtualFile.");
+
+      return;
+    }
+
+    Document document = projectAPI.getDocument(virtualFile);
+    if (document == null) {
+      LOG.warn(
+          "Could not recover file content of "
+              + path
+              + " as no valid Document representation was returned by the IntelliJ API.");
+
+      return;
+    }
+
+    int documentLength = document.getTextLength();
+
+    IFile file = path.getFile();
+    annotationManager.removeAnnotations(file);
+
+    String text;
+    try {
+      text = new String(content, encoding);
+    } catch (UnsupportedEncodingException e) {
+      LOG.warn("Could not decode text using given encoding. Using default instead.", e);
+
+      text = new String(content);
+
+      NotificationPanel.showWarning(
+          String.format(
+              Messages.LocalEditorManipulator_incompatible_encoding_message,
+              file.getLocation(),
+              encoding,
+              Charset.defaultCharset()),
+          Messages.LocalEditorManipulator_incompatible_encoding_title);
+    }
+
+    boolean wasReadOnly = !document.isWritable();
+    boolean wasDocumentListenerEnabled = manager.isDocumentListenerEnabled();
+
+    try {
+      // TODO distinguish if read-only was set by the StopManager, abort otherwise
+      if (wasReadOnly) {
+        document.setReadOnly(false);
+      }
+
+      if (wasDocumentListenerEnabled) {
+        manager.disableDocumentListener();
+      }
+
+      editorAPI.deleteText(document, 0, documentLength);
+      editorAPI.insertText(document, 0, text);
+
+    } finally {
+
+      if (wasDocumentListenerEnabled) {
+        manager.enableDocumentListener();
+      }
+
+      if (wasReadOnly) {
+        document.setReadOnly(true);
+      }
+    }
+
+    Editor editor = null;
+    if (projectAPI.isOpen(virtualFile)) {
+      editor = projectAPI.openEditor(virtualFile, false);
+    }
+
+    annotationManager.addContributionAnnotation(source, file, 0, documentLength, editor);
   }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/SharedResourcesManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/SharedResourcesManager.java
@@ -175,10 +175,17 @@ public class SharedResourcesManager extends AbstractActivityProducer implements 
 
     try {
       if (type == FileActivity.Type.CREATED) {
-        // TODO handle case if file already exists and only content needs to be recovered
-        handleFileCreation(activity);
+        if (path.getFile().exists()) {
+          localEditorManipulator.handleContentRecovery(
+              path, activity.getContent(), activity.getEncoding(), activity.getSource());
+
+        } else {
+          handleFileCreation(activity);
+        }
+
       } else if (type == FileActivity.Type.REMOVED) {
         handleFileDeletion(activity);
+
       } else {
         LOG.warn("performing recovery for type " + type + " is not supported");
       }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/Messages.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/Messages.java
@@ -106,5 +106,8 @@ public class Messages {
   public static String SessionStatusChangeHandler_kicked;
   public static String SessionStatusChangeHandler_connection_lost;
 
+  public static String LocalEditorManipulator_incompatible_encoding_title;
+  public static String LocalEditorManipulator_incompatible_encoding_message;
+
   private Messages() {}
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/messages.properties
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/messages.properties
@@ -92,3 +92,6 @@ SessionStatusChangeHandler_local_user_left=You left the session.
 SessionStatusChangeHandler_host_left=The host left the session.
 SessionStatusChangeHandler_kicked=The host removed you from the session.
 SessionStatusChangeHandler_connection_lost=You lost the connection to the host.
+
+LocalEditorManipulator_incompatible_encoding_title=Incompatible Encoding Detected
+LocalEditorManipulator_incompatible_encoding_message=The encoding for the received file content for {0} is not known to the local JVM. The default encoding is used instead. If the content is parsed incorrectly, please reach a consensus with the other session participants and and start a new session all using the same encoding.\nReceived encoding: {1}, default encoding: {2}

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/views/SarosToolbar.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/views/SarosToolbar.java
@@ -18,8 +18,6 @@ public class SarosToolbar extends JToolBar {
   public static final String ADD_CONTACT_ICON_PATH = "/icons/famfamfam/contact_add_tsk.png";
   public static final String OPEN_REFS_ICON_PATH = "/icons/famfamfam/test_con.gif";
 
-  private static final boolean ENABLE_RECOVERY =
-      Boolean.getBoolean("saros.intellij.ENABLE_RECOVERY");
   private static final boolean ENABLE_FOLLOW_MODE =
       Boolean.getBoolean("saros.intellij.ENABLE_FOLLOW_MODE");
   private static final boolean ENABLE_ADD_CONTACT =
@@ -59,9 +57,7 @@ public class SarosToolbar extends JToolBar {
       add(new FollowButton());
     }
 
-    if (ENABLE_RECOVERY) {
-      add(new ConsistencyButton());
-    }
+    add(new ConsistencyButton());
 
     add(new LeaveSessionButton());
   }


### PR DESCRIPTION
Adds logic to handle content recovery, meaning the content of an
existing file needs to be adjusted. Previously, this was handled on the
filesystem level, meaning the changes made by the recovery were not
undo-able. This commit introduces a logic to handle content recoveries
on the document level to avoid such issues.

Resolves #285.

Subsequently enables the recovery button as the feature should now be
functional.