### PR TITLE
[C][FEATURE] Introduce PropertyHooks

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/hooks/AbstractPropertyHook.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/hooks/AbstractPropertyHook.java
@@ -1,0 +1,89 @@
+package de.fu_berlin.inf.dpp.negotiation.hooks;
+
+import de.fu_berlin.inf.dpp.net.xmpp.JID;
+import de.fu_berlin.inf.dpp.preferences.IPreferenceStore;
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class AbstractPropertyHook implements ISessionNegotiationHook {
+  protected abstract Object getValue();
+
+  protected abstract Object fromString(String value);
+
+  public static String keyFromIdentifier(String identifier) {
+    return identifier + "Property";
+  }
+
+  private String getKey() {
+    return keyFromIdentifier(getIdentifier());
+  }
+
+  private String getServerKey() {
+    return "server" + getKey();
+  }
+
+  private String getClientKey() {
+    return "client" + getKey();
+  }
+
+  @Override
+  public final void setInitialHostPreferences(IPreferenceStore hostPreferences) {
+    Object value = getValue();
+    if (value instanceof Boolean) {
+      hostPreferences.setValue(getKey(), (Boolean) value);
+    } else if (value instanceof Integer) {
+      hostPreferences.setValue(getKey(), (Integer) value);
+    } else if (value instanceof Long) {
+      hostPreferences.setValue(getKey(), (Long) value);
+    } else if (value instanceof String) {
+      hostPreferences.setValue(getKey(), (String) value);
+    } else {
+      throw new IllegalArgumentException(
+          "PropertyHook values must be either bool,int,long or String");
+    }
+  }
+
+  @Override
+  public final Map<String, String> tellClientPreferences() {
+    Map<String, String> clientPreferences = new HashMap<>();
+    clientPreferences.put(getClientKey(), getValue().toString());
+    return clientPreferences;
+  }
+
+  @Override
+  public final Map<String, String> considerClientPreferences(
+      JID client, Map<String, String> input) {
+    Map<String, String> defined = new HashMap<>();
+    defined.put(getClientKey(), input.get(getClientKey()));
+    defined.put(getServerKey(), getValue().toString());
+    return defined;
+  }
+
+  @Override
+  public final void applyActualParameters(
+      Map<String, String> input,
+      IPreferenceStore hostPreferences,
+      IPreferenceStore clientPreferences) {
+    Object clientValue = fromString(input.get(getClientKey()));
+    Object serverValue = fromString(input.get(getServerKey()));
+
+    assert clientValue.getClass() != serverValue.getClass();
+
+    if (clientValue instanceof Boolean) {
+      clientPreferences.setValue(getKey(), (Boolean) clientValue);
+      hostPreferences.setValue(getKey(), (Boolean) serverValue);
+    } else if (clientValue instanceof Integer) {
+      clientPreferences.setValue(getKey(), (Integer) clientValue);
+      hostPreferences.setValue(getKey(), (Integer) serverValue);
+    } else if (clientValue instanceof Long) {
+      clientPreferences.setValue(getKey(), (Long) clientValue);
+      hostPreferences.setValue(getKey(), (Long) serverValue);
+    } else if (clientValue instanceof String) {
+      clientPreferences.setValue(getKey(), (String) clientValue);
+      hostPreferences.setValue(getKey(), (String) serverValue);
+    } else {
+      throw new IllegalArgumentException(
+          "PropertyHook values must be either bool,int,long or String");
+    }
+  }
+}


### PR DESCRIPTION
@srossbach This a PR to address one of your concerns regarding #284, namely:

> I know that this XMPP stuff is not the right way to archive this. But if you look at this solution. You modified over 10 files and added multiple LOCs to just expose a single boolean value.

Onto which I replied:

> I know this adds some lines, but it is essentially the same code as for sharing the colors or any other value over the new hook system. If you think this should be redesigned again, feel free to open an issue and assign me. But that is the way data exchange during negotiation works now or did I miss something?

I get that the new hook system is quite complex given the fact that is needs to work for a lot of use-cases. This PR introduces a new abstract class for the very generic case of sharing a single value with the host.

Right now there is not a single Hook, that could benefit from this class and I have not found a way to make this fit for any. So this technically does not bring the LOC for #284 down, because there would be just a single hook using it. However it is a much more general approach that could be used by other hooks in the future.

One remaining problem with this solution is, that the KEY in the `IPreferenceStore` is derived from the `identifier`, which means you would need an actual instance of the hook to receive it.

Which is why I added a static helper function to the abstract class to derive the key for any identifier, which must now be a `public static String` in every PropertyHook, instead of the key (which is the case for most hooks [e.g.](https://github.com/saros-project/saros/pull/284/files#diff-2877d1e59fb83ca3aeb7df8c3afe7487R17) right now) to enable [access from the Session](https://github.com/saros-project/saros/pull/284/files#diff-37c625925db40c245b5b5244088fbdebR1073).

Also this is missing docs, I just wanted to get some initial feedback on the solution at first.

(Offtopic: @srossbach It would also be nice to get a response to the remaining points in #284, namely if you would still prefer this being removed from the `User` class and if you have any further suggestion, how I could remove this from core. There needs to be a way for all client implementation to figure out, which other clients are a server or at least if the host is.)