### PR TITLE
Prepare to remove project from plugin context (1 of X)

### DIFF
--- a/intellij/src/saros/core/project/internal/SarosIntellijSessionContextFactory.java
+++ b/intellij/src/saros/core/project/internal/SarosIntellijSessionContextFactory.java
@@ -2,6 +2,7 @@ package saros.core.project.internal;
 
 import saros.intellij.editor.LocalEditorHandler;
 import saros.intellij.editor.LocalEditorManipulator;
+import saros.intellij.editor.SelectedEditorStateSnapshotFactory;
 import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.eventhandler.editor.document.LocalClosedEditorModificationHandler;
 import saros.intellij.eventhandler.editor.document.LocalDocumentModificationHandler;
@@ -28,6 +29,7 @@ public class SarosIntellijSessionContextFactory extends SarosCoreSessionContextF
     // Editor interaction
     container.addComponent(LocalEditorHandler.class);
     container.addComponent(LocalEditorManipulator.class);
+    container.addComponent(SelectedEditorStateSnapshotFactory.class);
 
     // Annotation utility to create, remove, and manage annotations
     container.addComponent(AnnotationManager.class);

--- a/intellij/src/saros/core/project/internal/SarosIntellijSessionContextFactory.java
+++ b/intellij/src/saros/core/project/internal/SarosIntellijSessionContextFactory.java
@@ -1,5 +1,6 @@
 package saros.core.project.internal;
 
+import saros.intellij.editor.EditorAPI;
 import saros.intellij.editor.LocalEditorHandler;
 import saros.intellij.editor.LocalEditorManipulator;
 import saros.intellij.editor.SelectedEditorStateSnapshotFactory;
@@ -27,6 +28,7 @@ public class SarosIntellijSessionContextFactory extends SarosCoreSessionContextF
   @Override
   public void createNonCoreComponents(ISarosSession session, MutablePicoContainer container) {
     // Editor interaction
+    container.addComponent(EditorAPI.class);
     container.addComponent(LocalEditorHandler.class);
     container.addComponent(LocalEditorManipulator.class);
     container.addComponent(SelectedEditorStateSnapshotFactory.class);

--- a/intellij/src/saros/core/project/internal/SarosIntellijSessionContextFactory.java
+++ b/intellij/src/saros/core/project/internal/SarosIntellijSessionContextFactory.java
@@ -14,6 +14,7 @@ import saros.intellij.eventhandler.editor.editorstate.ViewportAdjustmentExecutor
 import saros.intellij.eventhandler.editor.selection.LocalTextSelectionChangeHandler;
 import saros.intellij.eventhandler.editor.viewport.LocalViewPortChangeHandler;
 import saros.intellij.eventhandler.filesystem.LocalFilesystemModificationHandler;
+import saros.intellij.filesystem.VirtualFileConverter;
 import saros.intellij.followmode.FollowModeNotificationDispatcher;
 import saros.intellij.project.SharedResourcesManager;
 import saros.intellij.project.filesystem.ModuleInitialization;
@@ -60,5 +61,8 @@ public class SarosIntellijSessionContextFactory extends SarosCoreSessionContextF
 
     // User notifications
     container.addComponent(FollowModeNotificationDispatcher.class);
+
+    // Utility
+    container.addComponent(VirtualFileConverter.class);
   }
 }

--- a/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
+++ b/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
@@ -18,7 +18,6 @@ import saros.filesystem.IPathFactory;
 import saros.filesystem.IWorkspace;
 import saros.filesystem.IWorkspaceRoot;
 import saros.filesystem.NullChecksumCache;
-import saros.intellij.editor.EditorAPI;
 import saros.intellij.editor.EditorManager;
 import saros.intellij.editor.ProjectAPI;
 import saros.intellij.negotiation.hooks.ModuleTypeNegotiationHook;
@@ -54,7 +53,6 @@ public class SarosIntellijContextFactory extends AbstractContextFactory {
     return new Component[] {
       // Core Managers
 
-      Component.create(EditorAPI.class),
       Component.create(ProjectAPI.class),
       Component.create(IEditorManager.class, EditorManager.class),
       Component.create(ISarosSessionContextFactory.class, SarosIntellijSessionContextFactory.class),

--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -380,8 +380,8 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
   private void addProjectResources(IProject project) {
     VirtualFile[] openFiles = projectAPI.getOpenFiles();
 
-    SelectedEditorStateSnapshot selectedEditorStateSnapshot = new SelectedEditorStateSnapshot();
-    selectedEditorStateSnapshot.captureState();
+    SelectedEditorStateSnapshot selectedEditorStateSnapshot =
+        selectedEditorStateSnapshotFactory.capturedState();
 
     try {
       setLocalEditorStatusChangeHandlersEnabled(false);
@@ -437,6 +437,9 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
           annotationManager = sarosSession.getComponent(AnnotationManager.class);
 
+          selectedEditorStateSnapshotFactory =
+              sarosSession.getComponent(SelectedEditorStateSnapshotFactory.class);
+
           localDocumentModificationHandler =
               sarosSession.getComponent(LocalDocumentModificationHandler.class);
           localClosedEditorModificationHandler =
@@ -463,6 +466,8 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
           localEditorManipulator = null;
 
           annotationManager = null;
+
+          selectedEditorStateSnapshotFactory = null;
 
           localDocumentModificationHandler = null;
           localClosedEditorModificationHandler = null;
@@ -519,6 +524,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
   private LocalEditorHandler localEditorHandler;
   private LocalEditorManipulator localEditorManipulator;
   private AnnotationManager annotationManager;
+  private SelectedEditorStateSnapshotFactory selectedEditorStateSnapshotFactory;
 
   /* Event handlers */
   // document changes
@@ -551,7 +557,6 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
     sessionManager.addSessionLifecycleListener(sessionLifecycleListener);
     this.fileReplacementInProgressObservable = fileReplacementInProgressObservable;
     this.editorAPI = editorAPI;
-
     this.projectAPI = projectAPI;
   }
 

--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -432,6 +432,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
           userEditorStateManager = session.getComponent(UserEditorStateManager.class);
 
+          editorAPI = sarosSession.getComponent(EditorAPI.class);
           localEditorHandler = sarosSession.getComponent(LocalEditorHandler.class);
           localEditorManipulator = sarosSession.getComponent(LocalEditorManipulator.class);
 
@@ -462,6 +463,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
           userEditorStateManager = null;
 
+          editorAPI = null;
           localEditorHandler = null;
           localEditorManipulator = null;
 
@@ -516,11 +518,11 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
   private final FileReplacementInProgressObservable fileReplacementInProgressObservable;
   private final ProjectAPI projectAPI;
-  private final EditorAPI editorAPI;
 
   /* Session Components */
   private UserEditorStateManager userEditorStateManager;
   private ISarosSession session;
+  private EditorAPI editorAPI;
   private LocalEditorHandler localEditorHandler;
   private LocalEditorManipulator localEditorManipulator;
   private AnnotationManager annotationManager;
@@ -551,12 +553,10 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
   public EditorManager(
       ISarosSessionManager sessionManager,
       ProjectAPI projectAPI,
-      FileReplacementInProgressObservable fileReplacementInProgressObservable,
-      EditorAPI editorAPI) {
+      FileReplacementInProgressObservable fileReplacementInProgressObservable) {
 
     sessionManager.addSessionLifecycleListener(sessionLifecycleListener);
     this.fileReplacementInProgressObservable = fileReplacementInProgressObservable;
-    this.editorAPI = editorAPI;
     this.projectAPI = projectAPI;
   }
 

--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -380,8 +380,8 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
   private void addProjectResources(IProject project) {
     VirtualFile[] openFiles = projectAPI.getOpenFiles();
 
-    SelectedEditorState selectedEditorState = new SelectedEditorState();
-    selectedEditorState.captureState();
+    SelectedEditorStateSnapshot selectedEditorStateSnapshot = new SelectedEditorStateSnapshot();
+    selectedEditorStateSnapshot.captureState();
 
     try {
       setLocalEditorStatusChangeHandlersEnabled(false);
@@ -396,7 +396,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
       setLocalEditorStatusChangeHandlersEnabled(true);
     }
 
-    selectedEditorState.applyCapturedState();
+    selectedEditorStateSnapshot.applyHeldState();
   }
 
   @SuppressWarnings("FieldCanBeLocal")

--- a/intellij/src/saros/intellij/editor/LocalEditorHandler.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorHandler.java
@@ -23,16 +23,21 @@ public class LocalEditorHandler {
   private final ProjectAPI projectAPI;
   private final EditorManager manager;
   private final ISarosSession sarosSession;
+  private final VirtualFileConverter virtualFileConverter;
 
   /** This is just a reference to {@link EditorManager}'s editorPool and not a separate pool. */
   private final EditorPool editorPool;
 
   public LocalEditorHandler(
-      ProjectAPI projectAPI, EditorManager editorManager, ISarosSession sarosSession) {
+      ProjectAPI projectAPI,
+      EditorManager editorManager,
+      ISarosSession sarosSession,
+      VirtualFileConverter virtualFileConverter) {
 
     this.projectAPI = projectAPI;
     this.manager = editorManager;
     this.sarosSession = sarosSession;
+    this.virtualFileConverter = virtualFileConverter;
 
     this.editorPool = manager.getEditorPool();
   }
@@ -55,7 +60,7 @@ public class LocalEditorHandler {
       return null;
     }
 
-    SPath path = VirtualFileConverter.convertToSPath(virtualFile);
+    SPath path = virtualFileConverter.convertToSPath(virtualFile);
 
     if (path == null || !sarosSession.isShared(path.getResource())) {
       LOG.debug(
@@ -146,7 +151,7 @@ public class LocalEditorHandler {
    * @param virtualFile
    */
   public void closeEditor(@NotNull VirtualFile virtualFile) {
-    SPath path = VirtualFileConverter.convertToSPath(virtualFile);
+    SPath path = virtualFileConverter.convertToSPath(virtualFile);
 
     if (path != null && sarosSession.isShared(path.getResource())) {
       editorPool.removeEditor(path);
@@ -213,7 +218,7 @@ public class LocalEditorHandler {
       return;
     }
 
-    SPath path = VirtualFileConverter.convertToSPath(file);
+    SPath path = virtualFileConverter.convertToSPath(file);
 
     if (path != null && sarosSession.isShared(path.getResource())) {
       manager.generateEditorActivated(path);

--- a/intellij/src/saros/intellij/editor/SelectedEditorStateSnapshot.java
+++ b/intellij/src/saros/intellij/editor/SelectedEditorStateSnapshot.java
@@ -14,8 +14,8 @@ import saros.repackaged.picocontainer.annotations.Inject;
 
 /** Class used to capture and re-apply which editors are currently selected by the user. */
 // TODO consider duplicated open editors during screen splitting
-public class SelectedEditorState {
-  private static final Logger log = Logger.getLogger(SelectedEditorState.class);
+public class SelectedEditorStateSnapshot {
+  private static final Logger log = Logger.getLogger(SelectedEditorStateSnapshot.class);
 
   private final List<VirtualFile> selectedEditors;
 
@@ -26,10 +26,10 @@ public class SelectedEditorState {
   @Inject private static EditorManager editorManager;
 
   static {
-    SarosPluginContext.initComponent(new SelectedEditorState());
+    SarosPluginContext.initComponent(new SelectedEditorStateSnapshot());
   }
 
-  public SelectedEditorState() {
+  public SelectedEditorStateSnapshot() {
     this.selectedEditors = new ArrayList<>();
     this.hasCapturedState = false;
   }
@@ -48,7 +48,7 @@ public class SelectedEditorState {
   }
 
   /** Applies the captured selected editor state to the local IDE. */
-  public void applyCapturedState() {
+  public void applyHeldState() {
     if (!hasCapturedState) {
       log.warn("Trying to applying state before capturing a local state to" + "re-apply.");
 

--- a/intellij/src/saros/intellij/editor/SelectedEditorStateSnapshotFactory.java
+++ b/intellij/src/saros/intellij/editor/SelectedEditorStateSnapshotFactory.java
@@ -1,0 +1,28 @@
+package saros.intellij.editor;
+
+/**
+ * Factory class that can be used to create and obtain snapshots of the current selected editor
+ * state.
+ *
+ * @see SelectedEditorStateSnapshot
+ */
+public class SelectedEditorStateSnapshotFactory {
+
+  private final ProjectAPI projectAPI;
+  private final EditorManager editorManager;
+
+  public SelectedEditorStateSnapshotFactory(ProjectAPI projectAPI, EditorManager editorManager) {
+    this.projectAPI = projectAPI;
+    this.editorManager = editorManager;
+  }
+
+  /**
+   * Returns a snapshot of the current selected editor state.
+   *
+   * @return a snapshot of the current selected editor state
+   * @see SelectedEditorStateSnapshot
+   */
+  public SelectedEditorStateSnapshot capturedState() {
+    return new SelectedEditorStateSnapshot(projectAPI, editorManager);
+  }
+}

--- a/intellij/src/saros/intellij/eventhandler/editor/document/AbstractLocalDocumentModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/document/AbstractLocalDocumentModificationHandler.java
@@ -22,7 +22,9 @@ public abstract class AbstractLocalDocumentModificationHandler
       Logger.getLogger(AbstractLocalDocumentModificationHandler.class);
 
   protected final EditorManager editorManager;
+
   private final ISarosSession sarosSession;
+  private final VirtualFileConverter virtualFileConverter;
 
   private boolean enabled;
   private boolean disposed;
@@ -35,10 +37,14 @@ public abstract class AbstractLocalDocumentModificationHandler
    * @param editorManager the EditorManager instance
    */
   AbstractLocalDocumentModificationHandler(
-      EditorManager editorManager, ISarosSession sarosSession) {
+      EditorManager editorManager,
+      ISarosSession sarosSession,
+      VirtualFileConverter virtualFileConverter) {
 
     this.editorManager = editorManager;
+
     this.sarosSession = sarosSession;
+    this.virtualFileConverter = virtualFileConverter;
 
     this.enabled = false;
     this.disposed = false;
@@ -121,7 +127,7 @@ public abstract class AbstractLocalDocumentModificationHandler
       return null;
     }
 
-    path = VirtualFileConverter.convertToSPath(virtualFile);
+    path = virtualFileConverter.convertToSPath(virtualFile);
 
     if (path == null || !sarosSession.isShared(path.getResource())) {
       if (LOG.isTraceEnabled()) {

--- a/intellij/src/saros/intellij/eventhandler/editor/document/LocalClosedEditorModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/document/LocalClosedEditorModificationHandler.java
@@ -9,6 +9,7 @@ import saros.filesystem.IFile;
 import saros.intellij.editor.EditorManager;
 import saros.intellij.editor.ProjectAPI;
 import saros.intellij.editor.annotations.AnnotationManager;
+import saros.intellij.filesystem.VirtualFileConverter;
 import saros.session.ISarosSession;
 
 /**
@@ -31,11 +32,12 @@ public class LocalClosedEditorModificationHandler extends AbstractLocalDocumentM
 
   public LocalClosedEditorModificationHandler(
       EditorManager editorManager,
+      VirtualFileConverter virtualFileConverter,
       ISarosSession sarosSession,
       ProjectAPI projectAPI,
       AnnotationManager annotationManager) {
 
-    super(editorManager, sarosSession);
+    super(editorManager, sarosSession, virtualFileConverter);
 
     this.projectAPI = projectAPI;
     this.annotationManager = annotationManager;

--- a/intellij/src/saros/intellij/eventhandler/editor/document/LocalDocumentModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/document/LocalDocumentModificationHandler.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.editor.event.DocumentListener;
 import org.jetbrains.annotations.NotNull;
 import saros.activities.SPath;
 import saros.intellij.editor.EditorManager;
+import saros.intellij.filesystem.VirtualFileConverter;
 import saros.session.ISarosSession;
 
 /**
@@ -24,8 +25,12 @@ public class LocalDocumentModificationHandler extends AbstractLocalDocumentModif
         }
       };
 
-  public LocalDocumentModificationHandler(EditorManager editorManager, ISarosSession sarosSession) {
-    super(editorManager, sarosSession);
+  public LocalDocumentModificationHandler(
+      EditorManager editorManager,
+      ISarosSession sarosSession,
+      VirtualFileConverter virtualFileConverter) {
+
+    super(editorManager, sarosSession, virtualFileConverter);
   }
 
   /**

--- a/intellij/src/saros/intellij/eventhandler/editor/editorstate/AnnotationUpdater.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/editorstate/AnnotationUpdater.java
@@ -23,6 +23,7 @@ public class AnnotationUpdater extends AbstractLocalEditorStatusChangeHandler {
   private final AnnotationManager annotationManager;
   private final LocalEditorHandler localEditorHandler;
   private final ISarosSession sarosSession;
+  private final VirtualFileConverter virtualFileConverter;
 
   private final FileEditorManagerListener fileEditorManagerListener =
       new FileEditorManagerListener() {
@@ -49,13 +50,15 @@ public class AnnotationUpdater extends AbstractLocalEditorStatusChangeHandler {
       Project project,
       AnnotationManager annotationManager,
       LocalEditorHandler localEditorHandler,
-      ISarosSession sarosSession) {
+      ISarosSession sarosSession,
+      VirtualFileConverter virtualFileConverter) {
 
     super(project);
 
     this.annotationManager = annotationManager;
     this.localEditorHandler = localEditorHandler;
     this.sarosSession = sarosSession;
+    this.virtualFileConverter = virtualFileConverter;
 
     setEnabled(true);
   }
@@ -70,7 +73,7 @@ public class AnnotationUpdater extends AbstractLocalEditorStatusChangeHandler {
   private void setUpOpenedEditor(@NotNull VirtualFile virtualFile) {
     Editor editor = localEditorHandler.openEditor(virtualFile, false);
 
-    SPath sPath = VirtualFileConverter.convertToSPath(virtualFile);
+    SPath sPath = virtualFileConverter.convertToSPath(virtualFile);
 
     if (sPath == null || editor == null) {
       return;
@@ -90,7 +93,7 @@ public class AnnotationUpdater extends AbstractLocalEditorStatusChangeHandler {
    * @see FileEditorManagerListener.Before#beforeFileClosed(FileEditorManager, VirtualFile)
    */
   private void cleanUpAnnotations(@NotNull VirtualFile virtualFile) {
-    SPath sPath = VirtualFileConverter.convertToSPath(virtualFile);
+    SPath sPath = virtualFileConverter.convertToSPath(virtualFile);
 
     if (sPath == null) {
       return;

--- a/intellij/src/saros/intellij/eventhandler/editor/editorstate/PreexistingSelectionDispatcher.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/editorstate/PreexistingSelectionDispatcher.java
@@ -27,6 +27,7 @@ public class PreexistingSelectionDispatcher extends AbstractLocalEditorStatusCha
   private final EditorManager editorManager;
   private final LocalEditorHandler localEditorHandler;
   private final ISarosSession sarosSession;
+  private final VirtualFileConverter virtualFileConverter;
 
   private final FileEditorManagerListener fileEditorManagerListener =
       new FileEditorManagerListener() {
@@ -42,13 +43,15 @@ public class PreexistingSelectionDispatcher extends AbstractLocalEditorStatusCha
       Project project,
       EditorManager editorManager,
       LocalEditorHandler localEditorHandler,
-      ISarosSession sarosSession) {
+      ISarosSession sarosSession,
+      VirtualFileConverter virtualFileConverter) {
 
     super(project);
 
     this.editorManager = editorManager;
     this.localEditorHandler = localEditorHandler;
     this.sarosSession = sarosSession;
+    this.virtualFileConverter = virtualFileConverter;
 
     setEnabled(true);
   }
@@ -63,7 +66,7 @@ public class PreexistingSelectionDispatcher extends AbstractLocalEditorStatusCha
   private void sendExistingSelection(@NotNull VirtualFile virtualFile) {
     Editor editor = localEditorHandler.openEditor(virtualFile, false);
 
-    SPath sPath = VirtualFileConverter.convertToSPath(virtualFile);
+    SPath sPath = virtualFileConverter.convertToSPath(virtualFile);
 
     if (sPath != null && sarosSession.isShared(sPath.getResource()) && editor != null) {
       editorManager.sendExistingSelection(sPath, editor);

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -67,6 +67,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
   private final AnnotationManager annotationManager;
   private final Project project;
   private final LocalEditorHandler localEditorHandler;
+  private final VirtualFileConverter virtualFileConverter;
 
   private boolean enabled;
   private boolean disposed;
@@ -171,7 +172,8 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
       ProjectAPI projectAPI,
       AnnotationManager annotationManager,
       Project project,
-      LocalEditorHandler localEditorHandler) {
+      LocalEditorHandler localEditorHandler,
+      VirtualFileConverter virtualFileConverter) {
 
     this.editorManager = editorManager;
     this.session = session;
@@ -180,6 +182,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
     this.annotationManager = annotationManager;
     this.project = project;
     this.localEditorHandler = localEditorHandler;
+    this.virtualFileConverter = virtualFileConverter;
 
     this.enabled = false;
     this.disposed = false;
@@ -204,7 +207,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
       LOG.trace("Reacting before resource contents changed: " + file);
     }
 
-    SPath path = VirtualFileConverter.convertToSPath(file);
+    SPath path = virtualFileConverter.convertToSPath(file);
 
     if (path == null || !session.isShared(path.getResource())) {
       if (LOG.isTraceEnabled()) {
@@ -262,7 +265,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
       LOG.trace("Reacting to resource creation: " + createdVirtualFile);
     }
 
-    SPath path = VirtualFileConverter.convertToSPath(createdVirtualFile);
+    SPath path = virtualFileConverter.convertToSPath(createdVirtualFile);
 
     if (path == null || !session.isShared(path.getResource())) {
       if (LOG.isTraceEnabled()) {
@@ -322,7 +325,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
               + copy);
     }
 
-    SPath copyPath = VirtualFileConverter.convertToSPath(copy);
+    SPath copyPath = virtualFileConverter.convertToSPath(copy);
 
     if (copyPath == null || !session.isShared(copyPath.getResource())) {
       if (LOG.isTraceEnabled()) {
@@ -362,7 +365,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
       LOG.trace("Reacting before resource deletion: " + deletedVirtualFile);
     }
 
-    SPath path = VirtualFileConverter.convertToSPath(deletedVirtualFile);
+    SPath path = virtualFileConverter.convertToSPath(deletedVirtualFile);
 
     if (path == null || !session.isShared(path.getResource())) {
       if (LOG.isTraceEnabled()) {
@@ -468,8 +471,8 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
     String folderName = newFolderName != null ? newFolderName : oldFile.getName();
 
-    SPath oldPath = VirtualFileConverter.convertToSPath(oldFile);
-    SPath newParentPath = VirtualFileConverter.convertToSPath(newParent);
+    SPath oldPath = virtualFileConverter.convertToSPath(oldFile);
+    SPath newParentPath = virtualFileConverter.convertToSPath(newParent);
 
     User user = session.getLocalUser();
 
@@ -609,8 +612,8 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
     String encoding = oldFile.getCharset().name();
 
-    SPath oldFilePath = VirtualFileConverter.convertToSPath(oldFile);
-    SPath newParentPath = VirtualFileConverter.convertToSPath(newBaseParent);
+    SPath oldFilePath = virtualFileConverter.convertToSPath(oldFile);
+    SPath newParentPath = virtualFileConverter.convertToSPath(newBaseParent);
 
     User user = session.getLocalUser();
 
@@ -776,7 +779,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
         if (parent == null) {
 
-          SPath path = VirtualFileConverter.convertToSPath(file);
+          SPath path = virtualFileConverter.convertToSPath(file);
 
           if (path != null && session.isShared(path.getResource())) {
             LOG.error(

--- a/intellij/src/saros/intellij/filesystem/VirtualFileConverter.java
+++ b/intellij/src/saros/intellij/filesystem/VirtualFileConverter.java
@@ -7,11 +7,9 @@ import com.intellij.openapi.vfs.VirtualFile;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import saros.SarosPluginContext;
 import saros.activities.SPath;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
-import saros.repackaged.picocontainer.annotations.Inject;
 
 /**
  * Provides static methods to convert VirtualFiles to Saros resource objects or Saros resources
@@ -21,14 +19,10 @@ public class VirtualFileConverter {
 
   private static final Logger log = Logger.getLogger(VirtualFileConverter.class);
 
-  @Inject private static Project project;
+  private final Project project;
 
-  static {
-    SarosPluginContext.initComponent(new VirtualFileConverter());
-  }
-
-  private VirtualFileConverter() {
-    // NOP
+  public VirtualFileConverter(Project project) {
+    this.project = project;
   }
 
   /**
@@ -41,7 +35,7 @@ public class VirtualFileConverter {
    *     constructed
    */
   @Nullable
-  public static SPath convertToSPath(@NotNull VirtualFile virtualFile) {
+  public SPath convertToSPath(@NotNull VirtualFile virtualFile) {
 
     IResource resource = convertToResource(virtualFile);
 
@@ -58,7 +52,7 @@ public class VirtualFileConverter {
    *     be constructed
    */
   @Nullable
-  public static IResource convertToResource(@NotNull VirtualFile virtualFile) {
+  public IResource convertToResource(@NotNull VirtualFile virtualFile) {
 
     Module module = ModuleUtil.findModuleForFile(virtualFile, project);
 

--- a/intellij/src/saros/intellij/project/SharedResourcesManager.java
+++ b/intellij/src/saros/intellij/project/SharedResourcesManager.java
@@ -18,6 +18,7 @@ import saros.filesystem.IFolder;
 import saros.intellij.editor.LocalEditorHandler;
 import saros.intellij.editor.LocalEditorManipulator;
 import saros.intellij.editor.SelectedEditorStateSnapshot;
+import saros.intellij.editor.SelectedEditorStateSnapshotFactory;
 import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.eventhandler.filesystem.LocalFilesystemModificationHandler;
 import saros.repackaged.picocontainer.Startable;
@@ -36,14 +37,11 @@ public class SharedResourcesManager implements Startable {
   private static final boolean LOCAL = false;
 
   private final ISarosSession sarosSession;
-
   private final LocalFilesystemModificationHandler localFilesystemModificationHandler;
-
   private final LocalEditorHandler localEditorHandler;
-
   private final LocalEditorManipulator localEditorManipulator;
-
   private final AnnotationManager annotationManager;
+  private final SelectedEditorStateSnapshotFactory selectedEditorStateSnapshotFactory;
 
   @Override
   public void start() {
@@ -66,13 +64,15 @@ public class SharedResourcesManager implements Startable {
       LocalEditorHandler localEditorHandler,
       LocalEditorManipulator localEditorManipulator,
       AnnotationManager annotationManager,
-      LocalFilesystemModificationHandler localFilesystemModificationHandler) {
+      LocalFilesystemModificationHandler localFilesystemModificationHandler,
+      SelectedEditorStateSnapshotFactory selectedEditorStateSnapshotFactory) {
 
     this.sarosSession = sarosSession;
     this.localEditorHandler = localEditorHandler;
     this.localEditorManipulator = localEditorManipulator;
     this.annotationManager = annotationManager;
     this.localFilesystemModificationHandler = localFilesystemModificationHandler;
+    this.selectedEditorStateSnapshotFactory = selectedEditorStateSnapshotFactory;
   }
 
   private final IActivityConsumer consumer =
@@ -210,8 +210,7 @@ public class SharedResourcesManager implements Startable {
     SelectedEditorStateSnapshot selectedEditorStateSnapshot = null;
 
     if (fileOpen) {
-      selectedEditorStateSnapshot = new SelectedEditorStateSnapshot();
-      selectedEditorStateSnapshot.captureState();
+      selectedEditorStateSnapshot = selectedEditorStateSnapshotFactory.capturedState();
     }
 
     localEditorManipulator.closeEditor(oldPath);

--- a/intellij/src/saros/intellij/project/SharedResourcesManager.java
+++ b/intellij/src/saros/intellij/project/SharedResourcesManager.java
@@ -17,7 +17,7 @@ import saros.filesystem.IFile;
 import saros.filesystem.IFolder;
 import saros.intellij.editor.LocalEditorHandler;
 import saros.intellij.editor.LocalEditorManipulator;
-import saros.intellij.editor.SelectedEditorState;
+import saros.intellij.editor.SelectedEditorStateSnapshot;
 import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.eventhandler.filesystem.LocalFilesystemModificationHandler;
 import saros.repackaged.picocontainer.Startable;
@@ -207,11 +207,11 @@ public class SharedResourcesManager implements Startable {
 
     boolean fileOpen = localEditorHandler.isOpenEditor(oldPath);
 
-    SelectedEditorState selectedEditorState = null;
+    SelectedEditorStateSnapshot selectedEditorStateSnapshot = null;
 
     if (fileOpen) {
-      selectedEditorState = new SelectedEditorState();
-      selectedEditorState.captureState();
+      selectedEditorStateSnapshot = new SelectedEditorStateSnapshot();
+      selectedEditorStateSnapshot.captureState();
     }
 
     localEditorManipulator.closeEditor(oldPath);
@@ -229,12 +229,12 @@ public class SharedResourcesManager implements Startable {
         localEditorManipulator.openEditor(newPath, false);
 
         try {
-          selectedEditorState.replaceSelectedFile(oldFile, newFile);
+          selectedEditorStateSnapshot.replaceSelectedFile(oldFile, newFile);
         } catch (IllegalStateException e) {
           LOG.warn("Failed to update the captured selected editor state", e);
         }
 
-        selectedEditorState.applyCapturedState();
+        selectedEditorStateSnapshot.applyHeldState();
       }
 
       oldFile.delete(DELETION_FLAGS);

--- a/intellij/test/junit/saros/intellij/eventhandler/editor/document/LocalDocumentModificationHandlerTest.java
+++ b/intellij/test/junit/saros/intellij/eventhandler/editor/document/LocalDocumentModificationHandlerTest.java
@@ -29,7 +29,7 @@ public class LocalDocumentModificationHandlerTest {
   public void before() {
     mockEditorFactory();
     localDocumentModificationHandler =
-        new LocalDocumentModificationHandler(dummyEditorManager(), null);
+        new LocalDocumentModificationHandler(dummyEditorManager(), null, null);
     listening = false;
   }
 


### PR DESCRIPTION
This PR starts to move project dependent components to the session context.

This is done in preparation of an upcoming change that would no longer make the project object accessible in the plugin context.

Moving the project into the session context is needed when moving Saros from a project plugin to an application plugin as we can no longer determine which project to run on during the plugin initialization. The project-module combination will be chosen by the user as part of the session start, meaning the project object will only be available in the session context.