### PR TITLE
[REFACTOR] Remove unnecessary TransferType usage

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/communication/extensions/ProjectNegotiationOfferingExtension.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/communication/extensions/ProjectNegotiationOfferingExtension.java
@@ -3,7 +3,6 @@ package de.fu_berlin.inf.dpp.communication.extensions;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import de.fu_berlin.inf.dpp.negotiation.FileList;
 import de.fu_berlin.inf.dpp.negotiation.ProjectNegotiationData;
-import de.fu_berlin.inf.dpp.negotiation.TransferType;
 import java.util.List;
 
 @XStreamAlias(/* ProjectNegotiationOffering */ "PNOF")
@@ -12,24 +11,15 @@ public class ProjectNegotiationOfferingExtension extends ProjectNegotiationExten
   public static final Provider PROVIDER = new Provider();
 
   private List<ProjectNegotiationData> projectNegotiationData;
-  private TransferType transferType;
 
   public ProjectNegotiationOfferingExtension(
-      String sessionID,
-      String negotiationID,
-      List<ProjectNegotiationData> projectNegotiationData,
-      TransferType transferType) {
+      String sessionID, String negotiationID, List<ProjectNegotiationData> projectNegotiationData) {
     super(sessionID, negotiationID);
     this.projectNegotiationData = projectNegotiationData;
-    this.transferType = transferType;
   }
 
   public List<ProjectNegotiationData> getProjectNegotiationData() {
     return projectNegotiationData;
-  }
-
-  public TransferType getTransferType() {
-    return transferType;
   }
 
   public static class Provider
@@ -40,7 +30,6 @@ public class ProjectNegotiationOfferingExtension extends ProjectNegotiationExten
           "pnof",
           ProjectNegotiationOfferingExtension.class,
           ProjectNegotiationData.class,
-          TransferType.class,
           FileList.class);
     }
   }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractIncomingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractIncomingProjectNegotiation.java
@@ -62,7 +62,6 @@ public abstract class AbstractIncomingProjectNegotiation extends ProjectNegotiat
 
   public AbstractIncomingProjectNegotiation(
       final JID peer, //
-      final TransferType transferType, //
       final String negotiationID, //
       final List<ProjectNegotiationData> projectNegotiationData, //
       final ISarosSessionManager sessionManager, //

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractIncomingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractIncomingProjectNegotiation.java
@@ -77,7 +77,6 @@ public abstract class AbstractIncomingProjectNegotiation extends ProjectNegotiat
     super(
         negotiationID,
         peer,
-        transferType,
         sessionManager,
         session,
         workspace,

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractOutgoingProjectNegotiation.java
@@ -200,8 +200,7 @@ public abstract class AbstractOutgoingProjectNegotiation extends ProjectNegotiat
      * current implementation opens a wizard on the remote side)
      */
     ProjectNegotiationOfferingExtension offering =
-        new ProjectNegotiationOfferingExtension(
-            getSessionID(), getID(), projectInfos, getTransferType());
+        new ProjectNegotiationOfferingExtension(getSessionID(), getID(), projectInfos);
 
     transmitter.send(
         ISarosSession.SESSION_CONNECTION_ID,

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractOutgoingProjectNegotiation.java
@@ -54,7 +54,6 @@ public abstract class AbstractOutgoingProjectNegotiation extends ProjectNegotiat
 
   protected AbstractOutgoingProjectNegotiation( //
       final JID peer, //
-      final TransferType transferType, //
       final ProjectSharingData projects, //
       final ISarosSessionManager sessionManager, //
       final ISarosSession session, //

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractOutgoingProjectNegotiation.java
@@ -68,7 +68,6 @@ public abstract class AbstractOutgoingProjectNegotiation extends ProjectNegotiat
     super(
         String.valueOf(NEGOTIATION_ID_GENERATOR.nextLong()),
         peer,
-        transferType,
         sessionManager,
         session,
         workspace,

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveIncomingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveIncomingProjectNegotiation.java
@@ -50,7 +50,6 @@ public class ArchiveIncomingProjectNegotiation extends AbstractIncomingProjectNe
       ) {
     super(
         peer,
-        TransferType.ARCHIVE,
         negotiationID,
         projectNegotiationData,
         sessionManager,

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveOutgoingProjectNegotiation.java
@@ -50,7 +50,6 @@ public class ArchiveOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
       ) {
     super(
         peer,
-        TransferType.ARCHIVE,
         projects,
         sessionManager,
         session,

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantIncomingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantIncomingProjectNegotiation.java
@@ -44,7 +44,6 @@ public class InstantIncomingProjectNegotiation extends AbstractIncomingProjectNe
       ) {
     super(
         peer,
-        TransferType.INSTANT,
         negotiationID,
         projectNegotiationData,
         sessionManager,

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantOutgoingProjectNegotiation.java
@@ -75,7 +75,6 @@ public class InstantOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
       {
     super(
         peer,
-        TransferType.INSTANT,
         projects,
         sessionManager,
         session,

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/NegotiationFactory.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/NegotiationFactory.java
@@ -130,13 +130,12 @@ public final class NegotiationFactory {
 
   public AbstractOutgoingProjectNegotiation newOutgoingProjectNegotiation(
       final JID remoteAddress,
-      TransferType transferType,
       final ProjectSharingData projectSharingData,
       final ISarosSessionManager sessionManager,
       final ISarosSession session) {
 
     User remoteUser = session.getUser(remoteAddress);
-    transferType = getTransferType(session, remoteUser);
+    TransferType transferType = getTransferType(session, remoteUser);
     if (transferType == null) {
       throw new IllegalArgumentException("transferType must not be null");
     }
@@ -173,14 +172,13 @@ public final class NegotiationFactory {
 
   public AbstractIncomingProjectNegotiation newIncomingProjectNegotiation(
       final JID remoteAddress,
-      TransferType transferType,
       final String negotiationID,
       final List<ProjectNegotiationData> projectNegotiationData,
       final ISarosSessionManager sessionManager,
       final ISarosSession session) {
 
     User remoteUser = session.getUser(remoteAddress);
-    transferType = getTransferType(session, remoteUser);
+    TransferType transferType = getTransferType(session, remoteUser);
     if (transferType == null) {
       throw new IllegalArgumentException("transferType must not be null");
     }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/NegotiationFactory.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/NegotiationFactory.java
@@ -14,6 +14,8 @@ import de.fu_berlin.inf.dpp.net.xmpp.discovery.DiscoveryManager;
 import de.fu_berlin.inf.dpp.observables.FileReplacementInProgressObservable;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
+import de.fu_berlin.inf.dpp.session.ProjectNegotiationTypeHook;
+import de.fu_berlin.inf.dpp.session.User;
 import de.fu_berlin.inf.dpp.versioning.VersionManager;
 import java.util.List;
 
@@ -128,11 +130,13 @@ public final class NegotiationFactory {
 
   public AbstractOutgoingProjectNegotiation newOutgoingProjectNegotiation(
       final JID remoteAddress,
-      final TransferType transferType,
+      TransferType transferType,
       final ProjectSharingData projectSharingData,
       final ISarosSessionManager sessionManager,
       final ISarosSession session) {
 
+    User remoteUser = session.getUser(remoteAddress);
+    transferType = getTransferType(session, remoteUser);
     if (transferType == null) {
       throw new IllegalArgumentException("transferType must not be null");
     }
@@ -169,12 +173,14 @@ public final class NegotiationFactory {
 
   public AbstractIncomingProjectNegotiation newIncomingProjectNegotiation(
       final JID remoteAddress,
-      final TransferType transferType,
+      TransferType transferType,
       final String negotiationID,
       final List<ProjectNegotiationData> projectNegotiationData,
       final ISarosSessionManager sessionManager,
       final ISarosSession session) {
 
+    User remoteUser = session.getUser(remoteAddress);
+    transferType = getTransferType(session, remoteUser);
     if (transferType == null) {
       throw new IllegalArgumentException("transferType must not be null");
     }
@@ -209,5 +215,10 @@ public final class NegotiationFactory {
       default:
         throw new UnsupportedOperationException("transferType not implemented");
     }
+  }
+
+  private TransferType getTransferType(ISarosSession session, User user) {
+    return TransferType.valueOf(
+        session.getUserProperties(user).getString(ProjectNegotiationTypeHook.KEY_TYPE));
   }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/NegotiationFactory.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/NegotiationFactory.java
@@ -136,9 +136,6 @@ public final class NegotiationFactory {
 
     User remoteUser = session.getUser(remoteAddress);
     TransferType transferType = getTransferType(session, remoteUser);
-    if (transferType == null) {
-      throw new IllegalArgumentException("transferType must not be null");
-    }
 
     switch (transferType) {
       case ARCHIVE:
@@ -179,9 +176,6 @@ public final class NegotiationFactory {
 
     User remoteUser = session.getUser(remoteAddress);
     TransferType transferType = getTransferType(session, remoteUser);
-    if (transferType == null) {
-      throw new IllegalArgumentException("transferType must not be null");
-    }
 
     switch (transferType) {
       case ARCHIVE:
@@ -216,7 +210,11 @@ public final class NegotiationFactory {
   }
 
   private TransferType getTransferType(ISarosSession session, User user) {
-    return TransferType.valueOf(
-        session.getUserProperties(user).getString(ProjectNegotiationTypeHook.KEY_TYPE));
+    String type = session.getUserProperties(user).getString(ProjectNegotiationTypeHook.KEY_TYPE);
+    if (type.isEmpty()) {
+      throw new IllegalArgumentException("Missing TransferType for User: " + user);
+    }
+
+    return TransferType.valueOf(type);
   }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/NegotiationFactory.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/NegotiationFactory.java
@@ -134,8 +134,7 @@ public final class NegotiationFactory {
       final ISarosSessionManager sessionManager,
       final ISarosSession session) {
 
-    User remoteUser = session.getUser(remoteAddress);
-    TransferType transferType = getTransferType(session, remoteUser);
+    TransferType transferType = getTransferType(session, remoteAddress);
 
     switch (transferType) {
       case ARCHIVE:
@@ -174,8 +173,7 @@ public final class NegotiationFactory {
       final ISarosSessionManager sessionManager,
       final ISarosSession session) {
 
-    User remoteUser = session.getUser(remoteAddress);
-    TransferType transferType = getTransferType(session, remoteUser);
+    TransferType transferType = getTransferType(session, remoteAddress);
 
     switch (transferType) {
       case ARCHIVE:
@@ -209,7 +207,12 @@ public final class NegotiationFactory {
     }
   }
 
-  private TransferType getTransferType(ISarosSession session, User user) {
+  private TransferType getTransferType(ISarosSession session, JID remoteAddress) {
+    User user = session.getUser(remoteAddress);
+    if (user == null) {
+      throw new IllegalStateException("User <" + user + "> is not part of the session.");
+    }
+
     String type = session.getUserProperties(user).getString(ProjectNegotiationTypeHook.KEY_TYPE);
     if (type.isEmpty()) {
       throw new IllegalArgumentException("Missing TransferType for User: " + user);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ProjectNegotiation.java
@@ -61,12 +61,9 @@ public abstract class ProjectNegotiation extends Negotiation {
    */
   protected FileTransferManager fileTransferManager;
 
-  protected TransferType transferType;
-
   public ProjectNegotiation(
       final String id,
       final JID peer,
-      final TransferType transferType,
       final ISarosSessionManager sessionManager,
       final ISarosSession session,
       final IWorkspace workspace,
@@ -85,8 +82,6 @@ public abstract class ProjectNegotiation extends Negotiation {
     Connection connection = connectionService.getConnection();
 
     if (connection != null) fileTransferManager = new FileTransferManager(connection);
-
-    this.transferType = transferType;
   }
 
   /**
@@ -159,14 +154,5 @@ public abstract class ProjectNegotiation extends Negotiation {
   @Override
   protected void notifyTerminated(NegotiationListener listener) {
     listener.negotiationTerminated(this);
-  }
-
-  /**
-   * Returns the {@link TransferType} used for this negotiation
-   *
-   * @return the {@link TransferType} used for this negotiation
-   */
-  public TransferType getTransferType() {
-    return transferType;
   }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/TransferType.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/TransferType.java
@@ -1,9 +1,6 @@
 package de.fu_berlin.inf.dpp.negotiation;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-
 /** Describes different types of transfers used to share projects */
-@XStreamAlias("TT")
 public enum TransferType {
   ARCHIVE,
   INSTANT

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/NegotiationPacketListener.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/NegotiationPacketListener.java
@@ -8,7 +8,6 @@ import de.fu_berlin.inf.dpp.communication.extensions.ProjectNegotiationOfferingE
 import de.fu_berlin.inf.dpp.negotiation.ProjectNegotiation;
 import de.fu_berlin.inf.dpp.negotiation.ProjectNegotiationData;
 import de.fu_berlin.inf.dpp.negotiation.SessionNegotiation;
-import de.fu_berlin.inf.dpp.negotiation.TransferType;
 import de.fu_berlin.inf.dpp.net.IReceiver;
 import de.fu_berlin.inf.dpp.net.ITransmitter;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
@@ -141,7 +140,6 @@ final class NegotiationPacketListener {
           projectNegotiationRequest(
               new JID(packet.getFrom()),
               extension.getNegotiationID(),
-              extension.getTransferType(),
               extension.getProjectNegotiationData());
         }
       };
@@ -307,13 +305,11 @@ final class NegotiationPacketListener {
   private void projectNegotiationRequest(
       final JID sender,
       final String negotiationID,
-      final TransferType transferType,
       final List<ProjectNegotiationData> projectNegotiationData) {
 
     LOG.info(
         "received project negotiation from " + sender + " with negotiation id: " + negotiationID);
 
-    sessionManager.projectNegotiationRequestReceived(
-        sender, transferType, projectNegotiationData, negotiationID);
+    sessionManager.projectNegotiationRequestReceived(sender, projectNegotiationData, negotiationID);
   }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/SarosSessionManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/SarosSessionManager.java
@@ -439,8 +439,9 @@ public class SarosSessionManager implements ISarosSessionManager {
       return;
     }
 
-    AbstractIncomingProjectNegotiation negotiation;
+    User remoteUser = session.getUser(remoteAddress);
 
+    AbstractIncomingProjectNegotiation negotiation;
     synchronized (this) {
       if (!startStopSessionLock.tryLock()) {
         log.warn(
@@ -451,7 +452,12 @@ public class SarosSessionManager implements ISarosSessionManager {
       try {
         negotiation =
             negotiationFactory.newIncomingProjectNegotiation(
-                remoteAddress, transferType, negotiationID, projectNegotiationData, this, session);
+                remoteAddress,
+                getTransferType(remoteUser),
+                negotiationID,
+                projectNegotiationData,
+                this,
+                session);
 
         negotiation.setNegotiationListener(negotiationListener);
         currentProjectNegotiations.add(negotiation);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/SarosSessionManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/SarosSessionManager.java
@@ -672,11 +672,9 @@ public class SarosSessionManager implements ISarosSessionManager {
 
     try {
       for (User user : recipients) {
-
-        TransferType type = getTransferType(user);
         AbstractOutgoingProjectNegotiation negotiation =
             negotiationFactory.newOutgoingProjectNegotiation(
-                user.getJID(), type, projectSharingData, this, session);
+                user.getJID(), getTransferType(user), projectSharingData, this, session);
 
         negotiation.setNegotiationListener(negotiationListener);
         currentProjectNegotiations.add(negotiation);
@@ -738,10 +736,9 @@ public class SarosSessionManager implements ISarosSessionManager {
           return;
         }
 
-        TransferType type = getTransferType(remoteUser);
         negotiation =
             negotiationFactory.newOutgoingProjectNegotiation(
-                user, type, currentSharedProjects, this, currentSession);
+                user, getTransferType(remoteUser), currentSharedProjects, this, currentSession);
 
         negotiation.setNegotiationListener(negotiationListener);
         currentProjectNegotiations.add(negotiation);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/SarosSessionManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/SarosSessionManager.java
@@ -673,9 +673,7 @@ public class SarosSessionManager implements ISarosSessionManager {
     try {
       for (User user : recipients) {
 
-        TransferType type =
-            TransferType.valueOf(
-                session.getUserProperties(user).getString(ProjectNegotiationTypeHook.KEY_TYPE));
+        TransferType type = getTransferType(user);
         AbstractOutgoingProjectNegotiation negotiation =
             negotiationFactory.newOutgoingProjectNegotiation(
                 user.getJID(), type, projectSharingData, this, session);
@@ -740,11 +738,7 @@ public class SarosSessionManager implements ISarosSessionManager {
           return;
         }
 
-        TransferType type =
-            TransferType.valueOf(
-                currentSession
-                    .getUserProperties(remoteUser)
-                    .getString(ProjectNegotiationTypeHook.KEY_TYPE));
+        TransferType type = getTransferType(remoteUser);
         negotiation =
             negotiationFactory.newOutgoingProjectNegotiation(
                 user, type, currentSharedProjects, this, currentSession);
@@ -852,5 +846,10 @@ public class SarosSessionManager implements ISarosSessionManager {
     }
 
     return terminated;
+  }
+
+  private TransferType getTransferType(User user) {
+    return TransferType.valueOf(
+        session.getUserProperties(user).getString(ProjectNegotiationTypeHook.KEY_TYPE));
   }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/SarosSessionManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/SarosSessionManager.java
@@ -428,7 +428,6 @@ public class SarosSessionManager implements ISarosSessionManager {
 
   void projectNegotiationRequestReceived(
       JID remoteAddress,
-      TransferType transferType,
       List<ProjectNegotiationData> projectNegotiationData,
       String negotiationID) {
 

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/SarosSessionManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/SarosSessionManager.java
@@ -36,7 +36,6 @@ import de.fu_berlin.inf.dpp.negotiation.ProjectNegotiationCollector;
 import de.fu_berlin.inf.dpp.negotiation.ProjectNegotiationData;
 import de.fu_berlin.inf.dpp.negotiation.ProjectSharingData;
 import de.fu_berlin.inf.dpp.negotiation.SessionNegotiation;
-import de.fu_berlin.inf.dpp.negotiation.TransferType;
 import de.fu_berlin.inf.dpp.negotiation.hooks.ISessionNegotiationHook;
 import de.fu_berlin.inf.dpp.negotiation.hooks.SessionNegotiationHookManager;
 import de.fu_berlin.inf.dpp.net.ConnectionState;
@@ -438,8 +437,6 @@ public class SarosSessionManager implements ISarosSessionManager {
       return;
     }
 
-    User remoteUser = session.getUser(remoteAddress);
-
     AbstractIncomingProjectNegotiation negotiation;
     synchronized (this) {
       if (!startStopSessionLock.tryLock()) {
@@ -451,12 +448,7 @@ public class SarosSessionManager implements ISarosSessionManager {
       try {
         negotiation =
             negotiationFactory.newIncomingProjectNegotiation(
-                remoteAddress,
-                getTransferType(remoteUser),
-                negotiationID,
-                projectNegotiationData,
-                this,
-                session);
+                remoteAddress, negotiationID, projectNegotiationData, this, session);
 
         negotiation.setNegotiationListener(negotiationListener);
         currentProjectNegotiations.add(negotiation);
@@ -679,7 +671,7 @@ public class SarosSessionManager implements ISarosSessionManager {
       for (User user : recipients) {
         AbstractOutgoingProjectNegotiation negotiation =
             negotiationFactory.newOutgoingProjectNegotiation(
-                user.getJID(), getTransferType(user), projectSharingData, this, session);
+                user.getJID(), projectSharingData, this, session);
 
         negotiation.setNegotiationListener(negotiationListener);
         currentProjectNegotiations.add(negotiation);
@@ -743,7 +735,7 @@ public class SarosSessionManager implements ISarosSessionManager {
 
         negotiation =
             negotiationFactory.newOutgoingProjectNegotiation(
-                user, getTransferType(remoteUser), currentSharedProjects, this, currentSession);
+                user, currentSharedProjects, this, currentSession);
 
         negotiation.setNegotiationListener(negotiationListener);
         currentProjectNegotiations.add(negotiation);
@@ -848,10 +840,5 @@ public class SarosSessionManager implements ISarosSessionManager {
     }
 
     return terminated;
-  }
-
-  private TransferType getTransferType(User user) {
-    return TransferType.valueOf(
-        session.getUserProperties(user).getString(ProjectNegotiationTypeHook.KEY_TYPE));
   }
 }


### PR DESCRIPTION
TransferType is set via session negotiation mechanism at session start
for the whole session making it unnecessary to transmit it again at 
project negotiation time.