### PR TITLE
Fix viewport adjustment logic

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorAPI.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorAPI.java
@@ -7,11 +7,15 @@ import com.intellij.openapi.command.CommandProcessor;
 import com.intellij.openapi.command.UndoConfirmationPolicy;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.LogicalPosition;
 import com.intellij.openapi.editor.ScrollType;
 import com.intellij.openapi.editor.VisualPosition;
 import com.intellij.openapi.project.Project;
+import de.fu_berlin.inf.dpp.editor.text.LineRange;
 import de.fu_berlin.inf.dpp.intellij.editor.colorstorage.ColorModel;
 import de.fu_berlin.inf.dpp.intellij.filesystem.Filesystem;
+import java.awt.Point;
+import java.awt.Rectangle;
 
 /**
  * IntellJ editor API. An Editor is a window for editing source files.
@@ -53,6 +57,26 @@ public class EditorAPI {
         };
 
     application.invokeAndWait(action, ModalityState.defaultModalityState());
+  }
+
+  /**
+   * Returns the logical line range of the local viewport for the given editor.
+   *
+   * @param editor the editor to get the viewport line range for
+   * @return the logical line range of the local viewport for the given editor
+   * @see LogicalPosition
+   */
+  LineRange getLocalViewportRange(Editor editor) {
+    Rectangle visibleAreaRectangle = editor.getScrollingModel().getVisibleAreaOnScrollingFinished();
+
+    int basePos = visibleAreaRectangle.y;
+    int endPos = visibleAreaRectangle.y + visibleAreaRectangle.height;
+
+    int currentViewportStartLine = editor.xyToLogicalPosition(new Point(0, basePos)).line;
+    int currentViewportEndLine = editor.xyToLogicalPosition(new Point(0, endPos)).line;
+
+    return new LineRange(
+        currentViewportStartLine, currentViewportEndLine - currentViewportStartLine);
   }
 
   /**

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorAPI.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorAPI.java
@@ -75,65 +75,58 @@ public class EditorAPI {
   }
 
   /**
-   * Inserts text at the given position inside the UI thread.
+   * Inserts the specified text at the specified offset in the document. Line breaks in the inserted
+   * text must be normalized as \n.
    *
-   * @param doc
-   * @param position
-   * @param text
+   * @param document the document to insert the text into
+   * @param offset the offset to insert the text at
+   * @param text the text to insert
+   * @see Document#insertString(int, CharSequence)
    */
-  public void insertText(final Document doc, final int position, final String text) {
+  void insertText(final Document document, final int offset, final String text) {
 
-    Runnable action =
-        new Runnable() {
-          @Override
-          public void run() {
-            commandProcessor.executeCommand(
-                project,
-                new Runnable() {
+    Runnable insertCommand =
+        () -> {
+          Runnable insertString = () -> document.insertString(offset, text);
 
-                  @Override
-                  public void run() {
-                    doc.insertString(position, text);
-                  }
-                },
-                "Saros text insertion at index " + position + " of \"" + text + "\"",
-                commandProcessor.getCurrentCommandGroupId(),
-                UndoConfirmationPolicy.REQUEST_CONFIRMATION,
-                doc);
-          }
+          String commandName = "Saros text insertion at index " + offset + " of \"" + text + "\"";
+
+          commandProcessor.executeCommand(
+              project,
+              insertString,
+              commandName,
+              commandProcessor.getCurrentCommandGroupId(),
+              UndoConfirmationPolicy.REQUEST_CONFIRMATION,
+              document);
         };
 
-    Filesystem.runWriteAction(action, ModalityState.defaultModalityState());
+    Filesystem.runWriteAction(insertCommand, ModalityState.defaultModalityState());
   }
 
   /**
-   * Deletes text in document in the specified range in the UI thread.
+   * Deletes the specified range of text from the given document.
    *
-   * @param doc
-   * @param start
-   * @param end
+   * @param doc the document to delete text from
+   * @param start the start offset of the range to delete
+   * @param end the end offset of the range to delete
+   * @see Document#deleteString(int, int)
    */
-  public void deleteText(final Document doc, final int start, final int end) {
-    Runnable action =
-        new Runnable() {
-          @Override
-          public void run() {
-            commandProcessor.executeCommand(
-                project,
-                new Runnable() {
+  void deleteText(final Document doc, final int start, final int end) {
+    Runnable deletionCommand =
+        () -> {
+          Runnable deleteRange = () -> doc.deleteString(start, end);
 
-                  @Override
-                  public void run() {
-                    doc.deleteString(start, end);
-                  }
-                },
-                "Saros text deletion from index " + start + " to " + end,
-                commandProcessor.getCurrentCommandGroupId(),
-                UndoConfirmationPolicy.REQUEST_CONFIRMATION,
-                doc);
-          }
+          String commandName = "Saros text deletion from index " + start + " to " + end;
+
+          commandProcessor.executeCommand(
+              project,
+              deleteRange,
+              commandName,
+              commandProcessor.getCurrentCommandGroupId(),
+              UndoConfirmationPolicy.REQUEST_CONFIRMATION,
+              doc);
         };
 
-    Filesystem.runWriteAction(action, ModalityState.defaultModalityState());
+    Filesystem.runWriteAction(deletionCommand, ModalityState.defaultModalityState());
   }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
@@ -406,7 +406,8 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
       ProjectAPI projectAPI,
       AnnotationManager annotationManager,
       FileReplacementInProgressObservable fileReplacementInProgressObservable,
-      Project project) {
+      Project project,
+      EditorAPI editorAPI) {
 
     sessionManager.addSessionLifecycleListener(sessionLifecycleListener);
     this.localEditorHandler = localEditorHandler;
@@ -421,7 +422,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
         new LocalEditorStatusChangeHandler(project, localEditorHandler, annotationManager);
 
     localTextSelectionChangeHandler = new LocalTextSelectionChangeHandler(this);
-    localViewPortChangeHandler = new LocalViewPortChangeHandler(this);
+    localViewPortChangeHandler = new LocalViewPortChangeHandler(this, editorAPI);
 
     localEditorHandler.initialize(this);
     localEditorManipulator.initialize(this);
@@ -748,6 +749,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
    * @param path {@inheritDoc}
    * @param range {@inheritDoc}
    * @param selection {@inheritDoc}
+   * @see LocalEditorManipulator#adjustViewport(Editor, LineRange, TextSelection)
    */
   @Override
   public void adjustViewport(

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorManipulator.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/LocalEditorManipulator.java
@@ -47,7 +47,7 @@ public class LocalEditorManipulator {
   }
 
   /** Initializes all fields that require an EditorManager. */
-  public void initialize(EditorManager editorManager) {
+  void initialize(EditorManager editorManager) {
     editorPool = editorManager.getEditorPool();
     manager = editorManager;
   }
@@ -82,7 +82,6 @@ public class LocalEditorManipulator {
       return null;
     }
 
-    // todo: in case it is already open, need to activate only, not open
     Editor editor = projectAPI.openEditor(virtualFile, activate);
 
     manager.startEditor(editor);
@@ -94,9 +93,9 @@ public class LocalEditorManipulator {
   }
 
   /**
-   * Closes the editor under path.
+   * Closes the editor under the given path.
    *
-   * @param path
+   * @param path the path of the file for which to close the editor
    */
   public void closeEditor(SPath path) {
     editorPool.removeEditor(path);
@@ -123,12 +122,13 @@ public class LocalEditorManipulator {
   }
 
   /**
-   * Applies the text operations on the path and marks them in color.
+   * Applies the text operations to the document for the given path and adds matching contribution
+   * annotations if necessary.
    *
-   * @param path
-   * @param operations
+   * @param path the path of the file whose document should be modified
+   * @param operations the operations to apply to the document
    */
-  public void applyTextOperations(SPath path, Operation operations) {
+  void applyTextOperations(SPath path, Operation operations) {
     Document doc = editorPool.getDocument(path);
 
     /*


### PR DESCRIPTION
To make the review process easier, the commits should be reviewed (or at least looked at) separately.

#### [FIX][I] Set correct line range in LocalViewPortChangeHandler
Adjusts the logic in LocalViewPortChangeHandler.getLineRange(...) to use
the IntelliJ API to calculate the lines from the given viewport
rectangle instead of calculating it by hand using the line height.

The new logic now uses the logical line positions, meaning it ignores
code folding/soft-wraps. This ensures that both participants see
approximately the same line range, independent of code folding.

#### [FIX][I] Fix basic viewport adjustment logic
Introduces a basic viewport adjustment logic used by the follow mode.
The logic currently always focuses on the center of the remote viewport
range if available or on the center of the remove selection range
otherwise.

There is currently no special handling for the case that the follower
viewport is smaller than the followee viewport.

#### [REFACTOR][I] Do minor cleanup
Adjusts javadoc to better describe the method responsibilities and
restrictions.

Replaces anonymous inner classes with lambda expressions. Subsequently
cleans up the body of the lambda expressions.

Reduces method visibility to minimal necessary level.