### PR TITLE
Fix whiteboard NullPointerException 

### DIFF
--- a/de.fu_berlin.inf.dpp.whiteboard/src/de/fu_berlin/inf/dpp/whiteboard/view/SarosWhiteboardView.java
+++ b/de.fu_berlin.inf.dpp.whiteboard/src/de/fu_berlin/inf/dpp/whiteboard/view/SarosWhiteboardView.java
@@ -18,6 +18,7 @@ import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IPersistableElement;
+import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchPartSite;
 import org.eclipse.ui.PartInitException;
@@ -209,7 +210,8 @@ public class SarosWhiteboardView extends ViewPart {
        * ISelection selection).
        */
 
-      if (SarosWhiteboardView.this.equals(getSite().getPage().getActivePart())) {
+      IWorkbenchPage page = getSite().getPage();
+      if (page != null && SarosWhiteboardView.this.equals(page.getActivePart())) {
         updateActions(getSelectionActions());
       }
     }


### PR DESCRIPTION
This should take care of the exception reported in #412. The stack trace indicates that [this specific line](https://github.com/saros-project/saros/blob/91a60b5d4618d589be7c34aafa75b6ffd6dcd896/de.fu_berlin.inf.dpp.whiteboard/src/de/fu_berlin/inf/dpp/whiteboard/view/SarosWhiteboardView.java#L222) was at fault prior to the code reformatting, i.e. the workbench page can be `null`.