### PR TITLE
[FIX][I] Use anonymous class for SelectionListener declaration

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalTextSelectionChangeHandler.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalTextSelectionChangeHandler.java
@@ -11,7 +11,13 @@ class LocalTextSelectionChangeHandler implements DisableableHandler {
 
   private final EditorManager editorManager;
 
-  private final SelectionListener selectionListener = this::generateSelectionActivity;
+  private final SelectionListener selectionListener =
+      new SelectionListener() {
+        @Override
+        public void selectionChanged(@NotNull SelectionEvent e) {
+          generateSelectionActivity(e);
+        }
+      };
 
   private boolean enabled;
 


### PR DESCRIPTION
Removes the declaration of a new SelectionListener through a method
reference assignment and replaces it with an anonymous class. The
method reference assignment requires the interface to be a functional
interface. This is no longer the case with IntelliJ IDEA 2018.3 as
the method defined in SelectionListener now has a default
implementation, meaning the interface now no longer has only exactly
once abstract method.