### PR TITLE
Adjust UI on host side of project negotiation to handle multiple open projects

### DIFF
--- a/intellij/src/saros/intellij/ui/Messages.java
+++ b/intellij/src/saros/intellij/ui/Messages.java
@@ -91,6 +91,9 @@ public class Messages {
 
   public static String Contact_saros_message_conditional;
 
+  public static String ContactPopMenu_root_popup_text;
+  public static String ContactPopMenu_menu_entry_no_modules_found;
+  public static String ContactPopMenu_menu_entry_no_valid_modules_found;
   public static String ContactPopMenu_unsupported_ide_title;
   public static String ContactPopMenu_unsupported_ide_message_condition;
   public static String ContactPopMenu_module_not_found_title;

--- a/intellij/src/saros/intellij/ui/messages.properties
+++ b/intellij/src/saros/intellij/ui/messages.properties
@@ -78,6 +78,9 @@ ConnectButton_connect_to_new_account_message=Connect to the created Account?\nNO
 
 Contact_saros_message_conditional={0}, please contact the Saros development team. You can reach us by writing to our mailing list (<a href=\"https://groups.google.com/forum/#!forum/saros-devel\">forum</a>, <a href=\"mailto:saros-devel@googlegroups.com\">mailto</a>).
 
+ContactPopMenu_root_popup_text=Work together on...
+ContactPopMenu_menu_entry_no_modules_found=No modules found!
+ContactPopMenu_menu_entry_no_valid_modules_found=No modules complying with our current release restrictions found!
 ContactPopMenu_unsupported_ide_title=Unsupported IDE
 ContactPopMenu_unsupported_ide_message_condition=The local module manager could not be found. This most likely means that you are not using IntelliJ IDEA or are using an unsupported version. If you are using a supported version of IntelliJ IDEA
 ContactPopMenu_module_not_found_title=Module not found - Project sharing aborted

--- a/intellij/src/saros/intellij/ui/tree/ContactPopMenu.java
+++ b/intellij/src/saros/intellij/ui/tree/ContactPopMenu.java
@@ -17,9 +17,11 @@ import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import saros.core.ui.util.CollaborationUtils;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
+import saros.intellij.context.SharedIDEContext;
 import saros.intellij.filesystem.IntelliJProjectImpl;
 import saros.intellij.ui.Messages;
 import saros.intellij.ui.util.IconManager;
@@ -144,7 +146,7 @@ class ContactPopMenu extends JPopupMenu {
       }
 
       JMenuItem moduleItem = new JMenuItem(moduleName);
-      moduleItem.addActionListener(new ShareDirectoryAction(moduleName, wrappedModule));
+      moduleItem.addActionListener(new ShareDirectoryAction(project, moduleName, wrappedModule));
 
       shownModules.add(moduleItem);
     }
@@ -179,10 +181,14 @@ class ContactPopMenu extends JPopupMenu {
 
   /** Action that is executed, when a project is selected for sharing. */
   private class ShareDirectoryAction implements ActionListener {
+    private final Project project;
     private final String moduleName;
     private final IProject module;
 
-    private ShareDirectoryAction(String moduleName, IProject module) {
+    private ShareDirectoryAction(
+        @NotNull Project project, @NotNull String moduleName, @Nullable IProject module) {
+
+      this.project = project;
       this.moduleName = moduleName;
       this.module = module;
     }
@@ -213,7 +219,7 @@ class ContactPopMenu extends JPopupMenu {
       List<JID> contacts = new ArrayList<>();
       contacts.add(user);
 
-      // TODO set the correct project for the session context
+      SharedIDEContext.preregisterProject(project);
       CollaborationUtils.startSession(resources, contacts);
     }
   }

--- a/intellij/src/saros/intellij/ui/tree/ContactPopMenu.java
+++ b/intellij/src/saros/intellij/ui/tree/ContactPopMenu.java
@@ -163,11 +163,15 @@ class ContactPopMenu extends JPopupMenu {
                   : "complying with our current release restrictions ")
               + "were found");
 
-      projectMenu.add(
+      JMenuItem noModulesFoundMenuItem =
           new JMenuItem(
               nonCompliantModules.isEmpty()
                   ? Messages.ContactPopMenu_menu_entry_no_modules_found
-                  : Messages.ContactPopMenu_menu_entry_no_valid_modules_found));
+                  : Messages.ContactPopMenu_menu_entry_no_valid_modules_found);
+
+      noModulesFoundMenuItem.setEnabled(false);
+
+      projectMenu.add(noModulesFoundMenuItem);
     }
 
     return new Pair<>(projectMenu, nonCompliantModules);

--- a/intellij/src/saros/intellij/ui/tree/ContactPopMenu.java
+++ b/intellij/src/saros/intellij/ui/tree/ContactPopMenu.java
@@ -39,7 +39,7 @@ class ContactPopMenu extends JPopupMenu {
   ContactPopMenu(ContactTreeRootNode.ContactInfo contactInfo) {
     this.contactInfo = contactInfo;
 
-    JMenu menuShareProject = new JMenu("Work together on...");
+    JMenu menuShareProject = new JMenu(Messages.ContactPopMenu_root_popup_text);
     menuShareProject.setIcon(IconManager.SESSIONS_ICON);
 
     List<String> nonCompliantModules = new ArrayList<>();
@@ -165,11 +165,9 @@ class ContactPopMenu extends JPopupMenu {
 
       projectMenu.add(
           new JMenuItem(
-              "No modules "
-                  + (nonCompliantModules.isEmpty()
-                      ? ""
-                      : "complying with our current release restrictions ")
-                  + " found!"));
+              nonCompliantModules.isEmpty()
+                  ? Messages.ContactPopMenu_menu_entry_no_modules_found
+                  : Messages.ContactPopMenu_menu_entry_no_valid_modules_found));
     }
 
     return new Pair<>(projectMenu, nonCompliantModules);

--- a/intellij/src/saros/intellij/ui/tree/ContactPopMenu.java
+++ b/intellij/src/saros/intellij/ui/tree/ContactPopMenu.java
@@ -17,16 +17,14 @@ import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
-import saros.SarosPluginContext;
 import saros.core.ui.util.CollaborationUtils;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
-import saros.filesystem.IWorkspace;
+import saros.intellij.filesystem.IntelliJProjectImpl;
 import saros.intellij.ui.Messages;
 import saros.intellij.ui.util.IconManager;
 import saros.intellij.ui.util.NotificationPanel;
 import saros.net.xmpp.JID;
-import saros.repackaged.picocontainer.annotations.Inject;
 
 /**
  * Contact pop-up menu for selecting a project and module to share. Opened when right-clicking on a
@@ -36,14 +34,10 @@ class ContactPopMenu extends JPopupMenu {
 
   private static final Logger LOG = Logger.getLogger(ContactPopMenu.class);
 
-  @Inject private IWorkspace workspace;
-
   private final ContactTreeRootNode.ContactInfo contactInfo;
 
   ContactPopMenu(ContactTreeRootNode.ContactInfo contactInfo) {
     this.contactInfo = contactInfo;
-
-    SarosPluginContext.initComponent(this);
 
     JMenu menuShareProject = new JMenu("Work together on...");
     menuShareProject.setIcon(IconManager.SESSIONS_ICON);
@@ -118,7 +112,7 @@ class ContactPopMenu extends JPopupMenu {
       IProject wrappedModule;
 
       try {
-        wrappedModule = workspace.getProject(moduleName);
+        wrappedModule = new IntelliJProjectImpl(module);
 
       } catch (IllegalArgumentException exception) {
         LOG.debug(


### PR DESCRIPTION
#### [INTERNAL][I] Add project selection to ContactPopMenu

Adjusts the ContactPopMenu to show all open modules grouped by their
project. This is needed to make the plugin context project independent.
Instead of setting the project at plugin initialization, we can instead
use the project selected by the user and set it in the session context.

#### [INTERNAL][I] Instantiate saros project object in ContactPopMenu

Replaces a call to IWorkspaceImpl.getProject(String) with directly
instantiating a new IntelliJProjectImpl object as the needed module
object is already present.

#### [INTERNAL][I] Move text shown to user to messages.properties

Moves text shown to user when interacting with the ContactPopMenu to the
messages.properties file.

#### [INTERNAL][I] Disable menu entry stating that no module was found

Disables the ContactPopMenu menu entry shown when Saros could not find
any (valid) module in the project the host is trying to share.

Otherwise, the user might get confused as it looks like they could still
interact with the menu entry, even though it is only meant as a way to
convey information.