### PR TITLE
Prepare to remove project from plugin context (3 of X)

### DIFF
--- a/intellij/src/saros/core/ui/eventhandler/NegotiationHandler.java
+++ b/intellij/src/saros/core/ui/eventhandler/NegotiationHandler.java
@@ -80,14 +80,11 @@ public class NegotiationHandler implements INegotiationHandler {
 
     ApplicationManager.getApplication()
         .invokeLater(
-            new Runnable() {
-              @Override
-              public void run() {
-                JoinSessionWizard wizard =
-                    new JoinSessionWizard(project, getWindow(project), negotiation);
-                wizard.setModal(true);
-                wizard.open();
-              }
+            () -> {
+              JoinSessionWizard wizard =
+                  new JoinSessionWizard(project, getWindow(project), negotiation);
+              wizard.setModal(true);
+              wizard.open();
             },
             ModalityState.defaultModalityState());
   }
@@ -97,16 +94,12 @@ public class NegotiationHandler implements INegotiationHandler {
 
     ApplicationManager.getApplication()
         .invokeLater(
-            new Runnable() {
-              @Override
-              public void run() {
+            () -> {
+              AddProjectToSessionWizard wizard =
+                  new AddProjectToSessionWizard(project, getWindow(project), negotiation);
 
-                AddProjectToSessionWizard wizard =
-                    new AddProjectToSessionWizard(project, getWindow(project), negotiation);
-
-                wizard.setModal(false);
-                wizard.open();
-              }
+              wizard.setModal(false);
+              wizard.open();
             },
             ModalityState.defaultModalityState());
   }
@@ -126,7 +119,7 @@ public class NegotiationHandler implements INegotiationHandler {
     private final OutgoingSessionNegotiation negotiation;
     private final String peer;
 
-    public OutgoingInvitationJob(OutgoingSessionNegotiation negotiation) {
+    OutgoingInvitationJob(OutgoingSessionNegotiation negotiation) {
       super(
           MessageFormat.format(
               Messages.NegotiationHandler_inviting_user, getNickname(negotiation.getPeer())));
@@ -189,7 +182,7 @@ public class NegotiationHandler implements INegotiationHandler {
     private final AbstractOutgoingProjectNegotiation negotiation;
     private final String peer;
 
-    public OutgoingProjectJob(AbstractOutgoingProjectNegotiation outgoingProjectNegotiation) {
+    OutgoingProjectJob(AbstractOutgoingProjectNegotiation outgoingProjectNegotiation) {
       super(Messages.NegotiationHandler_sharing_project);
       negotiation = outgoingProjectNegotiation;
       peer = negotiation.getPeer().getBase();
@@ -218,13 +211,9 @@ public class NegotiationHandler implements INegotiationHandler {
 
             ApplicationManager.getApplication()
                 .invokeLater(
-                    new Runnable() {
-                      @Override
-                      public void run() {
+                    () ->
                         NotificationPanel.showInformation(
-                            message, "Project sharing canceled remotely");
-                      }
-                    });
+                            message, "Project sharing canceled remotely"));
 
             return new Status(IStatus.CANCEL, SarosComponent.PLUGIN_ID, message);
 

--- a/intellij/src/saros/core/ui/eventhandler/XMPPAuthorizationHandler.java
+++ b/intellij/src/saros/core/ui/eventhandler/XMPPAuthorizationHandler.java
@@ -1,10 +1,12 @@
 package saros.core.ui.eventhandler;
 
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
 import java.text.MessageFormat;
 import org.apache.log4j.Logger;
 import saros.intellij.ui.Messages;
 import saros.intellij.ui.util.DialogUtils;
+import saros.intellij.ui.util.UIProjectUtils;
 import saros.net.xmpp.JID;
 import saros.net.xmpp.subscription.SubscriptionHandler;
 import saros.net.xmpp.subscription.SubscriptionListener;
@@ -13,34 +15,42 @@ import saros.net.xmpp.subscription.SubscriptionListener;
 public class XMPPAuthorizationHandler {
 
   private static final Logger LOG = Logger.getLogger(XMPPAuthorizationHandler.class);
+
+  private final UIProjectUtils projectUtils;
+
   private final SubscriptionListener subscriptionListener =
       new SubscriptionListener() {
 
         @Override
         public void subscriptionRequestReceived(final JID jid) {
 
-          ApplicationManager.getApplication()
-              .invokeLater(
-                  new Runnable() {
-                    @Override
-                    public void run() {
-                      handleAuthorizationRequest(jid);
-                    }
-                  });
+          projectUtils.runWithProject(
+              project ->
+                  ApplicationManager.getApplication()
+                      .invokeLater(
+                          new Runnable() {
+                            @Override
+                            public void run() {
+                              handleAuthorizationRequest(project, jid);
+                            }
+                          }));
         }
       };
   private final SubscriptionHandler subscriptionHandler;
 
-  public XMPPAuthorizationHandler(final SubscriptionHandler subscriptionHandler) {
+  public XMPPAuthorizationHandler(
+      final SubscriptionHandler subscriptionHandler, UIProjectUtils projectUtils) {
     this.subscriptionHandler = subscriptionHandler;
     this.subscriptionHandler.addSubscriptionListener(subscriptionListener);
+
+    this.projectUtils = projectUtils;
   }
 
-  private void handleAuthorizationRequest(final JID jid) {
+  private void handleAuthorizationRequest(Project project, final JID jid) {
 
     boolean accept =
-        DialogUtils.oldShowConfirm(
-            null,
+        DialogUtils.showConfirm(
+            project,
             Messages.SubscriptionManager_incoming_subscription_request_title,
             MessageFormat.format(
                 Messages.SubscriptionManager_incoming_subscription_request_message,

--- a/intellij/src/saros/core/ui/eventhandler/XMPPAuthorizationHandler.java
+++ b/intellij/src/saros/core/ui/eventhandler/XMPPAuthorizationHandler.java
@@ -3,7 +3,6 @@ package saros.core.ui.eventhandler;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import java.text.MessageFormat;
-import org.apache.log4j.Logger;
 import saros.intellij.ui.Messages;
 import saros.intellij.ui.util.DialogUtils;
 import saros.intellij.ui.util.UIProjectUtils;
@@ -13,11 +12,9 @@ import saros.net.xmpp.subscription.SubscriptionListener;
 
 /** Handler for accepting or rejecting incoming XMPP subscription requests */
 public class XMPPAuthorizationHandler {
-
-  private static final Logger LOG = Logger.getLogger(XMPPAuthorizationHandler.class);
-
   private final UIProjectUtils projectUtils;
 
+  @SuppressWarnings("FieldCanBeLocal")
   private final SubscriptionListener subscriptionListener =
       new SubscriptionListener() {
 
@@ -27,15 +24,10 @@ public class XMPPAuthorizationHandler {
           projectUtils.runWithProject(
               project ->
                   ApplicationManager.getApplication()
-                      .invokeLater(
-                          new Runnable() {
-                            @Override
-                            public void run() {
-                              handleAuthorizationRequest(project, jid);
-                            }
-                          }));
+                      .invokeLater(() -> handleAuthorizationRequest(project, jid)));
         }
       };
+
   private final SubscriptionHandler subscriptionHandler;
 
   public XMPPAuthorizationHandler(

--- a/intellij/src/saros/core/ui/eventhandler/XMPPAuthorizationHandler.java
+++ b/intellij/src/saros/core/ui/eventhandler/XMPPAuthorizationHandler.java
@@ -39,7 +39,7 @@ public class XMPPAuthorizationHandler {
   private void handleAuthorizationRequest(final JID jid) {
 
     boolean accept =
-        DialogUtils.showConfirm(
+        DialogUtils.oldShowConfirm(
             null,
             Messages.SubscriptionManager_incoming_subscription_request_title,
             MessageFormat.format(

--- a/intellij/src/saros/core/ui/util/CollaborationUtils.java
+++ b/intellij/src/saros/core/ui/util/CollaborationUtils.java
@@ -1,6 +1,7 @@
 package saros.core.ui.util;
 
 import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -107,7 +108,7 @@ public class CollaborationUtils {
    * Leaves the currently running {@link SarosSession}<br>
    * Does nothing if no {@link SarosSession} is running.
    */
-  public static void leaveSession() {
+  public static void leaveSession(Project project) {
 
     ISarosSession sarosSession = sessionManager.getSession();
 
@@ -124,15 +125,15 @@ public class CollaborationUtils {
         reallyLeave = true;
       } else {
         reallyLeave =
-            DialogUtils.oldShowConfirm(
-                null,
+            DialogUtils.showConfirm(
+                project,
                 Messages.CollaborationUtils_confirm_closing,
                 Messages.CollaborationUtils_confirm_closing_text);
       }
     } else {
       reallyLeave =
-          DialogUtils.oldShowConfirm(
-              null,
+          DialogUtils.showConfirm(
+              project,
               Messages.CollaborationUtils_confirm_leaving,
               Messages.CollaborationUtils_confirm_leaving_text);
     }

--- a/intellij/src/saros/core/ui/util/CollaborationUtils.java
+++ b/intellij/src/saros/core/ui/util/CollaborationUtils.java
@@ -124,14 +124,14 @@ public class CollaborationUtils {
         reallyLeave = true;
       } else {
         reallyLeave =
-            DialogUtils.showConfirm(
+            DialogUtils.oldShowConfirm(
                 null,
                 Messages.CollaborationUtils_confirm_closing,
                 Messages.CollaborationUtils_confirm_closing_text);
       }
     } else {
       reallyLeave =
-          DialogUtils.showConfirm(
+          DialogUtils.oldShowConfirm(
               null,
               Messages.CollaborationUtils_confirm_leaving,
               Messages.CollaborationUtils_confirm_leaving_text);

--- a/intellij/src/saros/core/util/IntelliJCollaborationUtilsImpl.java
+++ b/intellij/src/saros/core/util/IntelliJCollaborationUtilsImpl.java
@@ -3,6 +3,7 @@ package saros.core.util;
 import java.util.List;
 import saros.core.ui.util.CollaborationUtils;
 import saros.filesystem.IResource;
+import saros.intellij.ui.util.UIProjectUtils;
 import saros.net.xmpp.JID;
 import saros.ui.util.ICollaborationUtils;
 
@@ -13,6 +14,12 @@ import saros.ui.util.ICollaborationUtils;
 // directly
 public class IntelliJCollaborationUtilsImpl implements ICollaborationUtils {
 
+  private final UIProjectUtils projectUtils;
+
+  public IntelliJCollaborationUtilsImpl(UIProjectUtils projectUtils) {
+    this.projectUtils = projectUtils;
+  }
+
   @Override
   public void startSession(List<IResource> resources, List<JID> contacts) {
     CollaborationUtils.startSession(resources, contacts);
@@ -20,7 +27,7 @@ public class IntelliJCollaborationUtilsImpl implements ICollaborationUtils {
 
   @Override
   public void leaveSession() {
-    CollaborationUtils.leaveSession();
+    projectUtils.runWithProject(CollaborationUtils::leaveSession);
   }
 
   @Override

--- a/intellij/src/saros/core/util/IntellijCollaborationUtilsImpl.java
+++ b/intellij/src/saros/core/util/IntellijCollaborationUtilsImpl.java
@@ -8,15 +8,15 @@ import saros.net.xmpp.JID;
 import saros.ui.util.ICollaborationUtils;
 
 /**
- * This delegates the {@link ICollaborationUtils} methods to the actual implementation in IntelliJ.
+ * This delegates the {@link ICollaborationUtils} methods to the actual implementation in Intellij.
  */
 // TODO: make CollaborationUtils non static and let it implement the interface
 // directly
-public class IntelliJCollaborationUtilsImpl implements ICollaborationUtils {
+public class IntellijCollaborationUtilsImpl implements ICollaborationUtils {
 
   private final UIProjectUtils projectUtils;
 
-  public IntelliJCollaborationUtilsImpl(UIProjectUtils projectUtils) {
+  public IntellijCollaborationUtilsImpl(UIProjectUtils projectUtils) {
     this.projectUtils = projectUtils;
   }
 
@@ -31,8 +31,8 @@ public class IntelliJCollaborationUtilsImpl implements ICollaborationUtils {
   }
 
   @Override
-  public void addResourcesToSession(List<IResource> resoruces) {
-    CollaborationUtils.addResourcesToSession(resoruces);
+  public void addResourcesToSession(List<IResource> resources) {
+    CollaborationUtils.addResourcesToSession(resources);
   }
 
   @Override

--- a/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
+++ b/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
@@ -29,6 +29,7 @@ import saros.intellij.runtime.IntelliJSynchronizer;
 import saros.intellij.ui.eventhandler.SessionStatusChangeHandler;
 import saros.intellij.ui.swt_browser.IntelliJDialogManager;
 import saros.intellij.ui.swt_browser.IntelliJUIResourceLocator;
+import saros.intellij.ui.util.UIProjectUtils;
 import saros.monitoring.remote.IRemoteProgressIndicatorFactory;
 import saros.preferences.IPreferenceStore;
 import saros.preferences.Preferences;
@@ -65,6 +66,9 @@ public class SarosIntellijContextFactory extends AbstractContextFactory {
       Component.create(Preferences.class, IntelliJPreferences.class),
       Component.create(
           IRemoteProgressIndicatorFactory.class, IntelliJRemoteProgressIndicatorFactoryImpl.class),
+
+      // UI Utility
+      Component.create(UIProjectUtils.class),
 
       // IDE-specific classes for the HTML GUI
       Component.create(DialogManager.class, IntelliJDialogManager.class),

--- a/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
+++ b/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
@@ -11,7 +11,7 @@ import saros.core.project.internal.SarosIntellijSessionContextFactory;
 import saros.core.ui.eventhandler.NegotiationHandler;
 import saros.core.ui.eventhandler.UserStatusChangeHandler;
 import saros.core.ui.eventhandler.XMPPAuthorizationHandler;
-import saros.core.util.IntelliJCollaborationUtilsImpl;
+import saros.core.util.IntellijCollaborationUtilsImpl;
 import saros.editor.IEditorManager;
 import saros.filesystem.IChecksumCache;
 import saros.filesystem.IPathFactory;
@@ -27,8 +27,8 @@ import saros.intellij.project.filesystem.IntelliJWorkspaceRootImpl;
 import saros.intellij.project.filesystem.PathFactory;
 import saros.intellij.runtime.IntelliJSynchronizer;
 import saros.intellij.ui.eventhandler.SessionStatusChangeHandler;
-import saros.intellij.ui.swt_browser.IntelliJDialogManager;
 import saros.intellij.ui.swt_browser.IntelliJUIResourceLocator;
+import saros.intellij.ui.swt_browser.IntellijDialogManager;
 import saros.intellij.ui.util.UIProjectUtils;
 import saros.monitoring.remote.IRemoteProgressIndicatorFactory;
 import saros.preferences.IPreferenceStore;
@@ -71,9 +71,9 @@ public class SarosIntellijContextFactory extends AbstractContextFactory {
       Component.create(UIProjectUtils.class),
 
       // IDE-specific classes for the HTML GUI
-      Component.create(DialogManager.class, IntelliJDialogManager.class),
+      Component.create(DialogManager.class, IntellijDialogManager.class),
       Component.create(IUIResourceLocator.class, IntelliJUIResourceLocator.class),
-      Component.create(ICollaborationUtils.class, IntelliJCollaborationUtilsImpl.class),
+      Component.create(ICollaborationUtils.class, IntellijCollaborationUtilsImpl.class),
       Component.create(IWorkspaceRoot.class, IntelliJWorkspaceRootImpl.class),
 
       // Proxy Support for the XMPP server connection

--- a/intellij/src/saros/intellij/ui/SarosToolWindowFactory.java
+++ b/intellij/src/saros/intellij/ui/SarosToolWindowFactory.java
@@ -13,11 +13,9 @@ import saros.intellij.ui.views.SarosMainPanelView;
 /** This factory is the starting point of UI of the Saros plugin. */
 public class SarosToolWindowFactory implements ToolWindowFactory {
 
-  private SarosMainPanelView sarosMainPanelView;
-
   @Override
   public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
-    sarosMainPanelView = new SarosMainPanelView(project);
+    SarosMainPanelView sarosMainPanelView = new SarosMainPanelView(project);
 
     Content content =
         toolWindow

--- a/intellij/src/saros/intellij/ui/SarosToolWindowFactory.java
+++ b/intellij/src/saros/intellij/ui/SarosToolWindowFactory.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.ui.content.Content;
+import org.jetbrains.annotations.NotNull;
 import saros.intellij.SarosComponent;
 import saros.intellij.ui.views.SarosMainPanelView;
 
@@ -15,8 +16,8 @@ public class SarosToolWindowFactory implements ToolWindowFactory {
   private SarosMainPanelView sarosMainPanelView;
 
   @Override
-  public void createToolWindowContent(Project project, ToolWindow toolWindow) {
-    sarosMainPanelView = new SarosMainPanelView();
+  public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
+    sarosMainPanelView = new SarosMainPanelView(project);
 
     Content content =
         toolWindow

--- a/intellij/src/saros/intellij/ui/actions/AbstractSarosAction.java
+++ b/intellij/src/saros/intellij/ui/actions/AbstractSarosAction.java
@@ -10,7 +10,7 @@ import org.apache.log4j.Logger;
 public abstract class AbstractSarosAction {
   protected static final Logger LOG = Logger.getLogger(AbstractSarosAction.class);
 
-  private final List<ActionListener> actionListeners = new ArrayList<ActionListener>();
+  private final List<ActionListener> actionListeners = new ArrayList<>();
 
   protected void actionPerformed() {
     for (ActionListener actionListener : actionListeners) {

--- a/intellij/src/saros/intellij/ui/actions/AbstractSarosAction.java
+++ b/intellij/src/saros/intellij/ui/actions/AbstractSarosAction.java
@@ -1,25 +1,16 @@
 package saros.intellij.ui.actions;
 
-import com.intellij.openapi.project.Project;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.log4j.Logger;
-import saros.SarosPluginContext;
-import saros.repackaged.picocontainer.annotations.Inject;
 
 /** Parent class for all Saros actions */
 public abstract class AbstractSarosAction {
   protected static final Logger LOG = Logger.getLogger(AbstractSarosAction.class);
 
   private final List<ActionListener> actionListeners = new ArrayList<ActionListener>();
-
-  @Inject protected Project project;
-
-  protected AbstractSarosAction() {
-    SarosPluginContext.initComponent(this);
-  }
 
   protected void actionPerformed() {
     for (ActionListener actionListener : actionListeners) {

--- a/intellij/src/saros/intellij/ui/actions/ConnectServerAction.java
+++ b/intellij/src/saros/intellij/ui/actions/ConnectServerAction.java
@@ -49,7 +49,7 @@ public class ConnectServerAction extends AbstractSarosAction {
   /**
    * Connects an Account to the XMPPService and sets it as active.
    *
-   * @param account
+   * @param account the account to connect to
    */
   private void connectAccount(final XMPPAccount account) {
     ProgressManager.getInstance()
@@ -57,7 +57,7 @@ public class ConnectServerAction extends AbstractSarosAction {
             new Task.Modal(project, "Connecting...", false) {
 
               @Override
-              public void run(ProgressIndicator indicator) {
+              public void run(@NotNull ProgressIndicator indicator) {
 
                 LOG.info(
                     "Connecting server: ["

--- a/intellij/src/saros/intellij/ui/actions/ConnectServerAction.java
+++ b/intellij/src/saros/intellij/ui/actions/ConnectServerAction.java
@@ -3,6 +3,9 @@ package saros.intellij.ui.actions;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import saros.SarosPluginContext;
 import saros.account.XMPPAccount;
 import saros.account.XMPPAccountStore;
 import saros.communication.connection.ConnectionHandler;
@@ -12,9 +15,17 @@ import saros.repackaged.picocontainer.annotations.Inject;
 public class ConnectServerAction extends AbstractSarosAction {
   public static final String NAME = "connect";
 
+  private final Project project;
+
   @Inject private XMPPAccountStore accountStore;
 
   @Inject private ConnectionHandler connectionHandler;
+
+  public ConnectServerAction(@NotNull Project project) {
+    this.project = project;
+
+    SarosPluginContext.initComponent(this);
+  }
 
   @Override
   public String getActionName() {
@@ -41,9 +52,6 @@ public class ConnectServerAction extends AbstractSarosAction {
    * @param account
    */
   private void connectAccount(final XMPPAccount account) {
-
-    // FIXME use the project from the action event !
-    // AnActionEvent.getDataContext().getData(DataConstants.PROJECT)
     ProgressManager.getInstance()
         .run(
             new Task.Modal(project, "Connecting...", false) {

--- a/intellij/src/saros/intellij/ui/actions/ConsistencyAction.java
+++ b/intellij/src/saros/intellij/ui/actions/ConsistencyAction.java
@@ -3,7 +3,6 @@ package saros.intellij.ui.actions;
 import com.intellij.openapi.application.ApplicationManager;
 import saros.concurrent.watchdog.ConsistencyWatchdogClient;
 import saros.intellij.ui.Messages;
-import saros.intellij.ui.widgets.progress.MonitorProgressBar;
 import saros.intellij.ui.widgets.progress.ProgressFrame;
 import saros.monitoring.IProgressMonitor;
 import saros.util.ThreadUtils;
@@ -29,30 +28,17 @@ public class ConsistencyAction extends AbstractSarosAction {
     LOG.debug("user activated CW recovery.");
 
     final ProgressFrame progress = new ProgressFrame("Consistency action");
+
     progress.setFinishListener(
-        new MonitorProgressBar.FinishListener() {
-          @Override
-          public void finished() {
-            ApplicationManager.getApplication()
-                .invokeLater(
-                    new Runnable() {
-                      @Override
-                      public void run() {
-                        actionPerformed();
-                      }
-                    });
-          }
-        });
+        () -> ApplicationManager.getApplication().invokeLater(this::actionPerformed));
 
     ThreadUtils.runSafeAsync(
         LOG,
-        new Runnable() {
-          @Override
-          public void run() {
-            progress.beginTask(
-                Messages.ConsistencyAction_progress_perform_recovery, IProgressMonitor.UNKNOWN);
-            watchdogClient.runRecovery(progress);
-          }
+        () -> {
+          progress.beginTask(
+              Messages.ConsistencyAction_progress_perform_recovery, IProgressMonitor.UNKNOWN);
+
+          watchdogClient.runRecovery(progress);
         });
   }
 }

--- a/intellij/src/saros/intellij/ui/actions/DisconnectServerAction.java
+++ b/intellij/src/saros/intellij/ui/actions/DisconnectServerAction.java
@@ -4,13 +4,14 @@ import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
 import saros.SarosPluginContext;
 import saros.communication.connection.ConnectionHandler;
 import saros.repackaged.picocontainer.annotations.Inject;
 
 /** Disconnects from XMPP/Jabber server */
 public class DisconnectServerAction extends AbstractSarosAction {
-  public static final String NAME = "disconnect";
+  private static final String NAME = "disconnect";
 
   private final Project project;
 
@@ -34,7 +35,7 @@ public class DisconnectServerAction extends AbstractSarosAction {
             new Task.Modal(project, "Disconnecting...", false) {
 
               @Override
-              public void run(ProgressIndicator indicator) {
+              public void run(@NotNull ProgressIndicator indicator) {
 
                 LOG.info(
                     "Disconnecting current connection: " + connectionHandler.getConnectionID());

--- a/intellij/src/saros/intellij/ui/actions/DisconnectServerAction.java
+++ b/intellij/src/saros/intellij/ui/actions/DisconnectServerAction.java
@@ -3,6 +3,8 @@ package saros.intellij.ui.actions;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.project.Project;
+import saros.SarosPluginContext;
 import saros.communication.connection.ConnectionHandler;
 import saros.repackaged.picocontainer.annotations.Inject;
 
@@ -10,7 +12,15 @@ import saros.repackaged.picocontainer.annotations.Inject;
 public class DisconnectServerAction extends AbstractSarosAction {
   public static final String NAME = "disconnect";
 
+  private final Project project;
+
   @Inject private ConnectionHandler connectionHandler;
+
+  public DisconnectServerAction(Project project) {
+    this.project = project;
+
+    SarosPluginContext.initComponent(this);
+  }
 
   @Override
   public String getActionName() {
@@ -19,9 +29,6 @@ public class DisconnectServerAction extends AbstractSarosAction {
 
   @Override
   public void execute() {
-
-    // FIXME use the project from the action event !
-    // AnActionEvent.getDataContext().getData(DataConstants.PROJECT)
     ProgressManager.getInstance()
         .run(
             new Task.Modal(project, "Disconnecting...", false) {

--- a/intellij/src/saros/intellij/ui/actions/FollowModeAction.java
+++ b/intellij/src/saros/intellij/ui/actions/FollowModeAction.java
@@ -1,5 +1,6 @@
 package saros.intellij.ui.actions;
 
+import saros.SarosPluginContext;
 import saros.editor.FollowModeManager;
 import saros.repackaged.picocontainer.annotations.Inject;
 import saros.session.ISarosSession;
@@ -36,6 +37,8 @@ public class FollowModeAction extends AbstractSarosAction {
   private volatile FollowModeManager followModeManager;
 
   public FollowModeAction() {
+    SarosPluginContext.initComponent(this);
+
     sessionManager.addSessionLifecycleListener(sessionLifecycleListener);
   }
 

--- a/intellij/src/saros/intellij/ui/actions/LeaveSessionAction.java
+++ b/intellij/src/saros/intellij/ui/actions/LeaveSessionAction.java
@@ -5,7 +5,7 @@ import saros.core.ui.util.CollaborationUtils;
 
 /** Action to leave session */
 public class LeaveSessionAction extends AbstractSarosAction {
-  public static final String NAME = "leave";
+  private static final String NAME = "leave";
 
   private final Project project;
 

--- a/intellij/src/saros/intellij/ui/actions/LeaveSessionAction.java
+++ b/intellij/src/saros/intellij/ui/actions/LeaveSessionAction.java
@@ -1,10 +1,19 @@
 package saros.intellij.ui.actions;
 
+import com.intellij.openapi.project.Project;
 import saros.core.ui.util.CollaborationUtils;
 
 /** Action to leave session */
 public class LeaveSessionAction extends AbstractSarosAction {
   public static final String NAME = "leave";
+
+  private final Project project;
+
+  public LeaveSessionAction(Project project) {
+    super();
+
+    this.project = project;
+  }
 
   @Override
   public String getActionName() {
@@ -13,7 +22,7 @@ public class LeaveSessionAction extends AbstractSarosAction {
 
   @Override
   public void execute() {
-    CollaborationUtils.leaveSession();
+    CollaborationUtils.leaveSession(project);
     actionPerformed();
   }
 }

--- a/intellij/src/saros/intellij/ui/swt_browser/IntelliJDialogManager.java
+++ b/intellij/src/saros/intellij/ui/swt_browser/IntelliJDialogManager.java
@@ -1,11 +1,10 @@
 package saros.intellij.ui.swt_browser;
 
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.WindowManager;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import javax.swing.JDialog;
-import javax.swing.JFrame;
+import saros.intellij.ui.util.UIProjectUtils;
 import saros.synchronize.UISynchronizer;
 import saros.ui.ide_embedding.DialogManager;
 import saros.ui.ide_embedding.IBrowserDialog;
@@ -14,18 +13,21 @@ import saros.ui.pages.IBrowserPage;
 /** Implements the dialog manager for the IntelliJ platform. */
 public class IntelliJDialogManager extends DialogManager {
 
-  private Project project;
+  private UIProjectUtils projectUtils;
 
-  public IntelliJDialogManager(UISynchronizer uiSynchronizer, Project project) {
+  public IntelliJDialogManager(UISynchronizer uiSynchronizer, UIProjectUtils projectUtils) {
     super(uiSynchronizer);
 
-    this.project = project;
+    this.projectUtils = projectUtils;
   }
 
   @Override
   protected IBrowserDialog createDialog(final IBrowserPage startPage) {
-    JFrame parent = WindowManager.getInstance().getFrame(project);
-    JDialog jDialog = new JDialog(parent);
+    JDialog jDialog = new JDialog();
+
+    projectUtils.runWithProject(
+        project -> jDialog.setLocationRelativeTo(WindowManager.getInstance().getFrame(project)));
+
     jDialog.addWindowListener(
         new WindowAdapter() {
           @Override

--- a/intellij/src/saros/intellij/ui/swt_browser/IntellijDialogManager.java
+++ b/intellij/src/saros/intellij/ui/swt_browser/IntellijDialogManager.java
@@ -10,12 +10,12 @@ import saros.ui.ide_embedding.DialogManager;
 import saros.ui.ide_embedding.IBrowserDialog;
 import saros.ui.pages.IBrowserPage;
 
-/** Implements the dialog manager for the IntelliJ platform. */
-public class IntelliJDialogManager extends DialogManager {
+/** Implements the dialog manager for the Intellij platform. */
+public class IntellijDialogManager extends DialogManager {
 
   private UIProjectUtils projectUtils;
 
-  public IntelliJDialogManager(UISynchronizer uiSynchronizer, UIProjectUtils projectUtils) {
+  public IntellijDialogManager(UISynchronizer uiSynchronizer, UIProjectUtils projectUtils) {
     super(uiSynchronizer);
 
     this.projectUtils = projectUtils;

--- a/intellij/src/saros/intellij/ui/util/DialogUtils.java
+++ b/intellij/src/saros/intellij/ui/util/DialogUtils.java
@@ -28,8 +28,10 @@ public class DialogUtils {
    * @param title
    * @param msg
    * @return <code>true</code>, if OK was chosen, <code>false</code> otherwise
+   * @deprecated use {@link #showConfirm(Project, String, String)} instead
    */
-  public static boolean showConfirm(Component parent, String title, String msg) {
+  @Deprecated
+  public static boolean oldShowConfirm(Component parent, String title, String msg) {
 
     LOG.info("Showing confirmation dialog: " + title + " - " + msg);
 
@@ -41,26 +43,50 @@ public class DialogUtils {
   }
 
   /**
+   * Displays a confirmation dialog.
+   *
+   * @param project the project used as a reference to generate and position the dialog
+   * @param title the text displayed as the title of the dialog
+   * @param msg the text displayed as the message of the dialog
+   * @return <code>true</code>, if OK was chosen, <code>false</code> otherwise
+   */
+  public static boolean showConfirm(Project project, String title, String msg) {
+
+    LOG.info("Showing confirmation dialog: " + title + " - " + msg);
+
+    Component parentComponent = getProjectComponent(project);
+
+    int resp =
+        JOptionPane.showConfirmDialog(parentComponent, msg, title, JOptionPane.OK_CANCEL_OPTION);
+
+    return resp == JOptionPane.OK_OPTION;
+  }
+
+  /**
    * Shows a Yes/No question dialog.
    *
-   * @param parent the parent Component. If <code>parent</code> is null, the project's window is
-   *     used.
-   * @param title
-   * @param msg
+   * @param project the project used as a reference to generate and position the dialog
+   * @param title the text displayed as the title of the dialog
+   * @param msg the text displayed as the message of the dialog
    * @return <code>true</code> if Yes was chosen, <code>false</code> otherwise
    */
-  public static boolean showQuestion(Component parent, String title, String msg) {
+  public static boolean showQuestion(Project project, String title, String msg) {
 
     LOG.info("Showing question dialog: " + title + " - " + msg);
 
+    Component parentComponent = getProjectComponent(project);
+
     int answer =
-        JOptionPane.showConfirmDialog(
-            notNullOrDefaultParent(parent), msg, title, JOptionPane.YES_NO_OPTION);
+        JOptionPane.showConfirmDialog(parentComponent, msg, title, JOptionPane.YES_NO_OPTION);
 
     return answer == JOptionPane.YES_OPTION;
   }
 
   private static Component notNullOrDefaultParent(Component parent) {
     return parent != null ? parent : WindowManager.getInstance().getFrame(project);
+  }
+
+  private static Component getProjectComponent(Project project) {
+    return WindowManager.getInstance().getFrame(project);
   }
 }

--- a/intellij/src/saros/intellij/ui/util/DialogUtils.java
+++ b/intellij/src/saros/intellij/ui/util/DialogUtils.java
@@ -3,7 +3,6 @@ package saros.intellij.ui.util;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.WindowManager;
 import java.awt.Component;
-import java.awt.Container;
 import javax.swing.JOptionPane;
 import org.apache.log4j.Logger;
 import saros.SarosPluginContext;
@@ -19,21 +18,6 @@ public class DialogUtils {
 
   static {
     SarosPluginContext.initComponent(new DialogUtils());
-  }
-
-  /**
-   * Displays an error message.
-   *
-   * @param parent the parent Component. If <code>parent</code> is null, the project's window is
-   *     used.
-   * @param title
-   * @param msg
-   */
-  public static void showError(Component parent, String title, String msg) {
-    LOG.info("Showing error dialog: " + title + " - " + msg);
-
-    JOptionPane.showMessageDialog(
-        notNullOrDefaultParent(parent), msg, title, JOptionPane.ERROR_MESSAGE);
   }
 
   /**
@@ -74,21 +58,6 @@ public class DialogUtils {
             notNullOrDefaultParent(parent), msg, title, JOptionPane.YES_NO_OPTION);
 
     return answer == JOptionPane.YES_OPTION;
-  }
-
-  /**
-   * Shows an Info dialog.
-   *
-   * @param parent the parent Component. If <code>parent</code> is null, the project's window is
-   *     used.
-   * @param title
-   * @param msg
-   */
-  public static void showInfo(Container parent, String title, String msg) {
-    LOG.info("Showing info dialog: " + title + " - " + msg);
-
-    JOptionPane.showMessageDialog(
-        notNullOrDefaultParent(parent), msg, title, JOptionPane.INFORMATION_MESSAGE);
   }
 
   private static Component notNullOrDefaultParent(Component parent) {

--- a/intellij/src/saros/intellij/ui/util/DialogUtils.java
+++ b/intellij/src/saros/intellij/ui/util/DialogUtils.java
@@ -5,42 +5,12 @@ import com.intellij.openapi.wm.WindowManager;
 import java.awt.Component;
 import javax.swing.JOptionPane;
 import org.apache.log4j.Logger;
-import saros.SarosPluginContext;
-import saros.repackaged.picocontainer.annotations.Inject;
 
 /** Dialog message helper that shows Dialogs in the current Thread. */
 public class DialogUtils {
   private static final Logger LOG = Logger.getLogger(DialogUtils.class);
 
-  @Inject private static Project project;
-
   private DialogUtils() {}
-
-  static {
-    SarosPluginContext.initComponent(new DialogUtils());
-  }
-
-  /**
-   * Displays a confirmation dialog.
-   *
-   * @param parent the parent Component. If <code>parent</code> is null, the project's window is
-   *     used.
-   * @param title
-   * @param msg
-   * @return <code>true</code>, if OK was chosen, <code>false</code> otherwise
-   * @deprecated use {@link #showConfirm(Project, String, String)} instead
-   */
-  @Deprecated
-  public static boolean oldShowConfirm(Component parent, String title, String msg) {
-
-    LOG.info("Showing confirmation dialog: " + title + " - " + msg);
-
-    int resp =
-        JOptionPane.showConfirmDialog(
-            notNullOrDefaultParent(parent), msg, title, JOptionPane.OK_CANCEL_OPTION);
-
-    return resp == JOptionPane.OK_OPTION;
-  }
 
   /**
    * Displays a confirmation dialog.
@@ -80,10 +50,6 @@ public class DialogUtils {
         JOptionPane.showConfirmDialog(parentComponent, msg, title, JOptionPane.YES_NO_OPTION);
 
     return answer == JOptionPane.YES_OPTION;
-  }
-
-  private static Component notNullOrDefaultParent(Component parent) {
-    return parent != null ? parent : WindowManager.getInstance().getFrame(project);
   }
 
   private static Component getProjectComponent(Project project) {

--- a/intellij/src/saros/intellij/ui/util/NotificationPanel.java
+++ b/intellij/src/saros/intellij/ui/util/NotificationPanel.java
@@ -22,7 +22,7 @@ public class NotificationPanel {
   private static final NotificationListener.UrlOpeningListener URL_OPENING_LISTENER =
       new NotificationListener.UrlOpeningListener(false);
 
-  @Inject private static Project project;
+  @Inject private static UIProjectUtils projectUtils;
 
   static {
     SarosPluginContext.initComponent(new NotificationPanel());
@@ -35,10 +35,11 @@ public class NotificationPanel {
    * Displays a notification of the given type. Notifications support html formatting, including
    * hyperlinks, by using html tags.
    *
+   * <p>The notifications are displayed in all projects that are part of the session or in all open
+   * projects if there is no running session.
+   *
    * <p>Possible types are {@link NotificationType#INFORMATION}, {@link NotificationType#WARNING}
    * and {@link NotificationType#ERROR}.
-   *
-   * <p>
    *
    * @param notificationType type of the notification
    * @param message content of the notification
@@ -46,6 +47,8 @@ public class NotificationPanel {
    */
   private static void showNotification(
       NotificationType notificationType, String message, String title) {
+
+    Project project = projectUtils.getSharedProject();
 
     LOG.info("Showing notification - " + notificationType + ": " + title + " - " + message);
 

--- a/intellij/src/saros/intellij/ui/util/NotificationPanel.java
+++ b/intellij/src/saros/intellij/ui/util/NotificationPanel.java
@@ -12,7 +12,7 @@ import org.apache.log4j.Logger;
 import saros.SarosPluginContext;
 import saros.repackaged.picocontainer.annotations.Inject;
 
-/** Class uses IntelliJ API to show notifications */
+/** Class uses Intellij API to show notifications */
 public class NotificationPanel {
   private static final Logger LOG = Logger.getLogger(NotificationPanel.class);
 
@@ -56,13 +56,7 @@ public class NotificationPanel {
         GROUP_DISPLAY_ID_INFO.createNotification(
             title, message, notificationType, URL_OPENING_LISTENER);
     ApplicationManager.getApplication()
-        .invokeLater(
-            new Runnable() {
-              @Override
-              public void run() {
-                Notifications.Bus.notify(notification, project);
-              }
-            });
+        .invokeLater(() -> Notifications.Bus.notify(notification, project));
   }
 
   /**

--- a/intellij/src/saros/intellij/ui/util/SafeDialogUtils.java
+++ b/intellij/src/saros/intellij/ui/util/SafeDialogUtils.java
@@ -65,15 +65,12 @@ public class SafeDialogUtils {
     final AtomicReference<String> response = new AtomicReference<>();
 
     application.invokeAndWait(
-        new Runnable() {
-          @Override
-          public void run() {
-            String option =
-                Messages.showInputDialog(
-                    project, message, title, Messages.getQuestionIcon(), initialValue, null);
-            if (option != null) {
-              response.set(option);
-            }
+        () -> {
+          String option =
+              Messages.showInputDialog(
+                  project, message, title, Messages.getQuestionIcon(), initialValue, null);
+          if (option != null) {
+            response.set(option);
           }
         },
         ModalityState.defaultModalityState());
@@ -92,12 +89,7 @@ public class SafeDialogUtils {
     LOG.info("Showing error dialog: " + title + " - " + message);
 
     application.invokeLater(
-        new Runnable() {
-          @Override
-          public void run() {
-            Messages.showErrorDialog(project, message, title);
-          }
-        },
+        () -> Messages.showErrorDialog(project, message, title),
         ModalityState.defaultModalityState());
   }
 

--- a/intellij/src/saros/intellij/ui/util/SafeDialogUtils.java
+++ b/intellij/src/saros/intellij/ui/util/SafeDialogUtils.java
@@ -9,7 +9,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.log4j.Logger;
 import saros.SarosPluginContext;
 import saros.exceptions.IllegalAWTContextException;
-import saros.repackaged.picocontainer.annotations.Inject;
 
 /**
  * Dialog helper used to show messages in safe manner by starting it on the AWT event dispatcher
@@ -29,8 +28,6 @@ public class SafeDialogUtils {
 
   private static final Application application;
 
-  @Inject private static Project project;
-
   static {
     application = ApplicationManager.getApplication();
 
@@ -40,9 +37,14 @@ public class SafeDialogUtils {
   private SafeDialogUtils() {}
 
   /**
-   * Shows an input dialog. This method must not be called from a write safe context as it needs to
-   * be executed synchronously and AWT actions are not allowed from a write safe context.
+   * Synchronously shows an input dialog. This method must not be called from a write safe context
+   * as it needs to be executed synchronously and AWT actions are not allowed from a write safe
+   * context.
    *
+   * @param project the project used as a reference to generate and position the dialog
+   * @param message the text displayed as the message of the dialog
+   * @param initialValue the initial value contained in the text field of the input dialog
+   * @param title the text displayed as the title of the dialog
    * @return the <code>String</code> entered by the user or <code>null</code> if the dialog did not
    *     finish with the exit code 0 (it was not closed by pressing the "OK" button)
    * @throws IllegalAWTContextException if the calling thread is currently inside a write safe
@@ -51,7 +53,7 @@ public class SafeDialogUtils {
    * @see com.intellij.openapi.ui.DialogWrapper#OK_EXIT_CODE
    */
   public static String showInputDialog(
-      final String message, final String initialValue, final String title)
+      Project project, final String message, final String initialValue, final String title)
       throws IllegalAWTContextException {
 
     if (application.isWriteAccessAllowed()) {
@@ -79,7 +81,14 @@ public class SafeDialogUtils {
     return response.get();
   }
 
-  public static void showError(final String message, final String title) {
+  /**
+   * Asynchronously shows an error dialog.
+   *
+   * @param project the project used as a reference to generate and position the dialog
+   * @param message the text displayed as the message of the dialog
+   * @param title the text displayed as the title of the dialog
+   */
+  public static void showError(Project project, final String message, final String title) {
     LOG.info("Showing error dialog: " + title + " - " + message);
 
     application.invokeLater(
@@ -93,9 +102,13 @@ public class SafeDialogUtils {
   }
 
   /**
-   * Shows a password dialog. This method must not be called from a write safe context as it needs
-   * to be executed synchronously and AWT actions are not allowed from a write safe context.
+   * Synchronously shows a password dialog. This method must not be called from a write safe context
+   * as it needs to be executed synchronously and AWT actions are not allowed from a write safe
+   * context.
    *
+   * @param project the project used as a reference to generate and position the dialog
+   * @param message the text displayed as the message of the dialog
+   * @param title the text displayed as the title of the dialog
    * @return the <code>String</code> entered by the user or <code>null</code> if the dialog did not
    *     finish with the exit code 0 (it was not closed by pressing the "OK" button)
    * @throws IllegalAWTContextException if the calling thread is currently inside a write safe
@@ -103,7 +116,7 @@ public class SafeDialogUtils {
    * @see Messages.InputDialog#getInputString()
    * @see com.intellij.openapi.ui.DialogWrapper#OK_EXIT_CODE
    */
-  public static String showPasswordDialog(final String message, final String title)
+  public static String showPasswordDialog(Project project, final String message, final String title)
       throws IllegalAWTContextException {
 
     if (application.isWriteAccessAllowed()) {
@@ -129,15 +142,19 @@ public class SafeDialogUtils {
   }
 
   /**
-   * Shows a yes/no dialog. This method must not be called from a write safe context as it needs to
-   * be executed synchronously and AWT actions are not allowed from a write safe context.
+   * Synchronously shows a yes/no dialog. This method must not be called from a write safe context
+   * as it needs to be executed synchronously and AWT actions are not allowed from a write safe
+   * context.
    *
+   * @param project the project used as a reference to generate and position the dialog
+   * @param message the text displayed as the message of the dialog
+   * @param title the text displayed as the title of the dialog
    * @return the value {@link Messages#YES} if "Yes" is chosen and {@link Messages#NO} if "No" is
    *     chosen or the dialog is closed
    * @throws IllegalAWTContextException if the calling thread is currently inside a write safe
    *     context
    */
-  public static Integer showYesNoDialog(final String message, final String title)
+  public static Integer showYesNoDialog(Project project, final String message, final String title)
       throws IllegalAWTContextException {
 
     if (application.isWriteAccessAllowed()) {

--- a/intellij/src/saros/intellij/ui/util/SafeDialogUtils.java
+++ b/intellij/src/saros/intellij/ui/util/SafeDialogUtils.java
@@ -5,7 +5,6 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
-import java.awt.Component;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.log4j.Logger;
 import saros.SarosPluginContext;
@@ -80,19 +79,6 @@ public class SafeDialogUtils {
     return response.get();
   }
 
-  public static void showWarning(final String message, final String title) {
-    LOG.info("Showing warning dialog: " + title + " - " + message);
-
-    application.invokeLater(
-        new Runnable() {
-          @Override
-          public void run() {
-            Messages.showWarningDialog(project, message, title);
-          }
-        },
-        ModalityState.defaultModalityState());
-  }
-
   public static void showError(final String message, final String title) {
     LOG.info("Showing error dialog: " + title + " - " + message);
 
@@ -101,21 +87,6 @@ public class SafeDialogUtils {
           @Override
           public void run() {
             Messages.showErrorDialog(project, message, title);
-          }
-        },
-        ModalityState.defaultModalityState());
-  }
-
-  public static void showError(
-      final Component component, final String message, final String title) {
-
-    LOG.info("Showing error dialog: " + title + " - " + message);
-
-    application.invokeLater(
-        new Runnable() {
-          @Override
-          public void run() {
-            Messages.showErrorDialog(component, message, title);
           }
         },
         ModalityState.defaultModalityState());

--- a/intellij/src/saros/intellij/ui/util/UIProjectUtils.java
+++ b/intellij/src/saros/intellij/ui/util/UIProjectUtils.java
@@ -42,6 +42,18 @@ public class UIProjectUtils {
    * Returns the <code>Project</code> object contained in the session context or <code>null</code>
    * if there currently is no session.
    *
+   * @return the <code>Project</code> object contained in the session context or <code>null</code>
+   *     if there currently is no session.
+   */
+  @Nullable
+  Project getSharedProject() {
+    return getProjectFromSession();
+  }
+
+  /**
+   * Returns the <code>Project</code> object contained in the session context or <code>null</code>
+   * if there currently is no session.
+   *
    * <p><b>NOTE:</b> This method should only be used to for UI purposes. To interact with the
    * project whose module is shared as part of a Saros session, please use the Project object
    * contained in the session context.

--- a/intellij/src/saros/intellij/ui/util/UIProjectUtils.java
+++ b/intellij/src/saros/intellij/ui/util/UIProjectUtils.java
@@ -1,0 +1,107 @@
+package saros.intellij.ui.util;
+
+import com.intellij.ide.DataManager;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.DataKeys;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.concurrency.Promise;
+import saros.session.ISarosSession;
+import saros.session.ISarosSessionManager;
+import saros.session.ISessionLifecycleListener;
+import saros.session.SessionEndReason;
+
+/**
+ * Class to provide access to an active project object. This class should only be used for UI
+ * purposes. To interact with the project whose module is shared as part of a Saros session, please
+ * use the Project object contained in the session context.
+ */
+public class UIProjectUtils {
+  private volatile ISarosSession sarosSession;
+
+  @SuppressWarnings("FieldCanBeLocal")
+  private ISessionLifecycleListener sessionLifecycleListener =
+      new ISessionLifecycleListener() {
+        @Override
+        public void sessionStarted(ISarosSession session) {
+          sarosSession = session;
+        }
+
+        @Override
+        public void sessionEnded(ISarosSession session, SessionEndReason reason) {
+          sarosSession = null;
+        }
+      };
+
+  public UIProjectUtils(ISarosSessionManager sarosSessionManager) {
+    sarosSessionManager.addSessionLifecycleListener(sessionLifecycleListener);
+  }
+
+  /**
+   * Returns the <code>Project</code> object contained in the session context or <code>null</code>
+   * if there currently is no session.
+   *
+   * <p><b>NOTE:</b> This method should only be used to for UI purposes. To interact with the
+   * project whose module is shared as part of a Saros session, please use the Project object
+   * contained in the session context.
+   *
+   * @return the <code>Project</code> object contained in the session context or <code>null</code>
+   *     if there currently is no session.
+   */
+  @Nullable
+  private Project getProjectFromSession() {
+    ISarosSession currentSession = sarosSession;
+
+    if (currentSession == null) {
+      return null;
+    }
+
+    return currentSession.getComponent(Project.class);
+  }
+
+  /**
+   * Runs the given method with a current project object.
+   *
+   * <p>If there is currently a session, the given method is run immediately using the project
+   * contained in the session context. Otherwise, the currently focused project is requested and the
+   * method is run asynchronously when the request is done. In this case, the used project object
+   * can be <code>null</code> if the request fails.
+   *
+   * <p><b>NOTE:</b> This method should only be used to for UI purposes. To interact with the
+   * project whose module is shared as part of a Saros session, please use the Project object
+   * contained in the session context.
+   *
+   * @param projectRunner the method to call with the currently focused project
+   */
+  public void runWithProject(@NotNull ProjectRunner projectRunner) {
+    Project sessionProject = getProjectFromSession();
+
+    if (sessionProject != null) {
+      projectRunner.run(sessionProject);
+
+      return;
+    }
+
+    Promise<DataContext> promisedDataContext =
+        DataManager.getInstance().getDataContextFromFocusAsync();
+    Promise<Project> promisedProject = promisedDataContext.then(DataKeys.PROJECT::getData);
+
+    promisedProject.onProcessed(projectRunner::run);
+  }
+
+  /** Interface used to define tasks that need a project to run. */
+  public interface ProjectRunner {
+
+    /**
+     * Implement this method to define a task that can be run with a current project object using
+     * {@link #runWithProject(ProjectRunner)}.
+     *
+     * @param project the <code>Project</code> object held in the current session context or, if
+     *     there currently is no running session, either the currently focused project or <code>null
+     *     </code> if there is no such project
+     * @see #runWithProject(ProjectRunner)
+     */
+    void run(@Nullable Project project);
+  }
+}

--- a/intellij/src/saros/intellij/ui/views/SarosMainPanelView.java
+++ b/intellij/src/saros/intellij/ui/views/SarosMainPanelView.java
@@ -1,5 +1,6 @@
 package saros.intellij.ui.views;
 
+import com.intellij.openapi.project.Project;
 import com.intellij.ui.components.JBScrollPane;
 import java.awt.BorderLayout;
 import java.awt.Container;
@@ -9,6 +10,7 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
 import javax.swing.ScrollPaneConstants;
+import org.jetbrains.annotations.NotNull;
 import saros.intellij.ui.tree.SessionAndContactsTreeView;
 
 /**
@@ -21,10 +23,10 @@ public class SarosMainPanelView extends JPanel {
    * Creates the content of the tool window panel, with {@link SarosToolbar} and the {@link
    * SessionAndContactsTreeView}.
    */
-  public SarosMainPanelView() throws HeadlessException {
+  public SarosMainPanelView(@NotNull Project project) throws HeadlessException {
     super(new BorderLayout());
     SessionAndContactsTreeView sarosTree = new SessionAndContactsTreeView();
-    SarosToolbar sarosToolbar = new SarosToolbar();
+    SarosToolbar sarosToolbar = new SarosToolbar(project);
 
     JScrollPane treeScrollPane = new JBScrollPane(sarosTree);
     treeScrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);

--- a/intellij/src/saros/intellij/ui/views/SarosToolbar.java
+++ b/intellij/src/saros/intellij/ui/views/SarosToolbar.java
@@ -59,6 +59,6 @@ class SarosToolbar extends JToolBar {
 
     add(new ConsistencyButton(project));
 
-    add(new LeaveSessionButton());
+    add(new LeaveSessionButton(project));
   }
 }

--- a/intellij/src/saros/intellij/ui/views/SarosToolbar.java
+++ b/intellij/src/saros/intellij/ui/views/SarosToolbar.java
@@ -1,7 +1,9 @@
 package saros.intellij.ui.views;
 
+import com.intellij.openapi.project.Project;
 import java.awt.FlowLayout;
 import javax.swing.JToolBar;
+import org.jetbrains.annotations.NotNull;
 import saros.intellij.ui.actions.NotImplementedAction;
 import saros.intellij.ui.util.IconManager;
 import saros.intellij.ui.views.buttons.ConnectButton;
@@ -22,15 +24,20 @@ class SarosToolbar extends JToolBar {
   private static final boolean ENABLE_PREFERENCES =
       Boolean.getBoolean("saros.intellij.ENABLE_PREFERENCES");
 
-  SarosToolbar() {
+  private final Project project;
+
+  SarosToolbar(@NotNull Project project) {
     super("Saros IDEA toolbar");
+
+    this.project = project;
+
     setLayout(new FlowLayout(FlowLayout.RIGHT));
     addToolbarButtons();
   }
 
   private void addToolbarButtons() {
 
-    add(new ConnectButton());
+    add(new ConnectButton(project));
 
     if (ENABLE_ADD_CONTACT) {
       add(
@@ -50,7 +57,7 @@ class SarosToolbar extends JToolBar {
 
     add(new FollowButton());
 
-    add(new ConsistencyButton());
+    add(new ConsistencyButton(project));
 
     add(new LeaveSessionButton());
   }

--- a/intellij/src/saros/intellij/ui/views/buttons/ConnectButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/ConnectButton.java
@@ -1,5 +1,6 @@
 package saros.intellij.ui.views.buttons;
 
+import com.intellij.openapi.project.Project;
 import java.util.Scanner;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
@@ -37,13 +38,18 @@ public class ConnectButton extends ToolbarButton {
   private final ConnectServerAction connectAction;
   private final NotImplementedAction configureAccounts;
 
+  private final Project project;
+
   @Inject private XMPPAccountStore accountStore;
 
-  public ConnectButton() {
+  public ConnectButton(@NotNull Project project) {
     super(ConnectServerAction.NAME, "Connect", IconManager.CONNECT_ICON);
     SarosPluginContext.initComponent(this);
-    disconnectAction = new DisconnectServerAction();
-    connectAction = new ConnectServerAction();
+
+    this.project = project;
+
+    disconnectAction = new DisconnectServerAction(project);
+    connectAction = new ConnectServerAction(project);
 
     configureAccounts = new NotImplementedAction("configure accounts");
 
@@ -129,6 +135,7 @@ public class ConnectButton extends ToolbarButton {
     try {
       Integer option =
           SafeDialogUtils.showYesNoDialog(
+              project,
               Messages.ConnectButton_connect_to_new_account_message,
               Messages.ConnectButton_connect_to_new_account_title);
 
@@ -141,6 +148,7 @@ public class ConnectButton extends ToolbarButton {
       LOG.error("Account creation failed.", e);
 
       SafeDialogUtils.showError(
+          project,
           "There was an error creating the account.\nDetails: " + e.getMessage(),
           "Account creation failed");
     }
@@ -158,12 +166,13 @@ public class ConnectButton extends ToolbarButton {
     try {
       userID =
           SafeDialogUtils.showInputDialog(
-              "Your User-ID, e.g. user@saros-con.imp.fu-berlin.de", "", "Login");
+              project, "Your User-ID, e.g. user@saros-con.imp.fu-berlin.de", "", "Login");
 
     } catch (IllegalAWTContextException e) {
       LOG.error("Account creation failed.", e);
 
       SafeDialogUtils.showError(
+          project,
           "There was an error creating the account.\nDetails: " + e.getMessage(),
           "Account creation failed");
 
@@ -179,7 +188,8 @@ public class ConnectButton extends ToolbarButton {
     JID jid = new JID(userID);
 
     if (!jid.isValid() || jid.getName().isEmpty()) {
-      SafeDialogUtils.showError("Entered user id is not valid.", "Account creation aborted");
+      SafeDialogUtils.showError(
+          project, "Entered user id is not valid.", "Account creation aborted");
 
       LOG.debug("Account creation failed as the user did not provide a " + "valid user id.");
 
@@ -192,12 +202,13 @@ public class ConnectButton extends ToolbarButton {
     final String password;
 
     try {
-      password = SafeDialogUtils.showPasswordDialog("Password", "Password");
+      password = SafeDialogUtils.showPasswordDialog(project, "Password", "Password");
 
     } catch (IllegalAWTContextException e) {
       LOG.error("Account creation failed.", e);
 
       SafeDialogUtils.showError(
+          project,
           "There was an error creating the account.\nDetails: " + e.getMessage(),
           "Account creation failed");
 
@@ -210,7 +221,7 @@ public class ConnectButton extends ToolbarButton {
       return null;
 
     } else if (password.isEmpty()) {
-      SafeDialogUtils.showError("No password entered.", "Account creation aborted");
+      SafeDialogUtils.showError(project, "No password entered.", "Account creation aborted");
 
       LOG.debug("Account creation failed as the user did not provide a " + "valid password.");
 
@@ -224,12 +235,13 @@ public class ConnectButton extends ToolbarButton {
     try {
       server =
           SafeDialogUtils.showInputDialog(
-              "XMPP server (optional, not necessary in most cases)", "", "Server");
+              project, "XMPP server (optional, not necessary in most cases)", "", "Server");
 
     } catch (IllegalAWTContextException e) {
       LOG.error("Account creation failed.", e);
 
       SafeDialogUtils.showError(
+          project,
           "There was an error creating the account.\nDetails: " + e.getMessage(),
           "Account creation failed");
 
@@ -245,12 +257,14 @@ public class ConnectButton extends ToolbarButton {
       String portUserEntry;
 
       try {
-        portUserEntry = SafeDialogUtils.showInputDialog("XMPP server port", "", "Server port");
+        portUserEntry =
+            SafeDialogUtils.showInputDialog(project, "XMPP server port", "", "Server port");
 
       } catch (IllegalAWTContextException e) {
         LOG.error("Account creation failed.", e);
 
         SafeDialogUtils.showError(
+            project,
             "There was an error creating the account.\nDetails: " + e.getMessage(),
             "Account creation failed");
 
@@ -273,7 +287,8 @@ public class ConnectButton extends ToolbarButton {
       } else {
         scanner.close();
 
-        SafeDialogUtils.showError("No valid server port " + "entered.", "Account creation aborted");
+        SafeDialogUtils.showError(
+            project, "No valid server port " + "entered.", "Account creation aborted");
 
         LOG.debug("Account creation failed as the user did not " + "provide a valid server port.");
 
@@ -288,6 +303,7 @@ public class ConnectButton extends ToolbarButton {
       LOG.error("Account creation failed", e);
 
       SafeDialogUtils.showError(
+          project,
           "There was an error creating the account.\nDetails: " + e.getMessage(),
           "Account creation failed");
 

--- a/intellij/src/saros/intellij/ui/views/buttons/ConsistencyButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/ConsistencyButton.java
@@ -1,12 +1,14 @@
 package saros.intellij.ui.views.buttons;
 
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.text.MessageFormat;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import saros.SarosPluginContext;
 import saros.activities.SPath;
 import saros.concurrent.watchdog.ConsistencyWatchdogClient;
@@ -53,7 +55,7 @@ public class ConsistencyButton extends ToolbarButton {
 
           boolean userConfirmedRecovery =
               DialogUtils.showQuestion(
-                  null,
+                  project,
                   Messages.ConsistencyButton_confirm_dialog_title,
                   MessageFormat.format(
                       Messages.ConsistencyButton_confirm_dialog_message, inconsistentFiles));
@@ -91,6 +93,8 @@ public class ConsistencyButton extends ToolbarButton {
 
   private final ValueChangeListener<Boolean> isConsistencyListener = this::handleConsistencyChange;
 
+  private final Project project;
+
   @Inject private ISarosSessionManager sessionManager;
 
   @Inject private IsInconsistentObservable inconsistentObservable;
@@ -98,13 +102,15 @@ public class ConsistencyButton extends ToolbarButton {
   private volatile SessionInconsistencyState sessionInconsistencyState;
 
   /** Creates a Consistency button, adds a sessionListener and disables the button. */
-  public ConsistencyButton() {
+  public ConsistencyButton(@NotNull Project project) {
     super(
         ConsistencyAction.NAME,
         Messages.ConsistencyButton_tooltip_functionality,
         IconManager.IN_SYNC_ICON);
 
     SarosPluginContext.initComponent(this);
+
+    this.project = project;
 
     setSarosSession(sessionManager.getSession());
     sessionManager.addSessionLifecycleListener(sessionLifecycleListener);

--- a/intellij/src/saros/intellij/ui/views/buttons/LeaveSessionButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/LeaveSessionButton.java
@@ -1,5 +1,6 @@
 package saros.intellij.ui.views.buttons;
 
+import com.intellij.openapi.project.Project;
 import saros.SarosPluginContext;
 import saros.intellij.ui.actions.LeaveSessionAction;
 import saros.intellij.ui.util.IconManager;
@@ -33,8 +34,8 @@ public class LeaveSessionButton extends SimpleButton {
    *
    * <p>LeaveSessionButton is created as disabled.
    */
-  public LeaveSessionButton() {
-    super(new LeaveSessionAction(), "Leave session", IconManager.LEAVE_SESSION_ICON);
+  public LeaveSessionButton(Project project) {
+    super(new LeaveSessionAction(project), "Leave session", IconManager.LEAVE_SESSION_ICON);
     SarosPluginContext.initComponent(this);
     sessionManager.addSessionLifecycleListener(sessionLifecycleListener);
     setEnabled(false);

--- a/intellij/src/saros/intellij/ui/widgets/progress/ProgressFrame.java
+++ b/intellij/src/saros/intellij/ui/widgets/progress/ProgressFrame.java
@@ -2,8 +2,6 @@ package saros.intellij.ui.widgets.progress;
 
 import com.intellij.openapi.wm.WindowManager;
 import java.awt.Container;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
@@ -14,18 +12,17 @@ import saros.monitoring.IProgressMonitor;
 import saros.repackaged.picocontainer.annotations.Inject;
 
 /** Creates independent progress monitor window */
-// todo: use saros.monitoring.IProgressMonitor in all IntelliJ classes
+// todo: use saros.monitoring.IProgressMonitor in all Intellij classes
 public class ProgressFrame implements IProgressMonitor {
 
-  public static final String TITLE = "Progress monitor";
-  public static final String BUTTON_CANCEL = "Cancel";
+  private static final String TITLE = "Progress monitor";
+  private static final String BUTTON_CANCEL = "Cancel";
 
   private MonitorProgressBar monitorProgressBar;
 
   @Inject private UIProjectUtils projectUtils;
 
   private JFrame frmMain;
-  private JButton btnCancel;
 
   /** Constructor with default title */
   public ProgressFrame() {
@@ -51,14 +48,8 @@ public class ProgressFrame implements IProgressMonitor {
 
     frmMain.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
-    btnCancel = new JButton(BUTTON_CANCEL);
-    btnCancel.addActionListener(
-        new ActionListener() {
-          @Override
-          public void actionPerformed(ActionEvent e) {
-            setCanceled(true);
-          }
-        });
+    JButton btnCancel = new JButton(BUTTON_CANCEL);
+    btnCancel.addActionListener(actionEvent -> setCanceled(true));
 
     JProgressBar progressBar =
         new JProgressBar(MonitorProgressBar.MIN_VALUE, MonitorProgressBar.MAX_VALUE);

--- a/intellij/src/saros/intellij/ui/widgets/progress/ProgressFrame.java
+++ b/intellij/src/saros/intellij/ui/widgets/progress/ProgressFrame.java
@@ -1,6 +1,5 @@
 package saros.intellij.ui.widgets.progress;
 
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.WindowManager;
 import java.awt.Container;
 import java.awt.event.ActionEvent;
@@ -10,6 +9,7 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JProgressBar;
 import saros.SarosPluginContext;
+import saros.intellij.ui.util.UIProjectUtils;
 import saros.monitoring.IProgressMonitor;
 import saros.repackaged.picocontainer.annotations.Inject;
 
@@ -22,7 +22,7 @@ public class ProgressFrame implements IProgressMonitor {
 
   private MonitorProgressBar monitorProgressBar;
 
-  @Inject private Project project;
+  @Inject private UIProjectUtils projectUtils;
 
   private JFrame frmMain;
   private JButton btnCancel;
@@ -42,7 +42,9 @@ public class ProgressFrame implements IProgressMonitor {
 
     frmMain = new JFrame(title);
     frmMain.setSize(300, 160);
-    frmMain.setLocationRelativeTo(WindowManager.getInstance().getFrame(project));
+
+    projectUtils.runWithProject(
+        project -> frmMain.setLocationRelativeTo(WindowManager.getInstance().getFrame(project)));
 
     Container pane = frmMain.getContentPane();
     pane.setLayout(null);

--- a/intellij/src/saros/intellij/ui/wizards/AddProjectToSessionWizard.java
+++ b/intellij/src/saros/intellij/ui/wizards/AddProjectToSessionWizard.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.progress.PerformInBackgroundOption;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ModifiableRootModel;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.util.ThrowableComputable;
@@ -28,6 +29,7 @@ import java.util.Map;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import saros.SarosPluginContext;
 import saros.filesystem.IChecksumCache;
 import saros.filesystem.IProject;
 import saros.filesystem.IWorkspace;
@@ -382,17 +384,23 @@ public class AddProjectToSessionWizard extends Wizard {
       };
 
   /**
-   * Creates the wizard and its pages.
+   * Instantiates the wizard and its pages.
    *
+   * @param project the Intellij project to use for the wizard
+   * @param parent the parent window relative to which the dialog is positioned
    * @param negotiation The IPN this wizard handles
    */
-  public AddProjectToSessionWizard(Window parent, AbstractIncomingProjectNegotiation negotiation) {
+  public AddProjectToSessionWizard(
+      Project project, Window parent, AbstractIncomingProjectNegotiation negotiation) {
 
     super(
+        project,
         parent,
         Messages.AddProjectToSessionWizard_title,
         new HeaderPanel(
             Messages.EnterProjectNamePage_title2, Messages.EnterProjectNamePage_description));
+
+    SarosPluginContext.initComponent(this);
 
     this.negotiation = negotiation;
     this.peer = negotiation.getPeer();

--- a/intellij/src/saros/intellij/ui/wizards/JoinSessionWizard.java
+++ b/intellij/src/saros/intellij/ui/wizards/JoinSessionWizard.java
@@ -2,6 +2,7 @@ package saros.intellij.ui.wizards;
 
 import static saros.negotiation.NegotiationTools.CancelOption;
 
+import com.intellij.openapi.project.Project;
 import java.awt.Window;
 import java.text.MessageFormat;
 import org.apache.log4j.Logger;
@@ -49,16 +50,20 @@ public class JoinSessionWizard extends Wizard {
       };
 
   /**
-   * Creates wizard UI
+   * Instantiates the wizard and its pages.
    *
+   * @param project the Intellij project to use for the wizard
+   * @param parent the parent window relative to which the dialog is positioned
    * @param negotiation The negotiation this wizard displays
    */
-  public JoinSessionWizard(Window parent, IncomingSessionNegotiation negotiation) {
+  public JoinSessionWizard(Project project, Window parent, IncomingSessionNegotiation negotiation) {
     super(
+        project,
         parent,
         Messages.JoinSessionWizard_title,
         new HeaderPanel(
             Messages.ShowDescriptionPage_title2, Messages.ShowDescriptionPage_description));
+
     this.negotiation = negotiation;
 
     InfoPage infoPage = createInfoPage(negotiation);

--- a/intellij/src/saros/intellij/ui/wizards/JoinSessionWizard.java
+++ b/intellij/src/saros/intellij/ui/wizards/JoinSessionWizard.java
@@ -25,7 +25,7 @@ import saros.util.ThreadUtils;
  * <p>FIXME: Long-Running Operation after each step cancellation by a remote party auto-advance.
  */
 public class JoinSessionWizard extends Wizard {
-  public static final String PAGE_INFO_ID = "JoinSessionInfo";
+  private static final String PAGE_INFO_ID = "JoinSessionInfo";
 
   private static final Logger LOG = Logger.getLogger(JoinSessionWizard.class);
 
@@ -85,7 +85,7 @@ public class JoinSessionWizard extends Wizard {
    * Runs {@link IncomingSessionNegotiation#accept(IProgressMonitor)} with {@link #runTask(Runnable,
    * String)}. If the result is a cancel or error status, it displays an error message accordingly.
    */
-  public void joinSession() {
+  private void joinSession() {
 
     JobWithStatus job =
         new JobWithStatus() {
@@ -119,16 +119,11 @@ public class JoinSessionWizard extends Wizard {
    * Calls {@link IncomingSessionNegotiation#localCancel(String, CancelOption)} in a separate
    * thread.
    */
-  public void performCancel() {
+  private void performCancel() {
     ThreadUtils.runSafeAsync(
         "CancelJoinSessionWizard",
         LOG,
-        new Runnable() {
-          @Override
-          public void run() {
-            negotiation.localCancel(null, CancelOption.NOTIFY_PEER);
-          }
-        });
+        () -> negotiation.localCancel(null, CancelOption.NOTIFY_PEER));
   }
 
   private void showCancelMessage(JID jid, String errorMsg, CancelLocation cancelLocation) {

--- a/intellij/src/saros/intellij/ui/wizards/Wizard.java
+++ b/intellij/src/saros/intellij/ui/wizards/Wizard.java
@@ -19,11 +19,9 @@ import javax.swing.JDialog;
 import javax.swing.JPanel;
 import javax.swing.border.EmptyBorder;
 import org.jetbrains.annotations.NotNull;
-import saros.SarosPluginContext;
 import saros.intellij.ui.wizards.pages.AbstractWizardPage;
 import saros.intellij.ui.wizards.pages.HeaderPanel;
 import saros.intellij.ui.wizards.pages.NavigationPanel;
-import saros.repackaged.picocontainer.annotations.Inject;
 
 /**
  * Class represents a wizard. Usage:
@@ -71,17 +69,19 @@ public abstract class Wizard extends JDialog {
 
   private final NavigationPanel navigationPanel;
 
-  @Inject protected Project project;
-
+  protected Project project;
   /**
-   * Constructor creates wizard structure.
+   * Initializes the base structure of a wizard.
    *
+   * @param project the Intellij project to use for the wizard
+   * @param parent the parent window relative to which the dialog is positioned
    * @param title window title
-   * @param headerPanel
+   * @param headerPanel header panel of the wizard
    */
-  public Wizard(Window parent, String title, HeaderPanel headerPanel) {
+  public Wizard(Project project, Window parent, String title, HeaderPanel headerPanel) {
     super(parent, title);
-    SarosPluginContext.initComponent(this);
+
+    this.project = project;
 
     this.headerPanel = headerPanel;
 


### PR DESCRIPTION
Continuation of #451 and #452.

Adds a utility to obtains a valid project object for UI purposes. Replaces the plugin context project access of the UI components with calls to the newly added `UIProjectUtils`.

The commits of this PR should be reviewed separately.

### Commits
<details>
<summary>
Click here to show all commit messages.
</summary>

#### [NOP][I] Remove unused dialog methods

Removes unused methods to display different types of dialogs.

#### [INTERNAL][I] Use toolbar project object for UI components

Adjusts the UI logic related to the toolbar and its contained components
to use the project object passed to the toolbar during its
initialization. This allows the UI components to always use the correct
project object as the reference point when creating new UI components
like dialogs.

Subsequently adjusts the dialog utility classes to accept a project
object as an additional parameter instead of always using the project
object contained in the plugin context.

As DialogUtils.showConfirmationDialog(...) is still used by components
that currently can't access a project object (besides the one held in
the plugin context), the method is kept as oldShowConfirmationDialog.
The method is marked as deprecated and will be removed once all required
components have access to a project object.

#### [INTERNAL][I] Add UIProjectUtils

Adds a utility class that provides access to current project objects to
UI components.

#### [INTERNAL][I] Pass project to CollaborationUtils.leaveSession(...)

Adjusts CollaborationUtils.leaveSession(...) get the used project object
as a parameter instead of getting it from the plugin context.

Adjusts LeaveSessionButton to use the toolbar project object for the
call.

Adjusts IntelliJCollaborationUtilsImpl to use
UIProjectUtils.runWithProject(...) to obtain a project object.

#### [INTERNAL][I] Use UIProjectUtils in XMPPAuthorizationHandler

Replaces the usage of the project object contained in the session
context by using UIProjectUtils.runWithProject(...) to obtain a valid
project object.

Subsequently removes DialogUtils.oldShowConfirm(...) as it is no longer
used.

#### [INTERNAL][I] Use UIProjectUtils for incoming invitation wizards

Adjusts the Wizard base class to get the used project object as a CTOR
parameter instead of using the project object contained in the plugin
context.

Uses UIProjectUtils in NegotiationHandler to obtain a project object to
run the JoinSessionWizard and AddProjectToSessionWizard with.

#### [INTERNAL][I] Use UIProjectUtils in ProgressFrame

Uses UIProjectUtils in ProgressFrame to set the correct position of the
created progress frame without using the project object contained in the
plugin context.

#### [INTERNAL][I] Use UIProjectUtils in IntelliJDialogManager

Uses UIProjectUtils in IntelliJDialogManager to set the correct position
of the created dialog without using the project object contained in the
plugin context.

#### [INTERNAL][I] Adjust NotificationPanel to use the shared project

Adds the method UIProjectUtils.getSharedProject() which returns the
project object contained in the current session context if present. This
method is used to determine the project object to use in Notification
panel.

With this logic, notifications created through the NotificationPanel
will be displayed in all projects that are part of the session or all
open projects if there is no running session.

#### [REFACTOR][I] Do minor refactoring

Does some minor refactoring in the classes changed by the last few
commits.

Replaces anonymous inner class declarations with lambda expressions or
method references.

Reduces the visibility of classes, CTORs, methods, and parameters to the
required minimum.

Adds annotations to ignore listeners that could be declared inline.
These listeners are kept as explicit declarations in the class body to
improve readability.

Fixes typos. This includes the spelling of IntelliJ (ending on a capital
J), as such a camel case is not correctly recognized by the Intellij
code inspection.

Removes unnecessary generic type declarations when initializing a
generic data type.

Adds NotNull annotations that are implicitly inherited from the super-
class.

</details>