### PR TITLE
[E/S][FEATURE] Allow Saros/E to join server session

### DIFF
--- a/eclipse/src/saros/ui/Messages.java
+++ b/eclipse/src/saros/ui/Messages.java
@@ -325,6 +325,7 @@ public class Messages extends NLS {
   public static String RenameContactAction_rename_message;
   public static String RenameContactAction_title;
   public static String RenameContactAction_tooltip;
+  public static String RequestSessionInviteAction_title;
   public static String ResourceSelectionComposite_new_project;
   public static String ResourceSelectionComposite_undo;
   public static String ResourceSelectionComposite_redo;

--- a/eclipse/src/saros/ui/actions/RequestSessionInviteAction.java
+++ b/eclipse/src/saros/ui/actions/RequestSessionInviteAction.java
@@ -1,0 +1,77 @@
+package saros.ui.actions;
+
+import java.util.List;
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.ui.ISelectionListener;
+import org.eclipse.ui.IWorkbenchPart;
+import saros.SarosPluginContext;
+import saros.communication.extensions.JoinSessionRequestExtension;
+import saros.net.ITransmitter;
+import saros.net.xmpp.JID;
+import saros.repackaged.picocontainer.annotations.Inject;
+import saros.session.ISarosSession;
+import saros.session.ISarosSessionManager;
+import saros.ui.Messages;
+import saros.ui.util.selection.SelectionUtils;
+import saros.ui.util.selection.retriever.SelectionRetrieverFactory;
+
+/**
+ * Action for requesting an invitation to a session from a contact.
+ *
+ * <p>This currently relies on the fact, that only Saros/S has a working JoinSessionRequestHandler.
+ * To make this feature generic in the future we need to add another XMPP namespace
+ */
+public class RequestSessionInviteAction extends Action implements Disposable {
+
+  @Inject private ISarosSessionManager sessionManager;
+  @Inject private ITransmitter transmitter;
+
+  private ISelectionListener selectionListener =
+      new ISelectionListener() {
+        @Override
+        public void selectionChanged(IWorkbenchPart part, ISelection selection) {
+          updateActionState();
+        }
+      };
+
+  public static final String ACTION_ID = RequestSessionInviteAction.class.getName();
+
+  public RequestSessionInviteAction() {
+    super(Messages.RequestSessionInviteAction_title);
+    setId(ACTION_ID);
+    SarosPluginContext.initComponent(this);
+    SelectionUtils.getSelectionService().addSelectionListener(selectionListener);
+    updateActionState();
+  }
+
+  @Override
+  public void run() {
+    ISarosSession session = sessionManager.getSession();
+    JID jid = getSelectedJID();
+    if (session != null || jid == null) {
+      return;
+    }
+
+    transmitter.sendPacketExtension(
+        jid, JoinSessionRequestExtension.PROVIDER.create(new JoinSessionRequestExtension()));
+  }
+
+  private JID getSelectedJID() {
+    List<JID> selected = SelectionRetrieverFactory.getSelectionRetriever(JID.class).getSelection();
+
+    if (selected.size() != 1) return null;
+
+    return selected.get(0);
+  }
+
+  private void updateActionState() {
+    ISarosSession session = sessionManager.getSession();
+    setEnabled(session == null && getSelectedJID() != null);
+  }
+
+  @Override
+  public void dispose() {
+    SelectionUtils.getSelectionService().removeSelectionListener(selectionListener);
+  }
+}

--- a/eclipse/src/saros/ui/messages.properties
+++ b/eclipse/src/saros/ui/messages.properties
@@ -53,6 +53,8 @@ RenameContactAction_rename_message=Enter a nickname for {0}
 RenameContactAction_title=Rename...
 RenameContactAction_tooltip=Set the nickname for this Contact
 
+RequestSessionInviteAction_title=Request Session Invitation
+
 RestrictToReadOnlyAccessAction_title=Restrict to Read-Only Access
 RestrictToReadOnlyAccessAction_tooltip=Restrict this User to Read-Only Access
 

--- a/eclipse/src/saros/ui/views/SarosView.java
+++ b/eclipse/src/saros/ui/views/SarosView.java
@@ -37,11 +37,13 @@ import org.eclipse.ui.IWorkbenchActionConstants;
 import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.part.ViewPart;
 import org.jivesoftware.smack.packet.Presence;
+import saros.SarosConstants;
 import saros.SarosPluginContext;
 import saros.annotations.Component;
 import saros.editor.EditorManager;
 import saros.net.xmpp.JID;
 import saros.net.xmpp.XMPPConnectionService;
+import saros.net.xmpp.discovery.DiscoveryManager;
 import saros.net.xmpp.roster.IRosterListener;
 import saros.net.xmpp.roster.RosterTracker;
 import saros.preferences.EclipsePreferenceConstants;
@@ -68,6 +70,7 @@ import saros.ui.actions.OpenChatAction;
 import saros.ui.actions.OpenPreferencesAction;
 import saros.ui.actions.RemoveUserAction;
 import saros.ui.actions.RenameContactAction;
+import saros.ui.actions.RequestSessionInviteAction;
 import saros.ui.actions.SendFileAction;
 import saros.ui.actions.SkypeAction;
 import saros.ui.model.roster.RosterEntryElement;
@@ -228,6 +231,8 @@ public class SarosView extends ViewPart {
   @Inject protected RosterTracker rosterTracker;
 
   @Inject protected XMPPConnectionService connectionService;
+
+  @Inject private DiscoveryManager discoveryManager;
 
   private static volatile boolean showBalloonNotifications;
 
@@ -432,6 +437,15 @@ public class SarosView extends ViewPart {
              * version 14.1.31)
              */
             // manager.add(getAction(SkypeAction.class));
+
+            // TODO: Currently only Saros/S is known to have a working JoinSessionRequestHandler,
+            //       remove this once the situation changes / change this to it's own feature.
+            Boolean isServer =
+                discoveryManager.isFeatureSupported(
+                    contacts.get(0), SarosConstants.NAMESPACE_SERVER);
+            if (contacts.size() == 1 && isServer != null && isServer) {
+              manager.add(getAction(RequestSessionInviteAction.ACTION_ID));
+            }
             manager.add(new Separator());
             manager.add(getAction(OpenChatAction.ACTION_ID));
             manager.add(getAction(SendFileAction.ACTION_ID));
@@ -661,6 +675,7 @@ public class SarosView extends ViewPart {
     registerAction(new SendFileAction());
     registerAction(new ChangeColorAction());
     registerAction(new RemoveUserAction());
+    registerAction(new RequestSessionInviteAction());
 
     // ContextMenus Roster/Contact list
     registerAction(new SkypeAction());

--- a/server/src/saros/server/ServerContextFactory.java
+++ b/server/src/saros/server/ServerContextFactory.java
@@ -26,6 +26,7 @@ import saros.server.dummies.NullRemoteProgressIndicatorFactory;
 import saros.server.filesystem.ServerPathFactoryImpl;
 import saros.server.filesystem.ServerPathImpl;
 import saros.server.filesystem.ServerWorkspaceImpl;
+import saros.server.net.ServerFeatureAdvertiser;
 import saros.server.net.SubscriptionAuthorizer;
 import saros.server.preferences.PersistencePreferenceStore;
 import saros.server.preferences.ServerPreferences;
@@ -90,6 +91,7 @@ public class ServerContextFactory extends AbstractContextFactory {
     c.addComponent(SubscriptionAuthorizer.class);
     c.addComponent(NegotiationHandler.class);
     c.addComponent(JoinSessionRequestHandler.class);
+    c.addComponent(ServerFeatureAdvertiser.class);
     if (ServerConfig.isInteractive()) {
       c.addComponent(new ServerConsole(System.in, System.out));
       c.addComponent(InviteCommand.class);


### PR DESCRIPTION
Allows Saros/E to request an invitation to a server session.

Saros/E implements a `JoinSessionRequestHandler` as well, but that is based of the old Eclipse-Server-Prototype and not usable in it's current state. For that reason the "Request Session Invitation" menu item is only shown, if the contact advertises the server feature. Same goes for the action, it is a no-op, if the JID does not belong to a server.

Along with #355 this allows the server to be run completely headless (without using the console).