### PR TITLE
Make return type of IResource.getAdapter(Class) generic and rename it to adaptTo(Class)

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IResource.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IResource.java
@@ -9,7 +9,7 @@ import java.io.IOException;
  * <p>Represents an element (normally a file or folder) in the (virtual) file system.
  *
  * <p><b>Note:</b> Instances of this class should <b>NOT</b> be casted using the Java type cast
- * operator. Instead use the {@link #getAdapter(Class)} method.
+ * operator. Instead use the {@link #adaptTo(Class)} method.
  *
  * <p>Example:
  *
@@ -17,7 +17,7 @@ import java.io.IOException;
  *     IResource resource = getAResource();
  *
  *     if (resource == IResource.File) {
- *         IFile file = resource.getAdapter(IFile.class) // you may assume this will never return null
+ *         IFile file = resource.adaptTo(IFile.class) // you may assume this will never return null
  *
  *         // do stuff
  *     }
@@ -66,5 +66,5 @@ public interface IResource {
 
   public IPath getLocation();
 
-  public <T extends IResource> T getAdapter(Class<T> clazz);
+  public <T extends IResource> T adaptTo(Class<T> clazz);
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IResource.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IResource.java
@@ -5,6 +5,23 @@ import java.io.IOException;
 /**
  * This interface is under development. It currently equals its Eclipse counterpart. If not
  * mentioned otherwise all offered methods are equivalent to their Eclipse counterpart.
+ *
+ * <p>Represents an element (normally a file or folder) in the (virtual) file system.
+ *
+ * <p><b>Note:</b> Instances of this class should <b>NOT</b> be casted using the Java type cast
+ * operator. Instead use the {@link #getAdapter(Class)} method.
+ *
+ * <p>Example:
+ *
+ * <pre>
+ *     IResource resource = getAResource();
+ *
+ *     if (resource == IResource.File) {
+ *         IFile file = resource.getAdapter(IFile.class) // you may assume this will never return null
+ *
+ *         // do stuff
+ *     }
+ * </pre>
  */
 public interface IResource {
 
@@ -49,5 +66,5 @@ public interface IResource {
 
   public IPath getLocation();
 
-  public Object getAdapter(Class<? extends IResource> clazz);
+  public <T extends IResource> T getAdapter(Class<T> clazz);
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
@@ -281,7 +281,7 @@ public final class SarosSession implements ISarosSession {
 
     if (resource.getType() == IResource.FOLDER) {
       try {
-        IResource[] members = resource.getAdapter(IFolder.class).members();
+        IResource[] members = resource.adaptTo(IFolder.class).members();
 
         for (int i = 0; i < members.length; i++) list.addAll(getAllNonSharedChildren(members[i]));
       } catch (IOException e) {

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
@@ -281,7 +281,7 @@ public final class SarosSession implements ISarosSession {
 
     if (resource.getType() == IResource.FOLDER) {
       try {
-        IResource[] members = ((IFolder) resource.getAdapter(IFolder.class)).members();
+        IResource[] members = resource.getAdapter(IFolder.class).members();
 
         for (int i = 0; i < members.length; i++) list.addAll(getAllNonSharedChildren(members[i]));
       } catch (IOException e) {

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/core/ui/util/CollaborationUtils.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/core/ui/util/CollaborationUtils.java
@@ -365,7 +365,7 @@ public class CollaborationUtils {
        * we need the .iml file, otherwise the project type will not be set
        * correctly on the other side
        */
-      IntelliJProjectImpl intelliJProject = project.getAdapter(IntelliJProjectImpl.class);
+      IntelliJProjectImpl intelliJProject = project.adaptTo(IntelliJProjectImpl.class);
 
       Module module = intelliJProject.getModule();
       VirtualFile moduleFile = module.getModuleFile();
@@ -452,7 +452,7 @@ public class CollaborationUtils {
           totalFileCount++;
 
           try {
-            IFile file = resource.getAdapter(IFile.class);
+            IFile file = resource.adaptTo(IFile.class);
 
             totalFileSize += file.getSize();
           } catch (IOException e) {
@@ -466,7 +466,7 @@ public class CollaborationUtils {
           }
 
           try {
-            IContainer container = resource.getAdapter(IContainer.class);
+            IContainer container = resource.adaptTo(IContainer.class);
 
             Pair<Long, Long> subFileCountAndSize =
                 getFileCountAndSize(Arrays.asList(container.members(flags)), true, flags);

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/core/ui/util/CollaborationUtils.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/core/ui/util/CollaborationUtils.java
@@ -252,7 +252,7 @@ public class CollaborationUtils {
 
         if (sarosSession.isCompletelyShared(project)) {
           fileCountAndSize =
-              getFileCountAndSize(Arrays.asList(project.members()), true, IContainer.FILE);
+              getFileCountAndSize(Arrays.asList(project.members()), true, IResource.FILE);
 
           result.append(
               String.format(
@@ -365,8 +365,7 @@ public class CollaborationUtils {
        * we need the .iml file, otherwise the project type will not be set
        * correctly on the other side
        */
-      IntelliJProjectImpl intelliJProject =
-          (IntelliJProjectImpl) project.getAdapter(IntelliJProjectImpl.class);
+      IntelliJProjectImpl intelliJProject = project.getAdapter(IntelliJProjectImpl.class);
 
       Module module = intelliJProject.getModule();
       VirtualFile moduleFile = module.getModuleFile();
@@ -453,7 +452,7 @@ public class CollaborationUtils {
           totalFileCount++;
 
           try {
-            IFile file = (IFile) resource.getAdapter(IFile.class);
+            IFile file = resource.getAdapter(IFile.class);
 
             totalFileSize += file.getSize();
           } catch (IOException e) {
@@ -467,7 +466,7 @@ public class CollaborationUtils {
           }
 
           try {
-            IContainer container = ((IContainer) resource.getAdapter(IContainer.class));
+            IContainer container = resource.getAdapter(IContainer.class);
 
             Pair<Long, Long> subFileCountAndSize =
                 getFileCountAndSize(Arrays.asList(container.members(flags)), true, flags);

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJResourceImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJResourceImpl.java
@@ -8,7 +8,7 @@ public abstract class IntelliJResourceImpl implements IResource {
 
   @Nullable
   @Override
-  public <T extends IResource> T getAdapter(@NotNull Class<T> clazz) {
+  public <T extends IResource> T adaptTo(@NotNull Class<T> clazz) {
     return clazz.isInstance(this) ? clazz.cast(this) : null;
   }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJResourceImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJResourceImpl.java
@@ -8,7 +8,7 @@ public abstract class IntelliJResourceImpl implements IResource {
 
   @Nullable
   @Override
-  public Object getAdapter(@NotNull Class<? extends IResource> clazz) {
-    return clazz.isInstance(this) ? this : null;
+  public <T extends IResource> T getAdapter(@NotNull Class<T> clazz) {
+    return clazz.isInstance(this) ? clazz.cast(this) : null;
   }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/VirtualFileConverter.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/VirtualFileConverter.java
@@ -112,7 +112,7 @@ public class VirtualFileConverter {
   public static IResource convertToResource(
       @NotNull VirtualFile virtualFile, @NotNull IProject project) {
 
-    IntelliJProjectImpl wrappedModule = project.getAdapter(IntelliJProjectImpl.class);
+    IntelliJProjectImpl wrappedModule = project.adaptTo(IntelliJProjectImpl.class);
 
     return wrappedModule.getResource(virtualFile);
   }
@@ -151,7 +151,7 @@ public class VirtualFileConverter {
           "The given resource must be a file or a folder. resource: " + resource);
     }
 
-    IntelliJProjectImpl wrappedModule = resource.getProject().getAdapter(IntelliJProjectImpl.class);
+    IntelliJProjectImpl wrappedModule = resource.getProject().adaptTo(IntelliJProjectImpl.class);
 
     return wrappedModule.findVirtualFile(resource.getProjectRelativePath());
   }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/VirtualFileConverter.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/VirtualFileConverter.java
@@ -112,8 +112,7 @@ public class VirtualFileConverter {
   public static IResource convertToResource(
       @NotNull VirtualFile virtualFile, @NotNull IProject project) {
 
-    IntelliJProjectImpl wrappedModule =
-        (IntelliJProjectImpl) project.getAdapter(IntelliJProjectImpl.class);
+    IntelliJProjectImpl wrappedModule = project.getAdapter(IntelliJProjectImpl.class);
 
     return wrappedModule.getResource(virtualFile);
   }
@@ -152,8 +151,7 @@ public class VirtualFileConverter {
           "The given resource must be a file or a folder. resource: " + resource);
     }
 
-    IntelliJProjectImpl wrappedModule =
-        (IntelliJProjectImpl) resource.getProject().getAdapter(IntelliJProjectImpl.class);
+    IntelliJProjectImpl wrappedModule = resource.getProject().getAdapter(IntelliJProjectImpl.class);
 
     return wrappedModule.findVirtualFile(resource.getProjectRelativePath());
   }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/negotiation/hooks/ModuleTypeNegotiationHook.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/negotiation/hooks/ModuleTypeNegotiationHook.java
@@ -105,8 +105,7 @@ public class ModuleTypeNegotiationHook implements ISessionNegotiationHook {
 
     for (final IProject project : sessionManager.getSession().getProjects()) {
 
-      IntelliJProjectImpl intelliJProject =
-          (IntelliJProjectImpl) project.getAdapter(IntelliJProjectImpl.class);
+      IntelliJProjectImpl intelliJProject = project.getAdapter(IntelliJProjectImpl.class);
 
       String moduleType = ModuleType.get(intelliJProject.getModule()).getId();
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/negotiation/hooks/ModuleTypeNegotiationHook.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/negotiation/hooks/ModuleTypeNegotiationHook.java
@@ -105,7 +105,7 @@ public class ModuleTypeNegotiationHook implements ISessionNegotiationHook {
 
     for (final IProject project : sessionManager.getSession().getProjects()) {
 
-      IntelliJProjectImpl intelliJProject = project.getAdapter(IntelliJProjectImpl.class);
+      IntelliJProjectImpl intelliJProject = project.adaptTo(IntelliJProjectImpl.class);
 
       String moduleType = ModuleType.get(intelliJProject.getModule()).getId();
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJWorkspaceRootImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJWorkspaceRootImpl.java
@@ -102,7 +102,7 @@ public class IntelliJWorkspaceRootImpl implements IWorkspaceRoot {
   }
 
   @Override
-  public Object getAdapter(Class<? extends IResource> clazz) {
+  public <T extends IResource> T getAdapter(Class<T> clazz) {
     return null;
   }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJWorkspaceRootImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJWorkspaceRootImpl.java
@@ -102,7 +102,7 @@ public class IntelliJWorkspaceRootImpl implements IWorkspaceRoot {
   }
 
   @Override
-  public <T extends IResource> T getAdapter(Class<T> clazz) {
+  public <T extends IResource> T adaptTo(Class<T> clazz) {
     return null;
   }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/ModuleInitialization.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/ModuleInitialization.java
@@ -90,7 +90,7 @@ public class ModuleInitialization implements Startable {
     private IntelliJProjectImpl project;
 
     public ModuleReloader(IProject project) {
-      this.project = (IntelliJProjectImpl) project.getAdapter(IntelliJProjectImpl.class);
+      this.project = project.getAdapter(IntelliJProjectImpl.class);
     }
 
     @Override

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/ModuleInitialization.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/ModuleInitialization.java
@@ -90,7 +90,7 @@ public class ModuleInitialization implements Startable {
     private IntelliJProjectImpl project;
 
     public ModuleReloader(IProject project) {
-      this.project = project.getAdapter(IntelliJProjectImpl.class);
+      this.project = project.adaptTo(IntelliJProjectImpl.class);
     }
 
     @Override

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/editor/ServerEditorManager.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/editor/ServerEditorManager.java
@@ -95,7 +95,7 @@ public class ServerEditorManager implements IEditorManager {
         throw new NoSuchFileException(path.toString());
       }
 
-      IFile file = resource.getAdapter(IFile.class);
+      IFile file = resource.adaptTo(IFile.class);
       if (file == null) {
         throw new IOException("Not a file: " + path);
       }

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/editor/ServerEditorManager.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/editor/ServerEditorManager.java
@@ -95,7 +95,7 @@ public class ServerEditorManager implements IEditorManager {
         throw new NoSuchFileException(path.toString());
       }
 
-      IFile file = (IFile) resource.getAdapter(IFile.class);
+      IFile file = resource.getAdapter(IFile.class);
       if (file == null) {
         throw new IOException("Not a file: " + path);
       }

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerResourceImpl.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerResourceImpl.java
@@ -86,7 +86,7 @@ public abstract class ServerResourceImpl implements IResource {
   }
 
   @Override
-  public <T extends IResource> T getAdapter(Class<T> clazz) {
+  public <T extends IResource> T adaptTo(Class<T> clazz) {
     return clazz.isInstance(this) ? clazz.cast(this) : null;
   }
 

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerResourceImpl.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerResourceImpl.java
@@ -86,8 +86,8 @@ public abstract class ServerResourceImpl implements IResource {
   }
 
   @Override
-  public Object getAdapter(Class<? extends IResource> clazz) {
-    return clazz.isInstance(this) ? this : null;
+  public <T extends IResource> T getAdapter(Class<T> clazz) {
+    return clazz.isInstance(this) ? clazz.cast(this) : null;
   }
 
   @Override

--- a/de.fu_berlin.inf.dpp.server/test/junit/de/fu_berlin/inf/dpp/server/filesystem/ServerResourceImplTest.java
+++ b/de.fu_berlin.inf.dpp.server/test/junit/de/fu_berlin/inf/dpp/server/filesystem/ServerResourceImplTest.java
@@ -126,9 +126,9 @@ public class ServerResourceImplTest extends EasyMockSupport {
 
   @Test
   public void getAdapterDefault() {
-    assertSame(resource, resource.getAdapter(ExampleResource.class));
-    assertSame(resource, resource.getAdapter(IResource.class));
-    assertNull(resource.getAdapter(IFile.class));
+    assertSame(resource, resource.adaptTo(ExampleResource.class));
+    assertSame(resource, resource.adaptTo(IResource.class));
+    assertNull(resource.adaptTo(IFile.class));
   }
 
   private void createFileForResource() throws IOException {

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/EclipseResourceImpl.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/EclipseResourceImpl.java
@@ -142,7 +142,7 @@ public class EclipseResourceImpl implements IResource {
   }
 
   @Override
-  public <T extends IResource> T getAdapter(Class<T> clazz) {
+  public <T extends IResource> T adaptTo(Class<T> clazz) {
 
     /*
      * As we do not know what Eclipse is doing in the background play it safe and let Eclipse always

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/ResourceAdapterFactory.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/ResourceAdapterFactory.java
@@ -115,21 +115,15 @@ public class ResourceAdapterFactory {
 
     switch (resource.getType()) {
       case IResource.FILE:
-        return new EclipseFileImpl(
-            (org.eclipse.core.resources.IFile)
-                resource.getAdapter(org.eclipse.core.resources.IFile.class));
+        return new EclipseFileImpl(resource.getAdapter(org.eclipse.core.resources.IFile.class));
       case IResource.FOLDER:
-        return new EclipseFolderImpl(
-            (org.eclipse.core.resources.IFolder)
-                resource.getAdapter(org.eclipse.core.resources.IFolder.class));
+        return new EclipseFolderImpl(resource.getAdapter(org.eclipse.core.resources.IFolder.class));
       case IResource.PROJECT:
         return new EclipseProjectImpl(
-            (org.eclipse.core.resources.IProject)
-                resource.getAdapter(org.eclipse.core.resources.IProject.class));
+            resource.getAdapter(org.eclipse.core.resources.IProject.class));
       case IResource.ROOT:
         return new EclipseWorkspaceRootImpl(
-            (org.eclipse.core.resources.IWorkspaceRoot)
-                resource.getAdapter(org.eclipse.core.resources.IWorkspaceRoot.class));
+            resource.getAdapter(org.eclipse.core.resources.IWorkspaceRoot.class));
       default:
         return new EclipseResourceImpl(resource);
     }

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/model/roster/RosterAdapterFactory.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/model/roster/RosterAdapterFactory.java
@@ -13,8 +13,8 @@ import org.jivesoftware.smack.RosterGroup;
  * <p>E.g. let's you adapt {@link RosterGroupElement} to {@link RosterGroup} with
  *
  * <pre>
- * RosterGroup rosterGroup = (RosterGroup) rosterGroupElement
- *     .getAdapter(RosterGroup.class);
+ * RosterGroup rosterGroup = (RosterGroup) rosterGroupElement.getAdapter(RosterGroup.class);
+ *
  * if (rosterGroup != null)
  *     return true;
  * else

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/model/session/SessionContentAdapterFactory.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/model/session/SessionContentAdapterFactory.java
@@ -12,6 +12,7 @@ import org.eclipse.core.runtime.IAdapterFactory;
  *
  * <pre>
  * User user = (User) userElement.getAdapter(User.class);
+ *
  * if (user != null)
  *     return true;
  * else

--- a/de.fu_berlin.inf.dpp/test/junit/de/fu_berlin/inf/dpp/filesystem/IResourceTest.java
+++ b/de.fu_berlin.inf.dpp/test/junit/de/fu_berlin/inf/dpp/filesystem/IResourceTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 public class IResourceTest {
 
   @Test
-  public void testGetAdapter() {
+  public void testAdaptTo() {
 
     org.eclipse.core.resources.IFolder folder =
         EasyMock.createMock(org.eclipse.core.resources.IFolder.class);
@@ -24,7 +24,7 @@ public class IResourceTest {
 
     final IFolder coreFolder = new EclipseFolderImpl(folder);
 
-    final Object adapted = coreFolder.getAdapter(IFolder.class);
+    final Object adapted = coreFolder.adaptTo(IFolder.class);
 
     EasyMock.verify(folder);
 


### PR DESCRIPTION
This patch is mainly an updated version of patch
https://saros-build.imp.fu-berlin.de/gerrit/#/c/3291/1

without actually changing the method name of getAdapter