### PR TITLE
[FIX][I] Fix initialization of SessionUtils

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/context/SarosIntellijContextFactory.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/context/SarosIntellijContextFactory.java
@@ -30,6 +30,7 @@ import de.fu_berlin.inf.dpp.intellij.project.filesystem.IntelliJWorkspaceImpl;
 import de.fu_berlin.inf.dpp.intellij.project.filesystem.IntelliJWorkspaceRootImpl;
 import de.fu_berlin.inf.dpp.intellij.project.filesystem.PathFactory;
 import de.fu_berlin.inf.dpp.intellij.runtime.IntelliJSynchronizer;
+import de.fu_berlin.inf.dpp.intellij.session.SessionUtils;
 import de.fu_berlin.inf.dpp.intellij.ui.eventhandler.SessionStatusChangeHandler;
 import de.fu_berlin.inf.dpp.intellij.ui.swt_browser.IntelliJDialogManager;
 import de.fu_berlin.inf.dpp.intellij.ui.swt_browser.IntelliJUIResourceLocator;
@@ -87,6 +88,9 @@ public class SarosIntellijContextFactory extends AbstractContextFactory {
 
       // Proxy Support for the XMPP server connection
       Component.create(IProxyResolver.class, NullProxyResolver.class),
+
+      // Utility
+      Component.create(SessionUtils.class),
     };
   }
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/session/SessionUtils.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/session/SessionUtils.java
@@ -41,6 +41,12 @@ public class SessionUtils {
 
   private static volatile ISarosSession currentSarosSession;
 
+  /**
+   * Initializes the SessionUtils. This is only used as part of the plugin context initialization by
+   * the PicoContainer and should not be called otherwise.
+   *
+   * @param sarosSessionManager the current SarosSessionManager instance
+   */
   public SessionUtils(ISarosSessionManager sarosSessionManager) {
     sarosSessionManager.addSessionLifecycleListener(lifecycleListener);
   }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/session/SessionUtils.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/session/SessionUtils.java
@@ -1,6 +1,5 @@
 package de.fu_berlin.inf.dpp.intellij.session;
 
-import de.fu_berlin.inf.dpp.SarosPluginContext;
 import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
@@ -8,7 +7,6 @@ import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
 import de.fu_berlin.inf.dpp.session.ISessionLifecycleListener;
 import de.fu_berlin.inf.dpp.session.SessionEndReason;
 import org.jetbrains.annotations.NotNull;
-import org.picocontainer.annotations.Inject;
 
 /**
  * A utility class to provide easy access to functionality needing a session object.
@@ -24,31 +22,27 @@ import org.picocontainer.annotations.Inject;
 // separated
 @Deprecated
 public class SessionUtils {
+
+  @SuppressWarnings("FieldCanBeLocal")
+  private ISessionLifecycleListener lifecycleListener =
+      new ISessionLifecycleListener() {
+        @Override
+        public void sessionStarted(ISarosSession session) {
+
+          currentSarosSession = session;
+        }
+
+        @Override
+        public void sessionEnded(ISarosSession session, SessionEndReason reason) {
+
+          currentSarosSession = null;
+        }
+      };
+
   private static volatile ISarosSession currentSarosSession;
 
-  @Inject private static ISarosSessionManager sarosSessionManager;
-
-  static {
-    SarosPluginContext.initComponent(new SessionUtils());
-
-    sarosSessionManager.addSessionLifecycleListener(
-        new ISessionLifecycleListener() {
-          @Override
-          public void sessionStarted(ISarosSession session) {
-
-            currentSarosSession = session;
-          }
-
-          @Override
-          public void sessionEnded(ISarosSession session, SessionEndReason reason) {
-
-            currentSarosSession = null;
-          }
-        });
-  }
-
-  private SessionUtils() {
-    // NOP
+  public SessionUtils(ISarosSessionManager sarosSessionManager) {
+    sarosSessionManager.addSessionLifecycleListener(lifecycleListener);
   }
 
   /**


### PR DESCRIPTION
SessionUtils provides static access to methods to check whether a given
resource is shared. This check provides the current session object (if
existent), which is why it registers an ISarosSessionLifecycleListener
to update the locally held session object when there are any lifecycle
changes.

This listener was registered in a static block, which is problematic as
java uses lazy evaluation for static blocks, meaning they are only
computed once the object is accessed for the first time.
This leads to problems when the object is only first accessed after the
session has already started as the lifecycle listener will only be
registered at this point. In such situation, the SessionUtils object
will not have a session object even though there is currently a running
session, meaning it reports all resources as non-shared. This causes the
local saros instance to not send any activities for shared resources and
to drop most received activities.

This is the cause of the issue #409 as the SessionUtils is called
whenever an editor is opened or during the local session state
initialization if there are open editors. If both was not the case, the
SessionUtils will not have been initialized properly.

Resolves #409.