### PR TITLE
[FIX][I] #445 Enforce correct order of activities after file creation

### DIFF
--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -259,11 +259,13 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
       activity =
           new FileActivity(
               user, Type.CREATED, FileActivity.Purpose.ACTIVITY, path, null, content, charset);
-
-      editorManager.openEditor(path, false);
     }
 
     dispatchActivity(activity);
+
+    if (!createdVirtualFile.isDirectory()){
+      editorManager.openEditor(path, false);
+    }
   }
 
   /**


### PR DESCRIPTION
#### [FIX][I] #445 Avoid opening editor before sending file creation activity

Moves opening the created file in an editor after the file creation
activity was dispatched. This is necessary as the Saros otherwise
dispatches the editor opened activity before the file creation activity,
meaning the other participants receive an editor activation activity for
a non-existent resource. This is especially troublesome when the other
participant is following the user that created the file, as they then
automatically try to react to the editor activation activity by also
opening the (non-existent) file.

Fixes #445.

#### [REFACTOR][I] Do minor cleanup in LocalFilesystemModificationHandler

Moves the javadoc concerning the listener behavior from the handler
methods to the javadoc of the listener methods.

Fixes typo in method name 'generateResourceMoveActivity'.

Adds comment for IntelliJ code inspection to ignore the switch case in
generateRenamingResourceMoveActivity(...) having to few cases. The
switch gives us flexibility if we ever decide to add more cases and it
does not reduce the readability by much.