### PR TITLE
[DOC] Add gitter badge to support doc and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Saros
 
+[![Gitter chat](https://badges.gitter.im/saros-project/user.png)](https://gitter.im/saros-project/saros/user)
+
 Saros is an Open Source IDE plugin for distributed collaborative software
 development.
 

--- a/docs/support/index.md
+++ b/docs/support/index.md
@@ -6,6 +6,7 @@ title: Support
 
 If you have problems that cannot be solved via the [FAQ](/documentation/faq.md) or [troubleshooting](/documentation/troubleshooting.md) pages, you can contact the Saros team via:
 
+* our gitter user channel [![Gitter chat](https://badges.gitter.im/saros-project/user.png)](https://gitter.im/saros-project/saros/user)
 * the [Saros user mailing list](https://groups.google.com/forum/#!forum/saros-user)
 * the [Saros developer mailing list](https://groups.google.com/forum/#!forum/saros-devel)
 


### PR DESCRIPTION
I would like to use our already existing [Gitter community]( https://gitter.im/saros-project).
It has the advantage that the fear of contact of users (in channel saros-project/saros/user) is smaller and we are able to use write instant messages and discuss in the developer channel (saros-project/saros) instead of opening an issues that starts with "what do you think about ...". Nonetheless, technical discussions about an issue should be located in the corresponding GitHub issue.

Furthermore the integration of GitHub-"Activies" is a possible alternative to the deprecated GitHub email service.