### PR TITLE
[FEATURE][S] Support incoming ProjectNegotiations 

### DIFF
--- a/server/src/saros/server/filesystem/ServerProjectImpl.java
+++ b/server/src/saros/server/filesystem/ServerProjectImpl.java
@@ -1,6 +1,8 @@
 package saros.server.filesystem;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import saros.filesystem.IFile;
 import saros.filesystem.IFolder;
 import saros.filesystem.IPath;
@@ -74,5 +76,14 @@ public class ServerProjectImpl extends ServerContainerImpl implements IProject {
 
   private IPath getFullMemberPath(IPath memberPath) {
     return getFullPath().append(memberPath);
+  }
+
+  /**
+   * Creates the underlying folder structure for the project
+   *
+   * @throws IOException
+   */
+  public void create() throws IOException {
+    Files.createDirectory(toNioPath());
   }
 }

--- a/server/src/saros/server/session/NegotiationHandler.java
+++ b/server/src/saros/server/session/NegotiationHandler.java
@@ -1,11 +1,14 @@
 package saros.server.session;
 
+import java.io.IOException;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.apache.log4j.Logger;
 import saros.filesystem.IProject;
+import saros.filesystem.IWorkspace;
 import saros.monitoring.NullProgressMonitor;
 import saros.negotiation.AbstractIncomingProjectNegotiation;
 import saros.negotiation.AbstractOutgoingProjectNegotiation;
@@ -13,8 +16,11 @@ import saros.negotiation.IncomingSessionNegotiation;
 import saros.negotiation.NegotiationTools;
 import saros.negotiation.OutgoingSessionNegotiation;
 import saros.negotiation.ProjectNegotiation;
+import saros.negotiation.ProjectNegotiationData;
 import saros.negotiation.SessionNegotiation;
+import saros.net.xmpp.JID;
 import saros.server.ServerConfig;
+import saros.server.filesystem.ServerProjectImpl;
 import saros.server.progress.ConsoleProgressIndicator;
 import saros.session.INegotiationHandler;
 import saros.session.ISarosSessionManager;
@@ -25,6 +31,7 @@ public class NegotiationHandler implements INegotiationHandler {
   private static final Logger log = Logger.getLogger(NegotiationHandler.class);
 
   private final ISarosSessionManager sessionManager;
+  private final IWorkspace workspace;
   private final ThreadPoolExecutor sessionExecutor =
       new ThreadPoolExecutor(
           0,
@@ -42,9 +49,10 @@ public class NegotiationHandler implements INegotiationHandler {
           new LinkedBlockingQueue<Runnable>(),
           new NamedThreadFactory("ServerProjectNegotiation-"));
 
-  public NegotiationHandler(ISarosSessionManager sessionManager) {
+  public NegotiationHandler(ISarosSessionManager sessionManager, IWorkspace workspace) {
     sessionManager.setNegotiationHandler(this);
     this.sessionManager = sessionManager;
+    this.workspace = workspace;
   }
 
   @Override
@@ -118,26 +126,8 @@ public class NegotiationHandler implements INegotiationHandler {
               status = negotiation.run(new NullProgressMonitor());
             }
 
-            switch (status) {
-              case ERROR:
-                log.error("ERROR running project negotiation: " + negotiation.getErrorMessage());
-                break;
-              case REMOTE_ERROR:
-                log.error(
-                    "REMOTE_ERROR running project negotiation: "
-                        + negotiation.getErrorMessage()
-                        + " at remote: "
-                        + negotiation.getPeer().toString());
-                break;
-              case CANCEL:
-                log.info("Project negotiation was cancelled locally");
-                break;
-              case REMOTE_CANCEL:
-                log.info(
-                    "Project negotiation was cancelled by remote: "
-                        + negotiation.getPeer().toString());
-                break;
-            }
+            if (status != ProjectNegotiation.Status.OK)
+              handleErrorStatus(status, negotiation.getErrorMessage(), negotiation.getPeer());
           }
         });
   }
@@ -146,15 +136,64 @@ public class NegotiationHandler implements INegotiationHandler {
   public void handleIncomingProjectNegotiation(
       final AbstractIncomingProjectNegotiation negotiation) {
 
+    Map<String, IProject> projectMapping = new HashMap<>();
+
+    for (ProjectNegotiationData data : negotiation.getProjectNegotiationData()) {
+      String projectName = data.getProjectName();
+      IProject project = workspace.getProject(projectName);
+
+      // TODO: The file path is currently dictated by the name, potentially resulting in CONFLICTS
+      if (!project.exists()) {
+        try {
+          project.adaptTo(ServerProjectImpl.class).create();
+        } catch (IOException e) {
+          negotiation.localCancel(
+              "Error creating project folder", NegotiationTools.CancelOption.NOTIFY_PEER);
+          return;
+        }
+      }
+
+      projectMapping.put(data.getProjectID(), project);
+    }
+
     projectExecutor.execute(
         new Runnable() {
           @Override
           public void run() {
-            negotiation.localCancel(
-                "Server does not accept incoming projects",
-                NegotiationTools.CancelOption.NOTIFY_PEER);
-            negotiation.run(new HashMap<String, IProject>(), new NullProgressMonitor());
+            ProjectNegotiation.Status status;
+            if (ServerConfig.isInteractive()) {
+              status = negotiation.run(projectMapping, new ConsoleProgressIndicator(System.out));
+            } else {
+              status = negotiation.run(projectMapping, new NullProgressMonitor());
+            }
+
+            if (status != ProjectNegotiation.Status.OK)
+              handleErrorStatus(status, negotiation.getErrorMessage(), negotiation.getPeer());
           }
         });
+  }
+
+  private void handleErrorStatus(ProjectNegotiation.Status status, String errorMessage, JID peer) {
+    switch (status) {
+      case ERROR:
+        log.error("ERROR running project negotiation: " + errorMessage);
+        break;
+      case REMOTE_ERROR:
+        log.error(
+            "REMOTE_ERROR running project negotiation: "
+                + errorMessage
+                + " at remote: "
+                + peer.toString());
+        break;
+      case CANCEL:
+        log.info("Project negotiation was cancelled locally");
+        break;
+      case REMOTE_CANCEL:
+        log.info("Project negotiation was cancelled by remote: " + peer.toString());
+        break;
+      default:
+        throw new UnsupportedOperationException(
+            "Unknown ProjectNegotation.Status (" + status + "): " + errorMessage);
+    }
   }
 }


### PR DESCRIPTION
Add support for the server to handle `IncomingProjectNegotiation`s now that #355 has finally landed.

Better check commit separately, first commit adds the new functionality.
Second commit is only cleanup of code using newer Java-Features (lambdas, diamond operator).

There is no code to handle ProjectID conflicts in place, because otherwise sharing projects on a later run would not use files already there, and re-sharing new files, when doing partial shares, would not work as well.

This is an issue for later work on the Server, as it will require some more configuration options.
This is for a first alpha release, which should only be run in trusted environments anyway.