### PR TITLE
Fix FollowModeManager issues

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/editor/FollowModeManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/editor/FollowModeManager.java
@@ -76,20 +76,26 @@ public class FollowModeManager implements Startable {
             return;
           }
 
-          stopIfDiverted(filePath, Reason.FOLLOWER_CLOSED_OR_SWITCHED_EDITOR);
+          Reason reason = Reason.FOLLOWER_CLOSED_OR_SWITCHED_EDITOR;
+
+          EditorState remoteActiveEditor = followeeEditor();
+
+          if (remoteActiveEditor != null && !remoteActiveEditor.getPath().equals(filePath)) {
+
+            follow(null);
+            notifyStopped(reason);
+          }
         }
 
         @Override
         public void editorClosed(User user, SPath filePath) {
           if (!user.equals(localUser) || !isFollowing()) return;
 
-          stopIfDiverted(filePath, Reason.FOLLOWER_CLOSED_EDITOR);
-        }
+          Reason reason = Reason.FOLLOWER_CLOSED_EDITOR;
 
-        private void stopIfDiverted(SPath filePath, Reason reason) {
           EditorState remoteActiveEditor = followeeEditor();
 
-          if (remoteActiveEditor != null && !remoteActiveEditor.getPath().equals(filePath)) {
+          if (remoteActiveEditor != null && remoteActiveEditor.getPath().equals(filePath)) {
 
             follow(null);
             notifyStopped(reason);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/editor/FollowModeManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/editor/FollowModeManager.java
@@ -121,11 +121,6 @@ public class FollowModeManager implements Startable {
               }
               break;
             case CLOSED:
-              // TODO This closes every editor the followee closes -- desired?
-              // Problem: In order to determine whether the followee closed
-              // his/her active editor and just an editor in the background,
-              // one needs to keep track of the last few EditorActivities.
-              editorManager.closeEditor(path);
               break;
             case SAVED:
               break;

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/editor/FollowModeManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/editor/FollowModeManager.java
@@ -42,8 +42,7 @@ public class FollowModeManager implements Startable {
   private User localUser;
   private User currentlyFollowedUser;
 
-  private final CopyOnWriteArrayList<IFollowModeListener> listeners =
-      new CopyOnWriteArrayList<IFollowModeListener>();
+  private final CopyOnWriteArrayList<IFollowModeListener> listeners = new CopyOnWriteArrayList<>();
 
   /** If the user left which I am following, then stop following him/her */
   private ISessionListener stopFollowingWhenUserLeaves =
@@ -220,14 +219,15 @@ public class FollowModeManager implements Startable {
 
     currentlyFollowedUser = newFollowedUser;
 
-    if (newFollowedUser != null) {
+    if (newFollowedUser != null && !newFollowedUser.equals(previouslyFollowedUser)) {
       editorManager.jumpToUser(newFollowedUser);
 
       if (previouslyFollowedUser != null) {
         notifyStopped(Reason.FOLLOWER_SWITCHES_FOLLOWEE);
       }
       notifyStarted(newFollowedUser);
-    } else if (previouslyFollowedUser != null) {
+
+    } else if (newFollowedUser == null && previouslyFollowedUser != null) {
       notifyStopped(Reason.FOLLOWER_STOPPED);
     }
   }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/editor/FollowModeManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/editor/FollowModeManager.java
@@ -66,16 +66,6 @@ public class FollowModeManager implements Startable {
         public void editorActivated(User user, SPath filePath) {
           if (!user.equals(localUser) || !isFollowing()) return;
 
-          // TODO Find out which of the code below is actually necessary, as
-          // there is also the editorClosed method!
-
-          if (filePath == null) {
-            follow(null);
-            notifyStopped(Reason.FOLLOWER_CLOSED_OR_SWITCHED_EDITOR);
-
-            return;
-          }
-
           Reason reason = Reason.FOLLOWER_CLOSED_OR_SWITCHED_EDITOR;
 
           EditorState remoteActiveEditor = followeeEditor();

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/editor/FollowModeManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/editor/FollowModeManager.java
@@ -53,7 +53,8 @@ public class FollowModeManager implements Startable {
           if (!isFollowing()) return;
 
           if (user.equals(currentlyFollowedUser)) {
-            follow(null);
+
+            dropFollowModeState();
             notifyStopped(Reason.FOLLOWEE_LEFT_SESSION);
           }
         }
@@ -72,7 +73,7 @@ public class FollowModeManager implements Startable {
 
           if (remoteActiveEditor != null && !remoteActiveEditor.getPath().equals(filePath)) {
 
-            follow(null);
+            dropFollowModeState();
             notifyStopped(reason);
           }
         }
@@ -87,7 +88,7 @@ public class FollowModeManager implements Startable {
 
           if (remoteActiveEditor != null && remoteActiveEditor.getPath().equals(filePath)) {
 
-            follow(null);
+            dropFollowModeState();
             notifyStopped(reason);
           }
         }
@@ -288,6 +289,16 @@ public class FollowModeManager implements Startable {
     for (IFollowModeListener listener : listeners) {
       listener.startedFollowing(followee);
     }
+  }
+
+  /**
+   * Drops the currently held state of the follow mode, thereby ending the current follow mode.
+   *
+   * <p>This method does not notify the listener about the end of the follow mode. Notifying the
+   * listener using the correct reason is the responsibility of the caller.
+   */
+  private void dropFollowModeState() {
+    currentlyFollowedUser = null;
   }
 
   /* Helper */

--- a/de.fu_berlin.inf.dpp/test/stf/de/fu_berlin/inf/dpp/stf/test/permissions/AllParticipantsFollowUserWithWriteAccessTest.java
+++ b/de.fu_berlin.inf.dpp/test/stf/de/fu_berlin/inf/dpp/stf/test/permissions/AllParticipantsFollowUserWithWriteAccessTest.java
@@ -11,9 +11,7 @@ import static org.junit.Assert.assertTrue;
 import de.fu_berlin.inf.dpp.stf.client.StfTestCase;
 import de.fu_berlin.inf.dpp.stf.client.util.Util;
 import de.fu_berlin.inf.dpp.stf.test.Constants;
-import java.io.IOException;
 import java.rmi.RemoteException;
-import org.eclipse.core.runtime.CoreException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -81,9 +79,9 @@ public class AllParticipantsFollowUserWithWriteAccessTest extends StfTestCase {
     DAVE.remoteBot().waitUntilEditorOpen(Constants.CLS1_SUFFIX);
 
     ALICE.remoteBot().editor(Constants.CLS1_SUFFIX).closeWithSave();
-    BOB.remoteBot().waitUntilEditorClosed(Constants.CLS1_SUFFIX);
-    CARL.remoteBot().waitUntilEditorClosed(Constants.CLS1_SUFFIX);
-    DAVE.remoteBot().waitUntilEditorClosed(Constants.CLS1_SUFFIX);
+    BOB.remoteBot().editor(Constants.CLS1_SUFFIX).closeWithSave();
+    CARL.remoteBot().editor(Constants.CLS1_SUFFIX).closeWithSave();
+    DAVE.remoteBot().editor(Constants.CLS1_SUFFIX).closeWithSave();
   }
 
   /**
@@ -133,82 +131,10 @@ public class AllParticipantsFollowUserWithWriteAccessTest extends StfTestCase {
     assertTrue(DAVE.remoteBot().editor(Constants.CLS1_SUFFIX).isDirty());
     assertTrue(
         DAVE.remoteBot().editor(Constants.CLS1_SUFFIX).getText().equals(dirtyClsContentOfAlice));
+
+    ALICE.remoteBot().editor(Constants.CLS1 + SUFFIX_JAVA).closeWithSave();
     BOB.remoteBot().editor(Constants.CLS1 + SUFFIX_JAVA).closeWithSave();
     CARL.remoteBot().editor(Constants.CLS1 + SUFFIX_JAVA).closeWithSave();
     DAVE.remoteBot().editor(Constants.CLS1 + SUFFIX_JAVA).closeWithSave();
-    ALICE.remoteBot().editor(Constants.CLS1 + SUFFIX_JAVA).closeWithSave();
-  }
-
-  /**
-   * Steps:
-   *
-   * <ol>
-   *   <li>Alice open a class.
-   *   <li>Alice set text in the opened java editor and then close it with save.
-   * </ol>
-   *
-   * Result:
-   *
-   * <ol>
-   *   <li>BOB, CARL and DAVE open the class too
-   *   <li>BOB, CARL and DAVE have the same class content as ALICE and their opened editor are
-   *       closed too.
-   * </ol>
-   *
-   * @throws CoreException
-   * @throws IOException
-   */
-  @Test
-  public void testFollowModeByClosingEditorByAlice() throws Exception {
-    ALICE
-        .superBot()
-        .views()
-        .packageExplorerView()
-        .selectClass(Constants.PROJECT1, Constants.PKG1, Constants.CLS1)
-        .open();
-
-    BOB.remoteBot().waitUntilEditorOpen(Constants.CLS1_SUFFIX);
-    CARL.remoteBot().waitUntilEditorOpen(Constants.CLS1_SUFFIX);
-    DAVE.remoteBot().waitUntilEditorOpen(Constants.CLS1_SUFFIX);
-
-    ALICE.remoteBot().editor(Constants.CLS1_SUFFIX).setTextFromFile(Constants.CP1_CHANGE);
-
-    ALICE.remoteBot().editor(Constants.CLS1 + SUFFIX_JAVA).closeWithSave();
-
-    String clsContentOfAlice =
-        ALICE
-            .superBot()
-            .views()
-            .packageExplorerView()
-            .getFileContent(
-                Util.classPathToFilePath(Constants.PROJECT1, Constants.PKG1, Constants.CLS1));
-
-    BOB.remoteBot().waitUntilEditorClosed(Constants.CLS1_SUFFIX);
-    CARL.remoteBot().waitUntilEditorClosed(Constants.CLS1_SUFFIX);
-    DAVE.remoteBot().waitUntilEditorClosed(Constants.CLS1_SUFFIX);
-
-    assertTrue(
-        BOB.superBot()
-            .views()
-            .packageExplorerView()
-            .getFileContent(
-                Util.classPathToFilePath(Constants.PROJECT1, Constants.PKG1, Constants.CLS1))
-            .equals(clsContentOfAlice));
-
-    assertTrue(
-        CARL.superBot()
-            .views()
-            .packageExplorerView()
-            .getFileContent(
-                Util.classPathToFilePath(Constants.PROJECT1, Constants.PKG1, Constants.CLS1))
-            .equals(clsContentOfAlice));
-
-    assertTrue(
-        BOB.superBot()
-            .views()
-            .packageExplorerView()
-            .getFileContent(
-                Util.classPathToFilePath(Constants.PROJECT1, Constants.PKG1, Constants.CLS1))
-            .equals(clsContentOfAlice));
   }
 }


### PR DESCRIPTION
#### [FIX][CORE] Fix file closing ending follow mode
With the previous logic, either the follower or followee closing a file
would cause the follow mode to end. This commit adjusts the logic so
that the follower and followee can close editors as they please.
If the followee closes the active editor, the new active editor will
automatically be selected by the follower. If there is no active editor
for the followee after closing the previously active editor, the follow
mode is paused until a new editor is opened by the followee.

Subsequently inline stopIfDiverted as it is now only used by one method.

#### [FIX][CORE] Allow follower to close last editor while follow mode paused
Adjusts the logic in FollowModeManager to allow the follower to close
their last editor while the follow mode is paused, meaning the followee
currently has no open editors. If the followee opens an editor, the
editor is also opened for the follower, meaning the follow mode is
continued correctly irrespective of the local editor state of the
followee.

#### [CORE] Remove logic that automatically closes follower editors
Removes the logic from the FollowModeManager that closes editors on the
follower side when the corresponding editor is closed by the followee.
This allows the follower to have full control over which editors are
open during the follow mode.

Subsequently removes the STF tests that were checking for this behavior.

#### [FIX][CORE] Avoid duplicate notifications when follow mode ends
Changes the internal logic of the FollowModeManager that ends the
session based on received activities.

The previous handling used the follow(User) method to end the follow
mode and then notified the listener with the correct reason for the
follow mode end. The method follow(User) internally also notifies the
listener with the reason "FOLLOWER_STOPPED", meaning this incorrect
reason was dispatched first to the listeners. Furthermore, this meant
that the listener was called twice when the follow mode ended through
editor state changes.

The new logic now ends the follow mode in such cases by simply dropping
the held follow mode state without dispatching any notifications. This
means that it is the callers responsibility to notify the listener about
the follow mode end.

#### [FIX][CORE] Avoid unnecessary follow mode state change notifications
Avoids notifying the follow mode listeners on follow(User) calls that
don't change the state. Such calls are follow(...) on a user that is
currently already being followed or on null while there is no current
follow mode.