### PR TITLE
[UI][E] Prevent inviting invalid JID

### DIFF
--- a/eclipse/src/saros/ui/actions/OpenChatAction.java
+++ b/eclipse/src/saros/ui/actions/OpenChatAction.java
@@ -100,7 +100,7 @@ public class OpenChatAction extends Action implements Disposable {
 
         return user.getJID();
       } else {
-        return contacts.get(0);
+        return contacts.get(0).getBareJID();
       }
     }
 

--- a/eclipse/src/saros/ui/model/roster/RosterEntryElement.java
+++ b/eclipse/src/saros/ui/model/roster/RosterEntryElement.java
@@ -28,6 +28,10 @@ public class RosterEntryElement extends TreeElement {
 
   private final boolean hasSarosSupport;
 
+  /* TODO away mode is can be displayed wrong if multiple resources for a given JID exist. This
+   * currently does not matter as the content provider will only return one RosterEntryElement for a JID.
+   */
+
   public RosterEntryElement(Roster roster, JID jid, boolean hasSarosSupport) {
 
     this.roster = roster;
@@ -48,7 +52,7 @@ public class RosterEntryElement extends TreeElement {
     final RosterEntry rosterEntry = getRosterEntry();
 
     if (rosterEntry == null) {
-      styledString.append(jid.toString());
+      styledString.append(jid.getBase().toString());
       return styledString;
     }
 


### PR DESCRIPTION
Contacts with an invalid JID will no longer be invited. This ensures
that the Core can assume that it operates on FQJID all the time.