### PR TITLE
Fix local editor status change handling

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
@@ -355,9 +355,16 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
     SelectedEditorState selectedEditorState = new SelectedEditorState();
     selectedEditorState.captureState();
 
-    for (VirtualFile openFile : openFiles) {
-      localEditorHandler.openEditor(openFile, project, false);
-      // TODO create selection activity if there is a current selection
+    try {
+      localEditorStatusChangeHandler.setEnabled(false);
+
+      for (VirtualFile openFile : openFiles) {
+        localEditorHandler.openEditor(openFile, project, false);
+        // TODO create selection activity if there is a current selection
+      }
+
+    } finally {
+      localEditorStatusChangeHandler.setEnabled(true);
     }
 
     selectedEditorState.applyCapturedState();

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.event.SelectionEvent;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -469,7 +470,8 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
       LocalEditorManipulator localEditorManipulator,
       ProjectAPI projectAPI,
       AnnotationManager annotationManager,
-      FileReplacementInProgressObservable fileReplacementInProgressObservable) {
+      FileReplacementInProgressObservable fileReplacementInProgressObservable,
+      Project project) {
 
     sessionManager.addSessionLifecycleListener(sessionLifecycleListener);
     this.localEditorHandler = localEditorHandler;
@@ -481,7 +483,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
     localClosedEditorModificationHandler =
         new LocalClosedEditorModificationHandler(this, projectAPI, annotationManager);
     localEditorStatusChangeHandler =
-        new LocalEditorStatusChangeHandler(localEditorHandler, annotationManager);
+        new LocalEditorStatusChangeHandler(project, localEditorHandler, annotationManager);
 
     localTextSelectionChangeHandler = new LocalTextSelectionChangeHandler(this);
     localViewPortChangeHandler = new LocalViewPortChangeHandler(this);

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorHandler.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorHandler.java
@@ -206,9 +206,18 @@ public class LocalEditorHandler {
   /**
    * Calls {@link EditorManager#generateEditorActivated(SPath)}.
    *
-   * @param file
+   * @param file the file whose editor was activated or <code>null</code> if there is no editor open
    */
-  public void activateEditor(@NotNull VirtualFile file) {
+  void activateEditor(@Nullable VirtualFile file) {
+    if (file == null) {
+
+      if (manager.hasSession()) {
+        manager.generateEditorActivated(null);
+      }
+
+      return;
+    }
+
     SPath path = VirtualFileConverter.convertToSPath(file);
 
     if (path != null && SessionUtils.isShared(path)) {

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorHandler.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorHandler.java
@@ -44,7 +44,6 @@ public class LocalEditorHandler {
   public void initialize(EditorManager editorManager) {
     this.editorPool = editorManager.getEditorPool();
     this.manager = editorManager;
-    projectAPI.addFileEditorManagerListener(editorManager.getLocalEditorStatusChangeHandler());
   }
 
   /**

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorStatusChangeHandler.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorStatusChangeHandler.java
@@ -117,13 +117,7 @@ class LocalEditorStatusChangeHandler implements DisableableHandler {
   private void generateEditorActivatedActivity(@NotNull FileEditorManagerEvent event) {
     assert enabled : "the selection changed listener was triggered while it was disabled";
 
-    VirtualFile virtualFile = event.getNewFile();
-
-    if (virtualFile == null) {
-      return;
-    }
-
-    localEditorHandler.activateEditor(virtualFile);
+    localEditorHandler.activateEditor(event.getNewFile());
   }
 
   /**

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/ProjectAPI.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/ProjectAPI.java
@@ -182,13 +182,4 @@ public class ProjectAPI {
         },
         ModalityState.NON_MODAL);
   }
-
-  /**
-   * Subscribes the given <code>LocalEditorStatusChangeHandler</code> to the current project.
-   *
-   * @param listener the listener that should subscribe to the current project
-   */
-  void addFileEditorManagerListener(@NotNull LocalEditorStatusChangeHandler listener) {
-    listener.subscribe(project);
-  }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/SelectedEditorState.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/SelectedEditorState.java
@@ -1,6 +1,5 @@
 package de.fu_berlin.inf.dpp.intellij.editor;
 
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import de.fu_berlin.inf.dpp.SarosPluginContext;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
@@ -25,8 +24,6 @@ public class SelectedEditorState {
   @Inject private static ProjectAPI projectAPI;
 
   @Inject private static EditorManager editorManager;
-
-  @Inject private static Project project;
 
   static {
     SarosPluginContext.initComponent(new SelectedEditorState());
@@ -61,14 +58,14 @@ public class SelectedEditorState {
     ListIterator<VirtualFile> iterator = selectedEditors.listIterator(selectedEditors.size());
 
     try {
-      editorManager.getLocalEditorStatusChangeHandler().unsubscribe();
+      editorManager.getLocalEditorStatusChangeHandler().setEnabled(false);
 
       while (iterator.hasPrevious()) {
         projectAPI.openEditor(iterator.previous(), true);
       }
 
     } finally {
-      editorManager.getLocalEditorStatusChangeHandler().subscribe(project);
+      editorManager.getLocalEditorStatusChangeHandler().setEnabled(true);
     }
   }
 


### PR DESCRIPTION
#### [INTERNAL][I] Improve LocalEditorStatusChangeHandler.setEnabled(...)

Moves the subscribing and unsubscribing from the held IntelliJ listener
into the setEnabled(boolean) method. This unifies the functionality.
Furthermore, the previous solution that relied on the enabled flag could
cause consistency issues where events that should be ignored were
triggered while the flag was set to false but the listener was only
notified after the flag was set to true again. This is avoided by always
unsubscribing from the listener when disabling the handler.

#### [FIX][I] Fix editor selection change without open editor handling

Removes wrong nullcheck in
LocalEditorStatusChangeHandler.generateEditorActivatedActivity(...)
where null is a valid value.

Fix LocalEditorHandler.activateEditor(...) to also dispatch activities
when there is no editor selected locally as this is also a valid stat
that should be passed to other participants.

#### [FIX][I] Disable editor status handler when initializing editor pool

Disables the LocalEditorStatusChangeHandler while initializing the
editor pool at the start of a session. This is needed as
ProjectAPI.openEditor(...) still switches to the opened editor, even if
the focus flag is set to false. This editor switching would create false
editor activated activities that cause the user editor state of the
other participants to assume that the last editor added to the editor
pool is currently the active editor for the local user, which is not
necessarily the case.