### PR TITLE
Update plugin.xml

### DIFF
--- a/de.fu_berlin.inf.dpp.intellij/META-INF/plugin.xml
+++ b/de.fu_berlin.inf.dpp.intellij/META-INF/plugin.xml
@@ -1,23 +1,23 @@
-<idea-plugin version="2">
+<idea-plugin>
     <id>saros</id>
     <name>Saros</name>
     <version>0.1.0</version>
-    <vendor url="http://www.saros-project.org">Saros Project</vendor>
+    <vendor url="http://www.saros-project.org" email="saros-devel@googlegroups.com">
+        Saros Project
+    </vendor>
 
-    <description><![CDATA[
-      This is the brand new IntelliJ version of Saros.
-      ]]></description>
+    <description>
+        Saros is an Open Source IDE plugin for distributed collaborative software development.
+    </description>
 
-    <change-notes><![CDATA[
-      We just started, so don't expect too much functionality yet.
-      ]]>
+    <change-notes>
+        This is the first alpha version of Saros for IntelliJ. Use at your own risk.
     </change-notes>
 
-    <!-- please see http://confluence.jetbrains.net/display/IDEADEV/Build+Number+Ranges for description -->
-    <idea-version since-build="107.105"/>
+    <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
+    <idea-version since-build="173.4674.33"/>
 
-    <!-- please see http://confluence.jetbrains.net/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
-         on how to target different products -->
+    <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html on how to target different products -->
     <!-- uncomment to enable plugin in all products
     <depends>com.intellij.modules.lang</depends>
     -->

--- a/de.fu_berlin.inf.dpp.intellij/META-INF/plugin.xml
+++ b/de.fu_berlin.inf.dpp.intellij/META-INF/plugin.xml
@@ -1,5 +1,5 @@
 <idea-plugin version="2">
-    <id>de.fu_berlin.inf.dpp.intellij</id>
+    <id>saros</id>
     <name>Saros</name>
     <version>0.1.0</version>
     <vendor url="http://www.saros-project.org">Saros Project</vendor>

--- a/de.fu_berlin.inf.dpp.intellij/META-INF/plugin.xml
+++ b/de.fu_berlin.inf.dpp.intellij/META-INF/plugin.xml
@@ -1,10 +1,8 @@
 <idea-plugin>
-    <id>saros</id>
+
     <name>Saros</name>
-    <version>0.1.0</version>
-    <vendor url="http://www.saros-project.org" email="saros-devel@googlegroups.com">
-        Saros Project
-    </vendor>
+
+    <id>saros</id>
 
     <description>
         Saros is an Open Source IDE plugin for distributed collaborative software development.
@@ -13,6 +11,12 @@
     <change-notes>
         This is the first alpha version of Saros for IntelliJ. Use at your own risk.
     </change-notes>
+
+    <version>0.1.0</version>
+
+    <vendor url="http://www.saros-project.org" email="saros-devel@googlegroups.com">
+        Saros Project
+    </vendor>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
     <idea-version since-build="173.4674.33"/>

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/SarosComponent.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/SarosComponent.java
@@ -17,8 +17,11 @@ import org.jetbrains.annotations.NotNull;
  */
 public class SarosComponent implements com.intellij.openapi.components.ProjectComponent {
 
-  /** This is the plugin ID that identifies the saros plugin in the IDEA ecosystem. */
-  public static final String PLUGIN_ID = "de.fu_berlin.inf.dpp.intellij";
+  /**
+   * This is the plugin ID that identifies the saros plugin in the IDEA ecosystem. It is set in
+   * plugin.xml with the tag <code>id</code>.
+   */
+  public static final String PLUGIN_ID = "saros";
 
   public SarosComponent(final Project project) {
     loadLoggers();

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/context/IntelliJVersionProvider.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/context/IntelliJVersionProvider.java
@@ -4,15 +4,13 @@ import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.extensions.PluginId;
+import de.fu_berlin.inf.dpp.intellij.SarosComponent;
 
 /**
  * Methods in this class can be used to access version information about the running IntelliJ IDEA
  * version and Saros plugin version
  */
 public class IntelliJVersionProvider {
-  // plugin id set in plugin.xml with the tag <id>
-  protected static final String PLUGIN_ID = "de.fu_berlin.inf.dpp.intellij";
-
   private IntelliJVersionProvider() {
     // NOP
   }
@@ -23,10 +21,12 @@ public class IntelliJVersionProvider {
    * @return the version number of the used Saros plugin
    */
   public static String getPluginVersion() {
-    IdeaPluginDescriptor sarosPluginDescriptor = PluginManager.getPlugin(PluginId.getId(PLUGIN_ID));
+    IdeaPluginDescriptor sarosPluginDescriptor =
+        PluginManager.getPlugin(PluginId.getId(SarosComponent.PLUGIN_ID));
 
     if (sarosPluginDescriptor == null) {
-      throw new IllegalStateException("No plugin with the id \"" + PLUGIN_ID + "\" was found");
+      throw new IllegalStateException(
+          "No plugin with the id \"" + SarosComponent.PLUGIN_ID + "\" was found");
     }
 
     return sarosPluginDescriptor.getVersion();

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/SarosToolWindowFactory.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/SarosToolWindowFactory.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.ui.content.Content;
+import de.fu_berlin.inf.dpp.intellij.SarosComponent;
 import de.fu_berlin.inf.dpp.intellij.ui.views.SarosMainPanelView;
 
 /** This factory is the starting point of UI of the Saros plugin. */
@@ -23,7 +24,7 @@ public class SarosToolWindowFactory implements ToolWindowFactory {
             .getFactory()
             .createContent(
                 sarosMainPanelView,
-                PluginManager.getPlugin(PluginId.getId("de.fu_berlin.inf.dpp.intellij")).getName(),
+                PluginManager.getPlugin(PluginId.getId(SarosComponent.PLUGIN_ID)).getName(),
                 false);
     toolWindow.getContentManager().addContent(content);
   }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/swt_browser/SwtToolWindowFactory.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/swt_browser/SwtToolWindowFactory.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.ui.content.Content;
+import de.fu_berlin.inf.dpp.intellij.SarosComponent;
 import java.util.concurrent.CountDownLatch;
 
 /**
@@ -35,7 +36,7 @@ public class SwtToolWindowFactory implements ToolWindowFactory {
             .getFactory()
             .createContent(
                 swtBrowserPanel,
-                PluginManager.getPlugin(PluginId.getId("de.fu_berlin.inf.dpp.intellij")).getName(),
+                PluginManager.getPlugin(PluginId.getId(SarosComponent.PLUGIN_ID)).getName(),
                 false);
     toolWindow.getContentManager().addContent(content);
     swtBrowserPanel.initialize();


### PR DESCRIPTION
#### [I] Update plugin id
Sets the plugin id to "saros" instead of
"de.fu_berlin.inf.dpp.intellij".

Subsequently updates the reference to the plugin id in SarosComponent.

Also replaces all other places that had a hard-coded reference to the
actual plugin id with references to the variable defined in
SarosComponent.

#### [I] Update plugin.xml
Updates the information in the plugin.xml.
- Sets the correct minimal Intellij version
- Updates the plugin description
- Updates the change notes
- Adds a vendor email address
- Removes the deprecated modifier "version" from the idea-plugin field
- Replaces the links to Intellij documentation with new version

#### [REFACTOR][I] Restructure plugin.xml to match template