### PR TITLE
Adjusting Saros Core to ReferencePoints

### DIFF
--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/concurrent/management/JupiterServer.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/concurrent/management/JupiterServer.java
@@ -80,7 +80,7 @@ public class JupiterServer {
          * resources in question. Other clients that haven't accepted
          * the Project yet will be added later.
          */
-        if (sarosSession.userHasProject(client, path.getProject())) {
+        if (sarosSession.userHasReferencePoint(client, path.getProject().getReferencePoint())) {
           docServer.addProxyClient(client);
         }
       }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/editor/IEditorManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/editor/IEditorManager.java
@@ -3,7 +3,7 @@ package de.fu_berlin.inf.dpp.editor;
 import de.fu_berlin.inf.dpp.activities.SPath;
 import de.fu_berlin.inf.dpp.editor.text.LineRange;
 import de.fu_berlin.inf.dpp.editor.text.TextSelection;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.session.User;
 import java.util.Set;
 
@@ -54,13 +54,14 @@ public interface IEditorManager {
   String getContent(SPath path);
 
   /**
-   * Saves the local editors of all shared files belonging to the given project. If <code>null
-   * </code> is passed, the shared files of all projects will be saved.
+   * Saves the local editors of all shared files belonging to the given reference point. If <code>
+   * null
+   * </code> is passed, the shared files of all reference points will be saved.
    *
-   * @param project the project whose editors should be saved, or <code>null</code> to save all
-   *     editors
+   * @param referencePoint the reference point whose editors should be saved, or <code>null</code>
+   *     to save all editors
    */
-  void saveEditors(IProject project);
+  void saveEditors(IReferencePoint referencePoint);
 
   /**
    * Close the editor of given {@link SPath}.

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IReferencePoint.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IReferencePoint.java
@@ -1,0 +1,14 @@
+package de.fu_berlin.inf.dpp.filesystem;
+
+/**
+ * The IReferencePoint is an identical pointer to the root of the shared subtree of {@link
+ * IResource}s. For IDEs the root of the subtree is a container, on which {@link IResource}, like
+ * {@link IFolder} and {@link IFile}, is accessible via the relative path from IReferencePoint to
+ * {@link IResource}.
+ *
+ * <p>This interface is under development: The IReferencePoint is the absolute path of {@link
+ * IProject}
+ */
+public interface IReferencePoint {
+  /* Nothing here */
+}

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IResource.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IResource.java
@@ -50,4 +50,8 @@ public interface IResource {
   public IPath getLocation();
 
   public Object getAdapter(Class<? extends IResource> clazz);
+
+  /** Returns the {@link IReferencePoint} on which the resource is referenced to */
+  @Deprecated
+  public IReferencePoint getReferencePoint();
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IWorkspace.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IWorkspace.java
@@ -1,6 +1,7 @@
 package de.fu_berlin.inf.dpp.filesystem;
 
 import de.fu_berlin.inf.dpp.exceptions.OperationCanceledException;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import java.io.IOException;
 
 /**
@@ -35,7 +36,33 @@ public interface IWorkspace {
   public void run(IWorkspaceRunnable runnable, IResource[] resources)
       throws IOException, OperationCanceledException;
 
+  /**
+   * Executes the given runnable at the next opportunity. If supported parts of the workspace will
+   * be locked while the operation takes place. The parts to be lock are determined by the <code>
+   * resources</code> argument, i.e the locked regions will start with the given reference point and
+   * cascade down to all children of each resource. If the <code>resources</code> argument is <code>
+   * null</code> this call is equivalent to {@linkplain #run(IWorkspaceRunnable)}.
+   *
+   * @param runnable
+   * @param referencePoints
+   * @throws IOException
+   * @throws OperationCanceledException
+   */
+  public void run(
+      IWorkspaceRunnable runnable,
+      IReferencePoint[] referencePoints,
+      IReferencePointManager referencePointManager)
+      throws IOException, OperationCanceledException;
+
   public IProject getProject(String project);
+
+  /**
+   * Return the {@link IReferencePoint} reference point of the project, given by the project name
+   *
+   * @param project
+   * @return
+   */
+  public IReferencePoint getReferencePoint(String project);
 
   public IPath getLocation();
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IWorkspace.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/IWorkspace.java
@@ -24,21 +24,6 @@ public interface IWorkspace {
   /**
    * Executes the given runnable at the next opportunity. If supported parts of the workspace will
    * be locked while the operation takes place. The parts to be lock are determined by the <code>
-   * resources</code> argument, i.e the locked regions will start with the given resources and
-   * cascade down to all children of each resource. If the <code>resources</code> argument is <code>
-   * null</code> this call is equivalent to {@linkplain #run(IWorkspaceRunnable)}.
-   *
-   * @param runnable
-   * @param resources
-   * @throws IOException
-   * @throws OperationCanceledException
-   */
-  public void run(IWorkspaceRunnable runnable, IResource[] resources)
-      throws IOException, OperationCanceledException;
-
-  /**
-   * Executes the given runnable at the next opportunity. If supported parts of the workspace will
-   * be locked while the operation takes place. The parts to be lock are determined by the <code>
    * resources</code> argument, i.e the locked regions will start with the given reference point and
    * cascade down to all children of each resource. If the <code>resources</code> argument is <code>
    * null</code> this call is equivalent to {@linkplain #run(IWorkspaceRunnable)}.

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/ReferencePointImpl.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/filesystem/ReferencePointImpl.java
@@ -1,0 +1,30 @@
+package de.fu_berlin.inf.dpp.filesystem;
+
+public class ReferencePointImpl implements IReferencePoint {
+
+  private final IPath path;
+
+  public ReferencePointImpl(IPath path) {
+    this.path = path;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((path == null) ? 0 : path.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null) return false;
+    if (getClass() != obj.getClass()) return false;
+    ReferencePointImpl other = (ReferencePointImpl) obj;
+    if (path == null) {
+      if (other.path != null) return false;
+    } else if (!path.equals(other.path)) return false;
+    return true;
+  }
+}

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/misc/xstream/SPathConverter.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/misc/xstream/SPathConverter.java
@@ -48,7 +48,7 @@ public class SPathConverter implements Converter, Startable {
     this.referencePointManager = session.getComponent(IReferencePointManager.class);
 
     if (this.referencePointManager == null)
-      throw new IllegalStateException("ReferencePointManager is null. Session is not running");
+      throw new IllegalStateException("CoreReferencePointManager is null. Session is not running");
   }
 
   @Override

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/misc/xstream/SPathConverter.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/misc/xstream/SPathConverter.java
@@ -11,6 +11,7 @@ import de.fu_berlin.inf.dpp.communication.extensions.ActivitiesExtension;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IPathFactory;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import org.apache.log4j.Logger;
@@ -92,14 +93,15 @@ public class SPathConverter implements Converter, Startable {
     String i = reader.getAttribute(PROJECT_ID);
     String p = URLCodec.decode(reader.getAttribute(PATH));
 
-    IProject project = referencePointManager.get(session.getReferencePoint(i));
-    if (project == null) {
+    IReferencePoint referencePoint = session.getReferencePoint(i);
+
+    if (referencePoint == null) {
       LOG.error("Could not create SPath because there is no shared project for id '" + i + "'");
       return null;
     }
 
     IPath path = pathFactory.fromString(p);
 
-    return new SPath(project, path);
+    return referencePointManager.createSPath(referencePoint, path);
   }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractIncomingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractIncomingProjectNegotiation.java
@@ -47,17 +47,13 @@ public abstract class AbstractIncomingProjectNegotiation extends ProjectNegotiat
   private static final Logger LOG = Logger.getLogger(AbstractIncomingProjectNegotiation.class);
 
   private static int MONITOR_WORK_SCALE = 1000;
-
-  private final Map<String, ProjectNegotiationData> projectNegotiationData;
-
   protected final FileReplacementInProgressObservable fileReplacementInProgressObservable;
-
+  private final Map<String, ProjectNegotiationData> projectNegotiationData;
   protected boolean running;
-
-  private PacketCollector startActivityQueuingRequestCollector;
-
   /** used to handle file transmissions * */
   protected TransferListener transferListener = null;
+
+  private PacketCollector startActivityQueuingRequestCollector;
 
   public AbstractIncomingProjectNegotiation(
       final JID peer, //
@@ -163,7 +159,9 @@ public abstract class AbstractIncomingProjectNegotiation extends ProjectNegotiat
           for (final String path : paths) resources.add(getResource(project, path));
         }
 
-        session.addSharedResources(project, projectID, resources);
+        referencePointManager.put(project.getReferencePoint(), project);
+
+        session.addSharedResources(project.getReferencePoint(), projectID, resources);
       }
     } catch (Exception e) {
       exception = e;
@@ -219,7 +217,8 @@ public abstract class AbstractIncomingProjectNegotiation extends ProjectNegotiat
      * functionality. This will enable a specific Queuing mechanism per
      * TransferType (see github issue #137).
      */
-    for (IProject project : projectMapping.values()) session.disableQueuing(project);
+    for (IProject project : projectMapping.values())
+      session.disableQueuing(project.getReferencePoint());
 
     if (fileTransferManager != null)
       fileTransferManager.removeFileTransferListener(transferListener);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractIncomingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractIncomingProjectNegotiation.java
@@ -321,7 +321,8 @@ public abstract class AbstractIncomingProjectNegotiation extends ProjectNegotiat
 
       final FileList localProjectFileList =
           FileListFactory.createFileList(
-              project,
+              referencePointManager,
+              project.getReferencePoint(),
               null,
               checksumCache,
               new SubProgressMonitor(

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractIncomingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractIncomingProjectNegotiation.java
@@ -399,7 +399,7 @@ public abstract class AbstractIncomingProjectNegotiation extends ProjectNegotiat
       }
 
       for (final String path : diff.getAddedFolders()) {
-        final IFolder folder = referencePointManager.get(referencePoint).getFolder(path);
+        final IFolder folder = referencePointManager.getFolder(referencePoint, path);
 
         if (!folder.exists()) {
 
@@ -478,15 +478,15 @@ public abstract class AbstractIncomingProjectNegotiation extends ProjectNegotiat
 
       if (data == null) throw new IllegalArgumentException("invalid project id: " + id);
 
-      if (!referencePointManager.get(referencePoint).exists())
+      if (!referencePointManager.projectExists(referencePoint))
         throw new IllegalArgumentException("project does not exist: " + referencePoint);
     }
   }
 
   protected IResource getResource(IReferencePoint referencePoint, String path) {
     if (path.endsWith(FileList.DIR_SEPARATOR))
-      return referencePointManager.get(referencePoint).getFolder(path);
-    else return referencePointManager.get(referencePoint).getFile(path);
+      return referencePointManager.getFolder(referencePoint, path);
+    else return referencePointManager.getFile(referencePoint, path);
   }
 
   @Override

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractIncomingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractIncomingProjectNegotiation.java
@@ -84,7 +84,7 @@ public abstract class AbstractIncomingProjectNegotiation extends ProjectNegotiat
     this.projectNegotiationData = new HashMap<String, ProjectNegotiationData>();
 
     for (final ProjectNegotiationData data : projectNegotiationData)
-      this.projectNegotiationData.put(data.getProjectID(), data);
+      this.projectNegotiationData.put(data.getReferencePointID(), data);
 
     this.fileReplacementInProgressObservable = fileReplacementInProgressObservable;
   }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractOutgoingProjectNegotiation.java
@@ -311,8 +311,7 @@ public abstract class AbstractOutgoingProjectNegotiation extends ProjectNegotiat
          * force editor buffer flush because we read the files from the
          * underlying storage
          */
-        if (editorManager != null)
-          editorManager.saveEditors(referencePointManager.get(referencePoint));
+        if (editorManager != null) editorManager.saveEditors(referencePoint);
 
         FileList projectFileList =
             FileListFactory.createFileList(

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractOutgoingProjectNegotiation.java
@@ -40,13 +40,9 @@ import org.jivesoftware.smack.packet.Packet;
 public abstract class AbstractOutgoingProjectNegotiation extends ProjectNegotiation {
 
   private static final Logger LOG = Logger.getLogger(AbstractOutgoingProjectNegotiation.class);
-
-  protected List<IProject> projects;
-
   private static final Random NEGOTIATION_ID_GENERATOR = new Random();
-
   protected final IEditorManager editorManager;
-
+  protected List<IProject> projects;
   private PacketCollector remoteFileListResponseCollector;
 
   private PacketCollector startActivityQueuingResponseCollector;
@@ -321,7 +317,7 @@ public abstract class AbstractOutgoingProjectNegotiation extends ProjectNegotiat
         FileList projectFileList =
             FileListFactory.createFileList(
                 project,
-                session.getSharedResources(project),
+                session.getSharedResources(project.getReferencePoint()),
                 checksumCache,
                 new SubProgressMonitor(
                     monitor,
@@ -329,9 +325,9 @@ public abstract class AbstractOutgoingProjectNegotiation extends ProjectNegotiat
                     SubProgressMonitor.SUPPRESS_BEGINTASK
                         | SubProgressMonitor.SUPPRESS_SETTASKNAME));
 
-        boolean partial = !session.isCompletelyShared(project);
+        boolean partial = !session.isCompletelyShared(project.getReferencePoint());
 
-        String projectID = session.getProjectID(project);
+        String projectID = session.getReferencePointID(project.getReferencePoint());
         projectFileList.setProjectID(projectID);
 
         ProjectNegotiationData data =

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractOutgoingProjectNegotiation.java
@@ -8,7 +8,6 @@ import de.fu_berlin.inf.dpp.editor.IEditorManager;
 import de.fu_berlin.inf.dpp.exceptions.LocalCancellationException;
 import de.fu_berlin.inf.dpp.exceptions.SarosCancellationException;
 import de.fu_berlin.inf.dpp.filesystem.IChecksumCache;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
@@ -29,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CancellationException;
-import java.util.stream.Collectors;
 import org.apache.log4j.Logger;
 import org.jivesoftware.smack.packet.Packet;
 
@@ -44,7 +42,6 @@ public abstract class AbstractOutgoingProjectNegotiation extends ProjectNegotiat
   private static final Logger LOG = Logger.getLogger(AbstractOutgoingProjectNegotiation.class);
   private static final Random NEGOTIATION_ID_GENERATOR = new Random();
   protected final IEditorManager editorManager;
-  protected List<IProject> projects;
   protected List<IReferencePoint> referencePoints;
   private PacketCollector remoteFileListResponseCollector;
 
@@ -53,7 +50,7 @@ public abstract class AbstractOutgoingProjectNegotiation extends ProjectNegotiat
   protected AbstractOutgoingProjectNegotiation( //
       final JID peer, //
       final TransferType transferType, //
-      final List<IProject> projects, //
+      final List<IReferencePoint> referencePoints, //
       final ISarosSessionManager sessionManager, //
       final ISarosSession session, //
       final IEditorManager editorManager, //
@@ -75,15 +72,7 @@ public abstract class AbstractOutgoingProjectNegotiation extends ProjectNegotiat
         transmitter,
         receiver);
 
-    this.projects = projects;
-    this.referencePoints =
-        projects == null
-            ? null
-            : new ArrayList<>(
-                projects
-                    .stream()
-                    .map(project -> project.getReferencePoint())
-                    .collect(Collectors.toList()));
+    this.referencePoints = referencePoints;
     this.editorManager = editorManager;
   }
 

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractOutgoingProjectNegotiation.java
@@ -316,7 +316,8 @@ public abstract class AbstractOutgoingProjectNegotiation extends ProjectNegotiat
 
         FileList projectFileList =
             FileListFactory.createFileList(
-                project,
+                referencePointManager,
+                project.getReferencePoint(),
                 session.getSharedResources(project.getReferencePoint()),
                 checksumCache,
                 new SubProgressMonitor(

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/AbstractOutgoingProjectNegotiation.java
@@ -333,7 +333,7 @@ public abstract class AbstractOutgoingProjectNegotiation extends ProjectNegotiat
         ProjectNegotiationData data =
             new ProjectNegotiationData(
                 referencePointID,
-                referencePointManager.get(referencePoint).getName(),
+                referencePointManager.getName(referencePoint),
                 partial,
                 projectFileList);
 

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveIncomingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveIncomingProjectNegotiation.java
@@ -167,7 +167,10 @@ public class ArchiveIncomingProjectNegotiation extends AbstractIncomingProjectNe
      */
 
     try {
-      workspace.run(decompressTask, projectMapping.values().toArray(new IResource[0]));
+      workspace.run(
+          decompressTask,
+          localReferencePointMapping.values().toArray(new IReferencePoint[0]),
+          referencePointManager);
     } catch (de.fu_berlin.inf.dpp.exceptions.OperationCanceledException e) {
       LocalCancellationException canceled =
           new LocalCancellationException(null, CancelOption.DO_NOT_NOTIFY_PEER);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveIncomingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveIncomingProjectNegotiation.java
@@ -86,8 +86,10 @@ public class ArchiveIncomingProjectNegotiation extends AbstractIncomingProjectNe
        * functionality. This will enable a specific Queuing mechanism per
        * TransferType (see github issue #137).
        */
-      session.addProjectMapping(projectID, project);
-      session.enableQueuing(project);
+      referencePointManager.put(project.getReferencePoint(), project);
+
+      session.addReferencePointMapping(projectID, project.getReferencePoint());
+      session.enableQueuing(project.getReferencePoint());
     }
 
     transmitter.send(

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveIncomingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveIncomingProjectNegotiation.java
@@ -4,9 +4,7 @@ import de.fu_berlin.inf.dpp.communication.extensions.StartActivityQueuingRespons
 import de.fu_berlin.inf.dpp.exceptions.LocalCancellationException;
 import de.fu_berlin.inf.dpp.exceptions.SarosCancellationException;
 import de.fu_berlin.inf.dpp.filesystem.IChecksumCache;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
-import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
 import de.fu_berlin.inf.dpp.monitoring.SubProgressMonitor;
@@ -21,7 +19,6 @@ import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
 import de.fu_berlin.inf.dpp.util.CoreUtils;
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -146,13 +143,13 @@ public class ArchiveIncomingProjectNegotiation extends AbstractIncomingProjectNe
       final IProgressMonitor monitor)
       throws LocalCancellationException, IOException {
 
-    final Map<String, IProject> projectMapping = new HashMap<String, IProject>();
-
-    for (Entry<String, IReferencePoint> entry : localReferencePointMapping.entrySet())
-      projectMapping.put(entry.getKey(), referencePointManager.get(entry.getValue()));
-
     final DecompressArchiveTask decompressTask =
-        new DecompressArchiveTask(archiveFile, projectMapping, PATH_DELIMITER, monitor);
+        new DecompressArchiveTask(
+            archiveFile,
+            localReferencePointMapping,
+            PATH_DELIMITER,
+            monitor,
+            referencePointManager);
 
     long startTime = System.currentTimeMillis();
 

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveOutgoingProjectNegotiation.java
@@ -7,7 +7,6 @@ import de.fu_berlin.inf.dpp.exceptions.SarosCancellationException;
 import de.fu_berlin.inf.dpp.filesystem.IChecksumCache;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
 import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
-import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
 import de.fu_berlin.inf.dpp.negotiation.NegotiationTools.CancelOption;
@@ -159,8 +158,7 @@ public class ArchiveOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
        * force editor buffer flush because we read the files from the
        * underlying storage
        */
-      if (editorManager != null)
-        editorManager.saveEditors(referencePointManager.get(referencePoint));
+      if (editorManager != null) editorManager.saveEditors(referencePoint);
 
       final StringBuilder aliasBuilder = new StringBuilder();
 

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveOutgoingProjectNegotiation.java
@@ -146,7 +146,7 @@ public class ArchiveOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
     for (final FileList list : fileLists) {
       final String projectID = list.getProjectID();
 
-      final IProject project = session.getProject(projectID);
+      final IProject project = referencePointManager.get(session.getReferencePoint(projectID));
 
       if (project == null)
         throw new LocalCancellationException(

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveOutgoingProjectNegotiation.java
@@ -141,7 +141,7 @@ public class ArchiveOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
     final List<IFile> filesToCompress = new ArrayList<IFile>(fileCount);
     final List<String> fileAlias = new ArrayList<String>(fileCount);
 
-    final List<IResource> projectsToLock = new ArrayList<IResource>();
+    final List<IReferencePoint> referencePointsToLock = new ArrayList<IReferencePoint>();
 
     for (final FileList list : fileLists) {
       final String referencePointID = list.getProjectID();
@@ -153,7 +153,7 @@ public class ArchiveOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
             "project with id " + referencePointID + " was unshared during synchronization",
             CancelOption.NOTIFY_PEER);
 
-      projectsToLock.add(referencePointManager.get(referencePoint));
+      referencePointsToLock.add(referencePoint);
 
       /*
        * force editor buffer flush because we read the files from the
@@ -186,7 +186,8 @@ public class ArchiveOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
       tempArchive = File.createTempFile("saros_" + getID(), ".zip");
       workspace.run(
           new CreateArchiveTask(tempArchive, filesToCompress, fileAlias, monitor),
-          projectsToLock.toArray(new IResource[0]));
+          referencePointsToLock.toArray(new IReferencePoint[0]),
+          referencePointManager);
     } catch (OperationCanceledException e) {
       LocalCancellationException canceled = new LocalCancellationException();
       canceled.initCause(e);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveOutgoingProjectNegotiation.java
@@ -6,7 +6,6 @@ import de.fu_berlin.inf.dpp.exceptions.OperationCanceledException;
 import de.fu_berlin.inf.dpp.exceptions.SarosCancellationException;
 import de.fu_berlin.inf.dpp.filesystem.IChecksumCache;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
@@ -39,7 +38,7 @@ public class ArchiveOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
 
   public ArchiveOutgoingProjectNegotiation( //
       final JID peer, //
-      final List<IProject> projects, //
+      final List<IReferencePoint> referencePoints, //
       final ISarosSessionManager sessionManager, //
       final ISarosSession session, //
       final IEditorManager editorManager, //
@@ -52,7 +51,7 @@ public class ArchiveOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
     super(
         peer,
         TransferType.ARCHIVE,
-        projects,
+        referencePoints,
         sessionManager,
         session,
         editorManager,

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveOutgoingProjectNegotiation.java
@@ -162,7 +162,7 @@ public class ArchiveOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
 
       final StringBuilder aliasBuilder = new StringBuilder();
 
-      aliasBuilder.append(referencePoint).append(PATH_DELIMITER);
+      aliasBuilder.append(referencePointID).append(PATH_DELIMITER);
 
       final int prefixLength = aliasBuilder.length();
 

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveOutgoingProjectNegotiation.java
@@ -169,7 +169,7 @@ public class ArchiveOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
       for (final String path : list.getPaths()) {
 
         // assert path is relative !
-        filesToCompress.add(referencePointManager.get(referencePoint).getFile(path));
+        filesToCompress.add(referencePointManager.getFile(referencePoint, path));
         aliasBuilder.append(path);
         fileAlias.add(aliasBuilder.toString());
         aliasBuilder.setLength(prefixLength);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ArchiveOutgoingProjectNegotiation.java
@@ -7,6 +7,7 @@ import de.fu_berlin.inf.dpp.exceptions.SarosCancellationException;
 import de.fu_berlin.inf.dpp.filesystem.IChecksumCache;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
@@ -144,33 +145,34 @@ public class ArchiveOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
     final List<IResource> projectsToLock = new ArrayList<IResource>();
 
     for (final FileList list : fileLists) {
-      final String projectID = list.getProjectID();
+      final String referencePointID = list.getProjectID();
 
-      final IProject project = referencePointManager.get(session.getReferencePoint(projectID));
+      final IReferencePoint referencePoint = session.getReferencePoint(referencePointID);
 
-      if (project == null)
+      if (referencePoint == null)
         throw new LocalCancellationException(
-            "project with id " + projectID + " was unshared during synchronization",
+            "project with id " + referencePointID + " was unshared during synchronization",
             CancelOption.NOTIFY_PEER);
 
-      projectsToLock.add(project);
+      projectsToLock.add(referencePointManager.get(referencePoint));
 
       /*
        * force editor buffer flush because we read the files from the
        * underlying storage
        */
-      if (editorManager != null) editorManager.saveEditors(project);
+      if (editorManager != null)
+        editorManager.saveEditors(referencePointManager.get(referencePoint));
 
       final StringBuilder aliasBuilder = new StringBuilder();
 
-      aliasBuilder.append(projectID).append(PATH_DELIMITER);
+      aliasBuilder.append(referencePoint).append(PATH_DELIMITER);
 
       final int prefixLength = aliasBuilder.length();
 
       for (final String path : list.getPaths()) {
 
         // assert path is relative !
-        filesToCompress.add(project.getFile(path));
+        filesToCompress.add(referencePointManager.get(referencePoint).getFile(path));
         aliasBuilder.append(path);
         fileAlias.add(aliasBuilder.toString());
         aliasBuilder.setLength(prefixLength);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/DecompressArchiveTask.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/DecompressArchiveTask.java
@@ -3,11 +3,12 @@ package de.fu_berlin.inf.dpp.negotiation;
 import de.fu_berlin.inf.dpp.exceptions.OperationCanceledException;
 import de.fu_berlin.inf.dpp.filesystem.FileSystem;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspaceRunnable;
 import de.fu_berlin.inf.dpp.monitoring.CancelableInputStream;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import java.io.File;
 import java.io.IOException;
@@ -24,8 +25,9 @@ public class DecompressArchiveTask implements IWorkspaceRunnable {
 
   private final File file;
   private final IProgressMonitor monitor;
-  private final Map<String, IProject> idToProjectMapping;
+  private final Map<String, IReferencePoint> idToReferencePointMapping;
   private final String delimiter;
+  private final IReferencePointManager referencePointManager;
 
   /**
    * Creates a decompress task for an archive file that can be executed by {@link IWorkspace#run}.
@@ -33,20 +35,22 @@ public class DecompressArchiveTask implements IWorkspaceRunnable {
    * <b>overwritten without confirmation</b>!
    *
    * @param file Zip file containing the compressed data
-   * @param idToProjectMapping map containing the id to project mapping (see also {@link
-   *     ISarosSession#getReferencePointID(de.fu_berlin.inf.dpp.filesystem.IReferencePoint)}
+   * @param idToReferencePointMapping map containing the id to project mapping (see also {@link
+   *     ISarosSession#getReferencePointID(IReferencePoint)}
    * @param monitor monitor that is used for progress report and cancellation or <code>null</code>
    *     to use the monitor provided by the {@link #run(IProgressMonitor)} method
    */
   public DecompressArchiveTask(
       final File file,
-      final Map<String, IProject> idToProjectMapping,
+      final Map<String, IReferencePoint> idToReferencePointMapping,
       final String delimiter,
-      final IProgressMonitor monitor) {
+      final IProgressMonitor monitor,
+      final IReferencePointManager referencePointManager) {
     this.file = file;
-    this.idToProjectMapping = idToProjectMapping;
+    this.idToReferencePointMapping = idToReferencePointMapping;
     this.delimiter = delimiter;
     this.monitor = monitor;
+    this.referencePointManager = referencePointManager;
   }
 
   // TODO extract as much as possible even on some failures
@@ -88,16 +92,16 @@ public class DecompressArchiveTask implements IWorkspaceRunnable {
 
         final String path = entryName.substring(delimiterIdx + 1, entryName.length());
 
-        final IProject project = idToProjectMapping.get(id);
+        final IReferencePoint referencePoint = idToReferencePointMapping.get(id);
 
-        if (project == null) {
-          LOG.warn("skipping zip entry " + entryName + ", unknown project id: " + id);
+        if (referencePointManager == null) {
+          LOG.warn("skipping zip entry " + entryName + ", unknown reference point id: " + id);
 
           monitor.worked(1);
           continue;
         }
 
-        final IFile decompressedFile = project.getFile(path);
+        final IFile decompressedFile = referencePointManager.get(referencePoint).getFile(path);
 
         FileSystem.createFolder(decompressedFile);
 

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/DecompressArchiveTask.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/DecompressArchiveTask.java
@@ -101,7 +101,7 @@ public class DecompressArchiveTask implements IWorkspaceRunnable {
           continue;
         }
 
-        final IFile decompressedFile = referencePointManager.get(referencePoint).getFile(path);
+        final IFile decompressedFile = referencePointManager.getFile(referencePoint, path);
 
         FileSystem.createFolder(decompressedFile);
 

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/DecompressArchiveTask.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/DecompressArchiveTask.java
@@ -34,7 +34,7 @@ public class DecompressArchiveTask implements IWorkspaceRunnable {
    *
    * @param file Zip file containing the compressed data
    * @param idToProjectMapping map containing the id to project mapping (see also {@link
-   *     ISarosSession#getProjectID(de.fu_berlin.inf.dpp.filesystem.IProject)}
+   *     ISarosSession#getReferencePointID(de.fu_berlin.inf.dpp.filesystem.IReferencePoint)}
    * @param monitor monitor that is used for progress report and cancellation or <code>null</code>
    *     to use the monitor provided by the {@link #run(IProgressMonitor)} method
    */

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/FileListFactory.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/FileListFactory.java
@@ -4,11 +4,12 @@ import de.fu_berlin.inf.dpp.filesystem.FileSystem;
 import de.fu_berlin.inf.dpp.filesystem.IChecksumCache;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
 import de.fu_berlin.inf.dpp.filesystem.IFolder;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
 import de.fu_berlin.inf.dpp.monitoring.NullProgressMonitor;
 import de.fu_berlin.inf.dpp.negotiation.FileList.MetaData;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Deque;
@@ -20,8 +21,9 @@ import org.apache.log4j.Logger;
  * Offers two ways to create {@link FileList file lists}.
  *
  * <p>
- * <li>Either an inexpensive one that rescans the whole project to gather meta data:<br>
- *     {@link #createFileList(IProject, List, IChecksumCache, IProgressMonitor)}
+ * <li>Either an inexpensive one that rescans the whole reference point to gather meta data:<br>
+ *     {@link #createFileList(IReferencePointManager, IReferencePoint, List, IChecksumCache,
+ *     IProgressMonitor)}
  * <li>Or a cheap one which requires the caller to take care of the validity of input data:<br>
  *     {@link #createFileList(List)}
  */
@@ -31,23 +33,29 @@ public class FileListFactory {
 
   private IChecksumCache checksumCache;
   private IProgressMonitor monitor;
+  private IReferencePointManager referencePointManager;
 
-  private FileListFactory(IChecksumCache checksumCache, IProgressMonitor monitor) {
+  private FileListFactory(
+      IChecksumCache checksumCache,
+      IProgressMonitor monitor,
+      IReferencePointManager referencePointManager) {
     this.checksumCache = checksumCache;
     this.monitor = monitor;
+    this.referencePointManager = referencePointManager;
 
     if (this.monitor == null) this.monitor = new NullProgressMonitor();
   }
 
   public static FileList createFileList(
-      IProject project,
+      IReferencePointManager referencePointManager,
+      IReferencePoint referencePoint,
       List<IResource> resources,
       IChecksumCache checksumCache,
       IProgressMonitor monitor)
       throws IOException {
 
-    FileListFactory fact = new FileListFactory(checksumCache, monitor);
-    return fact.build(project, resources);
+    FileListFactory fact = new FileListFactory(checksumCache, monitor, referencePointManager);
+    return fact.build(referencePoint, resources);
   }
 
   /**
@@ -72,13 +80,14 @@ public class FileListFactory {
     return new FileList();
   }
 
-  private FileList build(IProject project, List<IResource> resources) throws IOException {
+  private FileList build(IReferencePoint referencePoint, List<IResource> resources)
+      throws IOException {
 
     FileList list = new FileList();
 
     if (resources == null) {
-      list.addEncoding(project.getDefaultCharset());
-      resources = Arrays.asList(project.members());
+      list.addEncoding(referencePointManager.get(referencePoint).getDefaultCharset());
+      resources = Arrays.asList(referencePointManager.get(referencePoint).members());
     }
 
     addMembersToList(list, resources);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/FileListFactory.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/FileListFactory.java
@@ -86,8 +86,8 @@ public class FileListFactory {
     FileList list = new FileList();
 
     if (resources == null) {
-      list.addEncoding(referencePointManager.get(referencePoint).getDefaultCharset());
-      resources = Arrays.asList(referencePointManager.get(referencePoint).members());
+      list.addEncoding(referencePointManager.getDefaultCharSet(referencePoint));
+      resources = Arrays.asList(referencePointManager.members(referencePoint));
     }
 
     addMembersToList(list, resources);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantIncomingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantIncomingProjectNegotiation.java
@@ -4,7 +4,7 @@ import de.fu_berlin.inf.dpp.communication.extensions.StartActivityQueuingRespons
 import de.fu_berlin.inf.dpp.exceptions.LocalCancellationException;
 import de.fu_berlin.inf.dpp.exceptions.SarosCancellationException;
 import de.fu_berlin.inf.dpp.filesystem.IChecksumCache;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
 import de.fu_berlin.inf.dpp.negotiation.NegotiationTools.CancelOption;
@@ -61,7 +61,9 @@ public class InstantIncomingProjectNegotiation extends AbstractIncomingProjectNe
 
   @Override
   protected void transfer(
-      IProgressMonitor monitor, Map<String, IProject> projectMapping, List<FileList> missingFiles)
+      IProgressMonitor monitor,
+      Map<String, IReferencePoint> referencePointMapping,
+      List<FileList> missingFiles)
       throws IOException, SarosCancellationException {
 
     awaitActivityQueueingActivation(monitor);
@@ -70,15 +72,14 @@ public class InstantIncomingProjectNegotiation extends AbstractIncomingProjectNe
      * the user who sends this ProjectNegotiation is now responsible for the
      * resources of the contained projects
      */
-    for (Entry<String, IProject> entry : projectMapping.entrySet()) {
-      final String projectID = entry.getKey();
-      final IProject project = entry.getValue();
+    for (Entry<String, IReferencePoint> entry : referencePointMapping.entrySet()) {
+      final String referencePointID = entry.getKey();
+      final IReferencePoint referencePoint = entry.getValue();
 
-      referencePointManager.put(project.getReferencePoint(), project);
-      session.addReferencePointMapping(projectID, project.getReferencePoint());
+      session.addReferencePointMapping(referencePointID, referencePoint);
 
       /* TODO change queuing to resource based queuing */
-      session.enableQueuing(project.getReferencePoint());
+      session.enableQueuing(referencePoint);
     }
 
     transmitter.send(

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantIncomingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantIncomingProjectNegotiation.java
@@ -74,9 +74,11 @@ public class InstantIncomingProjectNegotiation extends AbstractIncomingProjectNe
       final String projectID = entry.getKey();
       final IProject project = entry.getValue();
 
-      session.addProjectMapping(projectID, project);
+      referencePointManager.put(project.getReferencePoint(), project);
+      session.addReferencePointMapping(projectID, project.getReferencePoint());
+
       /* TODO change queuing to resource based queuing */
-      session.enableQueuing(project);
+      session.enableQueuing(project.getReferencePoint());
     }
 
     transmitter.send(

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantOutgoingProjectNegotiation.java
@@ -236,7 +236,7 @@ public class InstantOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
       while (!openedFiles.isEmpty()) {
         SPath openFile = openedFiles.poll();
         /* open files could be changed meanwhile */
-        editorManager.saveEditors(openFile.getProject());
+        editorManager.saveEditors(openFile.getProject().getReferencePoint());
         sendIfRequired(osp, openFile);
       }
 

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantOutgoingProjectNegotiation.java
@@ -7,7 +7,6 @@ import de.fu_berlin.inf.dpp.editor.remote.UserEditorStateManager;
 import de.fu_berlin.inf.dpp.exceptions.LocalCancellationException;
 import de.fu_berlin.inf.dpp.exceptions.SarosCancellationException;
 import de.fu_berlin.inf.dpp.filesystem.IChecksumCache;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
@@ -62,7 +61,7 @@ public class InstantOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
 
   public InstantOutgoingProjectNegotiation(
       final JID peer, //
-      final List<IProject> projects, //
+      final List<IReferencePoint> referencePoints, //
       final ISarosSessionManager sessionManager, //
       final ISarosSession session, //
       final IEditorManager editorManager, //
@@ -75,7 +74,7 @@ public class InstantOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
     super(
         peer,
         TransferType.INSTANT,
-        projects,
+        referencePoints,
         sessionManager,
         session,
         editorManager,

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantOutgoingProjectNegotiation.java
@@ -182,8 +182,8 @@ public class InstantOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
     List<SPath> files = new ArrayList<SPath>(fileCount);
     for (final FileList list : fileLists) {
       IReferencePoint referencePoint = session.getReferencePoint(list.getProjectID());
-      for (String file : list.getPaths()) {
-        files.add(new SPath(referencePointManager.get(referencePoint).getFile(file)));
+      for (String fileName : list.getPaths()) {
+        files.add(new SPath(referencePointManager.getFile(referencePoint, fileName)));
       }
     }
 
@@ -222,9 +222,9 @@ public class InstantOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
       ".settings/org.eclipse.jdt.ui.prefs"
     };
 
-    for (String string : eclipseProjFiles) {
+    for (String fileName : eclipseProjFiles) {
       for (IReferencePoint referencePoint : referencePoints) {
-        SPath file = new SPath(referencePointManager.get(referencePoint).getFile(string));
+        SPath file = new SPath(referencePointManager.getFile(referencePoint, fileName));
         sendIfRequired(osp, file);
       }
     }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantOutgoingProjectNegotiation.java
@@ -45,10 +45,6 @@ public class InstantOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
 
   /** used as LIFO queue * */
   private final Deque<SPath> openedFiles = new LinkedBlockingDeque<SPath>();
-
-  private Set<SPath> transferList;
-  private Set<SPath> transmittedFiles;
-
   /** receive open editors to prioritize these files * */
   private final ISharedEditorListener listener =
       new ISharedEditorListener() {
@@ -58,6 +54,8 @@ public class InstantOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
         }
       };
 
+  private Set<SPath> transferList;
+  private Set<SPath> transmittedFiles;
   private List<StartHandle> stoppedUsers = null;
   private User remoteUser = null;
 
@@ -117,7 +115,7 @@ public class InstantOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
       fileCount += list.getPaths().size();
 
       final String projectID = list.getProjectID();
-      final IProject project = session.getProject(projectID);
+      final IProject project = referencePointManager.get(session.getReferencePoint(projectID));
 
       if (project == null)
         throw new LocalCancellationException(
@@ -183,7 +181,7 @@ public class InstantOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
   private void createTransferList(List<FileList> fileLists, int fileCount) {
     List<SPath> files = new ArrayList<SPath>(fileCount);
     for (final FileList list : fileLists) {
-      IProject project = session.getProject(list.getProjectID());
+      IProject project = referencePointManager.get(session.getReferencePoint(list.getProjectID()));
       for (String file : list.getPaths()) {
         files.add(new SPath(project.getFile(file)));
       }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantOutgoingProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/InstantOutgoingProjectNegotiation.java
@@ -8,6 +8,7 @@ import de.fu_berlin.inf.dpp.exceptions.LocalCancellationException;
 import de.fu_berlin.inf.dpp.exceptions.SarosCancellationException;
 import de.fu_berlin.inf.dpp.filesystem.IChecksumCache;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
 import de.fu_berlin.inf.dpp.negotiation.NegotiationTools.CancelOption;
@@ -114,12 +115,12 @@ public class InstantOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
     for (final FileList list : fileLists) {
       fileCount += list.getPaths().size();
 
-      final String projectID = list.getProjectID();
-      final IProject project = referencePointManager.get(session.getReferencePoint(projectID));
+      final String referencePointID = list.getProjectID();
+      final IReferencePoint referencePoint = session.getReferencePoint(referencePointID);
 
-      if (project == null)
+      if (referencePoint == null)
         throw new LocalCancellationException(
-            "project with id " + projectID + " was unshared during synchronization",
+            "project with id " + referencePointID + " was unshared during synchronization",
             CancelOption.NOTIFY_PEER);
     }
 
@@ -181,9 +182,9 @@ public class InstantOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
   private void createTransferList(List<FileList> fileLists, int fileCount) {
     List<SPath> files = new ArrayList<SPath>(fileCount);
     for (final FileList list : fileLists) {
-      IProject project = referencePointManager.get(session.getReferencePoint(list.getProjectID()));
+      IReferencePoint referencePoint = session.getReferencePoint(list.getProjectID());
       for (String file : list.getPaths()) {
-        files.add(new SPath(project.getFile(file)));
+        files.add(new SPath(referencePointManager.get(referencePoint).getFile(file)));
       }
     }
 
@@ -223,8 +224,8 @@ public class InstantOutgoingProjectNegotiation extends AbstractOutgoingProjectNe
     };
 
     for (String string : eclipseProjFiles) {
-      for (IProject project : projects) {
-        SPath file = new SPath(project.getFile(string));
+      for (IReferencePoint referencePoint : referencePoints) {
+        SPath file = new SPath(referencePointManager.get(referencePoint).getFile(string));
         sendIfRequired(osp, file);
       }
     }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/NegotiationFactory.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/NegotiationFactory.java
@@ -3,7 +3,6 @@ package de.fu_berlin.inf.dpp.negotiation;
 import de.fu_berlin.inf.dpp.context.IContainerContext;
 import de.fu_berlin.inf.dpp.editor.IEditorManager;
 import de.fu_berlin.inf.dpp.filesystem.IChecksumCache;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 import de.fu_berlin.inf.dpp.negotiation.hooks.SessionNegotiationHookManager;
@@ -17,9 +16,7 @@ import de.fu_berlin.inf.dpp.observables.FileReplacementInProgressObservable;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
 import de.fu_berlin.inf.dpp.versioning.VersionManager;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public final class NegotiationFactory {
 
@@ -133,7 +130,7 @@ public final class NegotiationFactory {
   public AbstractOutgoingProjectNegotiation newOutgoingProjectNegotiation(
       final JID remoteAddress,
       final TransferType transferType,
-      final List<IProject> resources,
+      final List<IReferencePoint> referencePoints,
       final ISarosSessionManager sessionManager,
       final ISarosSession session) {
 
@@ -145,7 +142,7 @@ public final class NegotiationFactory {
       case ARCHIVE:
         return new ArchiveOutgoingProjectNegotiation(
             remoteAddress,
-            getReferencePointList(resources),
+            referencePoints,
             sessionManager,
             session, /* editorManager */
             context.getComponent(IEditorManager.class),
@@ -157,7 +154,7 @@ public final class NegotiationFactory {
       case INSTANT:
         return new InstantOutgoingProjectNegotiation(
             remoteAddress,
-            getReferencePointList(resources),
+            referencePoints,
             sessionManager,
             session, /* editorManager */
             context.getComponent(IEditorManager.class),
@@ -213,15 +210,5 @@ public final class NegotiationFactory {
       default:
         throw new UnsupportedOperationException("transferType not implemented");
     }
-  }
-
-  private List<IReferencePoint> getReferencePointList(List<IProject> projects) {
-    return projects == null
-        ? null
-        : new ArrayList<>(
-            projects
-                .stream()
-                .map(project -> project.getReferencePoint())
-                .collect(Collectors.toList()));
   }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/NegotiationFactory.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/NegotiationFactory.java
@@ -4,6 +4,7 @@ import de.fu_berlin.inf.dpp.context.IContainerContext;
 import de.fu_berlin.inf.dpp.editor.IEditorManager;
 import de.fu_berlin.inf.dpp.filesystem.IChecksumCache;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 import de.fu_berlin.inf.dpp.negotiation.hooks.SessionNegotiationHookManager;
 import de.fu_berlin.inf.dpp.net.IConnectionManager;
@@ -16,7 +17,9 @@ import de.fu_berlin.inf.dpp.observables.FileReplacementInProgressObservable;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
 import de.fu_berlin.inf.dpp.versioning.VersionManager;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public final class NegotiationFactory {
 
@@ -142,7 +145,7 @@ public final class NegotiationFactory {
       case ARCHIVE:
         return new ArchiveOutgoingProjectNegotiation(
             remoteAddress,
-            resources,
+            getReferencePointList(resources),
             sessionManager,
             session, /* editorManager */
             context.getComponent(IEditorManager.class),
@@ -154,7 +157,7 @@ public final class NegotiationFactory {
       case INSTANT:
         return new InstantOutgoingProjectNegotiation(
             remoteAddress,
-            resources,
+            getReferencePointList(resources),
             sessionManager,
             session, /* editorManager */
             context.getComponent(IEditorManager.class),
@@ -210,5 +213,15 @@ public final class NegotiationFactory {
       default:
         throw new UnsupportedOperationException("transferType not implemented");
     }
+  }
+
+  private List<IReferencePoint> getReferencePointList(List<IProject> projects) {
+    return projects == null
+        ? null
+        : new ArrayList<>(
+            projects
+                .stream()
+                .map(project -> project.getReferencePoint())
+                .collect(Collectors.toList()));
   }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ProjectNegotiation.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ProjectNegotiation.java
@@ -14,6 +14,7 @@ import de.fu_berlin.inf.dpp.net.IReceiver;
 import de.fu_berlin.inf.dpp.net.ITransmitter;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
 import de.fu_berlin.inf.dpp.net.xmpp.XMPPConnectionService;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
 import java.io.IOException;
@@ -29,32 +30,25 @@ import org.jivesoftware.smackx.filetransfer.FileTransferManager;
  */
 public abstract class ProjectNegotiation extends Negotiation {
 
-  private static final Logger LOG = Logger.getLogger(ProjectNegotiation.class);
-
   /** Prefix part of the id used in the SMACK XMPP file transfer protocol. */
   public static final String TRANSFER_ID_PREFIX = "saros-dpp-pn-server-client/";
-
   /**
    * Delimiter for every Zip entry to delimit the project id from the path entry.
    *
    * <p>E.g: <b>12345:foo/bar/foobar.java</b>
    */
   protected static final String PATH_DELIMITER = ":";
-
   /** Timeout for all packet exchanges during the project negotiation */
   protected static final long PACKET_TIMEOUT =
       Long.getLong("de.fu_berlin.inf.dpp.negotiation.project.PACKET_TIMEOUT", 30000L);
 
+  private static final Logger LOG = Logger.getLogger(ProjectNegotiation.class);
   protected final ISarosSessionManager sessionManager;
 
   protected final ISarosSession session;
-
-  private final String sessionID;
-
   protected final IWorkspace workspace;
-
   protected final IChecksumCache checksumCache;
-
+  private final String sessionID;
   /**
    * The file transfer manager can be <code>null</code> if no connection was established or was lost
    * when the class was instantiated.
@@ -62,6 +56,8 @@ public abstract class ProjectNegotiation extends Negotiation {
   protected FileTransferManager fileTransferManager;
 
   protected TransferType transferType;
+
+  protected IReferencePointManager referencePointManager;
 
   public ProjectNegotiation(
       final String id,
@@ -87,6 +83,7 @@ public abstract class ProjectNegotiation extends Negotiation {
     if (connection != null) fileTransferManager = new FileTransferManager(connection);
 
     this.transferType = transferType;
+    this.referencePointManager = session.getComponent(IReferencePointManager.class);
   }
 
   /**

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ProjectNegotiationCollector.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ProjectNegotiationCollector.java
@@ -1,6 +1,6 @@
 package de.fu_berlin.inf.dpp.negotiation;
 
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -14,30 +14,34 @@ import java.util.Map.Entry;
  * running project negotiations per user.
  */
 public class ProjectNegotiationCollector {
-  private Map<IProject, List<IResource>> mapping = new HashMap<IProject, List<IResource>>();
+  private Map<IReferencePoint, List<IResource>> mapping =
+      new HashMap<IReferencePoint, List<IResource>>();
 
   /**
-   * Add project resource mappings for the next project negotiation.
+   * Add reference point resource mappings for the next project negotiation.
    *
-   * @param projectResourcesMapping project resource mappings to add
+   * @param referencePointResourcesMapping reference point resource mappings to add
    */
-  public synchronized void add(Map<IProject, List<IResource>> projectResourcesMapping) {
-    for (Entry<IProject, List<IResource>> mapEntry : projectResourcesMapping.entrySet()) {
-      final IProject project = mapEntry.getKey();
+  public synchronized void add(
+      Map<IReferencePoint, List<IResource>> referencePointResourcesMapping) {
+    for (Entry<IReferencePoint, List<IResource>> mapEntry :
+        referencePointResourcesMapping.entrySet()) {
+      final IReferencePoint referencePoint = mapEntry.getKey();
       final List<IResource> resources = mapEntry.getValue();
 
-      boolean alreadyFullShared = mapping.containsKey(project) && mapping.get(project) == null;
+      boolean alreadyFullShared =
+          mapping.containsKey(referencePoint) && mapping.get(referencePoint) == null;
 
-      /* full shared project */
+      /* full shared project / reference point */
       if (resources == null || alreadyFullShared) {
-        mapping.put(project, null);
+        mapping.put(referencePoint, null);
         continue;
       }
 
-      /* update partial shared project */
-      List<IResource> mappedResources = mapping.get(project);
+      /* update partial shared project / reference point */
+      List<IResource> mappedResources = mapping.get(referencePoint);
       if (mappedResources == null) {
-        mapping.put(project, new ArrayList<IResource>(resources));
+        mapping.put(referencePoint, new ArrayList<IResource>(resources));
       } else {
         mappedResources.addAll(resources);
       }
@@ -45,14 +49,14 @@ public class ProjectNegotiationCollector {
   }
 
   /**
-   * Returns a list of project resource mappings that should be handled by a project negotiation.
-   * Resets the Collector for next additions.
+   * Returns a list of reference point resource mappings that should be handled by a project
+   * negotiation. Resets the Collector for next additions.
    *
-   * @return project resource mappings to add
+   * @return reference point resource mappings to add
    */
-  public synchronized Map<IProject, List<IResource>> get() {
-    Map<IProject, List<IResource>> tmp = mapping;
-    mapping = new HashMap<IProject, List<IResource>>();
+  public synchronized Map<IReferencePoint, List<IResource>> get() {
+    Map<IReferencePoint, List<IResource>> tmp = mapping;
+    mapping = new HashMap<IReferencePoint, List<IResource>>();
     return tmp;
   }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ProjectNegotiationData.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/ProjectNegotiationData.java
@@ -16,7 +16,7 @@ public class ProjectNegotiationData {
 
   @XStreamAlias("pid")
   @XStreamAsAttribute
-  private final String projectID;
+  private final String referencePointID;
 
   @XStreamAlias("partial")
   @XStreamAsAttribute
@@ -26,16 +26,17 @@ public class ProjectNegotiationData {
   private final FileList fileList;
 
   /**
-   * @param projectID Session wide ID of the project. This ID is the same for all users.
+   * @param referencePointID Session wide ID of the reference point. This ID is the same for all
+   *     users.
    * @param projectName Name of the project on inviter side.
    * @param fileList complete list of all files that are part of the sharing for the given project
    */
   public ProjectNegotiationData(
-      String projectID, String projectName, boolean partial, FileList fileList) {
+      String referencePointID, String projectName, boolean partial, FileList fileList) {
 
     this.fileList = fileList;
     this.projectName = projectName;
-    this.projectID = projectID;
+    this.referencePointID = referencePointID;
     this.partial = partial;
   }
 
@@ -47,8 +48,8 @@ public class ProjectNegotiationData {
     return projectName;
   }
 
-  public String getProjectID() {
-    return projectID;
+  public String getReferencePointID() {
+    return referencePointID;
   }
 
   public boolean isPartial() {

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/stream/IncomingStreamProtocol.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/stream/IncomingStreamProtocol.java
@@ -3,7 +3,7 @@ package de.fu_berlin.inf.dpp.negotiation.stream;
 import de.fu_berlin.inf.dpp.exceptions.LocalCancellationException;
 import de.fu_berlin.inf.dpp.filesystem.FileSystem;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
 import de.fu_berlin.inf.dpp.negotiation.NegotiationTools.CancelOption;
 import de.fu_berlin.inf.dpp.session.IReferencePointManager;
@@ -40,14 +40,14 @@ public class IncomingStreamProtocol extends AbstractStreamProtocol {
     BoundedInputStream fileIn = null;
     try {
       while (true) {
-        String projectID = in.readUTF();
+        String referencePointID = in.readUTF();
 
         /* check stream end */
-        if (projectID.isEmpty()) break;
+        if (referencePointID.isEmpty()) break;
 
         String fileName = in.readUTF();
-        IProject project = referencePointManager.get(session.getReferencePoint(projectID));
-        IFile file = project.getFile(fileName);
+        IReferencePoint referencePoint = session.getReferencePoint(referencePointID);
+        IFile file = referencePointManager.getFile(referencePoint, fileName);
 
         String message = "receiving " + displayName(file);
         log.debug(message);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/stream/IncomingStreamProtocol.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/stream/IncomingStreamProtocol.java
@@ -3,8 +3,10 @@ package de.fu_berlin.inf.dpp.negotiation.stream;
 import de.fu_berlin.inf.dpp.exceptions.LocalCancellationException;
 import de.fu_berlin.inf.dpp.filesystem.FileSystem;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
+import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
 import de.fu_berlin.inf.dpp.negotiation.NegotiationTools.CancelOption;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -19,10 +21,12 @@ public class IncomingStreamProtocol extends AbstractStreamProtocol {
   private static final Logger log = Logger.getLogger(IncomingStreamProtocol.class);
 
   private DataInputStream in;
+  private IReferencePointManager referencePointManager;
 
   public IncomingStreamProtocol(InputStream in, ISarosSession session, IProgressMonitor monitor) {
     super(session, monitor);
     this.in = new DataInputStream(in);
+    this.referencePointManager = session.getComponent(IReferencePointManager.class);
   }
 
   /**
@@ -42,7 +46,8 @@ public class IncomingStreamProtocol extends AbstractStreamProtocol {
         if (projectID.isEmpty()) break;
 
         String fileName = in.readUTF();
-        IFile file = session.getProject(projectID).getFile(fileName);
+        IProject project = referencePointManager.get(session.getReferencePoint(projectID));
+        IFile file = project.getFile(fileName);
 
         String message = "receiving " + displayName(file);
         log.debug(message);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/stream/OutgoingStreamProtocol.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/negotiation/stream/OutgoingStreamProtocol.java
@@ -71,9 +71,9 @@ public class OutgoingStreamProtocol extends AbstractStreamProtocol {
     monitor.worked(1);
   }
 
-  private void writeHeader(SPath file, long fileSize) throws IOException {
-    String projectID = session.getProjectID(file.getProject());
-    String fileName = file.getProjectRelativePath().toPortableString();
+  private void writeHeader(SPath path, long fileSize) throws IOException {
+    String projectID = session.getReferencePointID(path.getProject().getReferencePoint());
+    String fileName = path.getProjectRelativePath().toPortableString();
 
     out.writeUTF(projectID);
     out.writeUTF(fileName);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/CoreReferencePointManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/CoreReferencePointManager.java
@@ -13,11 +13,11 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /** The implementation of {@link IReferencePointManager} */
-public class ReferencePointManager implements IReferencePointManager {
+public class CoreReferencePointManager implements IReferencePointManager {
 
   ConcurrentHashMap<IReferencePoint, IProject> referencePointToProjectMapper;
 
-  public ReferencePointManager() {
+  public CoreReferencePointManager() {
     referencePointToProjectMapper = new ConcurrentHashMap<>();
   }
 

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/IReferencePointManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/IReferencePointManager.java
@@ -1,7 +1,13 @@
 package de.fu_berlin.inf.dpp.session;
 
+import de.fu_berlin.inf.dpp.activities.SPath;
+import de.fu_berlin.inf.dpp.filesystem.IFile;
+import de.fu_berlin.inf.dpp.filesystem.IFolder;
+import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
+import de.fu_berlin.inf.dpp.filesystem.IResource;
+import java.io.IOException;
 import java.util.Set;
 
 /** The IReferencePointManager maps an IReferencePoint to IProject */
@@ -30,4 +36,63 @@ public interface IReferencePointManager {
    * @return a set of IProject given by referencePoint
    */
   Set<IProject> getProjects(Set<IReferencePoint> referencePoints);
+
+  /**
+   * Returns a handle to the folder with given name.
+   *
+   * @param referencePoint The reference point on which the folder has to be determined
+   * @param name Name of the folder
+   * @return Returns a handle to the folder
+   */
+  IFolder getFolder(IReferencePoint referencePoint, String name);
+
+  /**
+   * Returns a handle to the file with given name.
+   *
+   * @param referencePoint The reference point on which the file has to be determined
+   * @param name Name of the file
+   * @return Returns a handle to the file
+   */
+  IFile getFile(IReferencePoint referencePoint, String name);
+
+  /**
+   * Checks if the reference point exists
+   *
+   * @param referencePoint
+   * @return True, if the reference point exists, otherwise false
+   */
+  boolean projectExists(IReferencePoint referencePoint);
+
+  /**
+   * Returns the name of the reference point
+   *
+   * @param referencePoint
+   * @return Returns the name of the reference point
+   */
+  String getName(IReferencePoint referencePoint);
+
+  /**
+   * Returns default charset of the reference point
+   *
+   * @param referencePoint
+   * @return default charset of the reference point
+   */
+  String getDefaultCharSet(IReferencePoint referencePoint) throws IOException;
+
+  /**
+   * Returns a list of existing member resources within the given reference point.
+   *
+   * @param referencePoint
+   * @return An array with existing member resources
+   * @throws IOException
+   */
+  IResource[] members(IReferencePoint referencePoint) throws IOException;
+
+  /**
+   * Creates and Returns a SPath given by the reference point and the relative path
+   *
+   * @param projectRelativePath
+   * @return Returns a SPath
+   */
+  SPath createSPath(IReferencePoint referencePoint, IPath projectRelativePath);
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/IReferencePointManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/IReferencePointManager.java
@@ -22,11 +22,12 @@ public interface IReferencePointManager {
   void put(IReferencePoint referencePoint, IProject project);
 
   /**
-   * Returns the IProject given by the IReferencePoint
+   * ATTENTION: Don't use this in Saros Core! Returns the IProject given by the IReferencePoint
    *
    * @param referencePoint the key for which the IProject should be returned
    * @return the IProject given by referencePoint
    */
+  @Deprecated
   IProject get(IReferencePoint referencePoint);
 
   /**

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/IReferencePointManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/IReferencePointManager.java
@@ -1,0 +1,33 @@
+package de.fu_berlin.inf.dpp.session;
+
+import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
+import java.util.Set;
+
+/** The IReferencePointManager maps an IReferencePoint to IProject */
+public interface IReferencePointManager {
+
+  /**
+   * Insert a pair of reference point and project
+   *
+   * @param referencePoint the key of the pair
+   * @param project the value of the pair
+   */
+  void put(IReferencePoint referencePoint, IProject project);
+
+  /**
+   * Returns the IProject given by the IReferencePoint
+   *
+   * @param referencePoint the key for which the IProject should be returned
+   * @return the IProject given by referencePoint
+   */
+  IProject get(IReferencePoint referencePoint);
+
+  /**
+   * Returns a set of IProjects given by a set of IReferencePoints
+   *
+   * @param referencePoints a set of referencePoints for which the set of IProjects should returned
+   * @return a set of IProject given by referencePoint
+   */
+  Set<IProject> getProjects(Set<IReferencePoint> referencePoints);
+}

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ISarosSession.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ISarosSession.java
@@ -23,7 +23,7 @@ import de.fu_berlin.inf.dpp.activities.IActivity;
 import de.fu_berlin.inf.dpp.activities.IResourceActivity;
 import de.fu_berlin.inf.dpp.concurrent.management.ConcurrentDocumentClient;
 import de.fu_berlin.inf.dpp.concurrent.management.ConcurrentDocumentServer;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
 import de.fu_berlin.inf.dpp.preferences.IPreferenceStore;
@@ -36,9 +36,9 @@ import java.util.Set;
 import java.util.concurrent.CancellationException;
 
 /**
- * A Saros session consists of one or more shared projects, which are the central concept of the
- * Saros plugin. They are associated with projects and make them available for synchronous/real-time
- * collaboration.
+ * A Saros session consists of one or more shared reference points, which are the central concept of
+ * the Saros plugin. They are associated with reference points and make them available for
+ * synchronous/real-time collaboration.
  *
  * @author rdjemili
  */
@@ -48,11 +48,11 @@ public interface ISarosSession {
    * @JTourBusStop 3, Architecture Overview, Session Management:
    *
    * <p>This Interface is the main entrance Point for the "Session Management"-Component. The
-   * Session Management is responsible for managing a Session and keeping the shared projects in a
-   * consistent state across the local copies of all participants. It functions as the core
-   * component in a running session and directs communication between all other components. In
-   * general this component takes input from the User Interface, processes it, and afterwards passes
-   * the result to the Network Layer.
+   * Session Management is responsible for managing a Session and keeping the shared reference point
+   * in a consistent state across the local * copies of all participants. It functions as the core *
+   * component in a running session and directs communication * between all other components. In
+   * general this component * takes input from the User Interface, processes it, and * afterwards
+   * passes the result to the Network Layer.
    */
 
   /** Connection identifier to use for sending data. */
@@ -107,7 +107,8 @@ public interface ISarosSession {
   public void addUser(User user, IPreferenceStore preferences);
 
   /**
-   * Informs all listeners that a user now has Projects and can process {@link IResourceActivity}s.
+   * Informs all listeners that a user now has reference points and can * process {@link
+   * IResourceActivity}s.
    *
    * @host This method may only called by the host.
    * @param user
@@ -154,10 +155,10 @@ public interface ISarosSession {
   public void removeListener(ISessionListener listener);
 
   /**
-   * @return the shared projects associated with this session, never <code>null</code> but may be
-   *     empty
+   * @return the shared reference points associated with this session, never <code>null</code> but
+   *     may be empty
    */
-  public Set<IProject> getProjects();
+  public Set<IReferencePoint> getReferencePoints();
 
   /**
    * FOR INTERNAL USE ONLY !
@@ -285,8 +286,10 @@ public interface ISarosSession {
    */
   public void removeActivityConsumer(IActivityConsumer consumer);
 
-  /** Checks if the user is ready to process {@link IResourceActivity}s for a given project */
-  public boolean userHasProject(User user, IProject project);
+  /**
+   * Checks if the user is ready to process {@link IResourceActivity}s for a given reference point
+   */
+  public boolean userHasReferencePoint(User user, IReferencePoint referencePoint);
 
   /**
    * @return <code>true</code> if the given {@link IResource resource} is currently shared in this
@@ -295,81 +298,88 @@ public interface ISarosSession {
   public boolean isShared(IResource resource);
 
   /**
-   * Checks if selected project is a complete shared one or partial shared.
+   * Checks if selected reference point is a complete shared one or partial shared.
    *
-   * @param project
+   * @param referencePoint
    * @return <code>true</code> if complete, <code>false</code> if partial
    */
-  public boolean isCompletelyShared(IProject project);
+  public boolean isCompletelyShared(IReferencePoint referencePoint);
 
   /**
-   * Returns the global ID of the project.
+   * Returns the global ID of the reference point.
    *
-   * @return the global ID of the project or <code>null</code> if this project is not shared
+   * @return the global ID of the reference point or <code>null</code> if this reference point is
+   *     not shared
+   * @param referencePoint
    */
-  public String getProjectID(IProject project);
+  public String getReferencePointID(IReferencePoint referencePoint);
 
   /**
-   * Returns the project with the given ID.
+   * Returns the reference point with the given ID.
    *
-   * @return the project with the given ID or <code>null</code> if no project with this ID is shared
+   * @return the referencePoint with the given ID or <code>null</code> if no reference point with
+   *     this ID is shared
+   * @param referencePointID
    */
-  public IProject getProject(String projectID);
+  public IReferencePoint getReferencePoint(String referencePointID);
 
   /**
-   * Adds the specified project and/or resources to this session.
+   * Adds the specified reference point and/or resources to this session.
    *
-   * @param project The project to share.
-   * @param projectID The global project ID.
-   * @param dependentResources The project dependent resources.
+   * @param referencePoint The reference point to share.
+   * @param referencePointID The global reference point ID.
+   * @param dependentResources
    */
   public void addSharedResources(
-      IProject project, String projectID, List<IResource> dependentResources);
+      IReferencePoint referencePoint, String referencePointID, List<IResource> dependentResources);
 
   /**
    * Returns all shared resources in this session.
    *
-   * @return a list of all shared resources (excluding projects) from this session.
+   * @return a list of all shared resources (excluding reference points) from this session.
    */
   public List<IResource> getSharedResources();
 
   /**
-   * Returns a map with the mapping of shared resources to their project.
+   * Returns a map with the mapping of shared resources to their reference point.
    *
-   * @return project-->resource mapping
+   * @return reference point-->resource mapping
    */
-  public Map<IProject, List<IResource>> getProjectResourcesMapping();
+  public Map<IReferencePoint, List<IResource>> getReferencePointResourcesMapping();
 
   /**
-   * Returns the shared resources of the project in this session.
+   * Returns the shared resources of the reference point in this session.
    *
-   * @param project
-   * @return the shared resources or <code>null</code> if this project is not or fully shared.
+   * @param referencePoint
+   * @return the shared resources or <code>null</code> if this reference point is not or fully
+   *     shared.
    */
-  public List<IResource> getSharedResources(IProject project);
+  public List<IResource> getSharedResources(IReferencePoint referencePoint);
 
   /**
-   * Stores a bidirectional mapping between <code>project</code> and <code>projectID</code>.
+   * Stores a bidirectional mapping between <code>referencePoint</code> and <code>referencePointID
+   * </code>.
    *
    * <p>This information is necessary for receiving (unserializing) resource-related activities.
    *
-   * @param projectID Session-wide ID of the project
-   * @param project the local representation of the project
-   * @see #removeProjectMapping(String, IProject)
+   * @param referencePointID Session-wide ID of the reference point
+   * @param referencePoint the local representation of the reference point
+   * @see #removeProjectMapping(String, IReferencePoint)
    */
-  public void addProjectMapping(String projectID, IProject project);
+  public void addReferencePointMapping(String referencePointID, IReferencePoint referencePoint);
 
   /**
-   * Removes the bidirectional mapping <code>project</code> and <code>projectId</code> that was
-   * created by {@link #addProjectMapping(String, IProject) addProjectMapping()} .
+   * Removes the bidirectional mapping <code>referencePoint</code> and <code>referencePointId</code>
+   * that was created by {@link #addReferencePointMapping(String, IReferencePoint)
+   * addReferencePointMapping()} .
    *
    * <p>TODO Why is the project parameter needed here? This forces callers to store the mapping
    * themselves (or retrieve it just before calling this method).
    *
-   * @param projectID Session-wide ID of the project
-   * @param project the local representation of the project
+   * @param referencePointID Session-wide ID of the project
+   * @param referencePoint the local representation of the project
    */
-  public void removeProjectMapping(String projectID, IProject project);
+  public void removeReferencePointMapping(String referencePointID, IReferencePoint referencePoint);
 
   /**
    * Return the stop manager of this session.
@@ -389,24 +399,28 @@ public interface ISarosSession {
   /**
    * FOR INTERNAL USE ONLY !
    *
-   * <p>Starts queuing of incoming {@linkplain IResourceActivity project-related activities}, since
-   * they cannot be applied before their corresponding project is received and extracted.
+   * <p>Starts queuing of incoming {@linkplain IResourceActivity reference point-related
+   * activities}, since they cannot be applied before their corresponding reference point is
+   * received and extracted.
    *
-   * <p>That queuing relies on an existing project-to-projectID mapping (see {@link
-   * #addProjectMapping(String, IProject)}), otherwise incoming activities cannot be queued and will
-   * be lost.
+   * <p>That queuing relies on an existing reference point-to-reference point mapping (see {@link
+   * #addReferencePointMapping(String, IReferencePoint)}), otherwise incoming activities cannot be
+   * queued and will be lost.
    *
-   * @param project the project for which project-related activities should be queued
+   * @param referencePoint the reference point for which reference point-related activities should
+   *     be queued
    * @see #disableQueuing
    */
-  public void enableQueuing(IProject project);
+  public void enableQueuing(IReferencePoint referencePoint);
 
   /**
    * FOR INTERNAL USE ONLY !
    *
-   * <p>Disables queuing for the given project and flushes all queued activities.
+   * <p>Disables queuing for the given reference point and flushes all queued activities.
+   *
+   * @param referencePoint
    */
-  public void disableQueuing(IProject project);
+  public void disableQueuing(IReferencePoint referencePoint);
 
   /**
    * Returns the id of the current session.

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ISarosSessionManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ISarosSessionManager.java
@@ -23,6 +23,7 @@ public interface ISarosSessionManager {
    *
    * @param projectResources the local project resources which should be shared.
    */
+  @Deprecated
   public void startSession(Map<IProject, List<IResource>> projectResources);
 
   // FIXME this method is error prone and only used by the IPN, find a better
@@ -89,6 +90,7 @@ public interface ISarosSessionManager {
    *
    * @param projectResourcesMapping
    */
+  @Deprecated
   public void addResourcesToSession(Map<IProject, List<IResource>> projectResourcesMapping);
 
   /**

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ISarosSessionManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ISarosSessionManager.java
@@ -18,13 +18,12 @@ public interface ISarosSessionManager {
   /** @return the active session or <code>null</code> if there is no active session. */
   public ISarosSession getSession();
 
-
   /**
    * Starts a new DPP session with the local user as only participant.
    *
    * @param referencePointResources the local reference point resources which should be shared.
    */
-  public void startSessionWithReferencePoints(Map<IReferencePoint, List<IResource>> referencePointResources);
+  public void startSession(Map<IReferencePoint, List<IResource>> referencePointResources);
 
   // FIXME this method is error prone and only used by the IPN, find a better
   // abstraction
@@ -90,7 +89,8 @@ public interface ISarosSessionManager {
    *
    * @param referencePointResourcesMapping
    */
-  public void addReferencePointResourcesToSession(Map<IReferencePoint, List<IResource>> referencePointResourcesMapping);
+  public void addResourcesToSession(
+      Map<IReferencePoint, List<IResource>> referencePointResourcesMapping);
 
   /**
    * Call this before a ISarosSession is started.

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ISarosSessionManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ISarosSessionManager.java
@@ -1,6 +1,7 @@
 package de.fu_berlin.inf.dpp.session;
 
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
@@ -25,6 +26,13 @@ public interface ISarosSessionManager {
    */
   @Deprecated
   public void startSession(Map<IProject, List<IResource>> projectResources);
+
+  /**
+   * Starts a new DPP session with the local user as only participant.
+   *
+   * @param referencePointResources the local reference point resources which should be shared.
+   */
+  public void startSessionWithReferencePoints(Map<IReferencePoint, List<IResource>> referencePointResources);
 
   // FIXME this method is error prone and only used by the IPN, find a better
   // abstraction
@@ -92,6 +100,13 @@ public interface ISarosSessionManager {
    */
   @Deprecated
   public void addResourcesToSession(Map<IProject, List<IResource>> projectResourcesMapping);
+
+  /**
+   * Adds reference point resources to an existing session.
+   *
+   * @param referencePointResourcesMapping
+   */
+  public void addReferencePointResourcesToSession(Map<IReferencePoint, List<IResource>> referencePointResourcesMapping);
 
   /**
    * Call this before a ISarosSession is started.

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ISarosSessionManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ISarosSessionManager.java
@@ -1,6 +1,5 @@
 package de.fu_berlin.inf.dpp.session;
 
-import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
@@ -19,13 +18,6 @@ public interface ISarosSessionManager {
   /** @return the active session or <code>null</code> if there is no active session. */
   public ISarosSession getSession();
 
-  /**
-   * Starts a new DPP session with the local user as only participant.
-   *
-   * @param projectResources the local project resources which should be shared.
-   */
-  @Deprecated
-  public void startSession(Map<IProject, List<IResource>> projectResources);
 
   /**
    * Starts a new DPP session with the local user as only participant.
@@ -92,14 +84,6 @@ public interface ISarosSessionManager {
    * @param jidsToInvite the JIDs of the users that should be invited.
    */
   public void invite(Collection<JID> jidsToInvite, String description);
-
-  /**
-   * Adds project resources to an existing session.
-   *
-   * @param projectResourcesMapping
-   */
-  @Deprecated
-  public void addResourcesToSession(Map<IProject, List<IResource>> projectResourcesMapping);
 
   /**
    * Adds reference point resources to an existing session.

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ISessionListener.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ISessionListener.java
@@ -19,7 +19,7 @@
  */
 package de.fu_berlin.inf.dpp.session;
 
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.session.User.Permission;
 
 /**
@@ -84,7 +84,8 @@ public interface ISessionListener {
   }
 
   /**
-   * Is fired when an user leaves the shared project.
+   * Is fired when an user leaves the shared {@link de.fu_berlin.inf.dpp.filesystem.IReferencePoint}
+   * reference point.
    *
    * <p>This method is called on the UI thread.
    *
@@ -95,29 +96,30 @@ public interface ISessionListener {
   }
 
   /**
-   * Is fired then a project has been made part of the session, either because the local user began
-   * sharing it or because it is being shared by a remote user.
+   * Is fired then a reference point has been made part of the session, either because the local
+   * user began sharing it or because it is being shared by a remote user.
    *
-   * <p>Note that this event is also fired if a project is re-shared with a different set of shared
-   * resources (e.g. by sharing a previously unshared folder of a partially shared project).
+   * <p>Note that this event is also fired if a reference point is re-shared with a different set of
+   * shared resources (e.g. by sharing a previously unshared folder of a partially shared reference
+   * point).
    *
    * <p>This method might <i>not</i> be called on the UI thread.
    *
-   * @param project the project that was added
+   * @param referencePoint the reference point that was added
    */
-  public default void projectAdded(IProject project) {
+  public default void projectAdded(IReferencePoint referencePoint) {
     // NOP
   }
 
   /**
-   * Is fired then a project has been removed from the session, meaning it is not shared between the
-   * session's users anymore.
+   * Is fired then a reference point has been removed from the session, meaning it is not shared
+   * between the session's users anymore.
    *
    * <p>This method might <i>not</i> be called on the UI thread.
    *
-   * @param project the project that was removed
+   * @param referencePoint the reference point that was removed
    */
-  public default void projectRemoved(IProject project) {
+  public default void projectRemoved(IReferencePoint referencePoint) {
     // NOP
   }
 
@@ -125,8 +127,10 @@ public interface ISessionListener {
    * Is fired when resources are added to the current session.
    *
    * <p>This method might <i>not</i> be called on the UI thread.
+   *
+   * @param referencePoint
    */
-  public default void resourcesAdded(IProject project) {
+  public default void resourcesAdded(IReferencePoint referencePoint) {
     // NOP
   }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ReferencePointManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ReferencePointManager.java
@@ -1,7 +1,13 @@
 package de.fu_berlin.inf.dpp.session;
 
+import de.fu_berlin.inf.dpp.activities.SPath;
+import de.fu_berlin.inf.dpp.filesystem.IFile;
+import de.fu_berlin.inf.dpp.filesystem.IFolder;
+import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
+import de.fu_berlin.inf.dpp.filesystem.IResource;
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -46,5 +52,65 @@ public class ReferencePointManager implements IReferencePointManager {
     }
 
     return projectSet;
+  }
+
+  @Override
+  public IFolder getFolder(IReferencePoint referencePoint, String name) {
+    IProject project = getProject(referencePoint);
+
+    return project.getFolder(name);
+  }
+
+  @Override
+  public IFile getFile(IReferencePoint referencePoint, String name) {
+    IProject project = getProject(referencePoint);
+
+    return project.getFile(name);
+  }
+
+  @Override
+  public boolean projectExists(IReferencePoint referencePoint) {
+    IProject project = getProject(referencePoint);
+
+    return project.exists();
+  }
+
+  @Override
+  public String getName(IReferencePoint referencePoint) {
+    IProject project = getProject(referencePoint);
+
+    return project.getName();
+  }
+
+  @Override
+  public String getDefaultCharSet(IReferencePoint referencePoint) throws IOException {
+    IProject project = getProject(referencePoint);
+
+    return project.getDefaultCharset();
+  }
+
+  @Override
+  public IResource[] members(IReferencePoint referencePoint) throws IOException {
+    IProject project = getProject(referencePoint);
+
+    return project.members();
+  }
+
+  @Override
+  public SPath createSPath(IReferencePoint referencePoint, IPath projectRelativePath) {
+    IProject project = getProject(referencePoint);
+
+    return new SPath(project, projectRelativePath);
+  }
+
+  private IProject getProject(IReferencePoint referencePoint) {
+    if (referencePoint == null) throw new IllegalArgumentException("ReferencePoint is null");
+
+    IProject project = get(referencePoint);
+
+    if (project == null)
+      throw new NullPointerException("Cannot find project for reference point " + referencePoint);
+
+    return project;
   }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ReferencePointManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/ReferencePointManager.java
@@ -1,0 +1,50 @@
+package de.fu_berlin.inf.dpp.session;
+
+import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** The implementation of {@link IReferencePointManager} */
+public class ReferencePointManager implements IReferencePointManager {
+
+  ConcurrentHashMap<IReferencePoint, IProject> referencePointToProjectMapper;
+
+  public ReferencePointManager() {
+    referencePointToProjectMapper = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public void put(IReferencePoint referencePoint, IProject project) {
+    if (referencePoint == null) throw new IllegalArgumentException("ReferencePoint is null");
+
+    if (project == null) throw new IllegalArgumentException("Project is null");
+
+    if (!referencePointToProjectMapper.containsKey(referencePoint)) {
+      referencePointToProjectMapper.put(referencePoint, project);
+    }
+  }
+
+  @Override
+  public IProject get(IReferencePoint referencePoint) {
+    if (referencePoint == null) throw new IllegalArgumentException("ReferencePoint is null");
+
+    return referencePointToProjectMapper.get(referencePoint);
+  }
+
+  @Override
+  public Set<IProject> getProjects(Set<IReferencePoint> referencePoints) {
+    if (referencePoints == null)
+      throw new IllegalArgumentException("Set of reference points is null");
+
+    Set<IProject> projectSet = new HashSet<IProject>();
+
+    for (IReferencePoint referencePoint : referencePoints) {
+      if (referencePointToProjectMapper.containsKey(referencePoint))
+        projectSet.add(get(referencePoint));
+    }
+
+    return projectSet;
+  }
+}

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/SarosSessionManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/SarosSessionManager.java
@@ -182,7 +182,7 @@ public class SarosSessionManager implements ISarosSessionManager {
    * point in order to start a session.)
    */
   @Override
-  public void startSessionWithReferencePoints(
+  public void startSession(
       final Map<IReferencePoint, List<IResource>> referencePointResourcesMapping) {
     /*
      * FIXME split the logic, start a session without anything and then add
@@ -483,7 +483,7 @@ public class SarosSessionManager implements ISarosSessionManager {
   }
 
   @Override
-  public synchronized void addReferencePointResourcesToSession(
+  public synchronized void addResourcesToSession(
       Map<IReferencePoint, List<IResource>> referencePointResourcesMapping) {
     if (referencePointResourcesMapping == null) {
       return;

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/SarosSessionManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/SarosSessionManager.java
@@ -561,28 +561,27 @@ public class SarosSessionManager implements ISarosSessionManager {
       return;
     }
 
-    List<IProject> projectsToShare = new ArrayList<IProject>();
+    List<IReferencePoint> referencePointsToShare = new ArrayList<IReferencePoint>();
     Map<IReferencePoint, List<IResource>> mapping = nextProjectNegotiation.get();
 
     for (Entry<IReferencePoint, List<IResource>> mapEntry : mapping.entrySet()) {
       final IReferencePoint referencePoint = mapEntry.getKey();
-      final IProject project = referencePointManager.get(referencePoint);
       final List<IResource> resourcesList = mapEntry.getValue();
 
       // side effect: non shared projects are always partial -.-
-      if (!currentSession.isCompletelyShared(project.getReferencePoint())) {
-        String projectID = currentSession.getReferencePointID(project.getReferencePoint());
+      if (!currentSession.isCompletelyShared(referencePoint)) {
+        String projectID = currentSession.getReferencePointID(referencePoint);
 
         if (projectID == null) {
           projectID = String.valueOf(SESSION_ID_GENERATOR.nextInt(Integer.MAX_VALUE));
         }
-        currentSession.addSharedResources(project.getReferencePoint(), projectID, resourcesList);
+        currentSession.addSharedResources(referencePoint, projectID, resourcesList);
 
-        projectsToShare.add(project);
+        referencePointsToShare.add(referencePoint);
       }
     }
 
-    if (projectsToShare.isEmpty()) {
+    if (referencePointsToShare.isEmpty()) {
       log.warn(
           "skipping project negotiation because no new projects were added to the current session");
       return;
@@ -613,14 +612,7 @@ public class SarosSessionManager implements ISarosSessionManager {
                     .getString(ProjectNegotiationTypeHook.KEY_TYPE));
         AbstractOutgoingProjectNegotiation negotiation =
             negotiationFactory.newOutgoingProjectNegotiation(
-                user.getJID(),
-                type,
-                projectsToShare
-                    .stream()
-                    .map(project -> project.getReferencePoint())
-                    .collect(Collectors.toList()),
-                this,
-                currentSession);
+                user.getJID(), type, referencePointsToShare, this, currentSession);
 
         negotiation.setNegotiationListener(negotiationListener);
         currentProjectNegotiations.add(negotiation);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/SarosSessionManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/SarosSessionManager.java
@@ -168,18 +168,6 @@ public class SarosSessionManager implements ISarosSessionManager {
     negotiationHandler = handler;
   }
 
-  @Override
-  public void startSession(final Map<IProject, List<IResource>> projectResourcesMapping) {
-
-    Map<IReferencePoint, List<IResource>> list = new HashMap<>();
-
-    for (Entry<IProject, List<IResource>> entry : projectResourcesMapping.entrySet()) {
-      list.put(entry.getKey().getReferencePoint(), entry.getValue());
-    }
-
-    startSessionWithReferencePoints(list);
-  }
-
   /**
    * @JTourBusStop 3, Invitation Process:
    *
@@ -543,24 +531,6 @@ public class SarosSessionManager implements ISarosSessionManager {
           }
         };
     nextProjectNegotiationWorker = ThreadUtils.runSafeAsync(log, worker);
-  }
-
-  /**
-   * Adds project resources to an existing session.
-   *
-   * @param projectResourcesMapping
-   */
-  @Override
-  public synchronized void addResourcesToSession(
-      Map<IProject, List<IResource>> projectResourcesMapping) {
-
-    Map<IReferencePoint, List<IResource>> list = new HashMap<>();
-
-    for (Entry<IProject, List<IResource>> entry : projectResourcesMapping.entrySet()) {
-      list.put(entry.getKey().getReferencePoint(), entry.getValue());
-    }
-
-    addReferencePointResourcesToSession(list);
   }
 
   /**

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/SarosSessionManager.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/SarosSessionManager.java
@@ -59,6 +59,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 import org.apache.log4j.Logger;
 import org.jivesoftware.smack.Connection;
 
@@ -606,7 +607,14 @@ public class SarosSessionManager implements ISarosSessionManager {
                     .getString(ProjectNegotiationTypeHook.KEY_TYPE));
         AbstractOutgoingProjectNegotiation negotiation =
             negotiationFactory.newOutgoingProjectNegotiation(
-                user.getJID(), type, projectsToShare, this, currentSession);
+                user.getJID(),
+                type,
+                projectsToShare
+                    .stream()
+                    .map(project -> project.getReferencePoint())
+                    .collect(Collectors.toList()),
+                this,
+                currentSession);
 
         negotiation.setNegotiationListener(negotiationListener);
         currentProjectNegotiations.add(negotiation);
@@ -673,7 +681,14 @@ public class SarosSessionManager implements ISarosSessionManager {
                     .getString(ProjectNegotiationTypeHook.KEY_TYPE));
         negotiation =
             negotiationFactory.newOutgoingProjectNegotiation(
-                user, type, currentSharedProjects, this, currentSession);
+                user,
+                type,
+                currentSharedProjects
+                    .stream()
+                    .map(project -> project.getReferencePoint())
+                    .collect(Collectors.toList()),
+                this,
+                currentSession);
 
         negotiation.setNegotiationListener(negotiationListener);
         currentProjectNegotiations.add(negotiation);

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/ActivityHandler.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/ActivityHandler.java
@@ -65,14 +65,6 @@ public final class ActivityHandler implements Startable {
   private final ConcurrentDocumentClient documentClient;
 
   private final UISynchronizer synchronizer;
-
-  /*
-   * We must use a thread for synchronous execution otherwise we would block
-   * the DispatchThreadContext which handles the dispatching of all network
-   * packets
-   */
-  private Thread dispatchThread;
-
   private final Runnable dispatchThreadRunnable =
       new Runnable() {
 
@@ -104,6 +96,12 @@ public final class ActivityHandler implements Startable {
           LOG.debug("activity dispatcher stopped");
         }
       };
+  /*
+   * We must use a thread for synchronous execution otherwise we would block
+   * the DispatchThreadContext which handles the dispatching of all network
+   * packets
+   */
+  private Thread dispatchThread;
 
   public ActivityHandler(
       ISarosSession session,
@@ -182,7 +180,8 @@ public final class ActivityHandler implements Startable {
         recipients = item.recipients;
       } else {
         for (User user : item.recipients) {
-          if (session.userHasProject(user, activity.getPath().getProject())) {
+          if (session.userHasReferencePoint(
+              user, activity.getPath().getProject().getReferencePoint())) {
             recipients.add(user);
           }
         }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
@@ -42,6 +42,7 @@ import de.fu_berlin.inf.dpp.net.xmpp.JID;
 import de.fu_berlin.inf.dpp.net.xmpp.XMPPConnectionService;
 import de.fu_berlin.inf.dpp.preferences.IPreferenceStore;
 import de.fu_berlin.inf.dpp.session.ColorNegotiationHook;
+import de.fu_berlin.inf.dpp.session.CoreReferencePointManager;
 import de.fu_berlin.inf.dpp.session.IActivityConsumer;
 import de.fu_berlin.inf.dpp.session.IActivityConsumer.Priority;
 import de.fu_berlin.inf.dpp.session.IActivityHandlerCallback;
@@ -51,7 +52,6 @@ import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionContextFactory;
 import de.fu_berlin.inf.dpp.session.ISessionListener;
-import de.fu_berlin.inf.dpp.session.ReferencePointManager;
 import de.fu_berlin.inf.dpp.session.SessionEndReason;
 import de.fu_berlin.inf.dpp.session.User;
 import de.fu_berlin.inf.dpp.session.User.Permission;
@@ -1099,7 +1099,7 @@ public final class SarosSession implements ISarosSession {
     sessionContainer = context.createChildContainer();
     sessionContainer.addComponent(ISarosSession.class, this);
     sessionContainer.addComponent(IActivityHandlerCallback.class, activityCallback);
-    sessionContainer.addComponent(IReferencePointManager.class, new ReferencePointManager());
+    sessionContainer.addComponent(IReferencePointManager.class, new CoreReferencePointManager());
     ISarosSessionContextFactory factory = context.getComponent(ISarosSessionContextFactory.class);
     factory.createComponents(this, sessionContainer);
 

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
@@ -34,6 +34,7 @@ import de.fu_berlin.inf.dpp.context.IContainerContext;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
 import de.fu_berlin.inf.dpp.filesystem.IFolder;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.net.IConnectionManager;
 import de.fu_berlin.inf.dpp.net.ITransmitter;
@@ -46,9 +47,11 @@ import de.fu_berlin.inf.dpp.session.IActivityConsumer.Priority;
 import de.fu_berlin.inf.dpp.session.IActivityHandlerCallback;
 import de.fu_berlin.inf.dpp.session.IActivityListener;
 import de.fu_berlin.inf.dpp.session.IActivityProducer;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionContextFactory;
 import de.fu_berlin.inf.dpp.session.ISessionListener;
+import de.fu_berlin.inf.dpp.session.ReferencePointManager;
 import de.fu_berlin.inf.dpp.session.SessionEndReason;
 import de.fu_berlin.inf.dpp.session.User;
 import de.fu_berlin.inf.dpp.session.User.Permission;
@@ -59,6 +62,7 @@ import de.fu_berlin.inf.dpp.util.ThreadUtils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -88,6 +92,8 @@ public final class SarosSession implements ISarosSession {
   @Inject private XMPPConnectionService connectionService;
 
   @Inject private IConnectionManager connectionManager;
+
+  private IReferencePointManager referencePointManager;
 
   private final IContainerContext containerContext;
 
@@ -235,32 +241,34 @@ public final class SarosSession implements ISarosSession {
   public void addSharedResources(IProject project, String id, List<IResource> resources) {
 
     Set<IResource> allResources = null;
+    IReferencePoint referencePoint = project.getReferencePoint();
 
     if (resources != null) {
       allResources = new HashSet<IResource>();
       for (IResource resource : resources) allResources.addAll(getAllNonSharedChildren(resource));
     }
 
-    if (!projectMapper.isShared(project)) {
+    if (!projectMapper.isShared(referencePoint)) {
       // new project
       if (allResources == null) {
         // new fully shared project
-        projectMapper.addProject(id, project, false);
+        projectMapper.addReferencePoint(id, referencePoint, false);
       } else {
         // new partially shared project
-        projectMapper.addProject(id, project, true);
-        projectMapper.addResources(project, allResources);
+        projectMapper.addReferencePoint(id, referencePoint, true);
+        projectMapper.addResources(referencePoint, allResources);
       }
 
+      referencePointManager.put(referencePoint, project);
       listenerDispatch.projectAdded(project);
     } else {
       // existing project
       if (allResources == null) {
         // upgrade partially shared to fully shared project
-        projectMapper.addProject(id, project, false);
+        projectMapper.addReferencePoint(id, referencePoint, false);
       } else {
         // increase scope of partially shared project
-        projectMapper.addResources(project, allResources);
+        projectMapper.addResources(referencePoint, allResources);
       }
     }
 
@@ -308,7 +316,7 @@ public final class SarosSession implements ISarosSession {
 
   @Override
   public boolean userHasProject(User user, IProject project) {
-    return projectMapper.userHasProject(user, project);
+    return projectMapper.userHasReferencePoint(user, project.getReferencePoint());
   }
 
   @Override
@@ -427,7 +435,7 @@ public final class SarosSession implements ISarosSession {
      * Updates the projects for the given user, so that host knows that he can now send ever
      * Activity
      */
-    projectMapper.addMissingProjectsToUser(user);
+    projectMapper.addMissingReferencePointsToUser(user);
 
     synchronizer.syncExec(
         ThreadUtils.wrapSafe(
@@ -564,7 +572,7 @@ public final class SarosSession implements ISarosSession {
 
   @Override
   public Set<IProject> getProjects() {
-    return projectMapper.getProjects();
+    return referencePointManager.getProjects(projectMapper.getReferencePoints());
   }
 
   // FIXME synchronization
@@ -779,14 +787,14 @@ public final class SarosSession implements ISarosSession {
   private boolean updatePartialSharedResources(final IFileSystemModificationActivity activity) {
 
     final IProject project = activity.getPath().getProject();
-
+    final IReferencePoint referencePoint = project.getReferencePoint();
     /*
      * The follow 'if check' assumes that move operations where at least one
      * project is not part of the sharing is announced as create and delete
      * activities.
      */
 
-    if (!projectMapper.isPartiallyShared(project)) return true;
+    if (!projectMapper.isPartiallyShared(referencePoint)) return true;
 
     if (activity instanceof FileActivity) {
       FileActivity fileActivity = ((FileActivity) activity);
@@ -813,7 +821,7 @@ public final class SarosSession implements ISarosSession {
             return false;
           }
 
-          projectMapper.addResources(project, Collections.singletonList(file));
+          projectMapper.addResources(referencePoint, Collections.singletonList(file));
 
           break;
 
@@ -832,7 +840,7 @@ public final class SarosSession implements ISarosSession {
             return false;
           }
 
-          projectMapper.removeResources(project, Collections.singletonList(file));
+          projectMapper.removeResources(referencePoint, Collections.singletonList(file));
 
           break;
 
@@ -878,7 +886,7 @@ public final class SarosSession implements ISarosSession {
           }
 
           projectMapper.removeAndAddResources(
-              project, Collections.singletonList(oldFile), Collections.singletonList(file));
+              referencePoint, Collections.singletonList(oldFile), Collections.singletonList(file));
 
           break;
       }
@@ -898,7 +906,7 @@ public final class SarosSession implements ISarosSession {
         return false;
       }
 
-      projectMapper.addResources(project, Collections.singletonList(folder));
+      projectMapper.addResources(referencePoint, Collections.singletonList(folder));
 
     } else if (activity instanceof FolderDeletedActivity) {
       IFolder folder = activity.getPath().getFolder();
@@ -917,7 +925,7 @@ public final class SarosSession implements ISarosSession {
         return false;
       }
 
-      projectMapper.removeResources(project, Collections.singletonList(folder));
+      projectMapper.removeResources(referencePoint, Collections.singletonList(folder));
     }
 
     return true;
@@ -966,41 +974,53 @@ public final class SarosSession implements ISarosSession {
 
   @Override
   public String getProjectID(IProject project) {
-    return projectMapper.getID(project);
+    return projectMapper.getID(project.getReferencePoint());
   }
 
   @Override
   public IProject getProject(String projectID) {
-    return projectMapper.getProject(projectID);
+    return referencePointManager.get(projectMapper.getReferencePoint(projectID));
   }
 
   @Override
   public Map<IProject, List<IResource>> getProjectResourcesMapping() {
-    return projectMapper.getProjectResourceMapping();
+    Map<IReferencePoint, List<IResource>> referencePointResourceMap =
+        projectMapper.getReferencePointResourceMapping();
+
+    Map<IProject, List<IResource>> projectResourceMap = new HashMap<IProject, List<IResource>>();
+
+    for (Map.Entry<IReferencePoint, List<IResource>> entry : referencePointResourceMap.entrySet()) {
+      projectResourceMap.put(referencePointManager.get(entry.getKey()), entry.getValue());
+    }
+
+    return projectResourceMap;
   }
 
   @Override
   public List<IResource> getSharedResources(IProject project) {
-    return projectMapper.getProjectResourceMapping().get(project);
+    return projectMapper.getReferencePointResourceMapping().get(project.getReferencePoint());
   }
 
   @Override
   public boolean isCompletelyShared(IProject project) {
-    return projectMapper.isCompletelyShared(project);
+    return projectMapper.isCompletelyShared(project.getReferencePoint());
   }
 
   @Override
   public void addProjectMapping(String projectID, IProject project) {
-    if (projectMapper.getProject(projectID) == null) {
-      projectMapper.addProject(projectID, project, true);
+    if (projectMapper.getReferencePoint(projectID) == null) {
+      IReferencePoint referencePoint = project.getReferencePoint();
+
+      referencePointManager.put(referencePoint, project);
+      projectMapper.addReferencePoint(projectID, referencePoint, true);
       listenerDispatch.projectAdded(project);
     }
   }
 
   @Override
   public void removeProjectMapping(String projectID, IProject project) {
-    if (projectMapper.getProject(projectID) != null) {
-      projectMapper.removeProject(projectID);
+    if (projectMapper.getReferencePoint(projectID) != null) {
+      projectMapper.removeReferencePoint(projectID);
       listenerDispatch.projectRemoved(project);
     }
   }
@@ -1091,7 +1111,7 @@ public final class SarosSession implements ISarosSession {
     sessionContainer = context.createChildContainer();
     sessionContainer.addComponent(ISarosSession.class, this);
     sessionContainer.addComponent(IActivityHandlerCallback.class, activityCallback);
-
+    sessionContainer.addComponent(IReferencePointManager.class, new ReferencePointManager());
     ISarosSessionContextFactory factory = context.getComponent(ISarosSessionContextFactory.class);
     factory.createComponents(this, sessionContainer);
 
@@ -1113,6 +1133,8 @@ public final class SarosSession implements ISarosSession {
     activitySequencer = sessionContainer.getComponent(ActivitySequencer.class);
 
     userListHandler = sessionContainer.getComponent(UserInformationHandler.class);
+
+    referencePointManager = sessionContainer.getComponent(IReferencePointManager.class);
 
     // ensure that the container uses caching
     assert sessionContainer.getComponent(ActivityHandler.class)

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
@@ -242,8 +242,6 @@ public final class SarosSession implements ISarosSession {
 
     Set<IResource> allResources = null;
 
-    IProject project = referencePointManager.get(referencePoint);
-
     if (resources != null) {
       allResources = new HashSet<IResource>();
       for (IResource resource : resources) allResources.addAll(getAllNonSharedChildren(resource));
@@ -260,7 +258,8 @@ public final class SarosSession implements ISarosSession {
         sharedReferencePointMapper.addResources(referencePoint, allResources);
       }
 
-      listenerDispatch.projectAdded(project);
+      listenerDispatch.projectAdded(referencePoint);
+
     } else {
       // existing project
       if (allResources == null) {
@@ -272,7 +271,7 @@ public final class SarosSession implements ISarosSession {
       }
     }
 
-    listenerDispatch.resourcesAdded(project);
+    listenerDispatch.resourcesAdded(referencePoint);
   }
 
   /**
@@ -1002,7 +1001,7 @@ public final class SarosSession implements ISarosSession {
   public void addReferencePointMapping(String referencePointID, IReferencePoint referencePoint) {
     if (sharedReferencePointMapper.getReferencePoint(referencePointID) == null) {
       sharedReferencePointMapper.addReferencePoint(referencePointID, referencePoint, true);
-      listenerDispatch.projectAdded(referencePointManager.get(referencePoint));
+      listenerDispatch.projectAdded(referencePoint);
     }
   }
 
@@ -1010,7 +1009,7 @@ public final class SarosSession implements ISarosSession {
   public void removeReferencePointMapping(String referencePointID, IReferencePoint referencePoint) {
     if (sharedReferencePointMapper.getReferencePoint(referencePointID) != null) {
       sharedReferencePointMapper.removeReferencePoint(referencePointID);
-      listenerDispatch.projectRemoved(referencePointManager.get(referencePoint));
+      listenerDispatch.projectRemoved(referencePoint);
     }
   }
 

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SarosSession.java
@@ -1046,12 +1046,12 @@ public final class SarosSession implements ISarosSession {
 
   @Override
   public void enableQueuing(IReferencePoint referencePoint) {
-    activityQueuer.enableQueuing(referencePointManager.get(referencePoint));
+    activityQueuer.enableQueuing(referencePoint);
   }
 
   @Override
   public void disableQueuing(IReferencePoint referencePoint) {
-    activityQueuer.disableQueuing(referencePointManager.get(referencePoint));
+    activityQueuer.disableQueuing(referencePoint);
     // send us a dummy activity to ensure the queues get flushed
     sendActivity(Collections.singletonList(localUser), new NOPActivity(localUser, localUser, 0));
   }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SessionListenerDispatch.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SessionListenerDispatch.java
@@ -1,6 +1,6 @@
 package de.fu_berlin.inf.dpp.session.internal;
 
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.session.ISessionListener;
 import de.fu_berlin.inf.dpp.session.User;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -42,18 +42,18 @@ public class SessionListenerDispatch implements ISessionListener {
   }
 
   @Override
-  public void projectAdded(IProject project) {
-    for (ISessionListener listener : listeners) listener.projectAdded(project);
+  public void projectAdded(IReferencePoint referencePoint) {
+    for (ISessionListener listener : listeners) listener.projectAdded(referencePoint);
   }
 
   @Override
-  public void projectRemoved(IProject project) {
-    for (ISessionListener listener : listeners) listener.projectRemoved(project);
+  public void projectRemoved(IReferencePoint referencePoint) {
+    for (ISessionListener listener : listeners) listener.projectRemoved(referencePoint);
   }
 
   @Override
-  public void resourcesAdded(IProject project) {
-    for (ISessionListener listener : listeners) listener.resourcesAdded(project);
+  public void resourcesAdded(IReferencePoint referencePoint) {
+    for (ISessionListener listener : listeners) listener.resourcesAdded(referencePoint);
   }
 
   public void add(ISessionListener listener) {

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SharedProjectMapper.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SharedProjectMapper.java
@@ -1,6 +1,6 @@
 package de.fu_berlin.inf.dpp.session.internal;
 
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.session.User;
 import java.util.ArrayList;
@@ -14,126 +14,145 @@ import java.util.Set;
 import org.apache.log4j.Logger;
 
 /**
- * This class is responsible for mapping global project IDs to local {@linkplain IProject projects},
- * as well as storing which resources are shared from each project. On the host, it also tracks
- * which users have already received which shared projects.
+ * This class is responsible for mapping global reference point IDs to local {@linkplain
+ * IReferencePoint referencePoints}, as well as storing which resources are shared from each
+ * reference point. On the host, it also tracks which users have already received which shared
+ * reference point.
  *
- * <p>The project IDs are used to identify shared projects across the network, even when the local
- * names of shared projects are different. The ID is determined by the project/file-host.
+ * <p>The reference point IDs are used to identify shared reference point across the network, even
+ * when the local names of shared reference point are different. The ID is determined by the
+ * reference point/file-host.
  */
 class SharedProjectMapper {
 
   private static final Logger LOG = Logger.getLogger(SharedProjectMapper.class);
 
-  /** Mapping from project IDs to currently registered shared projects. */
-  private Map<String, IProject> idToProjectMapping = new HashMap<String, IProject>();
+  /** Mapping from reference point IDs to currently registered shared reference point. */
+  private Map<String, IReferencePoint> idToReferencePointMapping;
 
-  /** Mapping from currently registered shared projects to their id's. */
-  private Map<IProject, String> projectToIDMapping = new HashMap<IProject, String>();
+  /** Mapping from currently registered shared reference point to their id's. */
+  private Map<IReferencePoint, String> referencePointToIDMapping;
 
   /**
-   * Map for storing which clients have which projects. Used by the host to determine who can
-   * currently process an activity related to a particular project. (Non-hosts don't maintain this
-   * map.)
+   * Map for storing which clients have which reference point. Used by the host to determine who can
+   * currently process an activity related to a particular reference point. (Non-hosts don't
+   * maintain this map.)
    */
-  private Map<User, List<String>> projectsOfUsers = new HashMap<User, List<String>>();
+  private Map<User, List<String>> referencePointsOfUsers;
 
   /**
-   * Map for storing the set of resources shared for each shared project. Maps to <code>null</code>
-   * for completely shared projects.
+   * Map for storing the set of resources shared for each shared reference point. Maps to <code>null
+   * </code> for completely shared reference points.
    */
-  private Map<IProject, Set<IResource>> partiallySharedResourceMapping =
-      new HashMap<IProject, Set<IResource>>();
+  private Map<IReferencePoint, Set<IResource>> partiallySharedResourceMapping;
 
-  /** Set containing the currently completely shared projects. */
-  private Set<IProject> completelySharedProjects = new HashSet<IProject>();
+  /** Set containing the currently completely shared reference points. */
+  private Set<IReferencePoint> completelySharedReferencePoints;
 
-  /** Set containing the currently partially shared projects. */
-  private Set<IProject> partiallySharedProjects = new HashSet<IProject>();
+  /** Set containing the currently partially shared reference points. */
+  private Set<IReferencePoint> partiallySharedReferencePoints;
+
+  public SharedProjectMapper() {
+    idToReferencePointMapping = new HashMap<String, IReferencePoint>();
+    referencePointToIDMapping = new HashMap<IReferencePoint, String>();
+    referencePointsOfUsers = new HashMap<User, List<String>>();
+    partiallySharedResourceMapping = new HashMap<IReferencePoint, Set<IResource>>();
+    completelySharedReferencePoints = new HashSet<IReferencePoint>();
+    partiallySharedReferencePoints = new HashSet<IReferencePoint>();
+  }
 
   /**
-   * Adds a project to the set of currently shared projects.
+   * Adds a reference point to the set of currently shared reference points.
    *
-   * <p>It is possible to "upgrade" a partially shared project to a completely shared project by
-   * just adding the same project with the same ID again that must now marked as not partially
-   * shared.
+   * <p>It is possible to "upgrade" a partially shared reference point to a completely shared
+   * reference point by just adding the same reference point with the same ID again that must now
+   * marked as not partially shared.
    *
-   * @param id the ID for the project
-   * @param project the project to add
-   * @param isPartially <code>true</code> if the project should be treated as a partially shared
-   *     project, <code>false</code> if it should be treated as completely shared
-   * @throws NullPointerException if the ID or project is <code>null</code>
-   * @throws IllegalStateException if the ID is already in use or the project was already added
+   * @param id the ID for the reference points
+   * @param referencePoint the reference points to add
+   * @param isPartially <code>true</code> if the reference point should be treated as a partially
+   *     shared reference point, <code>false</code> if it should be treated as completely shared
+   * @throws NullPointerException if the ID or reference point is <code>null</code>
+   * @throws IllegalStateException if the ID is already in use or the reference point was already
+   *     added
    */
-  public synchronized void addProject(String id, IProject project, boolean isPartially) {
+  public synchronized void addReferencePoint(
+      String id, IReferencePoint referencePoint, boolean isPartially) {
     boolean upgrade = false;
 
     if (id == null) throw new NullPointerException("ID is null");
 
-    if (project == null) throw new NullPointerException("project is null");
+    if (referencePoint == null) throw new NullPointerException("referencePoint is null");
 
-    String currentProjectID = projectToIDMapping.get(project);
-    IProject currentProject = idToProjectMapping.get(id);
+    String currentReferencePointID = referencePointToIDMapping.get(referencePoint);
+    IReferencePoint currentReferencePoint = idToReferencePointMapping.get(id);
 
-    if (currentProjectID != null && !id.equals(currentProjectID)) {
+    if (currentReferencePointID != null && !id.equals(currentReferencePointID)) {
       throw new IllegalStateException(
           "cannot assign ID "
               + id
-              + " to project "
-              + project
+              + " to referencePoint "
+              + referencePoint
               + " because it is already registered with ID "
-              + currentProjectID);
+              + currentReferencePointID);
     }
 
-    if (currentProject != null && !project.equals(currentProject)) {
+    if (currentReferencePoint != null && !referencePoint.equals(currentReferencePoint)) {
       throw new IllegalStateException(
-          "ID " + id + " for project " + project + " is already used by project " + currentProject);
+          "ID "
+              + id
+              + " for referencePoint "
+              + referencePoint
+              + " is already used by referencePoint "
+              + currentReferencePoint);
     }
 
-    if (isPartially && partiallySharedProjects.contains(project))
-      throw new IllegalStateException("project " + project + " is already partially shared");
-
-    if (!isPartially && completelySharedProjects.contains(project))
-      throw new IllegalStateException("project " + project + " is already completely shared");
-
-    if (isPartially && completelySharedProjects.contains(project))
+    if (isPartially && partiallySharedReferencePoints.contains(referencePoint))
       throw new IllegalStateException(
-          "project "
-              + project
-              + " is already completely shared (cannot downgrade a completely shared project)");
+          "referencePoint " + referencePoint + " is already partially shared");
 
-    if (!isPartially && partiallySharedProjects.contains(project)) {
-      partiallySharedProjects.remove(project);
+    if (!isPartially && completelySharedReferencePoints.contains(referencePoint))
+      throw new IllegalStateException(
+          "referencePoint " + referencePoint + " is already completely shared");
+
+    if (isPartially && completelySharedReferencePoints.contains(referencePoint))
+      throw new IllegalStateException(
+          "referencePoint "
+              + referencePoint
+              + " is already completely shared (cannot downgrade a completely shared referencePoint)");
+
+    if (!isPartially && partiallySharedReferencePoints.contains(referencePoint)) {
+      partiallySharedReferencePoints.remove(referencePoint);
       upgrade = true;
     }
 
-    if (isPartially) partiallySharedProjects.add(project);
-    else completelySharedProjects.add(project);
+    if (isPartially) partiallySharedReferencePoints.add(referencePoint);
+    else completelySharedReferencePoints.add(referencePoint);
 
-    assert Collections.disjoint(completelySharedProjects, partiallySharedProjects);
+    assert Collections.disjoint(completelySharedReferencePoints, partiallySharedReferencePoints);
 
     if (upgrade) {
       // release resources
-      partiallySharedResourceMapping.put(project, null);
+      partiallySharedResourceMapping.put(referencePoint, null);
 
       LOG.debug(
-          "upgraded partially shared project "
-              + project
+          "upgraded partially shared referencePoint "
+              + referencePoint
               + " with ID "
               + id
-              + " to a completely shared project");
+              + " to a completely shared referencePoint");
       return;
     }
 
-    idToProjectMapping.put(id, project);
-    projectToIDMapping.put(project, id);
+    idToReferencePointMapping.put(id, referencePoint);
+    referencePointToIDMapping.put(referencePoint, id);
 
-    if (isPartially) partiallySharedResourceMapping.put(project, new HashSet<IResource>());
-    else partiallySharedResourceMapping.put(project, null);
+    if (isPartially) partiallySharedResourceMapping.put(referencePoint, new HashSet<IResource>());
+    else partiallySharedResourceMapping.put(referencePoint, null);
 
     LOG.debug(
-        "added project "
-            + project
+        "added referencePoint "
+            + referencePoint
             + " with ID "
             + id
             + " [completely shared:"
@@ -142,33 +161,34 @@ class SharedProjectMapper {
   }
 
   /**
-   * Removes a project from the set of currently shared projects. Does nothing if the project is not
-   * shared.
+   * Removes a reference point from the set of currently shared referencePoint. Does nothing if the
+   * referencePoint is not shared.
    *
-   * @param id the ID of the project to remove
+   * @param id the ID of the referencePoint to remove
    */
-  public synchronized void removeProject(String id) {
-    IProject project = idToProjectMapping.get(id);
+  public synchronized void removeReferencePoint(String id) {
+    IReferencePoint referencePoint = idToReferencePointMapping.get(id);
 
-    if (project == null) {
-      LOG.warn("could not remove project, no project is registerid with ID: " + id);
+    if (referencePoint == null) {
+      LOG.warn("could not remove referencePoint, no referencePoint is registerid with ID: " + id);
       return;
     }
 
-    if (partiallySharedProjects.contains(project)) partiallySharedProjects.remove(project);
-    else completelySharedProjects.remove(project);
+    if (partiallySharedReferencePoints.contains(referencePoint))
+      partiallySharedReferencePoints.remove(referencePoint);
+    else completelySharedReferencePoints.remove(referencePoint);
 
-    idToProjectMapping.remove(id);
-    projectToIDMapping.remove(project);
-    partiallySharedResourceMapping.remove(project);
+    idToReferencePointMapping.remove(id);
+    referencePointToIDMapping.remove(referencePoint);
+    partiallySharedResourceMapping.remove(referencePoint);
 
-    LOG.debug("removed project " + project + " with ID " + id);
+    LOG.debug("removed referencePoint " + referencePoint + " with ID " + id);
   }
 
   /**
-   * Adds the given resources to a <b>partially</b> shared project.
+   * Adds the given resources to a <b>partially</b> shared reference point.
    *
-   * @param project a project that was added as a partially shared project
+   * @param referencePoint a referencePoint that was added as a partially shared referencePoint
    * @param resources the resources to add
    */
   /*
@@ -178,66 +198,72 @@ class SharedProjectMapper {
    * at all
    */
   public synchronized void addResources(
-      IProject project, Collection<? extends IResource> resources) {
+      IReferencePoint referencePoint, Collection<? extends IResource> resources) {
 
-    if (projectToIDMapping.get(project) == null) {
-      LOG.warn("could not add resources to project " + project + " because it is not shared");
+    if (referencePointToIDMapping.get(referencePoint) == null) {
+      LOG.warn(
+          "could not add resources to referencePoint "
+              + referencePoint
+              + " because it is not shared");
       // throw new IllegalStateException(
       // "could not add resources to project " + project
       // + " because it is not shared");
       return;
     }
 
-    if (completelySharedProjects.contains(project)) {
-      LOG.warn("cannot add resources to completely shared project: " + project);
+    if (completelySharedReferencePoints.contains(referencePoint)) {
+      LOG.warn("cannot add resources to completely shared referencePoint: " + referencePoint);
       // throw new IllegalStateException(
       // "cannot add resources to completely shared project: " + project);
       return;
     }
 
-    Set<IResource> partiallySharedResources = partiallySharedResourceMapping.get(project);
+    Set<IResource> partiallySharedResources = partiallySharedResourceMapping.get(referencePoint);
 
     if (partiallySharedResources.isEmpty()) {
       partiallySharedResources = new HashSet<IResource>(Math.max(1024, (resources.size() * 3) / 2));
 
-      partiallySharedResourceMapping.put(project, partiallySharedResources);
+      partiallySharedResourceMapping.put(referencePoint, partiallySharedResources);
     }
 
     partiallySharedResources.addAll(resources);
   }
 
   /**
-   * Removes the given resources from a <b>partially</b> shared project.
+   * Removes the given resources from a <b>partially</b> shared reference point.
    *
-   * @param project a project that was added as a partially shared project
+   * @param referencePoint a reference point that was added as a partially shared reference point
    * @param resources the resources to remove
    */
   /*
    * TODO needs proper sync. in the SarosSession class
    *
-   * @throws IllegalStateException if the project is completely or not shared
-   * at all
+   * @throws IllegalStateException if the referencePoint is completely or not
+   * shared at all
    */
   public synchronized void removeResources(
-      IProject project, Collection<? extends IResource> resources) {
+      IReferencePoint referencePoint, Collection<? extends IResource> resources) {
 
-    if (projectToIDMapping.get(project) == null) {
-      LOG.warn("could not remove resources from project " + project + " because it is not shared");
+    if (referencePointToIDMapping.get(referencePoint) == null) {
+      LOG.warn(
+          "could not remove resources from referencePoint "
+              + referencePoint
+              + " because it is not shared");
       // throw new IllegalStateException(
       // "could not remove resources from project " + project
       // + " because it is not shared");
       return;
     }
 
-    if (completelySharedProjects.contains(project)) {
-      LOG.warn("cannot remove resources from completely shared project: " + project);
+    if (completelySharedReferencePoints.contains(referencePoint)) {
+      LOG.warn("cannot remove resources from completely shared reference point: " + referencePoint);
       // throw new IllegalStateException(
       // "cannot remove resources from completely shared project: " +
       // project);
       return;
     }
 
-    Set<IResource> partiallySharedResources = partiallySharedResourceMapping.get(project);
+    Set<IResource> partiallySharedResources = partiallySharedResourceMapping.get(referencePoint);
 
     partiallySharedResources.removeAll(resources);
   }
@@ -246,48 +272,49 @@ class SharedProjectMapper {
    * Atomically removes and adds resources. The resources to remove will be removed first before the
    * resources to add will be added.
    *
-   * @param project a project that was added as a partially shared project
+   * @param referencePoint a reference point that was added as a partially shared reference point
    * @param resourcesToRemove the resources to remove
    * @param resourcesToAdd the resources to add
    */
   /*
    * TODO needs proper sync. in the SarosSession class
    *
-   * @throws IllegalStateException if the project is completely or not shared
-   * at all
+   * @throws IllegalStateException if the referencePoint is completely or not
+   * shared at all
    */
   public synchronized void removeAndAddResources(
-      IProject project,
+      IReferencePoint referencePoint,
       Collection<? extends IResource> resourcesToRemove,
       Collection<? extends IResource> resourcesToAdd) {
 
-    removeResources(project, resourcesToRemove);
-    addResources(project, resourcesToAdd);
+    removeResources(referencePoint, resourcesToRemove);
+    addResources(referencePoint, resourcesToAdd);
   }
 
   /**
-   * Returns the ID assigned to the given shared project.
+   * Returns the ID assigned to the given shared reference point.
    *
-   * @param project the project to look up the ID for
-   * @return the shared project's ID or <code>null</code> if the project is not shared
+   * @param referencePoint the reference point to look up the ID for
+   * @return the shared reference point's ID or <code>null</code> if the reference point is not
+   *     shared
    */
-  public synchronized String getID(IProject project) {
-    return projectToIDMapping.get(project);
+  public synchronized String getID(IReferencePoint referencePoint) {
+    return referencePointToIDMapping.get(referencePoint);
   }
 
   /**
-   * Returns the shared project with the given ID.
+   * Returns the shared reference point with the given ID.
    *
-   * @param id the ID to look up the project for
-   * @return the shared project for the given ID or <code>null</code> if no shared project is
-   *     registered with this ID
+   * @param id the ID to look up the reference point for
+   * @return the shared reference point for the given ID or <code>null</code> if no shared reference
+   *     point is registered with this ID
    */
-  public synchronized IProject getProject(String id) {
-    return idToProjectMapping.get(id);
+  public synchronized IReferencePoint getReferencePoint(String id) {
+    return idToReferencePointMapping.get(id);
   }
 
   /**
-   * Returns whether the given resource is included in one of the currently shared projects.
+   * Returns whether the given resource is included in one of the currently shared reference points.
    *
    * @param resource the resource to check for
    * @return <code>true</code> if the resource is shared, <code>false</code> otherwise
@@ -295,31 +322,38 @@ class SharedProjectMapper {
   public synchronized boolean isShared(IResource resource) {
     if (resource == null) return false;
 
-    if (resource.getType() == IResource.PROJECT) return idToProjectMapping.containsValue(resource);
+    if (resource.getType() == IResource.PROJECT) {
+      return isShared(resource.getReferencePoint());
+    }
 
-    IProject project = resource.getProject();
+    IReferencePoint referencePoint = resource.getReferencePoint();
 
-    if (!idToProjectMapping.containsValue(project)) return false;
+    if (!idToReferencePointMapping.containsValue(referencePoint)) return false;
 
-    if (isCompletelyShared(project))
+    if (isCompletelyShared(referencePoint))
       // TODO how should partial sharing handle this case ?
       return !resource.isDerived(true);
-    else return partiallySharedResourceMapping.get(project).contains(resource);
+    else return partiallySharedResourceMapping.get(referencePoint).contains(resource);
+  }
+
+  public synchronized boolean isShared(IReferencePoint referencePoint) {
+    return idToReferencePointMapping.containsValue(referencePoint);
   }
 
   /**
-   * Returns the currently shared projects.
+   * Returns the currently shared reference points.
    *
-   * @return a newly created {@link Set} with the shared projects
+   * @return a newly created {@link Set} with the shared reference points
    */
-  public synchronized Set<IProject> getProjects() {
-    return new HashSet<IProject>(idToProjectMapping.values());
+  public synchronized Set<IReferencePoint> getReferencePoints() {
+    return new HashSet<IReferencePoint>(idToReferencePointMapping.values());
   }
 
   /**
-   * Returns all resources from all partially shared projects.
+   * Returns all resources from all partially shared reference points.
    *
-   * @return a newly created {@link List} with all of the partially shared projects' resources
+   * @return a newly created {@link List} with all of the partially shared reference points'
+   *     resources
    */
   public synchronized List<IResource> getPartiallySharedResources() {
 
@@ -337,26 +371,27 @@ class SharedProjectMapper {
   }
 
   /**
-   * Returns the current number of shared projects.
+   * Returns the current number of shared reference points.
    *
-   * @return number of shared projects
+   * @return number of shared reference points
    */
   public synchronized int size() {
-    return idToProjectMapping.size();
+    return idToReferencePointMapping.size();
   }
 
   /**
-   * Returns a mapping for each shared project and its containing resources. The resource list is
-   * <b>always</b> <code>null</code> for completely shared projects.
+   * Returns a mapping for each shared reference point and its containing resources. The resource
+   * list is <b>always</b> <code>null</code> for completely shared reference points.
    *
-   * @return a map from project to resource list (partially shared) or <code>null</code> (completely
-   *     shared)
+   * @return a map from reference point to resource list (partially shared) or <code>null</code>
+   *     (completely shared)
    */
-  public synchronized Map<IProject, List<IResource>> getProjectResourceMapping() {
+  public synchronized Map<IReferencePoint, List<IResource>> getReferencePointResourceMapping() {
 
-    Map<IProject, List<IResource>> result = new HashMap<IProject, List<IResource>>();
+    Map<IReferencePoint, List<IResource>> result = new HashMap<IReferencePoint, List<IResource>>();
 
-    for (Map.Entry<IProject, Set<IResource>> entry : partiallySharedResourceMapping.entrySet()) {
+    for (Map.Entry<IReferencePoint, Set<IResource>> entry :
+        partiallySharedResourceMapping.entrySet()) {
 
       List<IResource> partiallySharedResources = null;
 
@@ -370,70 +405,71 @@ class SharedProjectMapper {
   }
 
   /**
-   * Checks whether a project is completely shared.
+   * Checks whether a reference point is completely shared.
    *
-   * @param project the project to check for
-   * @return <code>true</code> if the project is completely shared, <code>false</code> if the
-   *     project is not or partially shared
+   * @param referencePoint the referencePoint to check for
+   * @return <code>true</code> if the reference point is completely shared, <code>false</code> if
+   *     the reference point is not or partially shared
    */
-  public synchronized boolean isCompletelyShared(IProject project) {
-    return completelySharedProjects.contains(project);
+  public synchronized boolean isCompletelyShared(IReferencePoint referencePoint) {
+    return completelySharedReferencePoints.contains(referencePoint);
   }
 
   /**
-   * Checks if a project is partially shared.
+   * Checks if a reference point is partially shared.
    *
-   * @param project the project to check
-   * @return <code>true</code> if the project is partially shared, <code>false</code> if the project
-   *     is not or completely shared
+   * @param referencePoint the reference point to check
+   * @return <code>true</code> if the reference point is partially shared, <code>false</code> if the
+   *     reference point is not or completely shared
    */
-  public synchronized boolean isPartiallyShared(IProject project) {
-    return partiallySharedProjects.contains(project);
+  public synchronized boolean isPartiallyShared(IReferencePoint referencePoint) {
+    return partiallySharedReferencePoints.contains(referencePoint);
   }
 
   /**
-   * Checks if the given user already has the given project, and can thus process activities related
-   * to that project.
+   * Checks if the given user already has the given reference point, and can thus process activities
+   * related to that reference point.
    *
    * <p>This method should only be called by the session's host.
    *
    * @param user The user to be checked
-   * @param project The project to be checked
-   * @return <code>true</code> if the user currently has the project, <code>false</code> if not
+   * @param referencePoint The reference point to be checked
+   * @return <code>true</code> if the user currently has the reference point, <code>false</code> if
+   *     not
    */
-  public synchronized boolean userHasProject(User user, IProject project) {
-    if (projectsOfUsers.containsKey(user)) {
-      return projectsOfUsers.get(user).contains(getID(project));
+  public synchronized boolean userHasReferencePoint(User user, IReferencePoint referencePoint) {
+    if (referencePointsOfUsers.containsKey(user)) {
+      return referencePointsOfUsers.get(user).contains(getID(referencePoint));
     }
     return false;
   }
 
   /**
-   * Tells the mapper that the given user now has all currently shared projects.
+   * Tells the mapper that the given user now has all currently shared reference point.
    *
    * <p>This method should only be called by the session's host.
    *
-   * @param user user who now has all projects
-   * @see #userHasProject(User, IProject)
+   * @param user user who now has all reference points
+   * @see #userHasReferencePoint(User, IReferencePoint)
    */
-  public synchronized void addMissingProjectsToUser(User user) {
-    List<String> projects = new ArrayList<String>();
-    for (String project : idToProjectMapping.keySet()) {
-      projects.add(project);
+  public synchronized void addMissingReferencePointsToUser(User user) {
+    List<String> referencePoints = new ArrayList<String>();
+    for (String referencePoint : idToReferencePointMapping.keySet()) {
+      referencePoints.add(referencePoint);
     }
 
-    this.projectsOfUsers.put(user, projects);
+    this.referencePointsOfUsers.put(user, referencePoints);
   }
 
   /**
-   * Removes the user-project mapping of the user that left the session.
+   * Removes the user-referencePoint mapping of the user that left the session.
    *
    * <p>This method should only be called by the session's host.
    *
    * @param user user who left the session
-   * @see #userHasProject(User, IProject)
+   * @see #userHasReferencePoint(User, IReferencePoint)
    */
   public void userLeft(User user) {
-    projectsOfUsers.remove(user);
+    referencePointsOfUsers.remove(user);
   }
 }

--- a/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SharedReferencePointMapper.java
+++ b/de.fu_berlin.inf.dpp.core/src/de/fu_berlin/inf/dpp/session/internal/SharedReferencePointMapper.java
@@ -23,9 +23,9 @@ import org.apache.log4j.Logger;
  * when the local names of shared reference point are different. The ID is determined by the
  * reference point/file-host.
  */
-class SharedProjectMapper {
+class SharedReferencePointMapper {
 
-  private static final Logger LOG = Logger.getLogger(SharedProjectMapper.class);
+  private static final Logger LOG = Logger.getLogger(SharedReferencePointMapper.class);
 
   /** Mapping from reference point IDs to currently registered shared reference point. */
   private Map<String, IReferencePoint> idToReferencePointMapping;
@@ -52,7 +52,7 @@ class SharedProjectMapper {
   /** Set containing the currently partially shared reference points. */
   private Set<IReferencePoint> partiallySharedReferencePoints;
 
-  public SharedProjectMapper() {
+  public SharedReferencePointMapper() {
     idToReferencePointMapping = new HashMap<String, IReferencePoint>();
     referencePointToIDMapping = new HashMap<IReferencePoint, String>();
     referencePointsOfUsers = new HashMap<User, List<String>>();

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/misc/xstream/SPathConverterTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/misc/xstream/SPathConverterTest.java
@@ -38,9 +38,14 @@ public class SPathConverterTest {
     referencePoint = EasyMock.createNiceMock(IReferencePoint.class);
     project = EasyMock.createNiceMock(IProject.class);
     expect(project.getReferencePoint()).andStubReturn(referencePoint);
+    EasyMock.replay(pathFactory, referencePoint, path, project);
+
     referencePointManager = EasyMock.createNiceMock(IReferencePointManager.class);
     expect(referencePointManager.get(referencePoint)).andStubReturn(project);
-    EasyMock.replay(pathFactory, referencePoint, path, project, referencePointManager);
+    expect(referencePointManager.createSPath(referencePoint, path))
+        .andStubReturn(new SPath(project, path));
+
+    EasyMock.replay(referencePointManager);
   }
 
   @Test

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/negotiation/FileListTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/negotiation/FileListTest.java
@@ -117,29 +117,8 @@ public class FileListTest {
 
     final IProject project = EasyMock.createMock(IProject.class);
 
-    final IFolder barFolder = createFolderMock(project, "bar", new IResource[0]);
-
-    final IFolder foobarfooFolder = createFolderMock(project, "foobar/foo", new IResource[0]);
-
-    final IFile infoTxtFile = createFileMock(project, "info.txt", "1234", "UTF-8");
-
-    final IFile foobarInfoTxtFile =
-        createFileMock(project, "foobar/info.txt", "12345", "ISO-8859-1");
-
-    final IFolder foobarFolder =
-        createFolderMock(project, "foobar", new IResource[] {foobarfooFolder, foobarInfoTxtFile});
-
     EasyMock.expect(project.getName()).andStubReturn("foo");
     EasyMock.expect(project.getReferencePoint()).andStubReturn(referencePoint);
-
-    try {
-      EasyMock.expect(project.getDefaultCharset()).andStubReturn("UTF-16");
-
-      EasyMock.expect(project.members())
-          .andStubReturn(new IResource[] {barFolder, infoTxtFile, foobarFolder});
-    } catch (IOException e) {
-      // cannot happen
-    }
 
     EasyMock.replay(project);
 
@@ -225,9 +204,35 @@ public class FileListTest {
 
   private static IReferencePointManager createReferencePointManagerMock(
       IReferencePoint referencePoint, IProject project) {
+
+    final IFolder barFolder = createFolderMock(project, "bar", new IResource[0]);
+
+    final IFolder foobarfooFolder = createFolderMock(project, "foobar/foo", new IResource[0]);
+
+    final IFile infoTxtFile = createFileMock(project, "info.txt", "1234", "UTF-8");
+
+    final IFile foobarInfoTxtFile =
+        createFileMock(project, "foobar/info.txt", "12345", "ISO-8859-1");
+
+    final IFolder foobarFolder =
+        createFolderMock(project, "foobar", new IResource[] {foobarfooFolder, foobarInfoTxtFile});
+
     IReferencePointManager referencePointManager =
         EasyMock.createMock(IReferencePointManager.class);
     EasyMock.expect(referencePointManager.get(referencePoint)).andStubReturn(project);
+
+    EasyMock.expect(referencePointManager.getName(referencePoint)).andStubReturn("foo");
+
+    try {
+      EasyMock.expect(referencePointManager.getDefaultCharSet(referencePoint))
+          .andStubReturn("UTF-16");
+
+      EasyMock.expect(referencePointManager.members(referencePoint))
+          .andStubReturn(new IResource[] {barFolder, infoTxtFile, foobarFolder});
+    } catch (IOException e) {
+      // cannot happen
+    }
+
     EasyMock.replay(referencePointManager);
     return referencePointManager;
   }

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/CoreReferencePointManagerTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/CoreReferencePointManagerTest.java
@@ -21,7 +21,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class ReferencePointManagerTest {
+public class CoreReferencePointManagerTest {
 
   private final String PROJECT_RELATIVE_PATH_TO_FILE = "/toFile";
   private final String PROJECT_RELATIVE_PATH_TO_FOLDER = "/toFolder/";
@@ -55,7 +55,7 @@ public class ReferencePointManagerTest {
     expect(project.members()).andStubReturn(new IResource[] {file, folder});
     replay(referencePoint, project);
 
-    referencePointManager = new ReferencePointManager();
+    referencePointManager = new CoreReferencePointManager();
   }
 
   @Test

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/ReferencePointManagerTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/ReferencePointManagerTest.java
@@ -1,0 +1,103 @@
+package de.fu_berlin.inf.dpp.session;
+
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.fail;
+
+import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ReferencePointManagerTest {
+
+  private IReferencePointManager referencePointManager;
+  private IReferencePoint referencePoint;
+  private IProject project;
+
+  @Before
+  public void prepare() {
+    referencePoint = createMock(IReferencePoint.class);
+    project = createMock(IProject.class);
+
+    replay(referencePoint, project);
+
+    referencePointManager = new ReferencePointManager();
+  }
+
+  @Test
+  public void testPutOnce() {
+    referencePointManager.put(referencePoint, project);
+    IProject mappedProject = referencePointManager.get(referencePoint);
+
+    Assert.assertNotNull(mappedProject);
+    Assert.assertEquals(project, mappedProject);
+  }
+
+  @Test
+  public void testGetWithoutMapping() {
+    IProject mappedProject = referencePointManager.get(referencePoint);
+    Assert.assertNull(mappedProject);
+  }
+
+  @Test
+  public void testPutMultiplePutWithSameReferencePoint() {
+    IProject newProject = createMock(IProject.class);
+    replay(newProject);
+
+    referencePointManager.put(referencePoint, project);
+    referencePointManager.put(referencePoint, newProject);
+
+    IProject mappedProject = referencePointManager.get(referencePoint);
+
+    Assert.assertNotNull(mappedProject);
+    Assert.assertEquals(newProject, mappedProject);
+  }
+
+  @Test
+  public void testGetProjectSet() {
+    Set<IReferencePoint> referencePoints = new HashSet<>();
+    Set<IProject> projects = referencePointManager.getProjects(referencePoints);
+
+    Assert.assertEquals(0, projects.size());
+
+    referencePoints.add(referencePoint);
+    referencePointManager.put(referencePoint, project);
+
+    projects = referencePointManager.getProjects(referencePoints);
+
+    Assert.assertEquals(1, projects);
+
+    IProject mappedProject = (IProject) projects.toArray()[0];
+
+    Assert.assertEquals(project, mappedProject);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void putMappingWithNullProject() {
+    try {
+      referencePointManager.put(referencePoint, null);
+    } catch (RuntimeException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void putMappingWithNullReferencePoint() {
+    referencePointManager.put(null, project);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void putGetWithNullReferencePoint() {
+    referencePointManager.get(referencePoint);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void putGetWithNullReferencePointsSet() {
+    referencePointManager.getProjects(null);
+  }
+}

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/ReferencePointManagerTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/ReferencePointManagerTest.java
@@ -2,7 +2,6 @@ package de.fu_berlin.inf.dpp.session;
 
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.replay;
-import static org.junit.Assert.fail;
 
 import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
@@ -54,7 +53,7 @@ public class ReferencePointManagerTest {
     IProject mappedProject = referencePointManager.get(referencePoint);
 
     Assert.assertNotNull(mappedProject);
-    Assert.assertEquals(newProject, mappedProject);
+    Assert.assertEquals(project, mappedProject);
   }
 
   @Test
@@ -69,7 +68,7 @@ public class ReferencePointManagerTest {
 
     projects = referencePointManager.getProjects(referencePoints);
 
-    Assert.assertEquals(1, projects);
+    Assert.assertEquals(1, projects.size());
 
     IProject mappedProject = (IProject) projects.toArray()[0];
 
@@ -78,12 +77,7 @@ public class ReferencePointManagerTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void putMappingWithNullProject() {
-    try {
-      referencePointManager.put(referencePoint, null);
-    } catch (RuntimeException e) {
-      e.printStackTrace();
-      fail(e.getMessage());
-    }
+    referencePointManager.put(referencePoint, null);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -93,7 +87,7 @@ public class ReferencePointManagerTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void putGetWithNullReferencePoint() {
-    referencePointManager.get(referencePoint);
+    referencePointManager.get(null);
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/SarosSessionManagerTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/SarosSessionManagerTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import de.fu_berlin.inf.dpp.context.IContainerContext;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.net.IReceiver;
 import de.fu_berlin.inf.dpp.net.ITransmitter;
@@ -110,22 +110,22 @@ public class SarosSessionManagerTest {
   @Test
   public void testStartStopListenerCallback() {
     manager.addSessionLifecycleListener(new StateVerifyListener());
-    manager.startSession(new HashMap<IProject, List<IResource>>());
+    manager.startSessionWithReferencePoints(new HashMap<IReferencePoint, List<IResource>>());
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
   }
 
   @Test
   public void testMultipleStarts() {
     manager.addSessionLifecycleListener(new StateVerifyListener());
-    manager.startSession(new HashMap<IProject, List<IResource>>());
-    manager.startSession(new HashMap<IProject, List<IResource>>());
+    manager.startSessionWithReferencePoints(new HashMap<IReferencePoint, List<IResource>>());
+    manager.startSessionWithReferencePoints(new HashMap<IReferencePoint, List<IResource>>());
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
   }
 
   @Test
   public void testMultipleStops() {
     manager.addSessionLifecycleListener(new StateVerifyListener());
-    manager.startSession(new HashMap<IProject, List<IResource>>());
+    manager.startSessionWithReferencePoints(new HashMap<IReferencePoint, List<IResource>>());
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
   }
@@ -133,7 +133,7 @@ public class SarosSessionManagerTest {
   @Test(expected = DummyError.class)
   public void testListenerDispatchIsNotCatchingErrors() {
     manager.addSessionLifecycleListener(new ErrorThrowingListener());
-    manager.startSession(new HashMap<IProject, List<IResource>>());
+    manager.startSessionWithReferencePoints(new HashMap<IReferencePoint, List<IResource>>());
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
   }
 
@@ -151,7 +151,7 @@ public class SarosSessionManagerTest {
           }
         };
     manager.addSessionLifecycleListener(listener);
-    manager.startSession(new HashMap<IProject, List<IResource>>());
+    manager.startSessionWithReferencePoints(new HashMap<IReferencePoint, List<IResource>>());
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
   }
 
@@ -165,11 +165,12 @@ public class SarosSessionManagerTest {
           public void sessionStarting(ISarosSession oldSarosSession) {
             assertTrue("startSession is executed recusive", count == 0);
             count++;
-            manager.startSession(new HashMap<IProject, List<IResource>>());
+            manager.startSessionWithReferencePoints(
+                new HashMap<IReferencePoint, List<IResource>>());
           }
         };
     manager.addSessionLifecycleListener(listener);
-    manager.startSession(new HashMap<IProject, List<IResource>>());
+    manager.startSessionWithReferencePoints(new HashMap<IReferencePoint, List<IResource>>());
   }
 
   @Test(expected = IllegalStateException.class)
@@ -189,7 +190,7 @@ public class SarosSessionManagerTest {
           }
         };
     manager.addSessionLifecycleListener(listener);
-    manager.startSession(new HashMap<IProject, List<IResource>>());
+    manager.startSessionWithReferencePoints(new HashMap<IReferencePoint, List<IResource>>());
 
     RuntimeException rte = exception.get();
 
@@ -206,14 +207,15 @@ public class SarosSessionManagerTest {
           @Override
           public void sessionEnding(ISarosSession oldSarosSession) {
             try {
-              manager.startSession(new HashMap<IProject, List<IResource>>());
+              manager.startSessionWithReferencePoints(
+                  new HashMap<IReferencePoint, List<IResource>>());
             } catch (RuntimeException e) {
               exception.set(e);
             }
           }
         };
     manager.addSessionLifecycleListener(listener);
-    manager.startSession(new HashMap<IProject, List<IResource>>());
+    manager.startSessionWithReferencePoints(new HashMap<IReferencePoint, List<IResource>>());
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
 
     RuntimeException rte = exception.get();

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/SarosSessionManagerTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/SarosSessionManagerTest.java
@@ -110,22 +110,22 @@ public class SarosSessionManagerTest {
   @Test
   public void testStartStopListenerCallback() {
     manager.addSessionLifecycleListener(new StateVerifyListener());
-    manager.startSessionWithReferencePoints(new HashMap<IReferencePoint, List<IResource>>());
+    manager.startSession(new HashMap<IReferencePoint, List<IResource>>());
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
   }
 
   @Test
   public void testMultipleStarts() {
     manager.addSessionLifecycleListener(new StateVerifyListener());
-    manager.startSessionWithReferencePoints(new HashMap<IReferencePoint, List<IResource>>());
-    manager.startSessionWithReferencePoints(new HashMap<IReferencePoint, List<IResource>>());
+    manager.startSession(new HashMap<IReferencePoint, List<IResource>>());
+    manager.startSession(new HashMap<IReferencePoint, List<IResource>>());
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
   }
 
   @Test
   public void testMultipleStops() {
     manager.addSessionLifecycleListener(new StateVerifyListener());
-    manager.startSessionWithReferencePoints(new HashMap<IReferencePoint, List<IResource>>());
+    manager.startSession(new HashMap<IReferencePoint, List<IResource>>());
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
   }
@@ -133,7 +133,7 @@ public class SarosSessionManagerTest {
   @Test(expected = DummyError.class)
   public void testListenerDispatchIsNotCatchingErrors() {
     manager.addSessionLifecycleListener(new ErrorThrowingListener());
-    manager.startSessionWithReferencePoints(new HashMap<IReferencePoint, List<IResource>>());
+    manager.startSession(new HashMap<IReferencePoint, List<IResource>>());
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
   }
 
@@ -151,7 +151,7 @@ public class SarosSessionManagerTest {
           }
         };
     manager.addSessionLifecycleListener(listener);
-    manager.startSessionWithReferencePoints(new HashMap<IReferencePoint, List<IResource>>());
+    manager.startSession(new HashMap<IReferencePoint, List<IResource>>());
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
   }
 
@@ -165,12 +165,11 @@ public class SarosSessionManagerTest {
           public void sessionStarting(ISarosSession oldSarosSession) {
             assertTrue("startSession is executed recusive", count == 0);
             count++;
-            manager.startSessionWithReferencePoints(
-                new HashMap<IReferencePoint, List<IResource>>());
+            manager.startSession(new HashMap<IReferencePoint, List<IResource>>());
           }
         };
     manager.addSessionLifecycleListener(listener);
-    manager.startSessionWithReferencePoints(new HashMap<IReferencePoint, List<IResource>>());
+    manager.startSession(new HashMap<IReferencePoint, List<IResource>>());
   }
 
   @Test(expected = IllegalStateException.class)
@@ -190,7 +189,7 @@ public class SarosSessionManagerTest {
           }
         };
     manager.addSessionLifecycleListener(listener);
-    manager.startSessionWithReferencePoints(new HashMap<IReferencePoint, List<IResource>>());
+    manager.startSession(new HashMap<IReferencePoint, List<IResource>>());
 
     RuntimeException rte = exception.get();
 
@@ -207,15 +206,14 @@ public class SarosSessionManagerTest {
           @Override
           public void sessionEnding(ISarosSession oldSarosSession) {
             try {
-              manager.startSessionWithReferencePoints(
-                  new HashMap<IReferencePoint, List<IResource>>());
+              manager.startSession(new HashMap<IReferencePoint, List<IResource>>());
             } catch (RuntimeException e) {
               exception.set(e);
             }
           }
         };
     manager.addSessionLifecycleListener(listener);
-    manager.startSessionWithReferencePoints(new HashMap<IReferencePoint, List<IResource>>());
+    manager.startSession(new HashMap<IReferencePoint, List<IResource>>());
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
 
     RuntimeException rte = exception.get();

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/internal/ActivityHandlerTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/internal/ActivityHandlerTest.java
@@ -30,6 +30,7 @@ import de.fu_berlin.inf.dpp.activities.ViewportActivity;
 import de.fu_berlin.inf.dpp.concurrent.management.ConcurrentDocumentClient;
 import de.fu_berlin.inf.dpp.concurrent.management.ConcurrentDocumentServer;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.session.IActivityHandlerCallback;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.User;
@@ -72,12 +73,6 @@ public class ActivityHandlerTest {
 
   // Needed to compare localActivities
   private volatile CountDownLatch gate;
-
-  // Roles of the Users in this Test
-  private User target;
-  private User source;
-  private boolean host;
-
   // Callback that is called from the ActivityHandler
   public IActivityHandlerCallback callback =
       new IActivityHandlerCallback() {
@@ -100,6 +95,10 @@ public class ActivityHandlerTest {
           if (gateToCountdown != null) gateToCountdown.countDown();
         }
       };
+  // Roles of the Users in this Test
+  private User target;
+  private User source;
+  private boolean host;
   private SPath path;
 
   @Before
@@ -336,11 +335,19 @@ public class ActivityHandlerTest {
             })
         .anyTimes();
 
+    IReferencePoint referencePoint = EasyMock.createMock(IReferencePoint.class);
+
     IProject project = EasyMock.createMock(IProject.class);
 
-    EasyMock.expect(sessionMock.userHasProject(dave, project)).andStubReturn(false);
+    EasyMock.expect(project.getReferencePoint()).andStubReturn(referencePoint);
+
+    EasyMock.replay(referencePoint, project);
+
+    EasyMock.expect(sessionMock.userHasReferencePoint(dave, project.getReferencePoint()))
+        .andStubReturn(false);
     for (User user : remoteUsersWithProjects) {
-      EasyMock.expect(sessionMock.userHasProject(user, project)).andStubReturn(true);
+      EasyMock.expect(sessionMock.userHasReferencePoint(user, project.getReferencePoint()))
+          .andStubReturn(true);
     }
 
     EasyMock.expect(sessionMock.getUsers()).andStubReturn(participants);

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/internal/ActivityQueuerTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/internal/ActivityQueuerTest.java
@@ -17,6 +17,7 @@ import de.fu_berlin.inf.dpp.concurrent.jupiter.internal.JupiterVectorTime;
 import de.fu_berlin.inf.dpp.concurrent.jupiter.internal.text.NoOperation;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
 import de.fu_berlin.inf.dpp.session.User;
 import java.util.ArrayList;
@@ -33,6 +34,9 @@ public class ActivityQueuerTest {
   private static final User ALICE = new User(new JID("Alice"), true, true, 0, 0);
   private static final User BOB = new User(new JID("Bob"), false, false, 0, 0);
 
+  private static IReferencePoint SHARED_REFERENCEPOINT;
+  private static IReferencePoint NOT_SHARED_REFERENCEPOINT;
+
   private static IProject SHARED_PROJECT;
   private static IProject NOT_SHARED_PROJECT;
 
@@ -44,8 +48,18 @@ public class ActivityQueuerTest {
 
   @BeforeClass
   public static void prepare() {
+    SHARED_REFERENCEPOINT = EasyMock.createMock(IReferencePoint.class);
+    NOT_SHARED_REFERENCEPOINT = EasyMock.createMock(IReferencePoint.class);
+
     SHARED_PROJECT = EasyMock.createMock(IProject.class);
     NOT_SHARED_PROJECT = EasyMock.createMock(IProject.class);
+
+    EasyMock.expect(SHARED_PROJECT.getReferencePoint()).andStubReturn(SHARED_REFERENCEPOINT);
+
+    EasyMock.expect(NOT_SHARED_PROJECT.getReferencePoint())
+        .andStubReturn(NOT_SHARED_REFERENCEPOINT);
+
+    EasyMock.replay(SHARED_PROJECT, NOT_SHARED_PROJECT);
 
     FOO_PATH_SHARED_PROJECT = new SPath(SHARED_PROJECT, EasyMock.createMock(IPath.class));
 
@@ -82,7 +96,7 @@ public class ActivityQueuerTest {
     IActivity activityToBeQueued = createJupiterActivity(PATH_TO_NOT_SHARED_PROJECT);
     activities.add(activityToBeQueued);
 
-    activityQueuer.enableQueuing(NOT_SHARED_PROJECT);
+    activityQueuer.enableQueuing(NOT_SHARED_REFERENCEPOINT);
 
     List<IActivity> processedActivities = activityQueuer.process(activities);
 
@@ -103,7 +117,7 @@ public class ActivityQueuerTest {
     // flush queue
     IActivity nopActivity = new NOPActivity(ALICE, ALICE, 0);
 
-    activityQueuer.disableQueuing(NOT_SHARED_PROJECT);
+    activityQueuer.disableQueuing(NOT_SHARED_REFERENCEPOINT);
 
     processedActivities.addAll(activityQueuer.process(Collections.singletonList(nopActivity)));
 
@@ -119,7 +133,7 @@ public class ActivityQueuerTest {
 
   @Test
   public void testQueuingEnabledWithActivityWithoutPath() {
-    activityQueuer.enableQueuing(NOT_SHARED_PROJECT);
+    activityQueuer.enableQueuing(NOT_SHARED_REFERENCEPOINT);
 
     IActivity serializedEditorActivity =
         new EditorActivity(ALICE, EditorActivity.Type.ACTIVATED, null);
@@ -138,8 +152,8 @@ public class ActivityQueuerTest {
 
   @Test
   public void testInternalFushCounter() {
-    activityQueuer.enableQueuing(NOT_SHARED_PROJECT);
-    activityQueuer.enableQueuing(NOT_SHARED_PROJECT);
+    activityQueuer.enableQueuing(NOT_SHARED_REFERENCEPOINT);
+    activityQueuer.enableQueuing(NOT_SHARED_REFERENCEPOINT);
 
     IActivity firstActivityToBeQueued = new FolderCreatedActivity(BOB, PATH_TO_NOT_SHARED_PROJECT);
 
@@ -152,13 +166,13 @@ public class ActivityQueuerTest {
     IActivity secondActivityToBeQueued =
         new FolderDeletedActivity(ALICE, PATH_TO_NOT_SHARED_PROJECT);
 
-    activityQueuer.disableQueuing(NOT_SHARED_PROJECT);
+    activityQueuer.disableQueuing(NOT_SHARED_REFERENCEPOINT);
 
     result = activityQueuer.process(Collections.singletonList(secondActivityToBeQueued));
 
     assertEquals("activity was not queued", 0, result.size());
 
-    activityQueuer.disableQueuing(NOT_SHARED_PROJECT);
+    activityQueuer.disableQueuing(NOT_SHARED_REFERENCEPOINT);
 
     result = activityQueuer.process(Collections.<IActivity>emptyList());
 
@@ -205,10 +219,10 @@ public class ActivityQueuerTest {
     List<IActivity> activities;
 
     activityQueuer = new ActivityQueuer();
-    activityQueuer.enableQueuing(SHARED_PROJECT);
+    activityQueuer.enableQueuing(SHARED_REFERENCEPOINT);
 
     activityQueuer.process(Collections.singletonList(fooJupiterADO));
-    activityQueuer.disableQueuing(SHARED_PROJECT);
+    activityQueuer.disableQueuing(SHARED_REFERENCEPOINT);
 
     activities = activityQueuer.process(flush);
 
@@ -225,10 +239,10 @@ public class ActivityQueuerTest {
     // ------------------------------------------
 
     activityQueuer = new ActivityQueuer();
-    activityQueuer.enableQueuing(SHARED_PROJECT);
+    activityQueuer.enableQueuing(SHARED_REFERENCEPOINT);
 
     activityQueuer.process(Collections.singletonList(fooClosedEditorADO));
-    activityQueuer.disableQueuing(SHARED_PROJECT);
+    activityQueuer.disableQueuing(SHARED_REFERENCEPOINT);
 
     activities = activityQueuer.process(flush);
 
@@ -241,10 +255,10 @@ public class ActivityQueuerTest {
     // ------------------------------------------
 
     activityQueuer = new ActivityQueuer();
-    activityQueuer.enableQueuing(SHARED_PROJECT);
+    activityQueuer.enableQueuing(SHARED_REFERENCEPOINT);
 
     activityQueuer.process(Collections.singletonList(fooSavedEditorADO));
-    activityQueuer.disableQueuing(SHARED_PROJECT);
+    activityQueuer.disableQueuing(SHARED_REFERENCEPOINT);
 
     activities = activityQueuer.process(flush);
 
@@ -257,10 +271,10 @@ public class ActivityQueuerTest {
     // ------------------------------------------
 
     activityQueuer = new ActivityQueuer();
-    activityQueuer.enableQueuing(SHARED_PROJECT);
+    activityQueuer.enableQueuing(SHARED_REFERENCEPOINT);
 
     activityQueuer.process(Arrays.asList(fooJupiterADO, fooSavedEditorADO, fooClosedEditorADO));
-    activityQueuer.disableQueuing(SHARED_PROJECT);
+    activityQueuer.disableQueuing(SHARED_REFERENCEPOINT);
 
     activities = activityQueuer.process(flush);
 
@@ -273,10 +287,10 @@ public class ActivityQueuerTest {
     // ------------------------------------------
 
     activityQueuer = new ActivityQueuer();
-    activityQueuer.enableQueuing(SHARED_PROJECT);
+    activityQueuer.enableQueuing(SHARED_REFERENCEPOINT);
 
     activityQueuer.process(Arrays.asList(fooJupiterADO, barJupiterADO));
-    activityQueuer.disableQueuing(SHARED_PROJECT);
+    activityQueuer.disableQueuing(SHARED_REFERENCEPOINT);
 
     activities = activityQueuer.process(flush);
 
@@ -305,10 +319,10 @@ public class ActivityQueuerTest {
             new JupiterVectorTime(0, 0), new NoOperation(), BOB, FOO_PATH_SHARED_PROJECT);
 
     activityQueuer = new ActivityQueuer();
-    activityQueuer.enableQueuing(SHARED_PROJECT);
+    activityQueuer.enableQueuing(SHARED_REFERENCEPOINT);
 
     activityQueuer.process(Arrays.asList(aliceJupiterADO, bobJupiterADO));
-    activityQueuer.disableQueuing(SHARED_PROJECT);
+    activityQueuer.disableQueuing(SHARED_REFERENCEPOINT);
 
     activities = activityQueuer.process(flush);
 

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/internal/SharedProjectMapperTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/internal/SharedProjectMapperTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import java.util.Collections;
 import java.util.List;
@@ -27,211 +27,220 @@ public class SharedProjectMapperTest {
   }
 
   @Test(expected = NullPointerException.class)
-  public void testAddNullProject() {
-    mapper.addProject("0", null, false);
+  public void testAddNullReferencePoint() {
+    mapper.addReferencePoint("0", null, false);
   }
 
   @Test(expected = NullPointerException.class)
-  public void testAddProjectWithNullID() {
-    mapper.addProject(null, createProjectMock(), false);
+  public void testAddReferencePointWithNullID() {
+    mapper.addReferencePoint(null, createReferencePointMock(), false);
   }
 
   @Test
-  public void testAddCompletelySharedProject() {
-    IProject projectMock = createProjectMock();
+  public void testAddCompletelySharedReferencePoint() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
-    mapper.addProject("0", projectMock, false);
+    mapper.addReferencePoint("0", referencePointMock, false);
 
-    assertTrue("project is not shared at all", mapper.isShared(projectMock));
+    assertTrue("referencePoint is not shared at all", mapper.isShared(referencePointMock));
 
-    assertFalse("project is partially shared", mapper.isPartiallyShared(projectMock));
+    assertFalse("referencePoint is partially shared", mapper.isPartiallyShared(referencePointMock));
 
-    assertTrue("project is not completely shared", mapper.isCompletelyShared(projectMock));
+    assertTrue(
+        "referencePoint is not completely shared", mapper.isCompletelyShared(referencePointMock));
   }
 
   @Test
-  public void testAddPartiallySharedProject() {
-    IProject projectMock = createProjectMock();
+  public void testAddPartiallySharedReferencePoint() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
-    mapper.addProject("0", projectMock, true);
+    mapper.addReferencePoint("0", referencePointMock, true);
 
-    assertTrue("project is not shared at all", mapper.isShared(projectMock));
+    assertTrue("referencePoint is not shared at all", mapper.isShared(referencePointMock));
 
-    assertFalse("project is completely shared", mapper.isCompletelyShared(projectMock));
+    assertFalse(
+        "referencePoint is completely shared", mapper.isCompletelyShared(referencePointMock));
 
-    assertTrue("project is not partially shared", mapper.isPartiallyShared(projectMock));
+    assertTrue(
+        "referencePoint is not partially shared", mapper.isPartiallyShared(referencePointMock));
   }
 
   @Test(expected = IllegalStateException.class)
-  public void testAddCompletelySharedProjectTwice() {
-    IProject projectMock = createProjectMock();
+  public void testAddCompletelySharedReferencePointTwice() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
     try {
-      mapper.addProject("0", projectMock, false);
+      mapper.addReferencePoint("0", referencePointMock, false);
     } catch (RuntimeException e) {
       e.printStackTrace();
       fail(e.getMessage());
     }
-    mapper.addProject("0", projectMock, false);
+    mapper.addReferencePoint("0", referencePointMock, false);
   }
 
   @Test(expected = IllegalStateException.class)
-  public void testAddPartiallySharedProjectTwice() {
-    IProject projectMock = createProjectMock();
+  public void testAddPartiallySharedReferencePointTwice() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
     try {
-      mapper.addProject("0", projectMock, true);
+      mapper.addReferencePoint("0", referencePointMock, true);
     } catch (RuntimeException e) {
       e.printStackTrace();
       fail(e.getMessage());
     }
-    mapper.addProject("0", projectMock, true);
+    mapper.addReferencePoint("0", referencePointMock, true);
   }
 
   @Test(expected = IllegalStateException.class)
-  public void testAddSameProjectWithDifferentID() {
-    IProject projectMock = createProjectMock();
+  public void testAddSameReferencePointWithDifferentID() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
     try {
-      mapper.addProject("0", projectMock, true);
-    } catch (RuntimeException e) {
-      e.printStackTrace();
-      fail(e.getMessage());
-    }
-
-    mapper.addProject("1", projectMock, true);
-  }
-
-  @Test(expected = IllegalStateException.class)
-  public void testAddNewProjectWithIDAlreadyInUse() {
-    IProject projectMockA = createProjectMock();
-    IProject projectMockB = createProjectMock();
-
-    try {
-      mapper.addProject("0", projectMockA, true);
+      mapper.addReferencePoint("0", referencePointMock, true);
     } catch (RuntimeException e) {
       e.printStackTrace();
       fail(e.getMessage());
     }
 
-    mapper.addProject("0", projectMockB, true);
+    mapper.addReferencePoint("1", referencePointMock, true);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testAddNewReferencePointWithIDAlreadyInUse() {
+    IReferencePoint referencePointMockA = createReferencePointMock();
+    IReferencePoint referencePointMockB = createReferencePointMock();
+
+    try {
+      mapper.addReferencePoint("0", referencePointMockA, true);
+    } catch (RuntimeException e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+
+    mapper.addReferencePoint("0", referencePointMockB, true);
   }
 
   @Test
-  public void testPartiallySharedProjectUpgrade() {
-    IProject projectMock = createProjectMock();
+  public void testPartiallySharedReferencePointUpgrade() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
-    mapper.addProject("0", projectMock, true);
-    assertTrue("project is not partially shared", mapper.isPartiallyShared(projectMock));
+    mapper.addReferencePoint("0", referencePointMock, true);
+    assertTrue(
+        "referencePoint is not partially shared", mapper.isPartiallyShared(referencePointMock));
 
-    assertFalse("project is completely shared", mapper.isCompletelyShared(projectMock));
+    assertFalse(
+        "referencePoint is completely shared", mapper.isCompletelyShared(referencePointMock));
 
-    mapper.addProject("0", projectMock, false);
-    assertFalse("project is partially shared", mapper.isPartiallyShared(projectMock));
+    mapper.addReferencePoint("0", referencePointMock, false);
+    assertFalse("referencePoint is partially shared", mapper.isPartiallyShared(referencePointMock));
 
-    assertTrue("project is not completely shared", mapper.isCompletelyShared(projectMock));
+    assertTrue(
+        "referencePoint is not completely shared", mapper.isCompletelyShared(referencePointMock));
   }
 
   @Test(expected = IllegalStateException.class)
-  public void testCompletelySharedProjectDowngrade() {
-    IProject projectMock = createProjectMock();
+  public void testCompletelySharedReferencePointDowngrade() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
     try {
-      mapper.addProject("0", projectMock, false);
+      mapper.addReferencePoint("0", referencePointMock, false);
     } catch (RuntimeException e) {
       e.printStackTrace();
       fail(e.getMessage());
     }
 
-    mapper.addProject("0", projectMock, true);
+    mapper.addReferencePoint("0", referencePointMock, true);
   }
 
   @Test
-  public void testRemoveProjects() {
-    IProject projectMockA = createProjectMock();
-    IProject projectMockB = createProjectMock();
+  public void testRemoveReferencePoints() {
+    IReferencePoint referencePointMockA = createReferencePointMock();
+    IReferencePoint referencePointMockB = createReferencePointMock();
 
-    mapper.addProject("0", projectMockA, false);
-    mapper.addProject("1", projectMockB, true);
+    mapper.addReferencePoint("0", referencePointMockA, false);
+    mapper.addReferencePoint("1", referencePointMockB, true);
 
-    mapper.removeProject("0");
-    mapper.removeProject("1");
+    mapper.removeReferencePoint("0");
+    mapper.removeReferencePoint("1");
 
-    assertFalse("project is still shared", mapper.isShared(projectMockA));
-    assertFalse("project is still shared", mapper.isShared(projectMockB));
+    assertFalse("referencePoint is still shared", mapper.isShared(referencePointMockA));
+    assertFalse("referencePoint is still shared", mapper.isShared(referencePointMockB));
 
-    assertFalse("project is still completely shared", mapper.isCompletelyShared(projectMockA));
-    assertFalse("project is still partially shared", mapper.isPartiallyShared(projectMockB));
+    assertFalse(
+        "referencePoint is still completely shared",
+        mapper.isCompletelyShared(referencePointMockA));
+    assertFalse(
+        "referencePoint is still partially shared", mapper.isPartiallyShared(referencePointMockB));
   }
 
   @Test(expected = IllegalStateException.class)
   @Ignore(
       "logic is currently not performed - should be enabled after the SarosSession is properly synchronized")
-  public void testAddResourcesToCompletelySharedProject() {
-    IProject projectMock = createProjectMock();
-    mapper.addProject("0", projectMock, false);
+  public void testAddResourcesToCompletelySharedReferencePoint() {
+    IReferencePoint referencePointMock = createReferencePointMock();
+    mapper.addReferencePoint("0", referencePointMock, false);
     List<IResource> emptyList = Collections.emptyList();
-    mapper.addResources(projectMock, emptyList);
+    mapper.addResources(referencePointMock, emptyList);
   }
 
   @Test(expected = IllegalStateException.class)
   @Ignore(
       "logic is currently not performed - should be enabled after the SarosSession is properly synchronized")
-  public void testAddResourcesToNonSharedProject() {
-    IProject projectMock = createProjectMock();
+  public void testAddResourcesToNonSharedReferencePoint() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
     List<IResource> emptyList = Collections.emptyList();
-    mapper.addResources(projectMock, emptyList);
+    mapper.addResources(referencePointMock, emptyList);
   }
 
   @Test(expected = IllegalStateException.class)
   @Ignore(
       "logic is currently not performed - should be enabled after the SarosSession is properly synchronized")
-  public void testRemoveResourcesFromCompletelySharedProject() {
-    IProject projectMock = createProjectMock();
+  public void testRemoveResourcesFromCompletelySharedReferencePoint() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
-    mapper.addProject("0", projectMock, false);
+    mapper.addReferencePoint("0", referencePointMock, false);
 
     List<IResource> emptyList = Collections.emptyList();
-    mapper.removeResources(projectMock, emptyList);
+    mapper.removeResources(referencePointMock, emptyList);
   }
 
   @Test(expected = IllegalStateException.class)
   @Ignore(
       "logic is currently not performed - should be enabled after the SarosSession is properly synchronized")
-  public void testRemoveResourcesFromNonSharedProject() {
-    IProject projectMock = createProjectMock();
+  public void testRemoveResourcesFromNonSharedReferencePoint() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
     List<IResource> emptyList = Collections.emptyList();
-    mapper.removeResources(projectMock, emptyList);
+    mapper.removeResources(referencePointMock, emptyList);
   }
 
   @Test
-  public void testAddRemoveResourcesOfPartiallySharedProject() {
+  public void testAddRemoveResourcesOfPartiallySharedReferencePoint() {
 
-    IProject projectMock = createProjectMock();
+    IReferencePoint referencePointMock = createReferencePointMock();
 
     IResource resourceMockA = EasyMock.createNiceMock(IResource.class);
-    EasyMock.expect(resourceMockA.getProject()).andStubReturn(projectMock);
+    EasyMock.expect(resourceMockA.getReferencePoint()).andStubReturn(referencePointMock);
     IResource resourceMockB = EasyMock.createNiceMock(IResource.class);
-    EasyMock.expect(resourceMockB.getProject()).andStubReturn(projectMock);
+    EasyMock.expect(resourceMockB.getReferencePoint()).andStubReturn(referencePointMock);
     EasyMock.replay(resourceMockA, resourceMockB);
 
-    mapper.addProject("0", projectMock, true);
-    mapper.addResources(projectMock, Collections.singletonList(resourceMockA));
+    mapper.addReferencePoint("0", referencePointMock, true);
+    mapper.addResources(referencePointMock, Collections.singletonList(resourceMockA));
 
     assertTrue("resource is not shared", mapper.isShared(resourceMockA));
     assertEquals(1, mapper.getPartiallySharedResources().size());
 
-    mapper.removeResources(projectMock, Collections.singletonList(resourceMockA));
+    mapper.removeResources(referencePointMock, Collections.singletonList(resourceMockA));
 
     assertFalse("resource is still shared", mapper.isShared(resourceMockA));
     assertEquals(0, mapper.getPartiallySharedResources().size());
 
-    mapper.addResources(projectMock, Collections.singletonList(resourceMockA));
+    mapper.addResources(referencePointMock, Collections.singletonList(resourceMockA));
 
     mapper.removeAndAddResources(
-        projectMock,
+        referencePointMock,
         Collections.singletonList(resourceMockA),
         Collections.singletonList(resourceMockB));
 
@@ -241,16 +250,16 @@ public class SharedProjectMapperTest {
   }
 
   @Test
-  public void testDerivedResourcesOnCompletelySharedProject() {
-    IProject projectMock = createProjectMock();
+  public void testDerivedResourcesOnCompletelySharedReferencePoint() {
+    IReferencePoint referencePointMock = createReferencePointMock();
 
     IResource resourceMock = EasyMock.createNiceMock(IResource.class);
-    EasyMock.expect(resourceMock.getProject()).andStubReturn(projectMock);
+    EasyMock.expect(resourceMock.getReferencePoint()).andStubReturn(referencePointMock);
     EasyMock.expect(resourceMock.isDerived(true)).andReturn(true);
 
     EasyMock.replay(resourceMock);
 
-    mapper.addProject("0", projectMock, false);
+    mapper.addReferencePoint("0", referencePointMock, false);
 
     assertFalse("derived resource is marked as shared", mapper.isShared(resourceMock));
 
@@ -260,14 +269,14 @@ public class SharedProjectMapperTest {
   @Test
   public void testIsShared() {
 
-    IProject projectMockA = createProjectMock();
-    IProject projectMockB = createProjectMock();
+    IReferencePoint referencePointMockA = createReferencePointMock();
+    IReferencePoint referencePointMockB = createReferencePointMock();
 
     IResource resourceMockA = EasyMock.createNiceMock(IResource.class);
-    EasyMock.expect(resourceMockA.getProject()).andStubReturn(projectMockA);
+    EasyMock.expect(resourceMockA.getReferencePoint()).andStubReturn(referencePointMockA);
 
     IResource resourceMockB = EasyMock.createNiceMock(IResource.class);
-    EasyMock.expect(resourceMockB.getProject()).andStubReturn(projectMockB);
+    EasyMock.expect(resourceMockB.getReferencePoint()).andStubReturn(referencePointMockB);
 
     EasyMock.replay(resourceMockA, resourceMockB);
 
@@ -275,61 +284,66 @@ public class SharedProjectMapperTest {
 
     assertFalse("resource should not be marked as shared", mapper.isShared(resourceMockB));
 
-    mapper.addProject("0", projectMockA, false);
-    mapper.addProject("1", projectMockB, true);
+    mapper.addReferencePoint("0", referencePointMockA, false);
+    mapper.addReferencePoint("1", referencePointMockB, true);
 
     assertTrue("resource is not marked as shared", mapper.isShared(resourceMockA));
 
     assertFalse("resource should not be marked as shared", mapper.isShared(resourceMockB));
 
-    mapper.addResources(projectMockB, Collections.singletonList(resourceMockB));
+    mapper.addResources(referencePointMockB, Collections.singletonList(resourceMockB));
 
     assertTrue("resource is not marked as shared", mapper.isShared(resourceMockB));
   }
 
   @Test
-  public void testGetProjectResourceMapping() {
-    IProject projectMockA = createProjectMock();
-    IProject projectMockB = createProjectMock();
+  public void testGetReferencePointResourceMapping() {
+    IReferencePoint referencePointMockA = createReferencePointMock();
+    IReferencePoint referencePointMockB = createReferencePointMock();
 
     IResource resourceMockB = EasyMock.createNiceMock(IResource.class);
-    EasyMock.expect(resourceMockB.getProject()).andStubReturn(projectMockB);
+    EasyMock.expect(resourceMockB.getReferencePoint()).andStubReturn(referencePointMockB);
 
     EasyMock.replay(resourceMockB);
 
-    mapper.addProject("0", projectMockA, false);
-    mapper.addProject("1", projectMockB, true);
+    mapper.addReferencePoint("0", referencePointMockA, false);
+    mapper.addReferencePoint("1", referencePointMockB, true);
 
-    mapper.addResources(projectMockB, Collections.singletonList(resourceMockB));
+    mapper.addResources(referencePointMockB, Collections.singletonList(resourceMockB));
 
-    Map<IProject, List<IResource>> mapping = mapper.getProjectResourceMapping();
+    Map<IReferencePoint, List<IResource>> mapping = mapper.getReferencePointResourceMapping();
 
-    assertNull("completely shared projects have no resource list", mapping.get(projectMockA));
+    assertNull(
+        "completely shared referencePoint have no resource list", mapping.get(referencePointMockA));
 
-    assertNotNull("partially shared projects must have a resource list", mapping.get(projectMockB));
+    assertNotNull(
+        "partially shared referencePoint must have a resource list",
+        mapping.get(referencePointMockB));
 
     assertEquals(
-        "resource list does not contain the shared resource", 1, mapping.get(projectMockB).size());
+        "resource list does not contain the shared resource",
+        1,
+        mapping.get(referencePointMockB).size());
   }
 
   @Test
-  public void testGetProjects() {
-    IProject projectMockA = createProjectMock();
-    IProject projectMockB = createProjectMock();
+  public void testGetReferencePoints() {
+    IReferencePoint referencePointMockA = createReferencePointMock();
+    IReferencePoint referencePointMockB = createReferencePointMock();
 
-    mapper.addProject("0", projectMockA, false);
-    mapper.addProject("1", projectMockB, false);
+    mapper.addReferencePoint("0", referencePointMockA, false);
+    mapper.addReferencePoint("1", referencePointMockB, false);
 
-    assertEquals(2, mapper.getProjects().size());
+    assertEquals(2, mapper.getReferencePoints().size());
     assertEquals(2, mapper.size());
   }
 
   @Test
-  public void testIDToProjectMapping() {
-    IProject projectMock = createProjectMock();
-    mapper.addProject("0", projectMock, false);
-    assertEquals("0", mapper.getID(projectMock));
-    assertEquals(projectMock, mapper.getProject("0"));
+  public void testIDToReferencePointMapping() {
+    IReferencePoint referencePointMock = createReferencePointMock();
+    mapper.addReferencePoint("0", referencePointMock, false);
+    assertEquals("0", mapper.getID(referencePointMock));
+    assertEquals(referencePointMock, mapper.getReferencePoint("0"));
   }
 
   /*
@@ -337,10 +351,9 @@ public class SharedProjectMapperTest {
    * IllegalArgumentExceptions as well which may lead to false positive
    * (passed) test cases
    */
-  private IProject createProjectMock() {
-    IProject projectMock = EasyMock.createNiceMock(IProject.class);
-    EasyMock.expect(projectMock.getType()).andStubReturn(IResource.PROJECT);
-    EasyMock.replay(projectMock);
-    return projectMock;
+  private IReferencePoint createReferencePointMock() {
+    IReferencePoint referencePointMock = EasyMock.createNiceMock(IReferencePoint.class);
+    EasyMock.replay(referencePointMock);
+    return referencePointMock;
   }
 }

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/internal/SharedReferencePointMapperTest.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/internal/SharedReferencePointMapperTest.java
@@ -17,13 +17,13 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-public class SharedProjectMapperTest {
+public class SharedReferencePointMapperTest {
 
-  private SharedProjectMapper mapper;
+  private SharedReferencePointMapper mapper;
 
   @Before
   public void setUp() {
-    mapper = new SharedProjectMapper();
+    mapper = new SharedReferencePointMapper();
   }
 
   @Test(expected = NullPointerException.class)

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/internal/TestSuite.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/session/internal/TestSuite.java
@@ -8,7 +8,7 @@ import org.junit.runners.Suite;
   ActivityHandlerTest.class,
   ActivityQueuerTest.class,
   ActivitySequencerTest.class,
-  SharedProjectMapperTest.class,
+  SharedReferencePointMapperTest.class,
   UserInformationHandlerTest.class
 })
 public class TestSuite {

--- a/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/test/stubs/SarosSessionStub.java
+++ b/de.fu_berlin.inf.dpp.core/test/junit/de/fu_berlin/inf/dpp/test/stubs/SarosSessionStub.java
@@ -3,7 +3,7 @@ package de.fu_berlin.inf.dpp.test.stubs;
 import de.fu_berlin.inf.dpp.activities.IActivity;
 import de.fu_berlin.inf.dpp.concurrent.management.ConcurrentDocumentClient;
 import de.fu_berlin.inf.dpp.concurrent.management.ConcurrentDocumentServer;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
 import de.fu_berlin.inf.dpp.preferences.IPreferenceStore;
@@ -15,8 +15,8 @@ import de.fu_berlin.inf.dpp.session.ISessionListener;
 import de.fu_berlin.inf.dpp.session.User;
 import de.fu_berlin.inf.dpp.session.User.Permission;
 import de.fu_berlin.inf.dpp.synchronize.StopManager;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 
@@ -85,17 +85,17 @@ public class SarosSessionStub implements ISarosSession {
   }
 
   @Override
-  public Set<IProject> getProjects() {
+  public Set<IReferencePoint> getReferencePoints() {
     throw new RuntimeException("Unexpected call to Stub");
   }
 
   @Override
-  public String getProjectID(IProject project) {
+  public String getReferencePointID(IReferencePoint referencePoint) {
     throw new RuntimeException("Unexpected call to Stub");
   }
 
   @Override
-  public IProject getProject(String projectID) {
+  public IReferencePoint getReferencePoint(String referencePointID) {
     throw new RuntimeException("Unexpected call to Stub");
   }
 
@@ -141,7 +141,7 @@ public class SarosSessionStub implements ISarosSession {
 
   @Override
   public void addSharedResources(
-      IProject project, String projectID, List<IResource> dependentResources) {
+      IReferencePoint referencePoint, String referencePointID, List<IResource> dependentResources) {
     throw new RuntimeException("Unexpected call to Stub");
   }
 
@@ -151,27 +151,27 @@ public class SarosSessionStub implements ISarosSession {
   }
 
   @Override
-  public HashMap<IProject, List<IResource>> getProjectResourcesMapping() {
+  public Map<IReferencePoint, List<IResource>> getReferencePointResourcesMapping() {
     throw new RuntimeException("Unexpected call to Stub");
   }
 
   @Override
-  public boolean isCompletelyShared(IProject project) {
+  public boolean isCompletelyShared(IReferencePoint referencePoint) {
     throw new RuntimeException("Unexpected call to Stub");
   }
 
   @Override
-  public List<IResource> getSharedResources(IProject project) {
+  public List<IResource> getSharedResources(IReferencePoint referencePoint) {
     throw new RuntimeException("Unexpected call to Stub");
   }
 
   @Override
-  public void addProjectMapping(String projectID, IProject project) {
+  public void addReferencePointMapping(String referencePointID, IReferencePoint referencePoint) {
     throw new RuntimeException("Unexpected call to Stub");
   }
 
   @Override
-  public void removeProjectMapping(String projectID, IProject project) {
+  public void removeReferencePointMapping(String referencePointID, IReferencePoint referencePoint) {
     throw new RuntimeException("Unexpected call to Stub");
   }
 
@@ -196,12 +196,12 @@ public class SarosSessionStub implements ISarosSession {
   }
 
   @Override
-  public void enableQueuing(IProject project) {
+  public void enableQueuing(IReferencePoint referencePoint) {
     throw new RuntimeException("Unexpected call to Stub");
   }
 
   @Override
-  public void disableQueuing(IProject project) {
+  public void disableQueuing(IReferencePoint referencePoint) {
     throw new RuntimeException("Unexpected call to Stub");
   }
 
@@ -216,7 +216,7 @@ public class SarosSessionStub implements ISarosSession {
   }
 
   @Override
-  public boolean userHasProject(User user, IProject project) {
+  public boolean userHasReferencePoint(User user, IReferencePoint referencePoint) {
     throw new RuntimeException("Unexpected call to Stub");
   }
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/core/ui/util/CollaborationUtils.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/core/ui/util/CollaborationUtils.java
@@ -17,6 +17,7 @@ import de.fu_berlin.inf.dpp.intellij.ui.util.DialogUtils;
 import de.fu_berlin.inf.dpp.intellij.ui.util.NotificationPanel;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
 import de.fu_berlin.inf.dpp.session.SessionEndReason;
@@ -241,7 +242,10 @@ public class CollaborationUtils {
    */
   private static String getShareProjectDescription(ISarosSession sarosSession) {
 
-    Set<IProject> projects = sarosSession.getProjects();
+    IReferencePointManager referencePointManager =
+        sarosSession.getComponent(IReferencePointManager.class);
+
+    Set<IProject> projects = referencePointManager.getProjects(sarosSession.getReferencePoints());
 
     StringBuilder result = new StringBuilder();
 
@@ -250,7 +254,7 @@ public class CollaborationUtils {
 
         Pair<Long, Long> fileCountAndSize;
 
-        if (sarosSession.isCompletelyShared(project)) {
+        if (sarosSession.isCompletelyShared(project.getReferencePoint())) {
           fileCountAndSize =
               getFileCountAndSize(Arrays.asList(project.members()), true, IContainer.FILE);
 
@@ -261,7 +265,7 @@ public class CollaborationUtils {
                   fileCountAndSize.getRight(),
                   format(fileCountAndSize.getLeft())));
         } else {
-          List<IResource> resources = sarosSession.getSharedResources(project);
+          List<IResource> resources = sarosSession.getSharedResources(project.getReferencePoint());
 
           fileCountAndSize = getFileCountAndSize(resources, false, IResource.NONE);
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/core/ui/util/CollaborationUtils.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/core/ui/util/CollaborationUtils.java
@@ -8,6 +8,7 @@ import de.fu_berlin.inf.dpp.core.monitoring.Status;
 import de.fu_berlin.inf.dpp.filesystem.IContainer;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.intellij.SarosComponent;
 import de.fu_berlin.inf.dpp.intellij.filesystem.IntelliJProjectImpl;
@@ -67,7 +68,7 @@ public class CollaborationUtils {
    */
   public static void startSession(List<IResource> resources, final List<JID> contacts) {
 
-    final Map<IProject, List<IResource>> newResources = acquireResources(resources, null);
+    final Map<IReferencePoint, List<IResource>> newResources = acquireResources(resources, null);
 
     UIMonitoredJob sessionStartupJob =
         new UIMonitoredJob("Session Startup") {
@@ -76,7 +77,7 @@ public class CollaborationUtils {
           protected IStatus run(IProgressMonitor monitor) {
             monitor.beginTask("Starting session...", IProgressMonitor.UNKNOWN);
             try {
-              sessionManager.startSession(newResources);
+              sessionManager.startSessionWithReferencePoints(newResources);
               Set<JID> participantsToAdd = new HashSet<JID>(contacts);
 
               monitor.worked(50);
@@ -169,11 +170,11 @@ public class CollaborationUtils {
       return;
     }
 
-    final Map<IProject, List<IResource>> projectResources;
+    final Map<IReferencePoint, List<IResource>> referencePointResources;
 
-    projectResources = acquireResources(resourcesToAdd, sarosSession);
+    referencePointResources = acquireResources(resourcesToAdd, sarosSession);
 
-    if (projectResources.isEmpty()) {
+    if (referencePointResources.isEmpty()) {
       return;
     }
 
@@ -185,7 +186,7 @@ public class CollaborationUtils {
           public void run() {
 
             if (sarosSession.hasWriteAccess()) {
-              sessionManager.addResourcesToSession(projectResources);
+              sessionManager.addReferencePointResourcesToSession(referencePointResources);
               return;
             }
 
@@ -301,7 +302,7 @@ public class CollaborationUtils {
    * @param sarosSession
    * @return
    */
-  private static Map<IProject, List<IResource>> acquireResources(
+  private static Map<IReferencePoint, List<IResource>> acquireResources(
       List<IResource> selectedResources, ISarosSession sarosSession) {
 
     Map<IProject, Set<IResource>> projectsResources = new HashMap<IProject, Set<IResource>>();
@@ -406,11 +407,11 @@ public class CollaborationUtils {
       resources.addAll(additionalFilesForPartialSharing);
     }
 
-    HashMap<IProject, List<IResource>> resources = new HashMap<IProject, List<IResource>>();
+    HashMap<IReferencePoint, List<IResource>> resources = new HashMap<IReferencePoint, List<IResource>>();
 
     for (Entry<IProject, Set<IResource>> entry : projectsResources.entrySet()) {
       resources.put(
-          entry.getKey(),
+          entry.getKey().getReferencePoint(),
           entry.getValue() == null ? null : new ArrayList<IResource>(entry.getValue()));
     }
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/core/ui/util/CollaborationUtils.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/core/ui/util/CollaborationUtils.java
@@ -77,7 +77,7 @@ public class CollaborationUtils {
           protected IStatus run(IProgressMonitor monitor) {
             monitor.beginTask("Starting session...", IProgressMonitor.UNKNOWN);
             try {
-              sessionManager.startSessionWithReferencePoints(newResources);
+              sessionManager.startSession(newResources);
               Set<JID> participantsToAdd = new HashSet<JID>(contacts);
 
               monitor.worked(50);
@@ -186,7 +186,7 @@ public class CollaborationUtils {
           public void run() {
 
             if (sarosSession.hasWriteAccess()) {
-              sessionManager.addReferencePointResourcesToSession(referencePointResources);
+              sessionManager.addResourcesToSession(referencePointResources);
               return;
             }
 
@@ -407,7 +407,8 @@ public class CollaborationUtils {
       resources.addAll(additionalFilesForPartialSharing);
     }
 
-    HashMap<IReferencePoint, List<IResource>> resources = new HashMap<IReferencePoint, List<IResource>>();
+    HashMap<IReferencePoint, List<IResource>> resources =
+        new HashMap<IReferencePoint, List<IResource>>();
 
     for (Entry<IProject, Set<IResource>> entry : projectsResources.entrySet()) {
       resources.put(

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
@@ -738,7 +738,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
   }
 
   @Override
-  public void saveEditors(final IProject project) {
+  public void saveEditors(final IReferencePoint referencePoint) {
     executeInUIThreadSynchronous(
         () -> {
           Set<SPath> editorPaths = new HashSet<>(editorPool.getFiles());
@@ -748,7 +748,8 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
           }
 
           for (SPath editorPath : editorPaths) {
-            if (project == null || project.equals(editorPath.getProject())) {
+            if (referencePoint == null
+                || referencePoint.equals(editorPath.getProject().getReferencePoint())) {
 
               saveDocument(editorPath);
             }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/editor/EditorManager.java
@@ -29,6 +29,7 @@ import de.fu_berlin.inf.dpp.editor.text.LineRange;
 import de.fu_berlin.inf.dpp.editor.text.TextSelection;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.intellij.editor.annotations.AnnotationManager;
 import de.fu_berlin.inf.dpp.intellij.editor.annotations.LocalClosedEditorModificationHandler;
 import de.fu_berlin.inf.dpp.intellij.filesystem.Filesystem;
@@ -38,6 +39,7 @@ import de.fu_berlin.inf.dpp.session.AbstractActivityConsumer;
 import de.fu_berlin.inf.dpp.session.AbstractActivityProducer;
 import de.fu_berlin.inf.dpp.session.IActivityConsumer;
 import de.fu_berlin.inf.dpp.session.IActivityConsumer.Priority;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
 import de.fu_berlin.inf.dpp.session.ISessionLifecycleListener;
@@ -243,7 +245,11 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
         }
 
         @Override
-        public void resourcesAdded(final IProject project) {
+        public void resourcesAdded(final IReferencePoint referencePoint) {
+          IReferencePointManager referencePointManager =
+              session.getComponent(IReferencePointManager.class);
+          IProject project = referencePointManager.get(referencePoint);
+
           ApplicationManager.getApplication()
               .invokeAndWait(
                   () -> addProjectResources(project), ModalityState.defaultModalityState());

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJFileImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJFileImpl.java
@@ -30,6 +30,8 @@ public final class IntelliJFileImpl extends IntelliJResourceImpl implements IFil
   public IntelliJFileImpl(@NotNull final IntelliJProjectImpl project, @NotNull final IPath path) {
     this.project = project;
     this.path = path;
+
+    this.referencePoint = project.getReferencePoint();
   }
 
   /**

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJFolderImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJFolderImpl.java
@@ -29,6 +29,8 @@ public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IF
   public IntelliJFolderImpl(@NotNull final IntelliJProjectImpl project, @NotNull final IPath path) {
     this.project = project;
     this.path = path;
+
+    this.referencePoint = project.getReferencePoint();
   }
 
   @Override

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJProjectImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJProjectImpl.java
@@ -14,6 +14,7 @@ import de.fu_berlin.inf.dpp.filesystem.IFolder;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
+import de.fu_berlin.inf.dpp.filesystem.ReferencePointImpl;
 import de.fu_berlin.inf.dpp.intellij.project.filesystem.IntelliJPathImpl;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -69,6 +70,8 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
     this.moduleName = module.getName();
 
     moduleRoot = getModuleContentRoot(module);
+
+    this.referencePoint = new ReferencePointImpl(getFullPath());
 
     checkIfContentRootLocatedBelowProjectRoot(module, moduleRoot);
     checkIfModuleFileLocatedInContentRoot(module, moduleRoot);

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJResourceImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/filesystem/IntelliJResourceImpl.java
@@ -1,14 +1,22 @@
 package de.fu_berlin.inf.dpp.intellij.filesystem;
 
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public abstract class IntelliJResourceImpl implements IResource {
 
+  protected IReferencePoint referencePoint;
+
   @Nullable
   @Override
   public Object getAdapter(@NotNull Class<? extends IResource> clazz) {
     return clazz.isInstance(this) ? this : null;
+  }
+
+  @Override
+  public IReferencePoint getReferencePoint() {
+    return referencePoint;
   }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/negotiation/hooks/ModuleTypeNegotiationHook.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/negotiation/hooks/ModuleTypeNegotiationHook.java
@@ -9,6 +9,7 @@ import de.fu_berlin.inf.dpp.negotiation.hooks.ISessionNegotiationHook;
 import de.fu_berlin.inf.dpp.negotiation.hooks.SessionNegotiationHookManager;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
 import de.fu_berlin.inf.dpp.preferences.IPreferenceStore;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -103,7 +104,11 @@ public class ModuleTypeNegotiationHook implements ISessionNegotiationHook {
 
     StringBuilder stringBuilder = new StringBuilder();
 
-    for (final IProject project : sessionManager.getSession().getProjects()) {
+    IReferencePointManager referencePointManager =
+        sessionManager.getSession().getComponent(IReferencePointManager.class);
+
+    for (final IProject project :
+        referencePointManager.getProjects(sessionManager.getSession().getReferencePoints())) {
 
       IntelliJProjectImpl intelliJProject =
           (IntelliJProjectImpl) project.getAdapter(IntelliJProjectImpl.class);

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJWorkspaceImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJWorkspaceImpl.java
@@ -7,12 +7,14 @@ import com.intellij.openapi.util.Computable;
 import de.fu_berlin.inf.dpp.exceptions.OperationCanceledException;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspaceRunnable;
 import de.fu_berlin.inf.dpp.intellij.filesystem.Filesystem;
 import de.fu_berlin.inf.dpp.intellij.filesystem.IntelliJProjectImpl;
 import de.fu_berlin.inf.dpp.monitoring.NullProgressMonitor;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import java.io.IOException;
 import org.apache.log4j.Logger;
 
@@ -37,6 +39,15 @@ public class IntelliJWorkspaceImpl implements IWorkspace {
   }
 
   @Override
+  public void run(
+      IWorkspaceRunnable runnable,
+      IReferencePoint[] referencePoints,
+      IReferencePointManager referencePointManager)
+      throws IOException, OperationCanceledException {
+    run(runnable);
+  }
+
+  @Override
   public IProject getProject(final String moduleName) {
     Module module =
         Filesystem.runReadAction(
@@ -53,5 +64,12 @@ public class IntelliJWorkspaceImpl implements IWorkspace {
   @Override
   public IPath getLocation() {
     return IntelliJPathImpl.fromString(project.getBasePath());
+  }
+
+  @Override
+  public IReferencePoint getReferencePoint(String moduleName) {
+    IProject project = getProject(moduleName);
+
+    return project.getReferencePoint();
   }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJWorkspaceImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJWorkspaceImpl.java
@@ -8,7 +8,6 @@ import de.fu_berlin.inf.dpp.exceptions.OperationCanceledException;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
-import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspaceRunnable;
 import de.fu_berlin.inf.dpp.intellij.filesystem.Filesystem;
@@ -30,12 +29,6 @@ public class IntelliJWorkspaceImpl implements IWorkspace {
   @Override
   public void run(IWorkspaceRunnable procedure) throws IOException, OperationCanceledException {
     procedure.run(new NullProgressMonitor());
-  }
-
-  @Override
-  public void run(IWorkspaceRunnable runnable, IResource[] resources)
-      throws IOException, OperationCanceledException {
-    run(runnable);
   }
 
   @Override

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJWorkspaceRootImpl.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/IntelliJWorkspaceRootImpl.java
@@ -3,6 +3,7 @@ package de.fu_berlin.inf.dpp.intellij.project.filesystem;
 import de.fu_berlin.inf.dpp.filesystem.IContainer;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspaceRoot;
 import java.io.IOException;
@@ -104,5 +105,10 @@ public class IntelliJWorkspaceRootImpl implements IWorkspaceRoot {
   @Override
   public Object getAdapter(Class<? extends IResource> clazz) {
     return null;
+  }
+
+  @Override
+  public IReferencePoint getReferencePoint() {
+    throw new UnsupportedOperationException();
   }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/ModuleInitialization.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/project/filesystem/ModuleInitialization.java
@@ -10,8 +10,10 @@ import com.intellij.openapi.util.InvalidDataException;
 import com.intellij.openapi.vfs.VirtualFile;
 import de.fu_berlin.inf.dpp.exceptions.ModuleNotFoundException;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.intellij.filesystem.IntelliJProjectImpl;
 import de.fu_berlin.inf.dpp.intellij.ui.wizards.AddProjectToSessionWizard;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISessionListener;
 import java.io.IOException;
@@ -44,8 +46,11 @@ public class ModuleInitialization implements Startable {
       new ISessionListener() {
 
         @Override
-        public void resourcesAdded(IProject module) {
-          final ModuleReloader moduleReloader = new ModuleReloader(module);
+        public void resourcesAdded(IReferencePoint referencePoint) {
+          IReferencePointManager referencePointManager =
+              session.getComponent(IReferencePointManager.class);
+          final ModuleReloader moduleReloader =
+              new ModuleReloader(referencePointManager.get(referencePoint));
 
           // Registers a ModuleLoader with the AWT event dispatching thread to be executed
           // asynchronously.

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/tree/SessionTreeRootNode.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/tree/SessionTreeRootNode.java
@@ -31,9 +31,6 @@ public class SessionTreeRootNode extends DefaultMutableTreeNode {
   private final Map<User, DefaultMutableTreeNode> userNodeList =
       new HashMap<User, DefaultMutableTreeNode>();
   private final DefaultTreeModel treeModel;
-
-  @Inject private ISarosSessionManager sessionManager;
-
   private final ISessionListener sessionListener =
       new ISessionListener() {
         @Override
@@ -69,7 +66,6 @@ public class SessionTreeRootNode extends DefaultMutableTreeNode {
               });
         }
       };
-
   private final ISessionLifecycleListener sessionLifecycleListener =
       new ISessionLifecycleListener() {
         @Override
@@ -97,6 +93,7 @@ public class SessionTreeRootNode extends DefaultMutableTreeNode {
               });
         }
       };
+  @Inject private ISarosSessionManager sessionManager;
 
   public SessionTreeRootNode(SessionAndContactsTreeView treeView) {
     super(treeView);
@@ -154,10 +151,11 @@ public class SessionTreeRootNode extends DefaultMutableTreeNode {
       ISarosSession session = ((SessionInfo) nSession.getUserObject()).getSession();
 
       ProjectInfo projInfo;
-      if (session.isCompletelyShared(project)) {
+      if (session.isCompletelyShared(project.getReferencePoint())) {
         projInfo = new ProjectInfo(project);
       } else {
-        projInfo = new ProjectInfo(project, session.getSharedResources(project));
+        projInfo =
+            new ProjectInfo(project, session.getSharedResources(project.getReferencePoint()));
       }
 
       DefaultMutableTreeNode nProject = new DefaultMutableTreeNode(projInfo);

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/tree/SessionTreeRootNode.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/tree/SessionTreeRootNode.java
@@ -3,8 +3,10 @@ package de.fu_berlin.inf.dpp.intellij.ui.tree;
 import com.intellij.util.ui.UIUtil;
 import de.fu_berlin.inf.dpp.SarosPluginContext;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.intellij.ui.util.IconManager;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
 import de.fu_berlin.inf.dpp.session.ISessionLifecycleListener;
@@ -56,12 +58,14 @@ public class SessionTreeRootNode extends DefaultMutableTreeNode {
         }
 
         @Override
-        public void resourcesAdded(final IProject project) {
+        public void resourcesAdded(final IReferencePoint referencePoint) {
           UIUtil.invokeLaterIfNeeded(
               new Runnable() {
                 @Override
                 public void run() {
-                  addProjectNode(project);
+                  IReferencePointManager referencePointManager =
+                      sessionManager.getSession().getComponent(IReferencePointManager.class);
+                  addProjectNode(referencePointManager.get(referencePoint));
                 }
               });
         }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/wizards/AddProjectToSessionWizard.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/wizards/AddProjectToSessionWizard.java
@@ -40,6 +40,7 @@ import de.fu_berlin.inf.dpp.negotiation.NegotiationTools;
 import de.fu_berlin.inf.dpp.negotiation.ProjectNegotiation;
 import de.fu_berlin.inf.dpp.negotiation.ProjectNegotiationData;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
 import de.fu_berlin.inf.dpp.util.ThreadUtils;
@@ -608,9 +609,15 @@ public class AddProjectToSessionWizard extends Wizard {
 
         if (data.isPartial()) throw new IllegalStateException("partial sharing is not supported");
 
+        IReferencePointManager referencePointManager =
+            session.getComponent(IReferencePointManager.class);
+
+        fillReferencePointManager(project, referencePointManager);
+
         FileList localFileList =
             FileListFactory.createFileList(
-                project,
+                referencePointManager,
+                project.getReferencePoint(),
                 null,
                 checksumCache,
                 new SubProgressMonitor(monitor, 1, SubProgressMonitor.SUPPRESS_SETTASKNAME));
@@ -631,5 +638,11 @@ public class AddProjectToSessionWizard extends Wizard {
       }
     }
     return modifiedResources;
+  }
+
+  private void fillReferencePointManager(
+      de.fu_berlin.inf.dpp.filesystem.IProject project,
+      IReferencePointManager referencePointManager) {
+    referencePointManager.put(project.getReferencePoint(), project);
   }
 }

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/wizards/AddProjectToSessionWizard.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/wizards/AddProjectToSessionWizard.java
@@ -54,6 +54,7 @@ import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.picocontainer.annotations.Inject;
@@ -473,7 +474,14 @@ public class AddProjectToSessionWizard extends Wizard {
               @Override
               public void run(ProgressIndicator indicator) {
                 final ProjectNegotiation.Status status =
-                    negotiation.run(localProjects, new ProgessMonitorAdapter(indicator));
+                    negotiation.run(
+                        localProjects
+                            .entrySet()
+                            .stream()
+                            .collect(
+                                Collectors.toMap(
+                                    e -> e.getKey(), e -> e.getValue().getReferencePoint())),
+                        new ProgessMonitorAdapter(indicator));
 
                 indicator.stop();
 

--- a/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/wizards/AddProjectToSessionWizard.java
+++ b/de.fu_berlin.inf.dpp.intellij/src/de/fu_berlin/inf/dpp/intellij/ui/wizards/AddProjectToSessionWizard.java
@@ -404,7 +404,7 @@ public class AddProjectToSessionWizard extends Wizard {
 
     localProjects = new HashMap<String, IProject>();
 
-    remoteProjectID = data.get(0).getProjectID();
+    remoteProjectID = data.get(0).getReferencePointID();
     remoteProjectName = data.get(0).getProjectName();
 
     selectProjectPage =

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/ServerLifecycle.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/ServerLifecycle.java
@@ -6,7 +6,7 @@ import de.fu_berlin.inf.dpp.communication.connection.ConnectionHandler;
 import de.fu_berlin.inf.dpp.context.AbstractContextLifecycle;
 import de.fu_berlin.inf.dpp.context.ContainerContext;
 import de.fu_berlin.inf.dpp.context.IContextFactory;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
 import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
@@ -33,7 +33,7 @@ public class ServerLifecycle extends AbstractContextLifecycle {
     connectToXMPPServer(context);
     context
         .getComponent(ISarosSessionManager.class)
-        .startSession(new HashMap<IProject, List<IResource>>());
+        .startSessionWithReferencePoints(new HashMap<IReferencePoint, List<IResource>>());
   }
 
   @Override

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/ServerLifecycle.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/ServerLifecycle.java
@@ -33,7 +33,7 @@ public class ServerLifecycle extends AbstractContextLifecycle {
     connectToXMPPServer(context);
     context
         .getComponent(ISarosSessionManager.class)
-        .startSessionWithReferencePoints(new HashMap<IReferencePoint, List<IResource>>());
+        .startSession(new HashMap<IReferencePoint, List<IResource>>());
   }
 
   @Override

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/console/ShareCommand.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/console/ShareCommand.java
@@ -54,7 +54,7 @@ public class ShareCommand extends ConsoleCommand {
           log.error(path + " could not be added to the session", e);
         }
       }
-      sessionManager.addReferencePointResourcesToSession(referencePointResources);
+      sessionManager.addResourcesToSession(referencePointResources);
     } catch (Exception e) {
       log.error("Error sharing resources", e);
     }

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/console/ShareCommand.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/console/ShareCommand.java
@@ -1,6 +1,7 @@
 package de.fu_berlin.inf.dpp.server.console;
 
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 import de.fu_berlin.inf.dpp.server.filesystem.ServerProjectImpl;
@@ -44,16 +45,16 @@ public class ShareCommand extends ConsoleCommand {
     }
 
     try {
-      Map<IProject, List<IResource>> projects = new HashMap<>();
+      Map<IReferencePoint, List<IResource>> referencePointResources = new HashMap<>();
       for (String path : args) {
         try {
           IProject project = new ServerProjectImpl(this.workspace, path);
-          projects.put(project, null);
+          referencePointResources.put(project.getReferencePoint(), null);
         } catch (Exception e) {
           log.error(path + " could not be added to the session", e);
         }
       }
-      sessionManager.addResourcesToSession(projects);
+      sessionManager.addReferencePointResourcesToSession(referencePointResources);
     } catch (Exception e) {
       log.error("Error sharing resources", e);
     }

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/editor/ServerEditorManager.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/editor/ServerEditorManager.java
@@ -7,7 +7,7 @@ import de.fu_berlin.inf.dpp.editor.ISharedEditorListener;
 import de.fu_berlin.inf.dpp.editor.text.LineRange;
 import de.fu_berlin.inf.dpp.editor.text.TextSelection;
 import de.fu_berlin.inf.dpp.filesystem.IFile;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.session.User;
 import java.io.IOException;
@@ -53,7 +53,7 @@ public class ServerEditorManager implements IEditorManager {
   }
 
   @Override
-  public void saveEditors(IProject project) {
+  public void saveEditors(IReferencePoint referencePoint) {
     // do nothing?
     // we do not keep dirty editors,
     // because the LRUMap might close Editors at any time

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerResourceImpl.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerResourceImpl.java
@@ -3,8 +3,10 @@ package de.fu_berlin.inf.dpp.server.filesystem;
 import de.fu_berlin.inf.dpp.filesystem.IContainer;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
+import de.fu_berlin.inf.dpp.filesystem.ReferencePointImpl;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -16,6 +18,7 @@ public abstract class ServerResourceImpl implements IResource {
 
   private IWorkspace workspace;
   private IPath path;
+  private IReferencePoint referencePoint;
 
   /**
    * Creates a ServerResourceImpl.
@@ -26,6 +29,7 @@ public abstract class ServerResourceImpl implements IResource {
   public ServerResourceImpl(IWorkspace workspace, IPath path) {
     this.path = path;
     this.workspace = workspace;
+    this.referencePoint = new ReferencePointImpl(workspace.getLocation());
   }
 
   /**
@@ -122,5 +126,10 @@ public abstract class ServerResourceImpl implements IResource {
    */
   Path toNioPath() {
     return ((ServerPathImpl) getLocation()).getDelegate();
+  }
+
+  @Override
+  public IReferencePoint getReferencePoint() {
+    return referencePoint;
   }
 }

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerWorkspaceImpl.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerWorkspaceImpl.java
@@ -4,7 +4,6 @@ import de.fu_berlin.inf.dpp.exceptions.OperationCanceledException;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
-import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspaceRunnable;
 import de.fu_berlin.inf.dpp.monitoring.NullProgressMonitor;
@@ -42,7 +41,10 @@ public class ServerWorkspaceImpl implements IWorkspace {
   }
 
   @Override
-  public void run(IWorkspaceRunnable runnable, IResource[] resources)
+  public void run(
+      IWorkspaceRunnable runnable,
+      IReferencePoint[] referencePoints,
+      IReferencePointManager referencePointManager)
       throws IOException, OperationCanceledException {
 
     /*
@@ -51,15 +53,6 @@ public class ServerWorkspaceImpl implements IWorkspace {
     synchronized (this) {
       runnable.run(new NullProgressMonitor());
     }
-  }
-
-  @Override
-  public void run(
-      IWorkspaceRunnable runnable,
-      IReferencePoint[] referencePoints,
-      IReferencePointManager referencePointManager)
-      throws IOException, OperationCanceledException {
-    run(runnable, null);
   }
 
   @Override

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerWorkspaceImpl.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerWorkspaceImpl.java
@@ -38,7 +38,7 @@ public class ServerWorkspaceImpl implements IWorkspace {
   @Override
   public void run(IWorkspaceRunnable runnable) throws IOException, OperationCanceledException {
 
-    run(runnable, null);
+    run(runnable, null, null);
   }
 
   @Override

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerWorkspaceImpl.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/filesystem/ServerWorkspaceImpl.java
@@ -3,10 +3,12 @@ package de.fu_berlin.inf.dpp.server.filesystem;
 import de.fu_berlin.inf.dpp.exceptions.OperationCanceledException;
 import de.fu_berlin.inf.dpp.filesystem.IPath;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspace;
 import de.fu_berlin.inf.dpp.filesystem.IWorkspaceRunnable;
 import de.fu_berlin.inf.dpp.monitoring.NullProgressMonitor;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import java.io.IOException;
 
 /** Server implementation of the {@link IWorkspace} interface. */
@@ -49,5 +51,19 @@ public class ServerWorkspaceImpl implements IWorkspace {
     synchronized (this) {
       runnable.run(new NullProgressMonitor());
     }
+  }
+
+  @Override
+  public void run(
+      IWorkspaceRunnable runnable,
+      IReferencePoint[] referencePoints,
+      IReferencePointManager referencePointManager)
+      throws IOException, OperationCanceledException {
+    run(runnable, null);
+  }
+
+  @Override
+  public IReferencePoint getReferencePoint(String projectName) {
+    return getProject(projectName).getReferencePoint();
   }
 }

--- a/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/session/NegotiationHandler.java
+++ b/de.fu_berlin.inf.dpp.server/src/de/fu_berlin/inf/dpp/server/session/NegotiationHandler.java
@@ -1,6 +1,6 @@
 package de.fu_berlin.inf.dpp.server.session;
 
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.monitoring.NullProgressMonitor;
 import de.fu_berlin.inf.dpp.negotiation.AbstractIncomingProjectNegotiation;
 import de.fu_berlin.inf.dpp.negotiation.AbstractOutgoingProjectNegotiation;
@@ -153,7 +153,7 @@ public class NegotiationHandler implements INegotiationHandler {
             negotiation.localCancel(
                 "Server does not accept incoming projects",
                 NegotiationTools.CancelOption.NOTIFY_PEER);
-            negotiation.run(new HashMap<String, IProject>(), new NullProgressMonitor());
+            negotiation.run(new HashMap<String, IReferencePoint>(), new NullProgressMonitor());
           }
         });
   }

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/editor/EditorManager.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/editor/EditorManager.java
@@ -25,7 +25,6 @@ import de.fu_berlin.inf.dpp.editor.remote.UserEditorStateManager;
 import de.fu_berlin.inf.dpp.editor.text.LineRange;
 import de.fu_berlin.inf.dpp.editor.text.TextSelection;
 import de.fu_berlin.inf.dpp.filesystem.EclipseFileImpl;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
 import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.ResourceAdapterFactory;
 import de.fu_berlin.inf.dpp.observables.FileReplacementInProgressObservable;
@@ -1396,7 +1395,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
   }
 
   @Override
-  public void saveEditors(final IProject project) {
+  public void saveEditors(final IReferencePoint referencePoint) {
     SWTUtils.runSafeSWTSync(
         LOG,
         new Runnable() {
@@ -1415,7 +1414,8 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
             editorPaths.addAll(openEditorPaths);
 
             for (final SPath path : editorPaths) {
-              if (project == null || project.equals(path.getProject())) saveLazy(path);
+              if (referencePoint == null
+                  || referencePoint.equals(path.getProject().getReferencePoint())) saveLazy(path);
             }
           }
         });

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/editor/EditorManager.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/editor/EditorManager.java
@@ -26,6 +26,7 @@ import de.fu_berlin.inf.dpp.editor.text.LineRange;
 import de.fu_berlin.inf.dpp.editor.text.TextSelection;
 import de.fu_berlin.inf.dpp.filesystem.EclipseFileImpl;
 import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.ResourceAdapterFactory;
 import de.fu_berlin.inf.dpp.observables.FileReplacementInProgressObservable;
 import de.fu_berlin.inf.dpp.session.AbstractActivityConsumer;
@@ -321,7 +322,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
         }
 
         @Override
-        public void resourcesAdded(IProject project) {
+        public void resourcesAdded(IReferencePoint referencePoint) {
           SWTUtils.runSafeSWTSync(
               LOG,
               new Runnable() {

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/feedback/ProjectCollector.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/feedback/ProjectCollector.java
@@ -1,7 +1,7 @@
 package de.fu_berlin.inf.dpp.feedback;
 
 import de.fu_berlin.inf.dpp.annotations.Component;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.IResource;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISessionListener;
@@ -29,8 +29,8 @@ public class ProjectCollector extends AbstractStatisticCollector {
   private final ISessionListener sessionListener =
       new ISessionListener() {
         @Override
-        public void resourcesAdded(IProject project) {
-          String referencePointID = sarosSession.getReferencePointID(project.getReferencePoint());
+        public void resourcesAdded(IReferencePoint referencePoint) {
+          String referencePointID = sarosSession.getReferencePointID(referencePoint);
 
           ProjectInformation info = sharedProjects.get(referencePointID);
 
@@ -39,7 +39,7 @@ public class ProjectCollector extends AbstractStatisticCollector {
             sharedProjects.put(referencePointID, info);
           }
 
-          boolean isPartial = !sarosSession.isCompletelyShared(project.getReferencePoint());
+          boolean isPartial = !sarosSession.isCompletelyShared(referencePoint);
 
           /*
            * ignore partial shared projects that were upgraded to full shared
@@ -47,8 +47,7 @@ public class ProjectCollector extends AbstractStatisticCollector {
            */
           if (!info.isPartial && isPartial) info.isPartial = true;
 
-          List<IResource> sharedResources =
-              sarosSession.getSharedResources(project.getReferencePoint());
+          List<IResource> sharedResources = sarosSession.getSharedResources(referencePoint);
 
           if (sharedResources != null) {
             for (Iterator<IResource> it = sharedResources.iterator(); it.hasNext(); ) {

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/feedback/ProjectCollector.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/feedback/ProjectCollector.java
@@ -24,29 +24,22 @@ public class ProjectCollector extends AbstractStatisticCollector {
   private static final String KEY_PARTIAL_SHARED_PROJECTS = "session.shared.project.partial.count";
   private static final String KEY_PARTIAL_SHARED_PROJECTS_FILES =
       "session.shared.project.partial.files.count";
-
-  private static class ProjectInformation {
-    public boolean isPartial;
-    public int files;
-  }
-
   private final Map<String, ProjectInformation> sharedProjects =
       new HashMap<String, ProjectInformation>();
-
   private final ISessionListener sessionListener =
       new ISessionListener() {
         @Override
         public void resourcesAdded(IProject project) {
-          String projectID = sarosSession.getProjectID(project);
+          String referencePointID = sarosSession.getReferencePointID(project.getReferencePoint());
 
-          ProjectInformation info = sharedProjects.get(projectID);
+          ProjectInformation info = sharedProjects.get(referencePointID);
 
           if (info == null) {
             info = new ProjectInformation();
-            sharedProjects.put(projectID, info);
+            sharedProjects.put(referencePointID, info);
           }
 
-          boolean isPartial = !sarosSession.isCompletelyShared(project);
+          boolean isPartial = !sarosSession.isCompletelyShared(project.getReferencePoint());
 
           /*
            * ignore partial shared projects that were upgraded to full shared
@@ -54,7 +47,8 @@ public class ProjectCollector extends AbstractStatisticCollector {
            */
           if (!info.isPartial && isPartial) info.isPartial = true;
 
-          List<IResource> sharedResources = sarosSession.getSharedResources(project);
+          List<IResource> sharedResources =
+              sarosSession.getSharedResources(project.getReferencePoint());
 
           if (sharedResources != null) {
             for (Iterator<IResource> it = sharedResources.iterator(); it.hasNext(); ) {
@@ -99,5 +93,10 @@ public class ProjectCollector extends AbstractStatisticCollector {
   @Override
   protected void doOnSessionEnd(ISarosSession sarosSession) {
     sarosSession.removeListener(sessionListener);
+  }
+
+  private static class ProjectInformation {
+    public boolean isPartial;
+    public int files;
   }
 }

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/EclipseResourceImpl.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/EclipseResourceImpl.java
@@ -7,11 +7,15 @@ import org.eclipse.core.runtime.OperationCanceledException;
 public class EclipseResourceImpl implements IResource {
 
   protected final org.eclipse.core.resources.IResource delegate;
+  protected IReferencePoint referencePoint;
 
   EclipseResourceImpl(org.eclipse.core.resources.IResource delegate) {
     if (delegate == null) throw new NullPointerException("delegate is null");
 
     this.delegate = delegate;
+    if (delegate.getProject() != null)
+      this.referencePoint =
+          new ReferencePointImpl(new EclipsePathImpl(delegate.getProject().getFullPath()));
   }
 
   @Override
@@ -173,5 +177,10 @@ public class EclipseResourceImpl implements IResource {
   @Override
   public String toString() {
     return delegate.toString() + " (" + getClass().getSimpleName() + ")";
+  }
+
+  @Override
+  public IReferencePoint getReferencePoint() {
+    return referencePoint;
   }
 }

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/EclipseWorkspaceImpl.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/EclipseWorkspaceImpl.java
@@ -7,7 +7,6 @@ import de.fu_berlin.inf.dpp.monitoring.ProgressMonitorAdapterFactory;
 import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
@@ -76,7 +75,10 @@ public class EclipseWorkspaceImpl implements IWorkspace {
   }
 
   @Override
-  public void run(IWorkspaceRunnable runnable, IResource[] resources)
+  public void run(
+      IWorkspaceRunnable runnable,
+      IReferencePoint[] referencePoints,
+      IReferencePointManager referencePointManager)
       throws IOException, OperationCanceledException {
 
     final org.eclipse.core.resources.IWorkspaceRunnable eclipseRunnable;
@@ -91,9 +93,14 @@ public class EclipseWorkspaceImpl implements IWorkspace {
       eclipseRunnable = new EclipseRunnableAdapter(runnable);
     }
 
-    final List<org.eclipse.core.resources.IResource> eclipseResources =
-        ResourceAdapterFactory.convertBack(resources != null ? Arrays.asList(resources) : null);
+    List<org.eclipse.core.resources.IResource> eclipseResources = null;
 
+    if (referencePoints != null) {
+      eclipseResources = new ArrayList<>();
+      for (IReferencePoint referencePoint : referencePoints)
+        eclipseResources.add(
+            ResourceAdapterFactory.convertBack(referencePointManager.get(referencePoint)));
+    }
     final ISchedulingRule schedulingRule;
 
     if (eclipseResources != null && !eclipseResources.isEmpty()) {
@@ -118,24 +125,6 @@ public class EclipseWorkspaceImpl implements IWorkspace {
 
       throw new OperationCanceledException(e);
     }
-  }
-
-  @Override
-  public void run(
-      IWorkspaceRunnable runnable,
-      IReferencePoint[] referencePoints,
-      IReferencePointManager referencePointManager)
-      throws IOException, OperationCanceledException {
-
-    IResource[] resources = null;
-
-    if (referencePoints != null) {
-      resources = new IResource[referencePoints.length];
-      for (int i = 0; i < referencePoints.length; i++) {
-        resources[i] = referencePointManager.get(referencePoints[i]);
-      }
-    }
-    run(runnable, resources);
   }
 
   @Override

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/EclipseWorkspaceImpl.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/EclipseWorkspaceImpl.java
@@ -72,7 +72,7 @@ public class EclipseWorkspaceImpl implements IWorkspace {
   @Override
   public void run(final IWorkspaceRunnable runnable)
       throws IOException, OperationCanceledException {
-    run(runnable, null);
+    run(runnable, null, null);
   }
 
   @Override

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/EclipseWorkspaceImpl.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/filesystem/EclipseWorkspaceImpl.java
@@ -4,7 +4,9 @@ import de.fu_berlin.inf.dpp.Saros;
 import de.fu_berlin.inf.dpp.exceptions.OperationCanceledException;
 import de.fu_berlin.inf.dpp.monitoring.IProgressMonitor;
 import de.fu_berlin.inf.dpp.monitoring.ProgressMonitorAdapterFactory;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.eclipse.core.runtime.CoreException;
@@ -119,8 +121,31 @@ public class EclipseWorkspaceImpl implements IWorkspace {
   }
 
   @Override
+  public void run(
+      IWorkspaceRunnable runnable,
+      IReferencePoint[] referencePoints,
+      IReferencePointManager referencePointManager)
+      throws IOException, OperationCanceledException {
+
+    IResource[] resources = null;
+
+    if (referencePoints != null) {
+      resources = new IResource[referencePoints.length];
+      for (int i = 0; i < referencePoints.length; i++) {
+        resources[i] = referencePointManager.get(referencePoints[i]);
+      }
+    }
+    run(runnable, resources);
+  }
+
+  @Override
   public IProject getProject(String project) {
     return ResourceAdapterFactory.create(delegate.getRoot().getProject(project));
+  }
+
+  @Override
+  public IReferencePoint getReferencePoint(String projectName) {
+    return getProject(projectName).getReferencePoint();
   }
 
   @Override

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/project/SharedResourcesManager.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/project/SharedResourcesManager.java
@@ -4,9 +4,11 @@ import de.fu_berlin.inf.dpp.activities.IActivity;
 import de.fu_berlin.inf.dpp.activities.IResourceActivity;
 import de.fu_berlin.inf.dpp.annotations.Component;
 import de.fu_berlin.inf.dpp.editor.EditorManager;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.ResourceAdapterFactory;
 import de.fu_berlin.inf.dpp.observables.FileReplacementInProgressObservable;
 import de.fu_berlin.inf.dpp.session.AbstractActivityProducer;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISessionListener;
 import de.fu_berlin.inf.dpp.synchronize.Blockable;
@@ -86,21 +88,30 @@ public class SharedResourcesManager extends AbstractActivityProducer
   /** map that holds the current open or closed state for every shared project */
   private final Map<IProject, Boolean> projectStates = new HashMap<IProject, Boolean>();
 
+  /** maps IReferencePoint objects to IProject objects * */
+  private IReferencePointManager referencePointManager;
+
   private final ISessionListener sessionListener =
       new ISessionListener() {
 
         @Override
-        public void projectAdded(de.fu_berlin.inf.dpp.filesystem.IProject project) {
+        public void projectAdded(IReferencePoint referencePoint) {
           synchronized (projectStates) {
-            IProject eclipseProject = (IProject) ResourceAdapterFactory.convertBack(project);
+            referencePointManager = sarosSession.getComponent(IReferencePointManager.class);
+            IProject eclipseProject =
+                (IProject)
+                    ResourceAdapterFactory.convertBack(referencePointManager.get(referencePoint));
             projectStates.put(eclipseProject, eclipseProject.isOpen());
           }
         }
 
         @Override
-        public void projectRemoved(de.fu_berlin.inf.dpp.filesystem.IProject project) {
+        public void projectRemoved(IReferencePoint referencePoint) {
           synchronized (projectStates) {
-            IProject eclipseProject = (IProject) ResourceAdapterFactory.convertBack(project);
+            referencePointManager = sarosSession.getComponent(IReferencePointManager.class);
+            IProject eclipseProject =
+                (IProject)
+                    ResourceAdapterFactory.convertBack(referencePointManager.get(referencePoint));
             projectStates.remove(eclipseProject);
           }
         }

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/decorators/SharedProjectDecorator.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/decorators/SharedProjectDecorator.java
@@ -56,9 +56,7 @@ public final class SharedProjectDecorator implements ILightweightLabelDecorator 
       new CopyOnWriteArrayList<ILabelProviderListener>();
 
   @Inject private ISarosSessionManager sessionManager;
-
   private volatile ISarosSession session;
-
   private final ISessionLifecycleListener sessionLifecycleListener =
       new ISessionLifecycleListener() {
 
@@ -112,7 +110,8 @@ public final class SharedProjectDecorator implements ILightweightLabelDecorator 
 
     if (resource.getType() == IResource.PROJECT) {
       boolean isCompletelyShared =
-          currentSession.isCompletelyShared(ResourceAdapterFactory.create(resource.getProject()));
+          currentSession.isCompletelyShared(
+              ResourceAdapterFactory.create(resource).getReferencePoint());
 
       decoration.addSuffix(
           isCompletelyShared

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/decorators/SharedProjectDecorator.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/decorators/SharedProjectDecorator.java
@@ -2,7 +2,7 @@ package de.fu_berlin.inf.dpp.ui.decorators;
 
 import de.fu_berlin.inf.dpp.SarosPluginContext;
 import de.fu_berlin.inf.dpp.annotations.Component;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.ResourceAdapterFactory;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
@@ -78,7 +78,7 @@ public final class SharedProjectDecorator implements ILightweightLabelDecorator 
   private final ISessionListener sessionListener =
       new ISessionListener() {
         @Override
-        public void resourcesAdded(IProject project) {
+        public void resourcesAdded(IReferencePoint referencePoint) {
           LOG.debug("updating project decoration for all shared projects");
           updateDecoratorsAsync(null); // update all labels
         }

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/eventhandler/SessionStatusRequestHandler.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/eventhandler/SessionStatusRequestHandler.java
@@ -7,6 +7,7 @@ import de.fu_berlin.inf.dpp.net.IReceiver;
 import de.fu_berlin.inf.dpp.net.ITransmitter;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
 import de.fu_berlin.inf.dpp.preferences.EclipsePreferenceConstants;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
 import de.fu_berlin.inf.dpp.ui.util.SWTUtils;
@@ -27,6 +28,8 @@ public final class SessionStatusRequestHandler {
   private final ITransmitter transmitter;
 
   private final IPreferenceStore preferenceStore;
+
+  private IReferencePointManager referencePointManager;
 
   private final PacketListener statusRequestListener =
       new PacketListener() {
@@ -73,6 +76,8 @@ public final class SessionStatusRequestHandler {
       // Don't count the server
       int participants = session.getUsers().size() - 1;
 
+      this.referencePointManager = session.getComponent(IReferencePointManager.class);
+
       response = new SessionStatusResponseExtension(participants, getSessionDescription(session));
     }
 
@@ -82,14 +87,14 @@ public final class SessionStatusRequestHandler {
   private String getSessionDescription(ISarosSession session) {
     String description = "Projects: ";
 
-    Set<IProject> projects = session.getProjects();
+    Set<IProject> projects = referencePointManager.getProjects(session.getReferencePoints());
     int i = 0;
     int numOfProjects = projects.size();
 
     for (IProject project : projects) {
       description += project.getName();
 
-      if (!session.isCompletelyShared(project)) description += " (partial)";
+      if (!session.isCompletelyShared(project.getReferencePoint())) description += " (partial)";
 
       if (i < numOfProjects - 1) description += ", ";
 

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/expressions/ProjectPropertyTester.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/expressions/ProjectPropertyTester.java
@@ -35,7 +35,8 @@ public class ProjectPropertyTester extends PropertyTester {
     if ("isInSarosSession".equals(property)) {
 
       if (resource.getType() == IResource.PROJECT) {
-        return session.isCompletelyShared(ResourceAdapterFactory.create((IProject) resource));
+        return session.isCompletelyShared(
+            ResourceAdapterFactory.create((IProject) resource).getReferencePoint());
       }
 
       return session.isShared(ResourceAdapterFactory.create(resource));

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/util/CollaborationUtils.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/util/CollaborationUtils.java
@@ -5,6 +5,7 @@ import de.fu_berlin.inf.dpp.SarosPluginContext;
 import de.fu_berlin.inf.dpp.filesystem.EclipseProjectImpl;
 import de.fu_berlin.inf.dpp.filesystem.ResourceAdapterFactory;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
 import de.fu_berlin.inf.dpp.session.SessionEndReason;
@@ -52,6 +53,8 @@ public class CollaborationUtils {
 
   @Inject private static ISarosSessionManager sessionManager;
 
+  private static IReferencePointManager referencePointManager;
+
   static {
     SarosPluginContext.initComponent(new CollaborationUtils());
   }
@@ -87,6 +90,8 @@ public class CollaborationUtils {
               ISarosSession session = sessionManager.getSession();
 
               if (session == null) return Status.CANCEL_STATUS;
+
+              referencePointManager = session.getComponent(IReferencePointManager.class);
 
               sessionManager.invite(participantsToAdd, getSessionDescription(session));
 
@@ -256,7 +261,8 @@ public class CollaborationUtils {
    */
   private static String getSessionDescription(ISarosSession sarosSession) {
 
-    final Set<de.fu_berlin.inf.dpp.filesystem.IProject> projects = sarosSession.getProjects();
+    Set<de.fu_berlin.inf.dpp.filesystem.IProject> projects =
+        referencePointManager.getProjects(sarosSession.getReferencePoints());
 
     final StringBuilder result = new StringBuilder();
 
@@ -264,13 +270,17 @@ public class CollaborationUtils {
 
       final Pair<Long, Long> fileCountAndSize;
 
-      final boolean isCompletelyShared = sarosSession.isCompletelyShared(project);
+      final boolean isCompletelyShared =
+          sarosSession.isCompletelyShared(project.getReferencePoint());
 
       final List<IResource> resources;
 
       if (isCompletelyShared)
         resources = Collections.singletonList(((EclipseProjectImpl) project).getDelegate());
-      else resources = ResourceAdapterFactory.convertBack(sarosSession.getSharedResources(project));
+      else
+        resources =
+            ResourceAdapterFactory.convertBack(
+                sarosSession.getSharedResources(project.getReferencePoint()));
 
       fileCountAndSize =
           FileUtils.getFileCountAndSize(

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/util/CollaborationUtils.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/util/CollaborationUtils.java
@@ -84,7 +84,7 @@ public class CollaborationUtils {
 
             try {
               refreshProjects(newResources.keySet(), null);
-              sessionManager.startSession(convert(newResources));
+              sessionManager.startSessionWithReferencePoints(convert(newResources));
               Set<JID> participantsToAdd = new HashSet<JID>(contacts);
 
               ISarosSession session = sessionManager.getSession();
@@ -212,7 +212,7 @@ public class CollaborationUtils {
                */
             }
 
-            sessionManager.addResourcesToSession(convert(projectResources));
+            sessionManager.addReferencePointResourcesToSession(convert(projectResources));
           }
         });
   }
@@ -443,18 +443,21 @@ public class CollaborationUtils {
   }
 
   private static Map<
-          de.fu_berlin.inf.dpp.filesystem.IProject, List<de.fu_berlin.inf.dpp.filesystem.IResource>>
+          de.fu_berlin.inf.dpp.filesystem.IReferencePoint,
+          List<de.fu_berlin.inf.dpp.filesystem.IResource>>
       convert(Map<IProject, List<IResource>> data) {
 
-    Map<de.fu_berlin.inf.dpp.filesystem.IProject, List<de.fu_berlin.inf.dpp.filesystem.IResource>>
+    Map<
+            de.fu_berlin.inf.dpp.filesystem.IReferencePoint,
+            List<de.fu_berlin.inf.dpp.filesystem.IResource>>
         result =
             new HashMap<
-                de.fu_berlin.inf.dpp.filesystem.IProject,
+                de.fu_berlin.inf.dpp.filesystem.IReferencePoint,
                 List<de.fu_berlin.inf.dpp.filesystem.IResource>>();
 
     for (Entry<IProject, List<IResource>> entry : data.entrySet())
       result.put(
-          ResourceAdapterFactory.create(entry.getKey()),
+          ResourceAdapterFactory.create(entry.getKey()).getReferencePoint(),
           ResourceAdapterFactory.convertTo(entry.getValue()));
 
     return result;

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/util/CollaborationUtils.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/util/CollaborationUtils.java
@@ -84,7 +84,7 @@ public class CollaborationUtils {
 
             try {
               refreshProjects(newResources.keySet(), null);
-              sessionManager.startSessionWithReferencePoints(convert(newResources));
+              sessionManager.startSession(convert(newResources));
               Set<JID> participantsToAdd = new HashSet<JID>(contacts);
 
               ISarosSession session = sessionManager.getSession();
@@ -212,7 +212,7 @@ public class CollaborationUtils {
                */
             }
 
-            sessionManager.addReferencePointResourcesToSession(convert(projectResources));
+            sessionManager.addResourcesToSession(convert(projectResources));
           }
         });
   }

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/widgets/viewer/project/BaseResourceSelectionComposite.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/widgets/viewer/project/BaseResourceSelectionComposite.java
@@ -476,7 +476,7 @@ public abstract class BaseResourceSelectionComposite extends ViewerComposite<Che
               return !sarosSession.isShared(ResourceAdapterFactory.create((IResource) element));
             } else if (element instanceof IProject) {
               return !(sarosSession.isCompletelyShared(
-                  ResourceAdapterFactory.create((IProject) element)));
+                  ResourceAdapterFactory.create((IProject) element).getReferencePoint()));
             }
           }
           return true;

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/widgets/viewer/session/SessionDisplayComposite.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/widgets/viewer/session/SessionDisplayComposite.java
@@ -2,7 +2,7 @@ package de.fu_berlin.inf.dpp.ui.widgets.viewer.session;
 
 import de.fu_berlin.inf.dpp.SarosPluginContext;
 import de.fu_berlin.inf.dpp.editor.EditorManager;
-import de.fu_berlin.inf.dpp.filesystem.IProject;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
 import de.fu_berlin.inf.dpp.session.ISessionLifecycleListener;
@@ -57,7 +57,7 @@ public abstract class SessionDisplayComposite extends ViewerComposite<TreeViewer
   private final ISessionListener sessionListener =
       new ISessionListener() {
         @Override
-        public void resourcesAdded(IProject project) {
+        public void resourcesAdded(IReferencePoint referencePoint) {
           ViewerUtils.refresh(getViewer(), true);
         }
       };

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/wizards/AddProjectToSessionWizard.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/wizards/AddProjectToSessionWizard.java
@@ -4,6 +4,7 @@ import de.fu_berlin.inf.dpp.Saros;
 import de.fu_berlin.inf.dpp.SarosPluginContext;
 import de.fu_berlin.inf.dpp.editor.internal.EditorAPI;
 import de.fu_berlin.inf.dpp.filesystem.IChecksumCache;
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.filesystem.ResourceAdapterFactory;
 import de.fu_berlin.inf.dpp.monitoring.ProgressMonitorAdapterFactory;
 import de.fu_berlin.inf.dpp.negotiation.AbstractIncomingProjectNegotiation;
@@ -305,8 +306,8 @@ public class AddProjectToSessionWizard extends Wizard {
                 }
               }
 
-              final Map<String, de.fu_berlin.inf.dpp.filesystem.IProject> convertedMapping =
-                  new HashMap<String, de.fu_berlin.inf.dpp.filesystem.IProject>();
+              final Map<String, de.fu_berlin.inf.dpp.filesystem.IReferencePoint> convertedMapping =
+                  new HashMap<String, IReferencePoint>();
 
               IReferencePointManager referencePointManager =
                   sessionManager.getSession().getComponent(IReferencePointManager.class);
@@ -315,7 +316,7 @@ public class AddProjectToSessionWizard extends Wizard {
                 de.fu_berlin.inf.dpp.filesystem.IProject coreProject =
                     ResourceAdapterFactory.create(entry.getValue());
                 fillReferencePointManager(coreProject, referencePointManager);
-                convertedMapping.put(entry.getKey(), coreProject);
+                convertedMapping.put(entry.getKey(), coreProject.getReferencePoint());
               }
 
               final ProjectNegotiation.Status status =

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/wizards/AddProjectToSessionWizard.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/wizards/AddProjectToSessionWizard.java
@@ -19,6 +19,7 @@ import de.fu_berlin.inf.dpp.negotiation.ProjectNegotiationData;
 import de.fu_berlin.inf.dpp.net.IConnectionManager;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
 import de.fu_berlin.inf.dpp.preferences.Preferences;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.session.ISarosSessionManager;
 import de.fu_berlin.inf.dpp.ui.Messages;
@@ -307,9 +308,14 @@ public class AddProjectToSessionWizard extends Wizard {
               final Map<String, de.fu_berlin.inf.dpp.filesystem.IProject> convertedMapping =
                   new HashMap<String, de.fu_berlin.inf.dpp.filesystem.IProject>();
 
+              IReferencePointManager referencePointManager =
+                  sessionManager.getSession().getComponent(IReferencePointManager.class);
+
               for (final Entry<String, IProject> entry : targetProjectMapping.entrySet()) {
-                convertedMapping.put(
-                    entry.getKey(), ResourceAdapterFactory.create(entry.getValue()));
+                de.fu_berlin.inf.dpp.filesystem.IProject coreProject =
+                    ResourceAdapterFactory.create(entry.getValue());
+                fillReferencePointManager(coreProject, referencePointManager);
+                convertedMapping.put(entry.getKey(), coreProject);
               }
 
               final ProjectNegotiation.Status status =
@@ -556,9 +562,15 @@ public class AddProjectToSessionWizard extends Wizard {
        */
 
       try {
+        IReferencePointManager referencePointManager =
+            session.getComponent(IReferencePointManager.class);
+
+        fillReferencePointManager(adaptedProject, referencePointManager);
+
         localFileList =
             FileListFactory.createFileList(
-                adaptedProject,
+                referencePointManager,
+                adaptedProject.getReferencePoint(),
                 null,
                 checksumCache,
                 ProgressMonitorAdapterFactory.convert(
@@ -662,5 +674,11 @@ public class AddProjectToSessionWizard extends Wizard {
     if (proceed) {
       for (IEditorPart editor : dirtyEditors) editor.doSave(new NullProgressMonitor());
     }
+  }
+
+  private void fillReferencePointManager(
+      de.fu_berlin.inf.dpp.filesystem.IProject project,
+      IReferencePointManager referencePointManager) {
+    referencePointManager.put(project.getReferencePoint(), project);
   }
 }

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/wizards/AddProjectToSessionWizard.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/wizards/AddProjectToSessionWizard.java
@@ -626,7 +626,7 @@ public class AddProjectToSessionWizard extends Wizard {
     final Map<String, IProject> result = new HashMap<String, IProject>();
 
     for (final ProjectNegotiationData data : negotiation.getProjectNegotiationData()) {
-      final String projectID = data.getProjectID();
+      final String projectID = data.getReferencePointID();
 
       result.put(
           projectID,

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/wizards/pages/EnterProjectNamePage.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/wizards/pages/EnterProjectNamePage.java
@@ -4,6 +4,7 @@ import de.fu_berlin.inf.dpp.negotiation.ProjectNegotiationData;
 import de.fu_berlin.inf.dpp.net.IConnectionManager;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
 import de.fu_berlin.inf.dpp.preferences.Preferences;
+import de.fu_berlin.inf.dpp.session.IReferencePointManager;
 import de.fu_berlin.inf.dpp.session.ISarosSession;
 import de.fu_berlin.inf.dpp.ui.ImageManager;
 import de.fu_berlin.inf.dpp.ui.Messages;
@@ -55,17 +56,14 @@ public class EnterProjectNamePage extends WizardPage {
   private final Map<String, String> remoteProjectMapping;
   private final Map<String, ProjectOptionComposite> projectOptionComposites =
       new HashMap<String, ProjectOptionComposite>();
-
+  private final Set<String> unsupportedCharsets = new HashSet<String>();
   /** Map containing the current error messages for every project id. */
   private Map<String, String> currentErrors = new HashMap<String, String>();
 
   private IConnectionManager connectionManager;
-
   private Preferences preferences;
-
   private boolean flashState;
-
-  private final Set<String> unsupportedCharsets = new HashSet<String>();
+  private IReferencePointManager referencePointManager;
 
   public EnterProjectNamePage(
       ISarosSession session,
@@ -79,6 +77,8 @@ public class EnterProjectNamePage extends WizardPage {
     this.connectionManager = connectionManager;
     this.preferences = preferences;
     this.peer = peer;
+
+    this.referencePointManager = session.getComponent(IReferencePointManager.class);
 
     remoteProjectMapping = new HashMap<String, String>();
 
@@ -353,7 +353,8 @@ public class EnterProjectNamePage extends WizardPage {
       String projectID = entry.getKey();
       ProjectOptionComposite projectOptionComposite = entry.getValue();
 
-      de.fu_berlin.inf.dpp.filesystem.IProject project = session.getProject(projectID);
+      de.fu_berlin.inf.dpp.filesystem.IProject project =
+          referencePointManager.get(session.getReferencePoint(projectID));
 
       if (project == null) continue;
 
@@ -367,7 +368,8 @@ public class EnterProjectNamePage extends WizardPage {
       String projectID = entry.getKey();
       ProjectOptionComposite projectOptionComposite = entry.getValue();
 
-      de.fu_berlin.inf.dpp.filesystem.IProject project = session.getProject(projectID);
+      de.fu_berlin.inf.dpp.filesystem.IProject project =
+          referencePointManager.get(session.getReferencePoint(projectID));
 
       if (project != null) continue;
 

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/wizards/pages/EnterProjectNamePage.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/wizards/pages/EnterProjectNamePage.java
@@ -1,5 +1,6 @@
 package de.fu_berlin.inf.dpp.ui.wizards.pages;
 
+import de.fu_berlin.inf.dpp.filesystem.IReferencePoint;
 import de.fu_berlin.inf.dpp.negotiation.ProjectNegotiationData;
 import de.fu_berlin.inf.dpp.net.IConnectionManager;
 import de.fu_berlin.inf.dpp.net.xmpp.JID;
@@ -350,13 +351,14 @@ public class EnterProjectNamePage extends WizardPage {
 
     for (Entry<String, ProjectOptionComposite> entry : projectOptionComposites.entrySet()) {
 
-      String projectID = entry.getKey();
+      String referencePointID = entry.getKey();
       ProjectOptionComposite projectOptionComposite = entry.getValue();
 
-      de.fu_berlin.inf.dpp.filesystem.IProject project =
-          referencePointManager.get(session.getReferencePoint(projectID));
+      IReferencePoint referencePoint = session.getReferencePoint(referencePointID);
 
-      if (project == null) continue;
+      if (referencePoint == null) continue;
+
+      de.fu_berlin.inf.dpp.filesystem.IProject project = referencePointManager.get(referencePoint);
 
       projectOptionComposite.setProjectName(true, project.getName());
       projectOptionComposite.setEnabled(false);
@@ -365,17 +367,17 @@ public class EnterProjectNamePage extends WizardPage {
 
     for (Entry<String, ProjectOptionComposite> entry : projectOptionComposites.entrySet()) {
 
-      String projectID = entry.getKey();
+      String referencePointID = entry.getKey();
       ProjectOptionComposite projectOptionComposite = entry.getValue();
 
-      de.fu_berlin.inf.dpp.filesystem.IProject project =
-          referencePointManager.get(session.getReferencePoint(projectID));
+      IReferencePoint referencePoint = session.getReferencePoint(referencePointID);
 
-      if (project != null) continue;
+      if (referencePoint != null) continue;
 
       String projectNameProposal =
           findProjectNameProposal(
-              remoteProjectMapping.get(projectID), reservedProjectNames.toArray(new String[0]));
+              remoteProjectMapping.get(referencePointID),
+              reservedProjectNames.toArray(new String[0]));
 
       projectOptionComposite.setProjectName(false, projectNameProposal);
       reservedProjectNames.add(projectNameProposal);

--- a/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/wizards/pages/EnterProjectNamePage.java
+++ b/de.fu_berlin.inf.dpp/src/de/fu_berlin/inf/dpp/ui/wizards/pages/EnterProjectNamePage.java
@@ -84,7 +84,7 @@ public class EnterProjectNamePage extends WizardPage {
 
     for (final ProjectNegotiationData data : projectNegotiationData) {
 
-      remoteProjectMapping.put(data.getProjectID(), data.getProjectName());
+      remoteProjectMapping.put(data.getReferencePointID(), data.getProjectName());
 
       unsupportedCharsets.addAll(getUnsupportedCharsets(data.getFileList().getEncodings()));
     }

--- a/de.fu_berlin.inf.dpp/test/junit/de/fu_berlin/inf/dpp/filesystem/IResourceTest.java
+++ b/de.fu_berlin.inf.dpp/test/junit/de/fu_berlin/inf/dpp/filesystem/IResourceTest.java
@@ -13,6 +13,11 @@ public class IResourceTest {
     org.eclipse.core.resources.IFolder folder =
         EasyMock.createMock(org.eclipse.core.resources.IFolder.class);
 
+    org.eclipse.core.resources.IProject project =
+        EasyMock.createMock(org.eclipse.core.resources.IProject.class);
+
+    org.eclipse.core.runtime.IPath path = EasyMock.createMock(org.eclipse.core.runtime.IPath.class);
+
     Capture<Class<Object>> mappedAdapterClassCapture = new Capture<Class<Object>>();
 
     EasyMock.expect(folder.getAdapter(EasyMock.capture(mappedAdapterClassCapture)))
@@ -20,7 +25,11 @@ public class IResourceTest {
 
     EasyMock.expect(folder.getType()).andStubReturn(org.eclipse.core.resources.IResource.FOLDER);
 
-    EasyMock.replay(folder);
+    EasyMock.expect(folder.getProject()).andStubReturn(project);
+
+    EasyMock.expect(project.getFullPath()).andStubReturn(path);
+
+    EasyMock.replay(folder, project, path);
 
     final IFolder coreFolder = new EclipseFolderImpl(folder);
 

--- a/de.fu_berlin.inf.dpp/test/junit/de/fu_berlin/inf/dpp/project/FileActivityConsumerTest.java
+++ b/de.fu_berlin.inf.dpp/test/junit/de/fu_berlin/inf/dpp/project/FileActivityConsumerTest.java
@@ -20,7 +20,9 @@ import de.fu_berlin.inf.dpp.session.User;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.junit.After;
 import org.junit.Before;
@@ -39,6 +41,9 @@ public class FileActivityConsumerTest {
   /** Partial file mock in recording state, has to be replayed in every test before being used. */
   private IFile file;
 
+  private IProject project;
+  private IPath path;
+
   private SharedResourcesManager resourceChangeListener;
 
   @Before
@@ -56,6 +61,13 @@ public class FileActivityConsumerTest {
 
     consumer = new FileActivityConsumer(null, resourceChangeListener, null);
 
+    path = createMock(IPath.class);
+    replay(path);
+
+    project = createMock(IProject.class);
+    expect(project.getFullPath()).andStubReturn(path);
+    replay(project);
+
     file = createMock(IFile.class);
 
     expect(file.getContents()).andStubReturn(new ByteArrayInputStream(FILE_CONTENT));
@@ -63,6 +75,7 @@ public class FileActivityConsumerTest {
     expect(file.exists()).andStubReturn(Boolean.TRUE);
     expect(file.getType()).andStubReturn(IResource.FILE);
     expect(file.getAdapter(IFile.class)).andStubReturn(file);
+    expect(file.getProject()).andStubReturn(project);
   }
 
   @After


### PR DESCRIPTION
This PR contains a subset of the commit of the https://github.com/saros-project/saros/pull/391.
In this PR, the Saros Core nearly completely based on reference points (I did'nt start trimming the SPath). 

In issue https://github.com/saros-project/saros/issues/177, I described the idea of the reference points and the reference point manager. 

The difference in this PR to https://github.com/saros-project/saros/pull/391 is, that I renamed the ReferencePointManager in Saros Core to CoreReferencePointManager and the CoreReferencePointManager provides functionalities (like getFile(..), getFolder(...)), that are used from the Saros IProject in Saros Core. 