### PR TITLE
Set 2018.2.6 as minimal required IntelliJ version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ _stf_setup_config: &stf_before_script
   env: J_TYPE=STF_TEST
   before_script:
     # Pull required images
-    - docker pull saros/ci_build:0.3
-    - docker pull saros/stf_test_slave:0.3
-    - docker pull saros/stf_xmpp_server:0.3
+    - docker pull saros/ci_build:0.4
+    - docker pull saros/stf_test_slave:0.4
+    - docker pull saros/stf_xmpp_server:0.4
     # Create shared workspace dir which is mounted by the build, master and slave containers
     - mkdir stf_ws
     # Start required containers and services
@@ -50,9 +50,9 @@ jobs:
 
     - stage: build
       if: type in (push, pull_request)
-      before_script: docker pull saros/ci_build:0.3
+      before_script: docker pull saros/ci_build:0.4
       script:
-        - docker run -td --name build -v $PWD:/home/ci/saros_src saros/ci_build:0.3 bash
+        - docker run -td --name build -v $PWD:/home/ci/saros_src saros/ci_build:0.4 bash
         - docker exec -t build /home/ci/saros_src/travis/script/build/build_all.sh
       after_success:
         - docker exec -t build /home/ci/saros_src/travis/script/scan/scan_all.sh $SONAR_TOKEN $TRAVIS_PULL_REQUEST

--- a/de.fu_berlin.inf.dpp.intellij/build.gradle
+++ b/de.fu_berlin.inf.dpp.intellij/build.gradle
@@ -71,7 +71,7 @@ intellij {
   if (project.hasProperty('intellijHome')) {
     localPath = intellijHome
   } else {
-    version = 'IC-2018.2'
+    version = 'IC-2018.2.6'
   }
 
   // don't overwrite the version compatibility defined in the plugin.xml

--- a/de.fu_berlin.inf.dpp.intellij/resources/META-INF/plugin.xml
+++ b/de.fu_berlin.inf.dpp.intellij/resources/META-INF/plugin.xml
@@ -19,7 +19,7 @@
     </vendor>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="173.4674.33"/>
+    <idea-version since-build="182.5107.16"/>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html on how to target different products -->
     <!-- uncomment to enable plugin in all products

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/eventhandler/editor/editorstate/AnnotationUpdater.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/eventhandler/editor/editorstate/AnnotationUpdater.java
@@ -42,16 +42,6 @@ public class AnnotationUpdater extends AbstractLocalEditorStatusChangeHandler {
 
           cleanUpAnnotations(file);
         }
-
-        /**
-         * NOP. Only needed to preserve backwards compatibility to Intellij versions older than
-         * 2018.2.6.
-         */
-        // TODO remove once requiring the users to use Intellij 2018.2.6 or newer is acceptable
-        @Override
-        public void beforeFileOpened(@NotNull FileEditorManager source, @NotNull VirtualFile file) {
-          // NOP
-        }
       };
 
   public AnnotationUpdater(

--- a/travis/script/stf/shared_vars.sh
+++ b/travis/script/stf/shared_vars.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
-stf_master_image="saros/ci_build:0.3"
-stf_slave_image="saros/stf_test_slave:0.3"
-stf_xmpp_image="saros/stf_xmpp_server:0.3"
+stf_master_image="saros/ci_build:0.4"
+stf_slave_image="saros/stf_test_slave:0.4"
+stf_xmpp_image="saros/stf_xmpp_server:0.4"
 
 stf_master_name="stf_master"
 stf_network_name="stf_test_network"


### PR DESCRIPTION
Also removes backwards-compatibility workarounds.

This PR will only build correctly after saros-project/dockerfiles#6 is merged and integrated into the current build environment.