### PR TITLE
[INTERNAL][I] Improve logging for IProject creation

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJProjectImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJProjectImpl.java
@@ -95,8 +95,8 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
 
     if (numberOfContentRoots != 1) {
       throw new IllegalArgumentException(
-          "Modules shared with Saros currently must contain exactly one "
-              + "content root. The given module "
+          "Modules shared with Saros currently must contain exactly one content root. The given "
+              + "module "
               + module
               + " has "
               + numberOfContentRoots
@@ -183,8 +183,7 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
               + moduleFile
               + " for the module "
               + module
-              + " is not located in the base directory of the content"
-              + " root "
+              + " is not located in the base directory of the content root "
               + moduleRoot
               + ".");
     }
@@ -226,8 +225,8 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
         throw new ModuleNotFoundException(
             "The module "
                 + moduleName
-                + " could not be refreshed as no module with the same"
-                + " name could be found in the current project "
+                + " could not be refreshed as no module with the same name could be found in the "
+                + "current project "
                 + project);
       }
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/VirtualFileConverter.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/VirtualFileConverter.java
@@ -76,8 +76,18 @@ public class VirtualFileConverter {
 
       return wrappedModule.getResource(virtualFile);
 
-    } catch (IllegalArgumentException | IllegalStateException e) {
-      log.debug(
+    } catch (IllegalArgumentException e) {
+      if (log.isTraceEnabled()) {
+        log.trace(
+            "Could not convert VirtualFile "
+                + virtualFile
+                + " as the module for the resource does not comply with the current restrictions.");
+      }
+
+      return null;
+
+    } catch (IllegalStateException e) {
+      log.warn(
           "Could not convert VirtualFile "
               + virtualFile
               + " as the creation of an IProject object for its module "

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/Messages.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/Messages.java
@@ -20,6 +20,8 @@ public class Messages {
   public static String AddProjectToSessionWizard_module_not_found_message_condition;
   public static String AddProjectToSessionWizard_invalid_module_title;
   public static String AddProjectToSessionWizard_invalid_module_message_condition;
+  public static String AddProjectToSessionWizard_error_creating_module_object_title;
+  public static String AddProjectToSessionWizard_error_creating_module_object_message;
 
   public static String CollaborationUtils_confirm_closing;
   public static String CollaborationUtils_confirm_closing_text;

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/menu/SarosFileShareGroup.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/menu/SarosFileShareGroup.java
@@ -100,21 +100,18 @@ public class SarosFileShareGroup extends ActionGroup {
             "Ignoring module "
                 + moduleName
                 + " as it does "
-                + "not meet the current release restrictions.",
-            exception);
+                + "not meet the current release restrictions.");
       }
 
       return false;
 
     } catch (IllegalStateException exception) {
-      if (LOG.isTraceEnabled()) {
-        LOG.trace(
-            "Ignoring module "
-                + moduleName
-                + " as an error "
-                + "occurred while trying to create an IProject object.",
-            exception);
-      }
+      LOG.warn(
+          "Ignoring module "
+              + moduleName
+              + " as an error "
+              + "occurred while trying to create an IProject object.",
+          exception);
 
       return false;
     }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/menu/SarosFileShareGroup.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/menu/SarosFileShareGroup.java
@@ -99,8 +99,7 @@ public class SarosFileShareGroup extends ActionGroup {
         LOG.trace(
             "Ignoring module "
                 + moduleName
-                + " as it does "
-                + "not meet the current release restrictions.");
+                + " as it does not meet the current release restrictions.");
       }
 
       return false;
@@ -109,8 +108,7 @@ public class SarosFileShareGroup extends ActionGroup {
       LOG.warn(
           "Ignoring module "
               + moduleName
-              + " as an error "
-              + "occurred while trying to create an IProject object.",
+              + " as an error occurred while trying to create an IProject object.",
           exception);
 
       return false;

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/messages.properties
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/messages.properties
@@ -7,6 +7,8 @@ AddProjectToSessionWizard_module_not_found_title=Module not found - Negotiation 
 AddProjectToSessionWizard_module_not_found_message_condition=The chosen module {0} could not be found. The project negotiation was aborted.\nPlease make sure that the module is correctly configured in the current project and exists on disk.\nIf there seems to be no problem with the module
 AddProjectToSessionWizard_invalid_module_title=Invalid module chosen - Negotiation aborted
 AddProjectToSessionWizard_invalid_module_message_condition=The chosen module {0} can not be used to accept a Saros session. This is probably due to the module not meeting the current restrictions. Modules should have exactly one content root that is located in the project root directory. Please delete the selected module, modify it to meet the given criteria, or ask the host to share a different module.\nIf the chosen module meets the given restrictions
+AddProjectToSessionWizard_error_creating_module_object_title=Problem while handling the module "{0} - Negotiation aborted"
+AddProjectToSessionWizard_error_creating_module_object_message=Saros encountered an error while trying to handle the module "{0}". Please make sure that the module is configured correctly.\n{1}
 
 CollaborationUtils_confirm_closing=Confirm Closing Session
 CollaborationUtils_confirm_closing_text=Are you sure that you want to close this Saros session? Since you are the creator of this session, it will be closed for all participants.
@@ -78,7 +80,7 @@ ContactPopMenu_module_not_found_message_condition=Saros could not find the chose
 ContactPopMenu_invalid_module_title=Invalid modules not shown
 ContactPopMenu_invalid_module_message_condition=The module(s) {0} can not be shared through Saros and are therefore not shown. This is probably due to the modules not meeting the current restrictions. Modules should have exactly one content root that is located in the project root directory.\nIf these modules do meets the given restrictions
 ContactPopMenu_error_creating_module_object_title=Problem while handling the module "{0}"
-ContactPopMenu_error_creating_module_object_message=Saros ran into an exception while trying to handle the module "{0}". Please make sure that the module is configured correctly.\n{1}
+ContactPopMenu_error_creating_module_object_message=Saros encountered an error while trying to handle the module "{0}". Please make sure that the module is configured correctly.\n{1}
 
 ShareWithUserAction_description=Share this module with {0}
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/tree/ContactPopMenu.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/tree/ContactPopMenu.java
@@ -45,8 +45,7 @@ class ContactPopMenu extends JPopupMenu {
       SarosPluginContext.initComponent(this);
 
       if (workspace == null || project == null) {
-        LOG.error(
-            "PicoContainer injection failed. Objects still not " + "present after injection.");
+        LOG.error("PicoContainer injection failed. Objects still not present after injection.");
 
         return;
       }
@@ -169,9 +168,8 @@ class ContactPopMenu extends JPopupMenu {
         LOG.error(
             "The IProject object for the module "
                 + moduleName
-                + " could not be created. This most likely means that"
-                + " the local IntelliJ instance does not know any"
-                + " module with the given name.");
+                + " could not be created. This most likely means that the local IntelliJ instance "
+                + "does not know any module with the given name.");
 
         NotificationPanel.showError(
             MessageFormat.format(

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/tree/ContactPopMenu.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/tree/ContactPopMenu.java
@@ -87,15 +87,14 @@ class ContactPopMenu extends JPopupMenu {
         LOG.debug(
             "Ignoring module "
                 + moduleName
-                + " as it does not meet the current release restrictions.",
-            exception);
+                + " as it does not meet the current release restrictions.");
 
         nonCompliantModules.add(moduleName);
 
         continue;
 
       } catch (IllegalStateException exception) {
-        LOG.debug(
+        LOG.warn(
             "Ignoring module "
                 + moduleName
                 + " as an error "

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/wizards/AddProjectToSessionWizard.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/wizards/AddProjectToSessionWizard.java
@@ -215,7 +215,7 @@ public class AddProjectToSessionWizard extends Wizard {
             if (sharedProject == null) {
               LOG.error("Could not find the shared module " + moduleName + ".");
 
-              cancelNegotiation("Could not find chosen local " + "representation of shared module");
+              cancelNegotiation("Could not find chosen local representation of shared module");
 
               NotificationPanel.showError(
                   MessageFormat.format(
@@ -286,7 +286,7 @@ public class AddProjectToSessionWizard extends Wizard {
     for (Module module : ModuleManager.getInstance(project).getModules()) {
       if (moduleName.equals(module.getName()))
         throw new ModuleWithNameAlreadyExists(
-            "Could not create stub " + "module as a module with the chosen name already exists",
+            "Could not create stub module as a module with the chosen name already exists",
             moduleName);
     }
 
@@ -300,7 +300,7 @@ public class AddProjectToSessionWizard extends Wizard {
 
                 if (baseDir == null) {
                   throw new FileNotFoundException(
-                      "Could not find base" + " directory for project " + project + ".");
+                      "Could not find base directory for project " + project + ".");
                 }
 
                 Path moduleBasePath = Paths.get(baseDir.getPath()).resolve(moduleName);
@@ -325,18 +325,14 @@ public class AddProjectToSessionWizard extends Wizard {
 
                 if (moduleFile == null) {
                   throw new FileNotFoundException(
-                      "Could not find "
-                          + "module file for module "
-                          + module
-                          + " after "
-                          + "creating it.");
+                      "Could not find module file for module " + module + " after creating it.");
                 }
 
                 VirtualFile moduleRoot = moduleFile.getParent();
 
                 if (moduleRoot == null) {
                   throw new FileNotFoundException(
-                      "Could not  find base" + " directory for module " + module + ".");
+                      "Could not  find base directory for module " + module + ".");
                 }
 
                 modifiableRootModel.addContentEntry(moduleRoot);

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/wizards/AddProjectToSessionWizard.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/wizards/AddProjectToSessionWizard.java
@@ -174,8 +174,9 @@ public class AddProjectToSessionWizard extends Wizard {
 
             try {
               sharedProject = workspace.getProject(moduleName);
-            } catch (IllegalArgumentException exception) {
-              LOG.debug("No session is started as an invalid module was " + "chosen", exception);
+
+            } catch (IllegalArgumentException e) {
+              LOG.debug("No session is started as an invalid module was chosen");
 
               cancelNegotiation("Invalid module chosen by client");
 
@@ -186,6 +187,27 @@ public class AddProjectToSessionWizard extends Wizard {
                           Messages.AddProjectToSessionWizard_invalid_module_message_condition,
                           moduleName)),
                   Messages.AddProjectToSessionWizard_invalid_module_title);
+
+              return;
+
+            } catch (IllegalStateException e) {
+              LOG.warn(
+                  "Aborted negotiation as an error occurred while trying to create an "
+                      + "IProject object for "
+                      + moduleName
+                      + ".",
+                  e);
+
+              cancelNegotiation("Error while processing module chosen by client");
+
+              NotificationPanel.showWarning(
+                  MessageFormat.format(
+                      Messages.AddProjectToSessionWizard_error_creating_module_object_message,
+                      moduleName,
+                      e),
+                  MessageFormat.format(
+                      Messages.AddProjectToSessionWizard_error_creating_module_object_title,
+                      moduleName));
 
               return;
             }


### PR DESCRIPTION
Improves the logging when creating IntelliJProjectImpl objects.

Removes the exception from the logging when they are expected and
inconsequential. This is the case when the exception was caused by the
given module not complying with the current restrictions. This is almost
always inconsequential. The only case where this is not expected to
happen is when refreshing the module, which is why the exception is
still logged in such cases.
The exceptions were removed from the log as they were causing many
false-positives when skimming the log for errors/exceptions.

Differentiates between non-compliant module choice handling and real
exception handling where this was not already done correctly.
Exceptions that require different handling and should be logged are
mostly IllegalStateExceptions in this context.
Changes the log-level to warn in such instance.