### PR TITLE
Use FollowModeManager to implement Saros/I follow mode functionality

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/editor/IEditorManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/editor/IEditorManager.java
@@ -34,14 +34,14 @@ public interface IEditorManager {
    * @param activate Determines whether the newly opened editor should get the focus or should be
    *     opened in the background.
    */
-  public void openEditor(SPath path, boolean activate);
+  void openEditor(SPath path, boolean activate);
 
   /**
    * Returns the paths of all shared files for which an editor is currently open locally.
    *
    * @return paths of locally open shared files
    */
-  public Set<SPath> getOpenEditors();
+  Set<SPath> getOpenEditors();
 
   /**
    * Returns the text content of the local editor associated with the specified file, or the content
@@ -51,7 +51,7 @@ public interface IEditorManager {
    * @return the text content of the matching local editor or file, or <code>null</code> if no file
    *     with the given path exists locally
    */
-  public String getContent(SPath path);
+  String getContent(SPath path);
 
   /**
    * Saves the local editors of all shared files belonging to the given project. If <code>null
@@ -60,37 +60,31 @@ public interface IEditorManager {
    * @param project the project whose editors should be saved, or <code>null</code> to save all
    *     editors
    */
-  public void saveEditors(IProject project);
+  void saveEditors(IProject project);
 
   /**
    * Close the editor of given {@link SPath}.
    *
    * @param path Path of the file of which the editor should be closed
    */
-  public void closeEditor(SPath path);
+  void closeEditor(SPath path);
 
   /**
-   * Adjusts viewport. Focus is set on the center of the range, but priority
-   * is given to selected lines. Either range or selection can be
-   * <code>null</null>, but
-   * not both.
+   * Adjusts viewport. Focus is set on the center of the range, but priority is given to selected
+   * lines. Either range or selection can be <code>null</code>, but not both.
    *
-   * @param path
-   *            Path of the open Editor
-   * @param range
-   *            viewport of the followed user. Can be <code>null</code>.
-   * @param selection
-   *            text selection of the followed user. Can be <code>null</code>.
-   *
+   * @param path Path of the open Editor
+   * @param range viewport of the followed user. Can be <code>null</code>.
+   * @param selection text selection of the followed user. Can be <code>null</code>.
    */
-  public void adjustViewport(SPath path, LineRange range, TextSelection selection);
+  void adjustViewport(SPath path, LineRange range, TextSelection selection);
 
   /**
    * Locally opens the editor that the User {@code target} has currently open, adjusts the viewport,
    * and calls {@link ISharedEditorListener#jumpedToUser(User)} to inform the session participants
    * of the jump.
    */
-  public void jumpToUser(User target);
+  void jumpToUser(User target);
 
   /**
    * Adds an {@link ISharedEditorListener} to listen for changes such as editors getting opened,
@@ -98,7 +92,7 @@ public interface IEditorManager {
    *
    * @param listener editor listener to add
    */
-  public void addSharedEditorListener(ISharedEditorListener listener);
+  void addSharedEditorListener(ISharedEditorListener listener);
 
   /**
    * Removes an {@link ISharedEditorListener} that was previously added with {@link
@@ -106,5 +100,5 @@ public interface IEditorManager {
    *
    * @param listener editor listener to remove
    */
-  public void removeSharedEditorListener(ISharedEditorListener listener);
+  void removeSharedEditorListener(ISharedEditorListener listener);
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/core/project/internal/SarosIntellijSessionContextFactory.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/core/project/internal/SarosIntellijSessionContextFactory.java
@@ -1,5 +1,6 @@
 package de.fu_berlin.inf.dpp.core.project.internal;
 
+import de.fu_berlin.inf.dpp.intellij.followmode.FollowModeNotificationDispatcher;
 import de.fu_berlin.inf.dpp.intellij.project.SharedResourcesManager;
 import de.fu_berlin.inf.dpp.intellij.project.filesystem.ModuleInitialization;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
@@ -18,5 +19,8 @@ public class SarosIntellijSessionContextFactory extends SarosCoreSessionContextF
       container.addComponent(ModuleInitialization.class);
     }
     container.addComponent(SharedResourcesManager.class);
+
+    // User notifications
+    container.addComponent(FollowModeNotificationDispatcher.class);
   }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
@@ -651,10 +651,10 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
   }
 
   /**
-   * Fires an EditorActivity.Type.CLOSED event for the given path and leaves following, if closing
-   * the followed editor.
+   * Fires an EditorActivity.Type.CLOSED event for the given path, notifies the local
+   * EditorListenerDispatcher and leaves following, if closing the followed editor.
    */
-  void generateEditorClosed(SPath path) {
+  void generateEditorClosed(@NotNull SPath path) {
     // if closing the followed editor, leave follow mode
     if (followedUser != null) {
       // TODO Let the FollowModeManager handle this
@@ -670,10 +670,11 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
       }
     }
 
-    // TODO What about cleaning up (editorPool, currentlyOpenEditors, ...)?
-    // TODO What about a editorListenerDispatch.editorClosed() call?
+    if (session.isShared(path.getResource())) {
+      editorListenerDispatch.editorClosed(session.getLocalUser(), path);
 
-    fireActivity(new EditorActivity(session.getLocalUser(), EditorActivity.Type.CLOSED, path));
+      fireActivity(new EditorActivity(session.getLocalUser(), EditorActivity.Type.CLOSED, path));
+    }
   }
 
   /**

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
@@ -958,15 +958,35 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
         });
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Only adjusts the viewport if there currently is an open editor for the given path (meaning
+   * such an editor is contained in the editor pool).
+   *
+   * @param path {@inheritDoc}
+   * @param range {@inheritDoc}
+   * @param selection {@inheritDoc}
+   */
   @Override
   public void adjustViewport(
-      final SPath path, final LineRange range, final TextSelection selection) {
+      @NotNull final SPath path, final LineRange range, final TextSelection selection) {
 
     executeInUIThreadSynchronous(
         new Runnable() {
           @Override
           public void run() {
-            Editor editor = localEditorManipulator.openEditor(path, false);
+            Editor editor = editorPool.getEditor(path);
+
+            if (editor == null) {
+              LOG.warn(
+                  "Failed to adjust viewport for "
+                      + path
+                      + " as it is not known to the editor pool.");
+
+              return;
+            }
+
             localEditorManipulator.adjustViewport(editor, range, selection);
           }
         });

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
@@ -774,13 +774,8 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
     return followedUser != null && followedUser.equals(user);
   }
 
-  /**
-   * Locally opens the editor that the User jumpTo has currently open, adjusts the viewport and
-   * calls {@link SharedEditorListenerDispatch#jumpedToUser(User)} to inform the session
-   * participants of the jump.
-   */
   @Override
-  public void jumpToUser(final User jumpTo) {
+  public void jumpToUser(@NotNull final User jumpTo) {
 
     // you can't jump to yourself
     if (session.getLocalUser().equals(jumpTo)) {
@@ -791,7 +786,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
         userEditorStateManager.getState(jumpTo).getActiveEditorState();
 
     if (remoteActiveEditor == null) {
-      LOG.info(jumpTo.getJID() + " has no editor open");
+      LOG.info("Remote user " + jumpTo + " does not have an open editor.");
       return;
     }
 
@@ -807,25 +802,9 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
             }
 
             LineRange viewport = remoteActiveEditor.getViewport();
+            TextSelection textSelection = remoteActiveEditor.getSelection();
 
-            if (viewport == null) {
-              LOG.warn(
-                  jumpTo.getJID() + " has no viewport in editor: " + remoteActiveEditor.getPath());
-              return;
-            }
-            // FIXME Why are we suddenly interested in the followedUser?
-            EditorState state =
-                userEditorStateManager.getState(followedUser).getActiveEditorState();
-
-            TextSelection selection = (state == null) ? null : state.getSelection();
-
-            // state.getSelection() can return null
-            if (selection != null) {
-              // FIXME Why are we only jumping if we know the selection,
-              // but not if there is no selection but a perfectly usable
-              // viewport?
-              localEditorManipulator.adjustViewport(newEditor, viewport, selection);
-            }
+            localEditorManipulator.adjustViewport(newEditor, viewport, textSelection);
           }
         });
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorManipulator.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorManipulator.java
@@ -188,20 +188,6 @@ public class LocalEditorManipulator {
   }
 
   /**
-   * Sets the viewport of the editor for path to the specified range.
-   *
-   * @param path
-   * @param lineStart
-   * @param lineEnd
-   */
-  public void setViewPort(final SPath path, final int lineStart, final int lineEnd) {
-    Editor editor = editorPool.getEditor(path);
-    if (editor != null) {
-      editorAPI.setViewPort(editor, lineStart, lineEnd);
-    }
-  }
-
-  /**
    * Adjusts viewport. Focus is set on the center of the range, but priority is given to selected
    * lines.
    *

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/followmode/FollowModeNotificationDispatcher.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/followmode/FollowModeNotificationDispatcher.java
@@ -1,0 +1,69 @@
+package de.fu_berlin.inf.dpp.intellij.followmode;
+
+import de.fu_berlin.inf.dpp.editor.FollowModeManager;
+import de.fu_berlin.inf.dpp.editor.IFollowModeListener;
+import de.fu_berlin.inf.dpp.intellij.ui.Messages;
+import de.fu_berlin.inf.dpp.intellij.ui.util.NotificationPanel;
+import de.fu_berlin.inf.dpp.session.User;
+import java.text.MessageFormat;
+import org.apache.log4j.Logger;
+
+/** Displays user notifications about follow mode status changes. */
+public class FollowModeNotificationDispatcher implements IFollowModeListener {
+
+  private static final Logger log = Logger.getLogger(FollowModeNotificationDispatcher.class);
+
+  private User followedUser;
+
+  public FollowModeNotificationDispatcher(FollowModeManager followModeManager) {
+    followModeManager.addListener(this);
+  }
+
+  @Override
+  public void stoppedFollowing(Reason reason) {
+    String shownReason;
+
+    switch (reason) {
+      case FOLLOWEE_LEFT_SESSION:
+        shownReason = Messages.FollowModeNotificationDispatcher_end_reason_FOLLOWEE_LEFT_SESSION;
+        break;
+      case FOLLOWER_CLOSED_OR_SWITCHED_EDITOR:
+        shownReason =
+            Messages.FollowModeNotificationDispatcher_end_reason_FOLLOWER_CLOSED_OR_SWITCHED_EDITOR;
+        break;
+      case FOLLOWER_CLOSED_EDITOR:
+        shownReason = Messages.FollowModeNotificationDispatcher_end_reason_FOLLOWER_CLOSED_EDITOR;
+        break;
+      case FOLLOWER_STOPPED:
+        shownReason = Messages.FollowModeNotificationDispatcher_end_reason_FOLLOWER_STOPPED;
+        break;
+      case FOLLOWER_SWITCHES_FOLLOWEE:
+        shownReason =
+            Messages.FollowModeNotificationDispatcher_end_reason_FOLLOWER_SWITCHES_FOLLOWEE;
+        break;
+
+      default:
+        shownReason = reason.name();
+        log.warn("Encountered unknown reason for follow mode end. reason: " + reason);
+    }
+
+    NotificationPanel.showInformation(
+        MessageFormat.format(
+            Messages.FollowModeNotificationDispatcher_stopped_following_message,
+            followedUser,
+            shownReason),
+        Messages.FollowModeNotificationDispatcher_stopped_following_title);
+
+    followedUser = null;
+  }
+
+  @Override
+  public void startedFollowing(User target) {
+    NotificationPanel.showInformation(
+        MessageFormat.format(
+            Messages.FollowModeNotificationDispatcher_started_following_message, target),
+        Messages.FollowModeNotificationDispatcher_started_following_title);
+
+    followedUser = target;
+  }
+}

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/Messages.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/Messages.java
@@ -111,5 +111,16 @@ public class Messages {
   public static String LocalEditorManipulator_incompatible_encoding_title;
   public static String LocalEditorManipulator_incompatible_encoding_message;
 
+  public static String FollowModeNotificationDispatcher_started_following_title;
+  public static String FollowModeNotificationDispatcher_started_following_message;
+  public static String FollowModeNotificationDispatcher_stopped_following_title;
+  public static String FollowModeNotificationDispatcher_stopped_following_message;
+  public static String FollowModeNotificationDispatcher_end_reason_FOLLOWEE_LEFT_SESSION;
+  public static String
+      FollowModeNotificationDispatcher_end_reason_FOLLOWER_CLOSED_OR_SWITCHED_EDITOR;
+  public static String FollowModeNotificationDispatcher_end_reason_FOLLOWER_CLOSED_EDITOR;
+  public static String FollowModeNotificationDispatcher_end_reason_FOLLOWER_STOPPED;
+  public static String FollowModeNotificationDispatcher_end_reason_FOLLOWER_SWITCHES_FOLLOWEE;
+
   private Messages() {}
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/actions/FollowModeAction.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/actions/FollowModeAction.java
@@ -9,11 +9,12 @@ import de.fu_berlin.inf.dpp.session.User;
 import de.fu_berlin.inf.dpp.ui.util.ModelFormatUtils;
 import org.picocontainer.annotations.Inject;
 
-/** Action to activateor deactivate follow mode. */
+/** Action to activate or deactivate follow mode. */
 public class FollowModeAction extends AbstractSarosAction {
 
   public static final String NAME = "follow";
 
+  @SuppressWarnings("FieldCanBeLocal")
   private final ISessionLifecycleListener sessionLifecycleListener =
       new ISessionLifecycleListener() {
         @Override

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/actions/FollowModeAction.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/actions/FollowModeAction.java
@@ -1,15 +1,12 @@
 package de.fu_berlin.inf.dpp.intellij.ui.actions;
 
-import de.fu_berlin.inf.dpp.intellij.editor.EditorManager;
+import de.fu_berlin.inf.dpp.editor.FollowModeManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
 import de.fu_berlin.inf.dpp.session.ISessionLifecycleListener;
 import de.fu_berlin.inf.dpp.session.SessionEndReason;
 import de.fu_berlin.inf.dpp.session.User;
 import de.fu_berlin.inf.dpp.ui.util.ModelFormatUtils;
-import de.fu_berlin.inf.dpp.util.ThreadUtils;
-import java.util.ArrayList;
-import java.util.List;
 import org.picocontainer.annotations.Inject;
 
 /** Action to activateor deactivate follow mode. */
@@ -21,37 +18,21 @@ public class FollowModeAction extends AbstractSarosAction {
       new ISessionLifecycleListener() {
         @Override
         public void sessionStarted(final ISarosSession session) {
-          ThreadUtils.runSafeAsync(
-              LOG,
-              new Runnable() {
-
-                @Override
-                public void run() {
-                  FollowModeAction.this.session = session;
-                }
-              });
+          FollowModeAction.this.session = session;
+          followModeManager = session.getComponent(FollowModeManager.class);
         }
 
         @Override
         public void sessionEnded(ISarosSession oldSarosSession, SessionEndReason reason) {
-
-          ThreadUtils.runSafeAsync(
-              LOG,
-              new Runnable() {
-
-                @Override
-                public void run() {
-                  session = null;
-                }
-              });
+          session = null;
+          followModeManager = null;
         }
       };
 
-  @Inject public ISarosSessionManager sessionManager;
+  @Inject private ISarosSessionManager sessionManager;
 
-  @Inject public EditorManager editorManager;
-
-  private ISarosSession session;
+  private volatile ISarosSession session;
+  private volatile FollowModeManager followModeManager;
 
   public FollowModeAction() {
     sessionManager.addSessionLifecycleListener(sessionLifecycleListener);
@@ -63,11 +44,14 @@ public class FollowModeAction extends AbstractSarosAction {
   }
 
   public void execute(String userName) {
-    if (session == null) {
+    FollowModeManager currentFollowModeManager = followModeManager;
+    User userToFollow = findUser(userName);
+
+    if (currentFollowModeManager == null) {
       return;
     }
 
-    editorManager.setFollowing(findUser(userName));
+    currentFollowModeManager.follow(userToFollow);
 
     actionPerformed();
   }
@@ -77,22 +61,14 @@ public class FollowModeAction extends AbstractSarosAction {
     // never called
   }
 
-  public User getCurrentlyFollowedUser() {
-    return editorManager.getFollowedUser();
-  }
-
-  public List<User> getCurrentRemoteSessionUsers() {
-    if (session == null) return new ArrayList<User>();
-
-    return session.getRemoteUsers();
-  }
-
   private User findUser(String userName) {
-    if (userName == null) {
+    ISarosSession currentSession = session;
+
+    if (userName == null || currentSession == null) {
       return null;
     }
 
-    for (User user : getCurrentRemoteSessionUsers()) {
+    for (User user : session.getRemoteUsers()) {
       String myUserName = ModelFormatUtils.getDisplayName(user);
       if (myUserName.equalsIgnoreCase(userName)) {
         return user;

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/messages.properties
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/messages.properties
@@ -97,3 +97,13 @@ SessionStatusChangeHandler_connection_lost=You lost the connection to the host.
 
 LocalEditorManipulator_incompatible_encoding_title=Incompatible Encoding Detected
 LocalEditorManipulator_incompatible_encoding_message=The encoding for the received file content for {0} is not known to the local JVM. The default encoding is used instead. If the content is parsed incorrectly, please reach a consensus with the other session participants and and start a new session all using the same encoding.\nReceived encoding: {1}, default encoding: {2}
+
+FollowModeNotificationDispatcher_started_following_title=Entered Follow Mode
+FollowModeNotificationDispatcher_started_following_message=Started following user {0}.
+FollowModeNotificationDispatcher_stopped_following_title=Left Follow Mode
+FollowModeNotificationDispatcher_stopped_following_message=Stopped following user {0} as {1}.
+FollowModeNotificationDispatcher_end_reason_FOLLOWEE_LEFT_SESSION=the followed user left the session
+FollowModeNotificationDispatcher_end_reason_FOLLOWER_CLOSED_OR_SWITCHED_EDITOR=you closed closed the current editor or manually switched to another editor
+FollowModeNotificationDispatcher_end_reason_FOLLOWER_CLOSED_EDITOR=you closed the current editor
+FollowModeNotificationDispatcher_end_reason_FOLLOWER_STOPPED=you stopped the follow mode
+FollowModeNotificationDispatcher_end_reason_FOLLOWER_SWITCHES_FOLLOWEE=you chose to follow another user

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/tree/SessionPopMenu.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/tree/SessionPopMenu.java
@@ -1,7 +1,11 @@
 package de.fu_berlin.inf.dpp.intellij.ui.tree;
 
 import de.fu_berlin.inf.dpp.SarosPluginContext;
-import de.fu_berlin.inf.dpp.intellij.editor.EditorManager;
+import de.fu_berlin.inf.dpp.editor.FollowModeManager;
+import de.fu_berlin.inf.dpp.session.ISarosSession;
+import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
+import de.fu_berlin.inf.dpp.session.ISessionLifecycleListener;
+import de.fu_berlin.inf.dpp.session.SessionEndReason;
 import de.fu_berlin.inf.dpp.session.User;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -12,17 +16,40 @@ import org.picocontainer.annotations.Inject;
 /** Session pop-up menu that displays the option to follow a participant. */
 class SessionPopMenu extends JPopupMenu {
 
-  @Inject private EditorManager editorManager;
+  @SuppressWarnings("FieldCanBeLocal")
+  private ISessionLifecycleListener sessionLifecycleListener =
+      new ISessionLifecycleListener() {
+        @Override
+        public void sessionStarted(ISarosSession session) {
+          followModeManager = session.getComponent(FollowModeManager.class);
+        }
 
-  public SessionPopMenu(final User user) {
+        @Override
+        public void sessionEnded(ISarosSession session, SessionEndReason reason) {
+          followModeManager = null;
+        }
+      };
+
+  @Inject private ISarosSessionManager sarosSessionManager;
+
+  private volatile FollowModeManager followModeManager;
+
+  SessionPopMenu(final User user) {
     SarosPluginContext.initComponent(this);
+
+    sarosSessionManager.addSessionLifecycleListener(sessionLifecycleListener);
+
     JMenuItem menuItemFollowParticipant = new JMenuItem("Follow participant");
     menuItemFollowParticipant.addActionListener(
         new ActionListener() {
 
           @Override
           public void actionPerformed(ActionEvent actionEvent) {
-            editorManager.setFollowing(user);
+            FollowModeManager currentFollowModeManager = followModeManager;
+
+            if (currentFollowModeManager != null) {
+              currentFollowModeManager.follow(user);
+            }
           }
         });
     add(menuItemFollowParticipant);

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/tree/SessionPopMenu.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/tree/SessionPopMenu.java
@@ -7,8 +7,6 @@ import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
 import de.fu_berlin.inf.dpp.session.ISessionLifecycleListener;
 import de.fu_berlin.inf.dpp.session.SessionEndReason;
 import de.fu_berlin.inf.dpp.session.User;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import org.picocontainer.annotations.Inject;
@@ -40,18 +38,16 @@ class SessionPopMenu extends JPopupMenu {
     sarosSessionManager.addSessionLifecycleListener(sessionLifecycleListener);
 
     JMenuItem menuItemFollowParticipant = new JMenuItem("Follow participant");
+
     menuItemFollowParticipant.addActionListener(
-        new ActionListener() {
+        actionEvent -> {
+          FollowModeManager currentFollowModeManager = followModeManager;
 
-          @Override
-          public void actionPerformed(ActionEvent actionEvent) {
-            FollowModeManager currentFollowModeManager = followModeManager;
-
-            if (currentFollowModeManager != null) {
-              currentFollowModeManager.follow(user);
-            }
+          if (currentFollowModeManager != null) {
+            currentFollowModeManager.follow(user);
           }
         });
+
     add(menuItemFollowParticipant);
   }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/views/buttons/FollowButton.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/views/buttons/FollowButton.java
@@ -12,8 +12,6 @@ import de.fu_berlin.inf.dpp.session.ISessionListener;
 import de.fu_berlin.inf.dpp.session.SessionEndReason;
 import de.fu_berlin.inf.dpp.session.User;
 import de.fu_berlin.inf.dpp.ui.util.ModelFormatUtils;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import javax.swing.JButton;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
@@ -51,6 +49,7 @@ public class FollowButton extends ToolbarButton {
         }
       };
 
+  @SuppressWarnings("FieldCanBeLocal")
   private final ISessionLifecycleListener sessionLifecycleListener =
       new ISessionLifecycleListener() {
         @Override
@@ -86,9 +85,9 @@ public class FollowButton extends ToolbarButton {
   private volatile FollowModeManager followModeManager;
 
   /**
-   * Creates a Follow button with Popupmenu, registers sessionListeners and editorlisteners.
+   * Creates a Follow button with a JPopupMenu, registers session listeners and editor listeners.
    *
-   * <p>The FollowButton is created as dissabled.
+   * <p>The FollowButton is created as disabled.
    */
   public FollowButton() {
     super(FollowModeAction.NAME, "Follow", FOLLOW_ICON_PATH, "Enter follow mode");
@@ -103,12 +102,7 @@ public class FollowButton extends ToolbarButton {
 
     final JButton button = this;
     addActionListener(
-        new ActionListener() {
-          @Override
-          public void actionPerformed(ActionEvent ev) {
-            popupMenu.show(button, 0, button.getBounds().y + button.getBounds().height);
-          }
-        });
+        ev -> popupMenu.show(button, 0, button.getBounds().y + button.getBounds().height));
   }
 
   private void createMenu() {
@@ -131,13 +125,7 @@ public class FollowButton extends ToolbarButton {
     popupMenu.addSeparator();
 
     JMenuItem leaveItem = new JMenuItem("Leave follow mode");
-    leaveItem.addActionListener(
-        new ActionListener() {
-          @Override
-          public void actionPerformed(ActionEvent e) {
-            followModeAction.execute(null);
-          }
-        });
+    leaveItem.addActionListener(e -> followModeAction.execute(null));
     leaveItem.setEnabled(currentFollowModeManager.getFollowedUser() != null);
 
     popupMenu.add(leaveItem);
@@ -169,23 +157,11 @@ public class FollowButton extends ToolbarButton {
     }
 
     menuItem.setActionCommand(userName);
-    menuItem.addActionListener(
-        new ActionListener() {
-          @Override
-          public void actionPerformed(ActionEvent e) {
-            followModeAction.execute(e.getActionCommand());
-          }
-        });
+    menuItem.addActionListener(e -> followModeAction.execute(e.getActionCommand()));
     return menuItem;
   }
 
   private void updateMenu() {
-    UIUtil.invokeAndWaitIfNeeded(
-        new Runnable() {
-          @Override
-          public void run() {
-            createMenu();
-          }
-        });
+    UIUtil.invokeAndWaitIfNeeded((Runnable) this::createMenu);
   }
 }


### PR DESCRIPTION
This PR contains multiple independent commits which should be review separately. Each commit has a commit message that gives some more information.

This PR does not fix the follow mode completely. For the follow mode to function correctly, there still have to be made some adjustments to the logic changing the local viewport and the consistency of the UserEditorState. For this reason, the saros.properties flag disabling the follow mode is not removed yet.

### PR structure

The commits in this PR can be grouped into the following sections:

#### Fix EditorManager methods
These commits fix some methods of the EditorManager used by the FollowModeManager.
- [DOC][C] Fix minor javadoc issues in IEditorManager
- [FIX][I] Fix EditorManager.adjustViewport(...)
- [FIX][I] Fix EditorManager.jumpToUser(...)
- [FIX][I] Fix EditorManager.generateEditorClosed(...)

#### Replace follow mode logic
These commits remove the custom logic that was added to realize the follow mode
functionality in Saros/I as it was redundant and not working correctly.
Replaces the logic with the usage of the FollowModeManager.

- [FIX][I] Use FollowModeManager instead of custom logic

#### Cleanup
These commits do some minor cleanup.
- [REFACTORING][I] Do minor cleanup

#### Add user notifications
These commits introduce user notifications for the follow mode.
- [UI][I] Add follow mode user notifications