### PR TITLE
[RELEASE FIX] Add workaround for project switching

### DIFF
--- a/intellij/src/saros/intellij/IntellijProjectLifecycle.java
+++ b/intellij/src/saros/intellij/IntellijProjectLifecycle.java
@@ -4,10 +4,13 @@ import com.intellij.openapi.project.Project;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import org.apache.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import saros.HTMLUIContextFactory;
 import saros.context.AbstractContextLifecycle;
 import saros.context.IContextFactory;
 import saros.intellij.context.SarosIntellijContextFactory;
+import saros.intellij.project.ProjectWrapper;
 import saros.intellij.ui.swt_browser.SwtLibLoader;
 
 /**
@@ -22,32 +25,48 @@ import saros.intellij.ui.swt_browser.SwtLibLoader;
  * FIXME: Project lifecycle causes serious issues, switch back to application lifecycle and correct the file system implementation as needed !
  */
 public class IntellijProjectLifecycle extends AbstractContextLifecycle {
+  private static final Logger log = Logger.getLogger(IntellijProjectLifecycle.class);
 
   private static IntellijProjectLifecycle instance;
+  private static ProjectWrapper projectWrapper;
 
   /**
-   * Creates a new IntellijProjectLifecycle singleton instance from a project.
+   * Returns the current instance of IntellijProjectLifecycle.
    *
-   * @param project
-   * @return
+   * <p>IntellijProjectLifecycle is singleton, meaning this call will always return the same object.
+   * If a new project object is passed, it will replace the currently held project object in the
+   * plugin context.
+   *
+   * @param project the project object to put into the plugin context
+   * @return the singleton instance of the IntellijProjectLifecycle
    */
-  public static synchronized IntellijProjectLifecycle getInstance(Project project) {
-    instance = new IntellijProjectLifecycle(project);
+  public static synchronized IntellijProjectLifecycle getInstance(@NotNull Project project) {
+    if (instance != null) {
+      if (projectWrapper.getProject().isDisposed()) {
+        log.debug(
+            "Replacing disposed project currently held in plugin context with project "
+                + project.getName());
+
+        projectWrapper.setProject(project);
+      }
+
+    } else {
+      log.debug("Initializing plugin context with project " + project.getName());
+      instance = new IntellijProjectLifecycle(project);
+    }
 
     return instance;
   }
 
-  private Project project;
-
   private IntellijProjectLifecycle(Project project) {
-    this.project = project;
+    projectWrapper = new ProjectWrapper(project);
   }
 
   @Override
   protected Collection<IContextFactory> additionalContextFactories() {
     List<IContextFactory> nonCoreFactories = new ArrayList<>();
 
-    nonCoreFactories.add(new SarosIntellijContextFactory(project));
+    nonCoreFactories.add(new SarosIntellijContextFactory(projectWrapper));
 
     if (SarosComponent.isSwtBrowserEnabled()) {
       SwtLibLoader.loadSwtLib();

--- a/intellij/src/saros/intellij/IntellijProjectLifecycle.java
+++ b/intellij/src/saros/intellij/IntellijProjectLifecycle.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.List;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import saros.HTMLUIContextFactory;
 import saros.context.AbstractContextLifecycle;
 import saros.context.IContextFactory;
@@ -60,6 +61,16 @@ public class IntellijProjectLifecycle extends AbstractContextLifecycle {
 
   private IntellijProjectLifecycle(Project project) {
     projectWrapper = new ProjectWrapper(project);
+  }
+
+  /**
+   * Returns the current project held by the lifecycle.
+   *
+   * @return the current project held by the lifecycle
+   */
+  @Nullable
+  Project getProject() {
+    return projectWrapper.getProject();
   }
 
   @Override

--- a/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
+++ b/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
@@ -1,6 +1,5 @@
 package saros.intellij.context;
 
-import com.intellij.openapi.project.Project;
 import java.util.Arrays;
 import org.picocontainer.BindKey;
 import org.picocontainer.MutablePicoContainer;
@@ -26,6 +25,7 @@ import saros.intellij.editor.ProjectAPI;
 import saros.intellij.negotiation.hooks.ModuleTypeNegotiationHook;
 import saros.intellij.preferences.IntelliJPreferences;
 import saros.intellij.preferences.PropertiesComponentAdapter;
+import saros.intellij.project.ProjectWrapper;
 import saros.intellij.project.filesystem.IntelliJWorkspaceImpl;
 import saros.intellij.project.filesystem.IntelliJWorkspaceRootImpl;
 import saros.intellij.project.filesystem.PathFactory;
@@ -82,10 +82,10 @@ public class SarosIntellijContextFactory extends AbstractContextFactory {
     };
   }
 
-  private Project project;
+  private ProjectWrapper projectWrapper;
 
-  public SarosIntellijContextFactory(Project project) {
-    this.project = project;
+  public SarosIntellijContextFactory(ProjectWrapper projectWrapper) {
+    this.projectWrapper = projectWrapper;
   }
 
   @Override
@@ -94,7 +94,7 @@ public class SarosIntellijContextFactory extends AbstractContextFactory {
     // Saros Core PathIntl Support
     container.addComponent(IPathFactory.class, new PathFactory());
 
-    container.addComponent(Project.class, project);
+    container.addComponent(ProjectWrapper.class, projectWrapper);
     container.addComponent(IWorkspace.class, IntelliJWorkspaceImpl.class);
 
     for (Component component : Arrays.asList(getContextComponents())) {

--- a/intellij/src/saros/intellij/editor/EditorAPI.java
+++ b/intellij/src/saros/intellij/editor/EditorAPI.java
@@ -9,13 +9,13 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.LogicalPosition;
 import com.intellij.openapi.editor.ScrollType;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
 import java.awt.Point;
 import java.awt.Rectangle;
 import org.jetbrains.annotations.NotNull;
 import saros.editor.text.LineRange;
 import saros.intellij.filesystem.Filesystem;
+import saros.intellij.project.ProjectWrapper;
 
 /**
  * IntellJ editor API. An Editor is a window for editing source files.
@@ -27,11 +27,11 @@ public class EditorAPI {
   private Application application;
   private CommandProcessor commandProcessor;
 
-  private Project project;
+  private ProjectWrapper projectWrapper;
 
   /** Creates an EditorAPI with the current Project and initializes Fields. */
-  public EditorAPI(Project project) {
-    this.project = project;
+  public EditorAPI(ProjectWrapper projectWrapper) {
+    this.projectWrapper = projectWrapper;
     this.application = ApplicationManager.getApplication();
     this.commandProcessor = CommandProcessor.getInstance();
   }
@@ -158,7 +158,7 @@ public class EditorAPI {
           String commandName = "Saros text insertion at index " + offset + " of \"" + text + "\"";
 
           commandProcessor.executeCommand(
-              project,
+              projectWrapper.getProject(),
               insertString,
               commandName,
               commandProcessor.getCurrentCommandGroupId(),
@@ -185,7 +185,7 @@ public class EditorAPI {
           String commandName = "Saros text deletion from index " + start + " to " + end;
 
           commandProcessor.executeCommand(
-              project,
+              projectWrapper.getProject(),
               deleteRange,
               commandName,
               commandProcessor.getCurrentCommandGroupId(),

--- a/intellij/src/saros/intellij/editor/ProjectAPI.java
+++ b/intellij/src/saros/intellij/editor/ProjectAPI.java
@@ -4,27 +4,24 @@ import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
-import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.OpenFileDescriptor;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import saros.intellij.filesystem.Filesystem;
+import saros.intellij.project.ProjectWrapper;
 
 /** IntellIJ API for project-level operations on editors and documents. */
 public class ProjectAPI {
   private FileDocumentManager fileDocumentManager;
 
-  private Project project;
-  private FileEditorManager editorFileManager;
+  private ProjectWrapper projectWrapper;
 
   /** Creates an ProjectAPI with the current Project and initializes Fields. */
-  public ProjectAPI(Project project) {
-    this.project = project;
+  public ProjectAPI(ProjectWrapper projectWrapper) {
+    this.projectWrapper = projectWrapper;
 
-    this.editorFileManager = FileEditorManager.getInstance(project);
     this.fileDocumentManager = FileDocumentManager.getInstance();
   }
 
@@ -35,7 +32,7 @@ public class ProjectAPI {
    * @return
    */
   public boolean isOpen(VirtualFile file) {
-    return editorFileManager.isFileOpen(file);
+    return projectWrapper.getFileEditorManager().isFileOpen(file);
   }
 
   /**
@@ -62,8 +59,10 @@ public class ProjectAPI {
 
           @Override
           public Editor compute() {
-            return editorFileManager.openTextEditor(
-                new OpenFileDescriptor(project, path), activate);
+            return projectWrapper
+                .getFileEditorManager()
+                .openTextEditor(
+                    new OpenFileDescriptor(projectWrapper.getProject(), path), activate);
           }
         });
   }
@@ -103,7 +102,7 @@ public class ProjectAPI {
 
           @Override
           public void run() {
-            editorFileManager.closeFile(file);
+            projectWrapper.getFileEditorManager().closeFile(file);
           }
         });
   }
@@ -120,11 +119,11 @@ public class ProjectAPI {
    * @return
    */
   public VirtualFile[] getOpenFiles() {
-    return editorFileManager.getOpenFiles();
+    return projectWrapper.getFileEditorManager().getOpenFiles();
   }
 
   public Editor getActiveEditor() {
-    return editorFileManager.getSelectedTextEditor();
+    return projectWrapper.getFileEditorManager().getSelectedTextEditor();
   }
 
   /**
@@ -134,7 +133,7 @@ public class ProjectAPI {
    * @return
    */
   public VirtualFile[] getSelectedFiles() {
-    return editorFileManager.getSelectedFiles();
+    return projectWrapper.getFileEditorManager().getSelectedFiles();
   }
 
   /**

--- a/intellij/src/saros/intellij/eventhandler/editor/editorstate/AbstractLocalEditorStatusChangeHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/editorstate/AbstractLocalEditorStatusChangeHandler.java
@@ -1,11 +1,11 @@
 package saros.intellij.eventhandler.editor.editorstate;
 
-import com.intellij.openapi.project.Project;
 import com.intellij.util.messages.MessageBusConnection;
 import com.intellij.util.messages.Topic;
 import org.jetbrains.annotations.NotNull;
 import org.picocontainer.Startable;
 import saros.intellij.eventhandler.DisableableHandler;
+import saros.intellij.project.ProjectWrapper;
 
 /**
  * Abstract class defining the base functionality needed to create and register/unregister a
@@ -23,7 +23,7 @@ import saros.intellij.eventhandler.DisableableHandler;
 public abstract class AbstractLocalEditorStatusChangeHandler
     implements DisableableHandler, Startable {
 
-  private final Project project;
+  private final ProjectWrapper projectWrapper;
 
   private boolean enabled;
   private boolean disposed;
@@ -34,10 +34,10 @@ public abstract class AbstractLocalEditorStatusChangeHandler
    * Abstract class for local editor status change handlers. The handler is enabled by default and
    * the listeners are also registered by default.
    *
-   * @param project the current Intellij project instance
+   * @param projectWrapper the current Intellij project wrapper instance
    */
-  AbstractLocalEditorStatusChangeHandler(Project project) {
-    this.project = project;
+  AbstractLocalEditorStatusChangeHandler(ProjectWrapper projectWrapper) {
+    this.projectWrapper = projectWrapper;
 
     this.enabled = false;
     this.disposed = false;
@@ -59,7 +59,7 @@ public abstract class AbstractLocalEditorStatusChangeHandler
    * #registerListeners(MessageBusConnection)} to register any needed handlers.
    */
   private void subscribe() {
-    messageBusConnection = project.getMessageBus().connect();
+    messageBusConnection = projectWrapper.getProject().getMessageBus().connect();
 
     registerListeners(messageBusConnection);
   }

--- a/intellij/src/saros/intellij/eventhandler/editor/editorstate/AnnotationUpdater.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/editorstate/AnnotationUpdater.java
@@ -3,7 +3,6 @@ package saros.intellij.eventhandler.editor.editorstate;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.FileEditorManagerListener;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.messages.MessageBusConnection;
 import org.jetbrains.annotations.NotNull;
@@ -12,6 +11,7 @@ import saros.filesystem.IFile;
 import saros.intellij.editor.LocalEditorHandler;
 import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.filesystem.VirtualFileConverter;
+import saros.intellij.project.ProjectWrapper;
 import saros.session.ISarosSession;
 
 /**
@@ -46,12 +46,12 @@ public class AnnotationUpdater extends AbstractLocalEditorStatusChangeHandler {
       };
 
   public AnnotationUpdater(
-      Project project,
+      ProjectWrapper projectWrapper,
       AnnotationManager annotationManager,
       LocalEditorHandler localEditorHandler,
       ISarosSession sarosSession) {
 
-    super(project);
+    super(projectWrapper);
 
     this.annotationManager = annotationManager;
     this.localEditorHandler = localEditorHandler;

--- a/intellij/src/saros/intellij/eventhandler/editor/editorstate/EditorStatusChangeActivityDispatcher.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/editorstate/EditorStatusChangeActivityDispatcher.java
@@ -3,11 +3,11 @@ package saros.intellij.eventhandler.editor.editorstate;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent;
 import com.intellij.openapi.fileEditor.FileEditorManagerListener;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.messages.MessageBusConnection;
 import org.jetbrains.annotations.NotNull;
 import saros.intellij.editor.LocalEditorHandler;
+import saros.intellij.project.ProjectWrapper;
 
 /**
  * Dispatches matching editor activities when an editor for a shared file is opened/selected or
@@ -35,9 +35,9 @@ public class EditorStatusChangeActivityDispatcher extends AbstractLocalEditorSta
       };
 
   public EditorStatusChangeActivityDispatcher(
-      Project project, LocalEditorHandler localEditorHandler) {
+      ProjectWrapper projectWrapper, LocalEditorHandler localEditorHandler) {
 
-    super(project);
+    super(projectWrapper);
 
     this.localEditorHandler = localEditorHandler;
 

--- a/intellij/src/saros/intellij/eventhandler/editor/editorstate/PreexistingSelectionDispatcher.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/editorstate/PreexistingSelectionDispatcher.java
@@ -3,7 +3,6 @@ package saros.intellij.eventhandler.editor.editorstate;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.FileEditorManagerListener;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.messages.MessageBusConnection;
 import org.jetbrains.annotations.NotNull;
@@ -11,6 +10,7 @@ import saros.activities.SPath;
 import saros.intellij.editor.EditorManager;
 import saros.intellij.editor.LocalEditorHandler;
 import saros.intellij.filesystem.VirtualFileConverter;
+import saros.intellij.project.ProjectWrapper;
 import saros.session.ISarosSession;
 
 /**
@@ -39,12 +39,12 @@ public class PreexistingSelectionDispatcher extends AbstractLocalEditorStatusCha
       };
 
   public PreexistingSelectionDispatcher(
-      Project project,
+      ProjectWrapper projectWrapper,
       EditorManager editorManager,
       LocalEditorHandler localEditorHandler,
       ISarosSession sarosSession) {
 
-    super(project);
+    super(projectWrapper);
 
     this.editorManager = editorManager;
     this.localEditorHandler = localEditorHandler;

--- a/intellij/src/saros/intellij/eventhandler/editor/editorstate/ViewportAdjustmentExecutor.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/editorstate/ViewportAdjustmentExecutor.java
@@ -4,7 +4,6 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent;
 import com.intellij.openapi.fileEditor.FileEditorManagerListener;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.messages.MessageBusConnection;
 import java.util.HashMap;
@@ -15,6 +14,7 @@ import saros.editor.text.LineRange;
 import saros.editor.text.TextSelection;
 import saros.intellij.editor.LocalEditorManipulator;
 import saros.intellij.editor.ProjectAPI;
+import saros.intellij.project.ProjectWrapper;
 
 /**
  * Queues viewport adjustments for editors that are not currently visible and executes the queued
@@ -37,9 +37,11 @@ public class ViewportAdjustmentExecutor extends AbstractLocalEditorStatusChangeH
       };
 
   public ViewportAdjustmentExecutor(
-      Project project, ProjectAPI projectAPI, LocalEditorManipulator localEditorManipulator) {
+      ProjectWrapper projectWrapper,
+      ProjectAPI projectAPI,
+      LocalEditorManipulator localEditorManipulator) {
 
-    super(project);
+    super(projectWrapper);
 
     this.projectAPI = projectAPI;
     this.localEditorManipulator = localEditorManipulator;

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -6,7 +6,6 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtil;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ContentIterator;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtilCore;
@@ -41,6 +40,7 @@ import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.eventhandler.DisableableHandler;
 import saros.intellij.eventhandler.editor.document.LocalDocumentModificationHandler;
 import saros.intellij.filesystem.VirtualFileConverter;
+import saros.intellij.project.ProjectWrapper;
 import saros.intellij.project.filesystem.IntelliJPathImpl;
 import saros.observables.FileReplacementInProgressObservable;
 import saros.session.AbstractActivityProducer;
@@ -65,7 +65,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
   private final FileReplacementInProgressObservable fileReplacementInProgressObservable;
   private final ProjectAPI projectAPI;
   private final AnnotationManager annotationManager;
-  private final Project project;
+  private final ProjectWrapper projectWrapper;
   private final LocalEditorHandler localEditorHandler;
 
   private boolean enabled;
@@ -170,7 +170,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
       FileReplacementInProgressObservable fileReplacementInProgressObservable,
       ProjectAPI projectAPI,
       AnnotationManager annotationManager,
-      Project project,
+      ProjectWrapper projectWrapper,
       LocalEditorHandler localEditorHandler) {
 
     this.editorManager = editorManager;
@@ -178,7 +178,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
     this.fileReplacementInProgressObservable = fileReplacementInProgressObservable;
     this.projectAPI = projectAPI;
     this.annotationManager = annotationManager;
-    this.project = project;
+    this.projectWrapper = projectWrapper;
     this.localEditorHandler = localEditorHandler;
 
     this.enabled = false;
@@ -502,8 +502,8 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
      */
     VirtualFileFilter virtualFileFilter =
         file -> {
-          Module baseModule = ModuleUtil.findModuleForFile(oldFile, project);
-          Module module = ModuleUtil.findModuleForFile(file, project);
+          Module baseModule = ModuleUtil.findModuleForFile(oldFile, projectWrapper.getProject());
+          Module module = ModuleUtil.findModuleForFile(file, projectWrapper.getProject());
 
           return baseModule != null && baseModule.equals(module);
         };

--- a/intellij/src/saros/intellij/filesystem/VirtualFileConverter.java
+++ b/intellij/src/saros/intellij/filesystem/VirtualFileConverter.java
@@ -2,7 +2,6 @@ package saros.intellij.filesystem;
 
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtil;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -12,6 +11,7 @@ import saros.SarosPluginContext;
 import saros.activities.SPath;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
+import saros.intellij.project.ProjectWrapper;
 
 /**
  * Provides static methods to convert VirtualFiles to Saros resource objects or Saros resources
@@ -21,7 +21,7 @@ public class VirtualFileConverter {
 
   private static final Logger log = Logger.getLogger(VirtualFileConverter.class);
 
-  @Inject private static Project project;
+  @Inject private static ProjectWrapper projectWrapper;
 
   static {
     SarosPluginContext.initComponent(new VirtualFileConverter());
@@ -60,7 +60,7 @@ public class VirtualFileConverter {
   @Nullable
   public static IResource convertToResource(@NotNull VirtualFile virtualFile) {
 
-    Module module = ModuleUtil.findModuleForFile(virtualFile, project);
+    Module module = ModuleUtil.findModuleForFile(virtualFile, projectWrapper.getProject());
 
     if (module == null) {
       log.debug(

--- a/intellij/src/saros/intellij/project/ProjectWrapper.java
+++ b/intellij/src/saros/intellij/project/ProjectWrapper.java
@@ -1,0 +1,61 @@
+package saros.intellij.project;
+
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Wraps the project instance held by the plugin context. This is done to abstract from the specific
+ * project object that is used as it can change when the user switches Intellij projects. For
+ * convenience' sake, this also wraps the access to the FileEditorManager as it is dependent on the
+ * project current object.
+ *
+ * <p><b>NOTE:</b> To avoid accessing disposed project objects, the project object returned by this
+ * class should not be stored in long-term data structures by the caller.
+ */
+public class ProjectWrapper {
+
+  private Project project;
+  private FileEditorManager fileEditorManager;
+
+  /**
+   * Instantiates a project wrapper with the given project.
+   *
+   * @param project the current Project object
+   */
+  public ProjectWrapper(@NotNull Project project) {
+    setProject(project);
+  }
+
+  /**
+   * Returns the current <code>Project</code> object.
+   *
+   * @return the current Project object
+   */
+  @NotNull
+  public synchronized Project getProject() {
+    return project;
+  }
+
+  /**
+   * Replaces the held <code>Project</code> object with the passed object. Subsequently updates all
+   * held objects dependent on the project.
+   *
+   * @param project the new <code>Project</code> object
+   */
+  public synchronized void setProject(@NotNull Project project) {
+    this.project = project;
+
+    this.fileEditorManager = FileEditorManager.getInstance(project);
+  }
+
+  /**
+   * Returns the current <code>FileEditorManager</code> object.
+   *
+   * @return the current <code>FileEditorManager</code> object
+   */
+  @NotNull
+  public synchronized FileEditorManager getFileEditorManager() {
+    return fileEditorManager;
+  }
+}

--- a/intellij/src/saros/intellij/project/filesystem/IntelliJWorkspaceImpl.java
+++ b/intellij/src/saros/intellij/project/filesystem/IntelliJWorkspaceImpl.java
@@ -2,7 +2,6 @@ package saros.intellij.project.filesystem;
 
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Computable;
 import java.io.IOException;
 import org.apache.log4j.Logger;
@@ -14,15 +13,16 @@ import saros.filesystem.IWorkspace;
 import saros.filesystem.IWorkspaceRunnable;
 import saros.intellij.filesystem.Filesystem;
 import saros.intellij.filesystem.IntelliJProjectImpl;
+import saros.intellij.project.ProjectWrapper;
 import saros.monitoring.NullProgressMonitor;
 
 public class IntelliJWorkspaceImpl implements IWorkspace {
   public static final Logger LOG = Logger.getLogger(IntelliJWorkspaceImpl.class);
 
-  private Project project;
+  private final ProjectWrapper projectWrapper;
 
-  public IntelliJWorkspaceImpl(Project project) {
-    this.project = project;
+  public IntelliJWorkspaceImpl(ProjectWrapper projectWrapper) {
+    this.projectWrapper = projectWrapper;
   }
 
   @Override
@@ -43,7 +43,8 @@ public class IntelliJWorkspaceImpl implements IWorkspace {
             new Computable<Module>() {
               @Override
               public Module compute() {
-                return ModuleManager.getInstance(project).findModuleByName(moduleName);
+                return ModuleManager.getInstance(projectWrapper.getProject())
+                    .findModuleByName(moduleName);
               }
             });
 
@@ -52,6 +53,6 @@ public class IntelliJWorkspaceImpl implements IWorkspace {
 
   @Override
   public IPath getLocation() {
-    return IntelliJPathImpl.fromString(project.getBasePath());
+    return IntelliJPathImpl.fromString(projectWrapper.getProject().getBasePath());
   }
 }

--- a/intellij/src/saros/intellij/ui/actions/AbstractSarosAction.java
+++ b/intellij/src/saros/intellij/ui/actions/AbstractSarosAction.java
@@ -1,6 +1,5 @@
 package saros.intellij.ui.actions;
 
-import com.intellij.openapi.project.Project;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
@@ -8,6 +7,7 @@ import java.util.List;
 import org.apache.log4j.Logger;
 import org.picocontainer.annotations.Inject;
 import saros.SarosPluginContext;
+import saros.intellij.project.ProjectWrapper;
 
 /** Parent class for all Saros actions */
 public abstract class AbstractSarosAction {
@@ -15,7 +15,7 @@ public abstract class AbstractSarosAction {
 
   private final List<ActionListener> actionListeners = new ArrayList<ActionListener>();
 
-  @Inject protected Project project;
+  @Inject protected ProjectWrapper projectWrapper;
 
   protected AbstractSarosAction() {
     SarosPluginContext.initComponent(this);

--- a/intellij/src/saros/intellij/ui/actions/ConnectServerAction.java
+++ b/intellij/src/saros/intellij/ui/actions/ConnectServerAction.java
@@ -46,7 +46,7 @@ public class ConnectServerAction extends AbstractSarosAction {
     // AnActionEvent.getDataContext().getData(DataConstants.PROJECT)
     ProgressManager.getInstance()
         .run(
-            new Task.Modal(project, "Connecting...", false) {
+            new Task.Modal(projectWrapper.getProject(), "Connecting...", false) {
 
               @Override
               public void run(ProgressIndicator indicator) {

--- a/intellij/src/saros/intellij/ui/actions/DisconnectServerAction.java
+++ b/intellij/src/saros/intellij/ui/actions/DisconnectServerAction.java
@@ -24,7 +24,7 @@ public class DisconnectServerAction extends AbstractSarosAction {
     // AnActionEvent.getDataContext().getData(DataConstants.PROJECT)
     ProgressManager.getInstance()
         .run(
-            new Task.Modal(project, "Disconnecting...", false) {
+            new Task.Modal(projectWrapper.getProject(), "Disconnecting...", false) {
 
               @Override
               public void run(ProgressIndicator indicator) {

--- a/intellij/src/saros/intellij/ui/swt_browser/IntelliJDialogManager.java
+++ b/intellij/src/saros/intellij/ui/swt_browser/IntelliJDialogManager.java
@@ -1,11 +1,11 @@
 package saros.intellij.ui.swt_browser;
 
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.WindowManager;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
+import saros.intellij.project.ProjectWrapper;
 import saros.synchronize.UISynchronizer;
 import saros.ui.ide_embedding.DialogManager;
 import saros.ui.ide_embedding.IBrowserDialog;
@@ -14,17 +14,17 @@ import saros.ui.pages.IBrowserPage;
 /** Implements the dialog manager for the IntelliJ platform. */
 public class IntelliJDialogManager extends DialogManager {
 
-  private Project project;
+  private ProjectWrapper projectWrapper;
 
-  public IntelliJDialogManager(UISynchronizer uiSynchronizer, Project project) {
+  public IntelliJDialogManager(UISynchronizer uiSynchronizer, ProjectWrapper projectWrapper) {
     super(uiSynchronizer);
 
-    this.project = project;
+    this.projectWrapper = projectWrapper;
   }
 
   @Override
   protected IBrowserDialog createDialog(final IBrowserPage startPage) {
-    JFrame parent = WindowManager.getInstance().getFrame(project);
+    JFrame parent = WindowManager.getInstance().getFrame(projectWrapper.getProject());
     JDialog jDialog = new JDialog(parent);
     jDialog.addWindowListener(
         new WindowAdapter() {

--- a/intellij/src/saros/intellij/ui/tree/ContactPopMenu.java
+++ b/intellij/src/saros/intellij/ui/tree/ContactPopMenu.java
@@ -2,7 +2,6 @@ package saros.intellij.ui.tree;
 
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
-import com.intellij.openapi.project.Project;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.text.MessageFormat;
@@ -20,6 +19,7 @@ import saros.core.ui.util.CollaborationUtils;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
 import saros.filesystem.IWorkspace;
+import saros.intellij.project.ProjectWrapper;
 import saros.intellij.ui.Messages;
 import saros.intellij.ui.util.IconManager;
 import saros.intellij.ui.util.NotificationPanel;
@@ -34,17 +34,17 @@ class ContactPopMenu extends JPopupMenu {
 
   @Inject private IWorkspace workspace;
 
-  @Inject private Project project;
+  @Inject private ProjectWrapper projectWrapper;
 
   private final ContactTreeRootNode.ContactInfo contactInfo;
 
   ContactPopMenu(ContactTreeRootNode.ContactInfo contactInfo) {
     this.contactInfo = contactInfo;
 
-    if (workspace == null || project == null) {
+    if (workspace == null || projectWrapper == null) {
       SarosPluginContext.initComponent(this);
 
-      if (workspace == null || project == null) {
+      if (workspace == null || projectWrapper == null) {
         LOG.error("PicoContainer injection failed. Objects still not present after injection.");
 
         return;
@@ -54,7 +54,7 @@ class ContactPopMenu extends JPopupMenu {
     JMenu menuShareProject = new JMenu("Work together on...");
     menuShareProject.setIcon(IconManager.SESSIONS_ICON);
 
-    ModuleManager moduleManager = ModuleManager.getInstance(project);
+    ModuleManager moduleManager = ModuleManager.getInstance(projectWrapper.getProject());
 
     if (moduleManager == null) {
 
@@ -73,7 +73,7 @@ class ContactPopMenu extends JPopupMenu {
     for (Module module : moduleManager.getModules()) {
       String moduleName = module.getName();
 
-      if (project.getName().equalsIgnoreCase(moduleName)) {
+      if (projectWrapper.getProject().getName().equalsIgnoreCase(moduleName)) {
         continue;
       }
 

--- a/intellij/src/saros/intellij/ui/util/DialogUtils.java
+++ b/intellij/src/saros/intellij/ui/util/DialogUtils.java
@@ -1,6 +1,5 @@
 package saros.intellij.ui.util;
 
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.WindowManager;
 import java.awt.Component;
 import java.awt.Container;
@@ -8,12 +7,13 @@ import javax.swing.JOptionPane;
 import org.apache.log4j.Logger;
 import org.picocontainer.annotations.Inject;
 import saros.SarosPluginContext;
+import saros.intellij.project.ProjectWrapper;
 
 /** Dialog message helper that shows Dialogs in the current Thread. */
 public class DialogUtils {
   private static final Logger LOG = Logger.getLogger(DialogUtils.class);
 
-  @Inject private static Project project;
+  @Inject private static ProjectWrapper projectWrapper;
 
   private DialogUtils() {}
 
@@ -92,6 +92,8 @@ public class DialogUtils {
   }
 
   private static Component notNullOrDefaultParent(Component parent) {
-    return parent != null ? parent : WindowManager.getInstance().getFrame(project);
+    return parent != null
+        ? parent
+        : WindowManager.getInstance().getFrame(projectWrapper.getProject());
   }
 }

--- a/intellij/src/saros/intellij/ui/util/NotificationPanel.java
+++ b/intellij/src/saros/intellij/ui/util/NotificationPanel.java
@@ -7,10 +7,10 @@ import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.project.Project;
 import org.apache.log4j.Logger;
 import org.picocontainer.annotations.Inject;
 import saros.SarosPluginContext;
+import saros.intellij.project.ProjectWrapper;
 
 /** Class uses IntelliJ API to show notifications */
 public class NotificationPanel {
@@ -22,7 +22,7 @@ public class NotificationPanel {
   private static final NotificationListener.UrlOpeningListener URL_OPENING_LISTENER =
       new NotificationListener.UrlOpeningListener(false);
 
-  @Inject private static Project project;
+  @Inject private static ProjectWrapper projectWrapper;
 
   static {
     SarosPluginContext.initComponent(new NotificationPanel());
@@ -57,7 +57,7 @@ public class NotificationPanel {
             new Runnable() {
               @Override
               public void run() {
-                Notifications.Bus.notify(notification, project);
+                Notifications.Bus.notify(notification, projectWrapper.getProject());
               }
             });
   }

--- a/intellij/src/saros/intellij/ui/util/NotificationPanel.java
+++ b/intellij/src/saros/intellij/ui/util/NotificationPanel.java
@@ -7,7 +7,9 @@ import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
 import org.apache.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import org.picocontainer.annotations.Inject;
 import saros.SarosPluginContext;
 import saros.intellij.project.ProjectWrapper;
@@ -93,5 +95,28 @@ public class NotificationPanel {
    */
   public static void showError(String message, String title) {
     showNotification(NotificationType.ERROR, message, title);
+  }
+
+  public static void showProjectSpecificWarning(
+      @NotNull Project project, @NotNull String message, @NotNull String title) {
+
+    NotificationType notificationType = NotificationType.WARNING;
+
+    LOG.info(
+        "Showing notification in project "
+            + project
+            + " - "
+            + notificationType
+            + ": "
+            + title
+            + " - "
+            + message);
+
+    final Notification notification =
+        GROUP_DISPLAY_ID_INFO.createNotification(
+            title, message, notificationType, URL_OPENING_LISTENER);
+
+    ApplicationManager.getApplication()
+        .invokeLater(() -> Notifications.Bus.notify(notification, project));
   }
 }

--- a/intellij/src/saros/intellij/ui/util/SafeDialogUtils.java
+++ b/intellij/src/saros/intellij/ui/util/SafeDialogUtils.java
@@ -3,7 +3,6 @@ package saros.intellij.ui.util;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import java.awt.Component;
 import java.util.concurrent.atomic.AtomicReference;
@@ -11,6 +10,7 @@ import org.apache.log4j.Logger;
 import org.picocontainer.annotations.Inject;
 import saros.SarosPluginContext;
 import saros.exceptions.IllegalAWTContextException;
+import saros.intellij.project.ProjectWrapper;
 
 /**
  * Dialog helper used to show messages in safe manner by starting it on the AWT event dispatcher
@@ -30,7 +30,7 @@ public class SafeDialogUtils {
 
   private static final Application application;
 
-  @Inject private static Project project;
+  @Inject private static ProjectWrapper projectWrapper;
 
   static {
     application = ApplicationManager.getApplication();
@@ -69,7 +69,12 @@ public class SafeDialogUtils {
           public void run() {
             String option =
                 Messages.showInputDialog(
-                    project, message, title, Messages.getQuestionIcon(), initialValue, null);
+                    projectWrapper.getProject(),
+                    message,
+                    title,
+                    Messages.getQuestionIcon(),
+                    initialValue,
+                    null);
             if (option != null) {
               response.set(option);
             }
@@ -87,7 +92,7 @@ public class SafeDialogUtils {
         new Runnable() {
           @Override
           public void run() {
-            Messages.showWarningDialog(project, message, title);
+            Messages.showWarningDialog(projectWrapper.getProject(), message, title);
           }
         },
         ModalityState.defaultModalityState());
@@ -100,7 +105,7 @@ public class SafeDialogUtils {
         new Runnable() {
           @Override
           public void run() {
-            Messages.showErrorDialog(project, message, title);
+            Messages.showErrorDialog(projectWrapper.getProject(), message, title);
           }
         },
         ModalityState.defaultModalityState());
@@ -146,7 +151,8 @@ public class SafeDialogUtils {
     application.invokeAndWait(
         () -> {
           String option =
-              Messages.showPasswordDialog(project, message, title, Messages.getQuestionIcon());
+              Messages.showPasswordDialog(
+                  projectWrapper.getProject(), message, title, Messages.getQuestionIcon());
 
           if (option != null) {
             response.set(option);
@@ -180,7 +186,8 @@ public class SafeDialogUtils {
     application.invokeAndWait(
         () -> {
           Integer option =
-              Messages.showYesNoDialog(project, message, title, Messages.getQuestionIcon());
+              Messages.showYesNoDialog(
+                  projectWrapper.getProject(), message, title, Messages.getQuestionIcon());
 
           response.set(option);
         },

--- a/intellij/src/saros/intellij/ui/widgets/progress/ProgressFrame.java
+++ b/intellij/src/saros/intellij/ui/widgets/progress/ProgressFrame.java
@@ -1,6 +1,5 @@
 package saros.intellij.ui.widgets.progress;
 
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.WindowManager;
 import java.awt.Container;
 import java.awt.event.ActionEvent;
@@ -11,6 +10,7 @@ import javax.swing.JLabel;
 import javax.swing.JProgressBar;
 import org.picocontainer.annotations.Inject;
 import saros.SarosPluginContext;
+import saros.intellij.project.ProjectWrapper;
 import saros.monitoring.IProgressMonitor;
 
 /** Creates independent progress monitor window */
@@ -22,7 +22,7 @@ public class ProgressFrame implements IProgressMonitor {
 
   private MonitorProgressBar monitorProgressBar;
 
-  @Inject private Project project;
+  @Inject private ProjectWrapper projectWrapper;
 
   private JFrame frmMain;
   private JButton btnCancel;
@@ -42,7 +42,8 @@ public class ProgressFrame implements IProgressMonitor {
 
     frmMain = new JFrame(title);
     frmMain.setSize(300, 160);
-    frmMain.setLocationRelativeTo(WindowManager.getInstance().getFrame(project));
+    frmMain.setLocationRelativeTo(
+        WindowManager.getInstance().getFrame(projectWrapper.getProject()));
 
     Container pane = frmMain.getContentPane();
     pane.setLayout(null);

--- a/intellij/src/saros/intellij/ui/wizards/AddProjectToSessionWizard.java
+++ b/intellij/src/saros/intellij/ui/wizards/AddProjectToSessionWizard.java
@@ -285,7 +285,7 @@ public class AddProjectToSessionWizard extends Wizard {
   private Module createModuleStub(@NotNull final String moduleName)
       throws IOException, ModuleWithNameAlreadyExists {
 
-    for (Module module : ModuleManager.getInstance(project).getModules()) {
+    for (Module module : ModuleManager.getInstance(projectWrapper.getProject()).getModules()) {
       if (moduleName.equals(module.getName()))
         throw new ModuleWithNameAlreadyExists(
             "Could not create stub module as a module with the chosen name already exists",
@@ -298,11 +298,13 @@ public class AddProjectToSessionWizard extends Wizard {
 
               @Override
               public Module compute() throws IOException {
-                VirtualFile baseDir = project.getBaseDir();
+                VirtualFile baseDir = projectWrapper.getProject().getBaseDir();
 
                 if (baseDir == null) {
                   throw new FileNotFoundException(
-                      "Could not find base directory for project " + project + ".");
+                      "Could not find base directory for project "
+                          + projectWrapper.getProject()
+                          + ".");
                 }
 
                 Path moduleBasePath = Paths.get(baseDir.getPath()).resolve(moduleName);
@@ -311,14 +313,14 @@ public class AddProjectToSessionWizard extends Wizard {
                     moduleBasePath.resolve(moduleName + ModuleFileType.DOT_DEFAULT_EXTENSION);
 
                 ModifiableModuleModel modifiableModuleModel =
-                    ModuleManager.getInstance(project).getModifiableModel();
+                    ModuleManager.getInstance(projectWrapper.getProject()).getModifiableModel();
 
                 Module module =
                     modifiableModuleModel.newModule(
                         moduleFilePath.toString(), IntelliJProjectImpl.RELOAD_STUB_MODULE_TYPE);
 
                 modifiableModuleModel.commit();
-                project.save();
+                projectWrapper.getProject().save();
 
                 ModifiableRootModel modifiableRootModel =
                     ModuleRootManager.getInstance(module).getModifiableModel();
@@ -469,7 +471,10 @@ public class AddProjectToSessionWizard extends Wizard {
     ProgressManager.getInstance()
         .run(
             new Task.Backgroundable(
-                project, "Sharing project...", true, PerformInBackgroundOption.DEAF) {
+                projectWrapper.getProject(),
+                "Sharing project...",
+                true,
+                PerformInBackgroundOption.DEAF) {
 
               @Override
               public void run(ProgressIndicator indicator) {

--- a/intellij/src/saros/intellij/ui/wizards/Wizard.java
+++ b/intellij/src/saros/intellij/ui/wizards/Wizard.java
@@ -3,7 +3,6 @@ package saros.intellij.ui.wizards;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
-import com.intellij.openapi.project.Project;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Dimension;
@@ -21,6 +20,7 @@ import javax.swing.border.EmptyBorder;
 import org.jetbrains.annotations.NotNull;
 import org.picocontainer.annotations.Inject;
 import saros.SarosPluginContext;
+import saros.intellij.project.ProjectWrapper;
 import saros.intellij.ui.wizards.pages.AbstractWizardPage;
 import saros.intellij.ui.wizards.pages.HeaderPanel;
 import saros.intellij.ui.wizards.pages.NavigationPanel;
@@ -71,7 +71,7 @@ public abstract class Wizard extends JDialog {
 
   private final NavigationPanel navigationPanel;
 
-  @Inject protected Project project;
+  @Inject protected ProjectWrapper projectWrapper;
 
   /**
    * Constructor creates wizard structure.
@@ -174,7 +174,7 @@ public abstract class Wizard extends JDialog {
   public void runTask(final Runnable runnable, String title) {
     ProgressManager.getInstance()
         .run(
-            new Task.Modal(project, title, false) {
+            new Task.Modal(projectWrapper.getProject(), title, false) {
 
               @Override
               public void run(@NotNull ProgressIndicator indicator) {

--- a/intellij/src/saros/intellij/ui/wizards/pages/SelectProjectPage.java
+++ b/intellij/src/saros/intellij/ui/wizards/pages/SelectProjectPage.java
@@ -2,7 +2,6 @@ package saros.intellij.ui.wizards.pages;
 
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
-import com.intellij.openapi.project.Project;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -23,6 +22,7 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import org.picocontainer.annotations.Inject;
 import saros.SarosPluginContext;
+import saros.intellij.project.ProjectWrapper;
 import saros.intellij.ui.Messages;
 
 /** Selects local project. FIXME: Add tabs for multiple projects. */
@@ -79,7 +79,7 @@ public class SelectProjectPage extends AbstractWizardPage {
   private JLabel lblNewProject;
   private JLabel lblExistingProject;
 
-  @Inject private transient Project project;
+  @Inject private transient ProjectWrapper projectWrapper;
 
   public SelectProjectPage(
       String id,
@@ -218,7 +218,7 @@ public class SelectProjectPage extends AbstractWizardPage {
         };
     browseButton.addActionListener(browseListener);
 
-    ModuleManager moduleManager = ModuleManager.getInstance(project);
+    ModuleManager moduleManager = ModuleManager.getInstance(projectWrapper.getProject());
 
     Optional<Module> module =
         Arrays.stream(moduleManager.getModules())

--- a/intellij/test/junit/saros/intellij/context/SarosIntellijContextFactoryTest.java
+++ b/intellij/test/junit/saros/intellij/context/SarosIntellijContextFactoryTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.powermock.core.classloader.annotations.MockPolicy;
 import saros.context.CoreContextFactory;
 import saros.context.IContextFactory;
+import saros.intellij.project.ProjectWrapper;
 import saros.test.mocks.ContextMocker;
 import saros.test.mocks.PrepareCoreComponents;
 
@@ -24,7 +25,7 @@ public class SarosIntellijContextFactoryTest extends AbstractContextTest {
 
   @Test
   public void testCreateComponents() {
-    IContextFactory factory = new SarosIntellijContextFactory(project);
+    IContextFactory factory = new SarosIntellijContextFactory(new ProjectWrapper(project));
 
     factory.createComponents(container);
     container.start();

--- a/intellij/test/junit/saros/intellij/context/SarosIntellijContextTest.java
+++ b/intellij/test/junit/saros/intellij/context/SarosIntellijContextTest.java
@@ -9,6 +9,7 @@ import saros.HTMLUIContextFactory;
 import saros.context.CoreContextFactory;
 import saros.context.IContainerContext;
 import saros.context.IContextFactory;
+import saros.intellij.project.ProjectWrapper;
 import saros.test.mocks.ContextMocker;
 
 /** Checks the Saros/I context for integrity. */
@@ -27,7 +28,7 @@ public class SarosIntellijContextTest extends AbstractContextTest {
   public void createComponentsWithoutSWT() {
     List<IContextFactory> factories = new ArrayList<>();
 
-    factories.add(new SarosIntellijContextFactory(project));
+    factories.add(new SarosIntellijContextFactory(new ProjectWrapper(project)));
     factories.add(new CoreContextFactory());
 
     for (IContextFactory factory : factories) {
@@ -43,7 +44,7 @@ public class SarosIntellijContextTest extends AbstractContextTest {
   public void createComponentsWithSWT() {
     List<IContextFactory> factories = new ArrayList<>();
 
-    factories.add(new SarosIntellijContextFactory(project));
+    factories.add(new SarosIntellijContextFactory(new ProjectWrapper(project)));
     factories.add(new CoreContextFactory());
     factories.add(new HTMLUIContextFactory());
 


### PR DESCRIPTION
This PR is a workaround for the issue #394.

This is only meant as a temporary solution for the upcoming release. Afterwards, this issue will be solved by making Saros/I an application level plugin an explicitly handling the choice which project to share.

#### [RELEASE-FIX][I] Add workaround to replace old project object

THIS IS A RELEASE FIX! DO NOT MERGE ONTO MASTER!

Makes the IntellijProjectLifecycle singleton.

Introduces a wrapper for the held project object as it is changeable
during the plugin lifecycle.

Adds a workaround to replace the old project object when a new project
is opened and the currently held project object is disposed. This is
needed as the internal Saros logic otherwise tries to work on the old
project object which is no longer valid, leading to an assertion error.

This is only a very rudimentary workaround as it still leaves users in a
headless state if they open two projects and then close the one opened
first. This state is not handled gracefully by Saros (it will cause
assertion errors shown to the user in the IDE when trying to start a
session). The headless state is resolved once the user opens another
project which will then be used for Saros.

#### [RELEASE-FIX][I] Stop session when current project is closed

THIS IS A RELEASE FIX! DO NOT MERGE ONTO MASTER!

Stops the current session when the shared project is closed. This is
done as the session state is dropped at that point, meaning we can no
longer work with the old session.

Furthermore, dropping the old session should guarantee that we don't
have any references to resources of the closed project. This is
necessary as trying to access these resources would lead to an assertion
error.

#### [RELEASE-FIX][I] Adhere to Intellij plugin lifecycle setup

THIS IS PART OF A RELEASE FIX! DO NOT MERGE ONTO MASTER!

Moves the plugin initialization in SarosComponent from the CTOR into
initComponent() in order to adhere to the Intellij plugin lifecycle
setup guidelines. This is important as getComponent() calls are not
allowed for Intellij object from within the CTOR.

Subsequently improves the javadoc of SarosComponent.

#### [RELEASE-FIX][I] Display warning message when entering headless state

THIS IS A RELEASE FIX! DO NOT MERGE ONTO MASTER!

Displays a warning message to the user in all remaining open projects
when the shareable project is closed. Closing the shareable project
leaves Saros in a headless state where it does not have access to a
valid project object to load shareable modules from. This headless state
gets resolved when the user opens a new project. The newly opened
project will be used as the shareable project.