### PR TITLE
Prepare to remove project from plugin context (2 of X)

### DIFF
--- a/intellij/src/saros/core/project/internal/SarosIntellijSessionContextFactory.java
+++ b/intellij/src/saros/core/project/internal/SarosIntellijSessionContextFactory.java
@@ -3,6 +3,7 @@ package saros.core.project.internal;
 import saros.intellij.editor.EditorAPI;
 import saros.intellij.editor.LocalEditorHandler;
 import saros.intellij.editor.LocalEditorManipulator;
+import saros.intellij.editor.ProjectAPI;
 import saros.intellij.editor.SelectedEditorStateSnapshotFactory;
 import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.eventhandler.editor.document.LocalClosedEditorModificationHandler;
@@ -28,6 +29,9 @@ public class SarosIntellijSessionContextFactory extends SarosCoreSessionContextF
 
   @Override
   public void createNonCoreComponents(ISarosSession session, MutablePicoContainer container) {
+    // Project interaction
+    container.addComponent(ProjectAPI.class);
+
     // Editor interaction
     container.addComponent(EditorAPI.class);
     container.addComponent(LocalEditorHandler.class);

--- a/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
+++ b/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
@@ -19,7 +19,6 @@ import saros.filesystem.IWorkspace;
 import saros.filesystem.IWorkspaceRoot;
 import saros.filesystem.NullChecksumCache;
 import saros.intellij.editor.EditorManager;
-import saros.intellij.editor.ProjectAPI;
 import saros.intellij.negotiation.hooks.ModuleTypeNegotiationHook;
 import saros.intellij.preferences.IntelliJPreferences;
 import saros.intellij.preferences.PropertiesComponentAdapter;
@@ -52,8 +51,6 @@ public class SarosIntellijContextFactory extends AbstractContextFactory {
   private final Component[] getContextComponents() {
     return new Component[] {
       // Core Managers
-
-      Component.create(ProjectAPI.class),
       Component.create(IEditorManager.class, EditorManager.class),
       Component.create(ISarosSessionContextFactory.class, SarosIntellijSessionContextFactory.class),
 

--- a/intellij/src/saros/intellij/editor/DocumentAPI.java
+++ b/intellij/src/saros/intellij/editor/DocumentAPI.java
@@ -37,6 +37,18 @@ public class DocumentAPI {
   }
 
   /**
+   * Returns the VirtualFile for the given document.
+   *
+   * @param document the Document whose VirtualFile to get
+   * @return the VirtualFile for the given document or <code>null</code> if the document was not
+   *     created from a VirtualFile
+   */
+  @Nullable
+  public static VirtualFile getVirtualFile(@NotNull final Document document) {
+    return fileDocumentManager.getFile(document);
+  }
+
+  /**
    * Saves the given document in the UI thread.
    *
    * @param document the document to save.

--- a/intellij/src/saros/intellij/editor/DocumentAPI.java
+++ b/intellij/src/saros/intellij/editor/DocumentAPI.java
@@ -1,0 +1,92 @@
+package saros.intellij.editor;
+
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.util.Computable;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import saros.intellij.filesystem.Filesystem;
+
+/**
+ * Wrapper for interacting with the Intellij document API.
+ *
+ * @see Document
+ */
+public class DocumentAPI {
+  private static final FileDocumentManager fileDocumentManager = FileDocumentManager.getInstance();
+
+  private DocumentAPI() {
+    // NOP
+  }
+
+  /**
+   * Returns a document for the given file.
+   *
+   * @param file the <code>VirtualFile</code> for which the document is requested
+   * @return a <code>Document</code> for the given file or <code>null</code> if the file does not
+   *     exist, could not be read, is a directory, or is to large
+   */
+  @Nullable
+  public static Document getDocument(@NotNull final VirtualFile file) {
+    if (!file.exists()) {
+      return null;
+    }
+
+    return Filesystem.runReadAction(
+        new Computable<Document>() {
+
+          @Override
+          public Document compute() {
+            return fileDocumentManager.getDocument(file);
+          }
+        });
+  }
+
+  /**
+   * Saves the given document in the UI thread.
+   *
+   * @param doc
+   */
+  public static void saveDocument(final Document doc) {
+    Filesystem.runWriteAction(
+        new Runnable() {
+
+          @Override
+          public void run() {
+            fileDocumentManager.saveDocument(doc);
+          }
+        },
+        ModalityState.NON_MODAL);
+  }
+
+  /**
+   * Reloads the current document in the UI thread.
+   *
+   * @param doc
+   */
+  public static void reloadFromDisk(final Document doc) {
+    Filesystem.runReadAction(
+        new Runnable() {
+
+          @Override
+          public void run() {
+            fileDocumentManager.reloadFromDisk(doc);
+          }
+        });
+  }
+
+  /** Saves all documents in the UI thread. */
+  public static void saveAllDocuments() {
+    Filesystem.runWriteAction(
+        new Runnable() {
+
+          @Override
+          public void run() {
+            fileDocumentManager.saveAllDocuments();
+          }
+        },
+        ModalityState.NON_MODAL);
+  }
+}

--- a/intellij/src/saros/intellij/editor/DocumentAPI.java
+++ b/intellij/src/saros/intellij/editor/DocumentAPI.java
@@ -3,7 +3,6 @@ package saros.intellij.editor;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
-import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -24,69 +23,31 @@ public class DocumentAPI {
   /**
    * Returns a document for the given file.
    *
-   * @param file the <code>VirtualFile</code> for which the document is requested
+   * @param virtualFile the <code>VirtualFile</code> for which the document is requested
    * @return a <code>Document</code> for the given file or <code>null</code> if the file does not
    *     exist, could not be read, is a directory, or is to large
    */
   @Nullable
-  public static Document getDocument(@NotNull final VirtualFile file) {
-    if (!file.exists()) {
+  public static Document getDocument(@NotNull final VirtualFile virtualFile) {
+    if (!virtualFile.exists()) {
       return null;
     }
 
-    return Filesystem.runReadAction(
-        new Computable<Document>() {
-
-          @Override
-          public Document compute() {
-            return fileDocumentManager.getDocument(file);
-          }
-        });
+    return Filesystem.runReadAction(() -> fileDocumentManager.getDocument(virtualFile));
   }
 
   /**
    * Saves the given document in the UI thread.
    *
-   * @param doc
+   * @param document the document to save.
    */
-  public static void saveDocument(final Document doc) {
+  public static void saveDocument(final Document document) {
     Filesystem.runWriteAction(
-        new Runnable() {
-
-          @Override
-          public void run() {
-            fileDocumentManager.saveDocument(doc);
-          }
-        },
-        ModalityState.NON_MODAL);
-  }
-
-  /**
-   * Reloads the current document in the UI thread.
-   *
-   * @param doc
-   */
-  public static void reloadFromDisk(final Document doc) {
-    Filesystem.runReadAction(
-        new Runnable() {
-
-          @Override
-          public void run() {
-            fileDocumentManager.reloadFromDisk(doc);
-          }
-        });
+        () -> fileDocumentManager.saveDocument(document), ModalityState.NON_MODAL);
   }
 
   /** Saves all documents in the UI thread. */
   public static void saveAllDocuments() {
-    Filesystem.runWriteAction(
-        new Runnable() {
-
-          @Override
-          public void run() {
-            fileDocumentManager.saveAllDocuments();
-          }
-        },
-        ModalityState.NON_MODAL);
+    Filesystem.runWriteAction(fileDocumentManager::saveAllDocuments, ModalityState.NON_MODAL);
   }
 }

--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -5,7 +5,6 @@ import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.event.SelectionEvent;
-import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -306,8 +305,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
             @NotNull Editor editor,
             @NotNull Set<String> visibleFilePaths) {
 
-          VirtualFile fileForEditor =
-              FileDocumentManager.getInstance().getFile(editor.getDocument());
+          VirtualFile fileForEditor = DocumentAPI.getVirtualFile(editor.getDocument());
 
           if (fileForEditor == null) {
             LOG.warn(

--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -430,6 +430,8 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
           userEditorStateManager = session.getComponent(UserEditorStateManager.class);
 
+          projectAPI = sarosSession.getComponent(ProjectAPI.class);
+
           editorAPI = sarosSession.getComponent(EditorAPI.class);
           localEditorHandler = sarosSession.getComponent(LocalEditorHandler.class);
           localEditorManipulator = sarosSession.getComponent(LocalEditorManipulator.class);
@@ -460,6 +462,8 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
           session = null;
 
           userEditorStateManager = null;
+
+          projectAPI = null;
 
           editorAPI = null;
           localEditorHandler = null;
@@ -515,11 +519,11 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
       };
 
   private final FileReplacementInProgressObservable fileReplacementInProgressObservable;
-  private final ProjectAPI projectAPI;
 
   /* Session Components */
   private UserEditorStateManager userEditorStateManager;
   private ISarosSession session;
+  private ProjectAPI projectAPI;
   private EditorAPI editorAPI;
   private LocalEditorHandler localEditorHandler;
   private LocalEditorManipulator localEditorManipulator;
@@ -550,12 +554,10 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
   public EditorManager(
       ISarosSessionManager sessionManager,
-      ProjectAPI projectAPI,
       FileReplacementInProgressObservable fileReplacementInProgressObservable) {
 
     sessionManager.addSessionLifecycleListener(sessionLifecycleListener);
     this.fileReplacementInProgressObservable = fileReplacementInProgressObservable;
-    this.projectAPI = projectAPI;
   }
 
   @Override

--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -582,7 +582,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
             return null;
           }
 
-          Document doc = projectAPI.getDocument(virtualFile);
+          Document doc = DocumentAPI.getDocument(virtualFile);
 
           return (doc != null) ? doc.getText() : null;
         });

--- a/intellij/src/saros/intellij/editor/LocalEditorHandler.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorHandler.java
@@ -187,7 +187,7 @@ public class LocalEditorHandler {
         return;
       }
 
-      document = projectAPI.getDocument(file);
+      document = DocumentAPI.getDocument(file);
 
       if (document == null) {
         LOG.warn("Failed to save document for " + file + " - could not get a matching Document");
@@ -196,7 +196,7 @@ public class LocalEditorHandler {
       }
     }
 
-    projectAPI.saveDocument(document);
+    DocumentAPI.saveDocument(document);
   }
 
   /**

--- a/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
@@ -8,7 +8,6 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
-import saros.activities.FileActivity;
 import saros.activities.SPath;
 import saros.concurrent.jupiter.Operation;
 import saros.concurrent.jupiter.internal.text.DeleteOperation;
@@ -19,7 +18,6 @@ import saros.editor.text.TextSelection;
 import saros.filesystem.IFile;
 import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.filesystem.VirtualFileConverter;
-import saros.intellij.project.SharedResourcesManager;
 import saros.intellij.ui.Messages;
 import saros.intellij.ui.util.NotificationPanel;
 import saros.session.ISarosSession;
@@ -293,7 +291,6 @@ public class LocalEditorManipulator {
    * @param encoding the encoding of the content
    * @param source the user that send the recovery action
    * @see Document
-   * @see SharedResourcesManager#handleFileRecovery(FileActivity)
    */
   public void handleContentRecovery(SPath path, byte[] content, String encoding, User source) {
     VirtualFile virtualFile = VirtualFileConverter.convertToVirtualFile(path);

--- a/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
@@ -2,7 +2,6 @@ package saros.intellij.editor;
 
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
@@ -210,7 +209,7 @@ public class LocalEditorManipulator {
    */
   public void adjustViewport(@NotNull Editor editor, LineRange range, TextSelection selection) {
     if (selection == null && range == null) {
-      VirtualFile file = FileDocumentManager.getInstance().getFile(editor.getDocument());
+      VirtualFile file = DocumentAPI.getVirtualFile(editor.getDocument());
 
       LOG.warn(
           "Could not adjust viewport for "

--- a/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
@@ -153,7 +153,7 @@ public class LocalEditorManipulator {
         return;
       }
 
-      doc = projectAPI.getDocument(virtualFile);
+      doc = DocumentAPI.getDocument(virtualFile);
 
       if (doc == null) {
         LOG.warn(
@@ -306,7 +306,7 @@ public class LocalEditorManipulator {
       return;
     }
 
-    Document document = projectAPI.getDocument(virtualFile);
+    Document document = DocumentAPI.getDocument(virtualFile);
     if (document == null) {
       LOG.warn(
           "Could not recover file content of "

--- a/intellij/src/saros/intellij/editor/ProjectAPI.java
+++ b/intellij/src/saros/intellij/editor/ProjectAPI.java
@@ -6,18 +6,16 @@ import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
 import saros.intellij.filesystem.Filesystem;
 
-/** IntellIJ API for project-level operations on editors. */
+/** Wrapper for interacting with the project-level Intellij editor API. */
 public class ProjectAPI {
   private FileDocumentManager fileDocumentManager;
 
   private Project project;
   private FileEditorManager editorFileManager;
 
-  /** Creates an ProjectAPI with the current Project and initializes Fields. */
   public ProjectAPI(Project project) {
     this.project = project;
 
@@ -26,77 +24,66 @@ public class ProjectAPI {
   }
 
   /**
-   * Returns whether the file is opened.
+   * Returns whether there is an open editor for the given file.
    *
-   * @param file
-   * @return
+   * @param virtualFile the file to check
+   * @return whether there is an open editor for the given file
    */
-  public boolean isOpen(VirtualFile file) {
-    return editorFileManager.isFileOpen(file);
+  public boolean isOpen(VirtualFile virtualFile) {
+    return editorFileManager.isFileOpen(virtualFile);
   }
 
   /**
-   * Returns whether the document is opened.
+   * Returns whether there is an open editor for the given document.
    *
-   * @param doc
-   * @return
+   * @param document the document to check
+   * @return Returns whether there is an open editor for the given document.
    */
-  public boolean isOpen(Document doc) {
-    VirtualFile file = fileDocumentManager.getFile(doc);
+  public boolean isOpen(Document document) {
+    VirtualFile file = fileDocumentManager.getFile(document);
+
     return isOpen(file);
   }
 
   /**
-   * Opens an editor for the given path in the UI thread.
+   * Opens an editor for the given file in the UI thread.
    *
-   * @param path path of the file to open
+   * @param virtualFile file for which to open an editor
    * @param activate activate editor after opening
    * @return Editor managing the passed file
    */
-  public Editor openEditor(final VirtualFile path, final boolean activate) {
+  public Editor openEditor(final VirtualFile virtualFile, final boolean activate) {
     return Filesystem.runReadAction(
-        new Computable<Editor>() {
-
-          @Override
-          public Editor compute() {
-            return editorFileManager.openTextEditor(
-                new OpenFileDescriptor(project, path), activate);
-          }
-        });
+        () ->
+            editorFileManager.openTextEditor(
+                new OpenFileDescriptor(project, virtualFile), activate));
   }
 
   /**
    * Closes the editor for the given file in the UI thread.
    *
-   * @param file
+   * @param virtualFile the file whose editor to close
    */
-  public void closeEditor(final VirtualFile file) {
+  public void closeEditor(final VirtualFile virtualFile) {
 
-    Filesystem.runReadAction(
-        new Runnable() {
-
-          @Override
-          public void run() {
-            editorFileManager.closeFile(file);
-          }
-        });
-  }
-
-  public void closeEditor(Document doc) {
-    VirtualFile file = fileDocumentManager.getFile(doc);
-    closeEditor(file);
+    Filesystem.runReadAction(() -> editorFileManager.closeFile(virtualFile));
   }
 
   /**
    * Returns an array containing the files of all currently open editors. It is sorted by the order
    * of the editor tabs.
    *
-   * @return
+   * @return array containing the files of all currently open editors
    */
   public VirtualFile[] getOpenFiles() {
     return editorFileManager.getOpenFiles();
   }
 
+  /**
+   * Returns the currently selected editor.
+   *
+   * @return the currently selected editor
+   */
   public Editor getActiveEditor() {
     return editorFileManager.getSelectedTextEditor();
   }
@@ -105,7 +92,7 @@ public class ProjectAPI {
    * Returns an array containing the files of all currently active editors. It is sorted by time of
    * last activation, starting with the most recent one.
    *
-   * @return
+   * @return an array containing the files of all currently active editors
    */
   public VirtualFile[] getSelectedFiles() {
     return editorFileManager.getSelectedFiles();

--- a/intellij/src/saros/intellij/editor/ProjectAPI.java
+++ b/intellij/src/saros/intellij/editor/ProjectAPI.java
@@ -2,7 +2,6 @@ package saros.intellij.editor;
 
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.project.Project;
@@ -11,8 +10,6 @@ import saros.intellij.filesystem.Filesystem;
 
 /** Wrapper for interacting with the project-level Intellij editor API. */
 public class ProjectAPI {
-  private FileDocumentManager fileDocumentManager;
-
   private Project project;
   private FileEditorManager editorFileManager;
 
@@ -20,7 +17,6 @@ public class ProjectAPI {
     this.project = project;
 
     this.editorFileManager = FileEditorManager.getInstance(project);
-    this.fileDocumentManager = FileDocumentManager.getInstance();
   }
 
   /**
@@ -40,7 +36,7 @@ public class ProjectAPI {
    * @return Returns whether there is an open editor for the given document.
    */
   public boolean isOpen(Document document) {
-    VirtualFile file = fileDocumentManager.getFile(document);
+    VirtualFile file = DocumentAPI.getVirtualFile(document);
 
     return isOpen(file);
   }

--- a/intellij/src/saros/intellij/editor/ProjectAPI.java
+++ b/intellij/src/saros/intellij/editor/ProjectAPI.java
@@ -1,6 +1,5 @@
 package saros.intellij.editor;
 
-import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
@@ -9,11 +8,9 @@ import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import saros.intellij.filesystem.Filesystem;
 
-/** IntellIJ API for project-level operations on editors and documents. */
+/** IntellIJ API for project-level operations on editors. */
 public class ProjectAPI {
   private FileDocumentManager fileDocumentManager;
 
@@ -69,29 +66,6 @@ public class ProjectAPI {
   }
 
   /**
-   * Returns a document for the given file.
-   *
-   * @param file the <code>VirtualFile</code> for which the document is requested
-   * @return a <code>Document</code> for the given file or <code>null</code> if the file does not
-   *     exist, could not be read, is a directory, or is to large
-   */
-  @Nullable
-  public Document getDocument(@NotNull final VirtualFile file) {
-    if (!file.exists()) {
-      return null;
-    }
-
-    return Filesystem.runReadAction(
-        new Computable<Document>() {
-
-          @Override
-          public Document compute() {
-            return fileDocumentManager.getDocument(file);
-          }
-        });
-  }
-
-  /**
    * Closes the editor for the given file in the UI thread.
    *
    * @param file
@@ -135,51 +109,5 @@ public class ProjectAPI {
    */
   public VirtualFile[] getSelectedFiles() {
     return editorFileManager.getSelectedFiles();
-  }
-
-  /**
-   * Saves the given document in the UI thread.
-   *
-   * @param doc
-   */
-  public void saveDocument(final Document doc) {
-    Filesystem.runWriteAction(
-        new Runnable() {
-
-          @Override
-          public void run() {
-            fileDocumentManager.saveDocument(doc);
-          }
-        },
-        ModalityState.NON_MODAL);
-  }
-
-  /**
-   * Reloads the current document in the UI thread.
-   *
-   * @param doc
-   */
-  public void reloadFromDisk(final Document doc) {
-    Filesystem.runReadAction(
-        new Runnable() {
-
-          @Override
-          public void run() {
-            fileDocumentManager.reloadFromDisk(doc);
-          }
-        });
-  }
-
-  /** Saves all documents in the UI thread. */
-  public void saveAllDocuments() {
-    Filesystem.runWriteAction(
-        new Runnable() {
-
-          @Override
-          public void run() {
-            fileDocumentManager.saveAllDocuments();
-          }
-        },
-        ModalityState.NON_MODAL);
   }
 }

--- a/intellij/src/saros/intellij/eventhandler/editor/document/AbstractLocalDocumentModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/document/AbstractLocalDocumentModificationHandler.java
@@ -3,11 +3,11 @@ package saros.intellij.eventhandler.editor.document;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.editor.event.DocumentListener;
-import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import saros.activities.SPath;
+import saros.intellij.editor.DocumentAPI;
 import saros.intellij.editor.EditorManager;
 import saros.intellij.eventhandler.DisableableHandler;
 import saros.intellij.filesystem.VirtualFileConverter;
@@ -113,7 +113,7 @@ public abstract class AbstractLocalDocumentModificationHandler
       return path;
     }
 
-    VirtualFile virtualFile = FileDocumentManager.getInstance().getFile(document);
+    VirtualFile virtualFile = DocumentAPI.getVirtualFile(document);
 
     if (virtualFile == null) {
       if (LOG.isTraceEnabled()) {

--- a/intellij/src/saros/intellij/eventhandler/editor/viewport/LocalViewPortChangeHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/viewport/LocalViewPortChangeHandler.java
@@ -5,13 +5,13 @@ import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.editor.LogicalPosition;
 import com.intellij.openapi.editor.event.VisibleAreaEvent;
 import com.intellij.openapi.editor.event.VisibleAreaListener;
-import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import java.awt.Rectangle;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import saros.activities.SPath;
 import saros.editor.text.LineRange;
+import saros.intellij.editor.DocumentAPI;
 import saros.intellij.editor.EditorAPI;
 import saros.intellij.editor.EditorManager;
 import saros.intellij.eventhandler.DisableableHandler;
@@ -77,7 +77,7 @@ public class LocalViewPortChangeHandler implements DisableableHandler, Startable
 
     if (path == null) {
       if (log.isTraceEnabled()) {
-        VirtualFile file = FileDocumentManager.getInstance().getFile(editor.getDocument());
+        VirtualFile file = DocumentAPI.getVirtualFile(editor.getDocument());
 
         log.trace(
             "Ignoring local view port change for "

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -33,6 +33,7 @@ import saros.activities.FolderDeletedActivity;
 import saros.activities.IActivity;
 import saros.activities.SPath;
 import saros.filesystem.IPath;
+import saros.intellij.editor.DocumentAPI;
 import saros.intellij.editor.EditorManager;
 import saros.intellij.editor.LocalEditorHandler;
 import saros.intellij.editor.ProjectAPI;
@@ -850,7 +851,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
    * @see VirtualFile
    */
   private byte[] getContent(VirtualFile file) {
-    Document document = projectAPI.getDocument(file);
+    Document document = DocumentAPI.getDocument(file);
 
     try {
       if (document != null) {

--- a/intellij/src/saros/intellij/ui/wizards/AddProjectToSessionWizard.java
+++ b/intellij/src/saros/intellij/ui/wizards/AddProjectToSessionWizard.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.Nullable;
 import saros.filesystem.IChecksumCache;
 import saros.filesystem.IProject;
 import saros.filesystem.IWorkspace;
-import saros.intellij.editor.ProjectAPI;
+import saros.intellij.editor.DocumentAPI;
 import saros.intellij.filesystem.Filesystem;
 import saros.intellij.filesystem.IntelliJProjectImpl;
 import saros.intellij.ui.Messages;
@@ -97,8 +97,6 @@ public class AddProjectToSessionWizard extends Wizard {
 
   @Inject private IWorkspace workspace;
 
-  @Inject private ProjectAPI projectAPI;
-
   private final SelectProjectPage selectProjectPage;
   private final TextAreaPage fileListPage;
 
@@ -116,7 +114,7 @@ public class AddProjectToSessionWizard extends Wizard {
         @Override
         public void next() {
 
-          projectAPI.saveAllDocuments();
+          DocumentAPI.saveAllDocuments();
 
           // FIXME: Only projects with the same name are supported,
           // because the project name is connected to the name of the .iml file

--- a/intellij/test/junit/saros/intellij/context/AbstractContextTest.java
+++ b/intellij/test/junit/saros/intellij/context/AbstractContextTest.java
@@ -4,7 +4,6 @@ import static saros.intellij.test.IntellijMocker.mockStaticGetInstance;
 
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.command.CommandProcessor;
-import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.module.ModuleTypeManager;
 import com.intellij.openapi.project.Project;
@@ -21,7 +20,6 @@ import saros.test.mocks.ContextMocker;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({
   CommandProcessor.class,
-  FileDocumentManager.class,
   FileEditorManager.class,
   LocalFileSystem.class,
   PropertiesComponent.class,
@@ -39,7 +37,6 @@ public class AbstractContextTest {
 
     // mock IntelliJ dependencies
     mockStaticGetInstance(CommandProcessor.class, null);
-    mockStaticGetInstance(FileDocumentManager.class, null);
     mockStaticGetInstance(FileEditorManager.class, Project.class);
     mockStaticGetInstance(LocalFileSystem.class, null);
     mockStaticGetInstance(PropertiesComponent.class, null);

--- a/intellij/test/junit/saros/intellij/context/AbstractContextTest.java
+++ b/intellij/test/junit/saros/intellij/context/AbstractContextTest.java
@@ -3,11 +3,8 @@ package saros.intellij.context;
 import static saros.intellij.test.IntellijMocker.mockStaticGetInstance;
 
 import com.intellij.ide.util.PropertiesComponent;
-import com.intellij.openapi.command.CommandProcessor;
-import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.module.ModuleTypeManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vfs.LocalFileSystem;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -18,14 +15,7 @@ import saros.repackaged.picocontainer.MutablePicoContainer;
 import saros.test.mocks.ContextMocker;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({
-  CommandProcessor.class,
-  FileEditorManager.class,
-  LocalFileSystem.class,
-  PropertiesComponent.class,
-  ModuleTypeManager.class,
-  IntelliJVersionProvider.class
-})
+@PrepareForTest({PropertiesComponent.class, ModuleTypeManager.class, IntelliJVersionProvider.class})
 public class AbstractContextTest {
 
   MutablePicoContainer container;
@@ -36,9 +26,6 @@ public class AbstractContextTest {
     container = ContextMocker.emptyContext();
 
     // mock IntelliJ dependencies
-    mockStaticGetInstance(CommandProcessor.class, null);
-    mockStaticGetInstance(FileEditorManager.class, Project.class);
-    mockStaticGetInstance(LocalFileSystem.class, null);
     mockStaticGetInstance(PropertiesComponent.class, null);
     mockStaticGetInstance(ModuleTypeManager.class, null);
 


### PR DESCRIPTION
Continuation of #451.

Splits off document handling from ProjectAPI and moves ProjectAPI to session context.