### PR TITLE
[INTERNAL][CORE] Move User Preferences to User Object

### DIFF
--- a/core/src/saros/negotiation/NegotiationFactory.java
+++ b/core/src/saros/negotiation/NegotiationFactory.java
@@ -213,7 +213,7 @@ public final class NegotiationFactory {
       throw new IllegalStateException("User <" + user + "> is not part of the session.");
     }
 
-    String type = session.getUserProperties(user).getString(ProjectNegotiationTypeHook.KEY_TYPE);
+    String type = user.getPreferences().getString(ProjectNegotiationTypeHook.KEY_TYPE);
     if (type.isEmpty()) {
       throw new IllegalArgumentException("Missing TransferType for User: " + user);
     }

--- a/core/src/saros/negotiation/OutgoingSessionNegotiation.java
+++ b/core/src/saros/negotiation/OutgoingSessionNegotiation.java
@@ -25,7 +25,6 @@ import saros.net.xmpp.JID;
 import saros.net.xmpp.discovery.DiscoveryManager;
 import saros.preferences.IPreferenceStore;
 import saros.preferences.PreferenceStore;
-import saros.session.ColorNegotiationHook;
 import saros.session.ISarosSession;
 import saros.session.ISarosSessionManager;
 import saros.session.User;
@@ -461,14 +460,16 @@ public final class OutgoingSessionNegotiation extends SessionNegotiation {
 
     monitor.setTaskName("Synchronizing user list...");
 
-    int clientColorID = properties.getInt(ColorNegotiationHook.KEY_INITIAL_COLOR);
-    int clientFavoriteColorID = properties.getInt(ColorNegotiationHook.KEY_FAV_COLOR);
-    User user = new User(getPeer(), false, false, clientColorID, clientFavoriteColorID);
+    User user = new User(getPeer(), false, false, properties);
 
     synchronized (REMOVE_ME_IF_SESSION_ADD_USER_IS_THREAD_SAFE) {
       sarosSession.addUser(user, properties);
       log.debug(
-          this + " : added " + getPeer() + " to the current session, colorID: " + clientColorID);
+          this
+              + " : added "
+              + getPeer()
+              + " to the current session, colorID: "
+              + user.getColorID());
 
       /* *
        *

--- a/core/src/saros/negotiation/OutgoingSessionNegotiation.java
+++ b/core/src/saros/negotiation/OutgoingSessionNegotiation.java
@@ -183,9 +183,7 @@ public final class OutgoingSessionNegotiation extends SessionNegotiation {
 
       IPreferenceStore clientProperties = new PreferenceStore();
       applySessionParameters(
-          actualSessionParameters,
-          sarosSession.getUserProperties(sarosSession.getHost()),
-          clientProperties);
+          actualSessionParameters, sarosSession.getHost().getPreferences(), clientProperties);
 
       User newUser = completeInvitation(clientProperties, monitor);
 

--- a/core/src/saros/negotiation/OutgoingSessionNegotiation.java
+++ b/core/src/saros/negotiation/OutgoingSessionNegotiation.java
@@ -463,7 +463,7 @@ public final class OutgoingSessionNegotiation extends SessionNegotiation {
     User user = new User(getPeer(), false, false, properties);
 
     synchronized (REMOVE_ME_IF_SESSION_ADD_USER_IS_THREAD_SAFE) {
-      sarosSession.addUser(user, properties);
+      sarosSession.addUser(user);
       log.debug(
           this
               + " : added "

--- a/core/src/saros/session/ISarosSession.java
+++ b/core/src/saros/session/ISarosSession.java
@@ -102,9 +102,8 @@ public interface ISarosSession {
    * will be noticed about the new user.
    *
    * @param user the user that is to be added
-   * @param preferences the initial properties of the new user
    */
-  public void addUser(User user, IPreferenceStore preferences);
+  public void addUser(User user);
 
   /**
    * Informs all listeners that a user now has Projects and can process {@link IResourceActivity}s.

--- a/core/src/saros/session/ISarosSession.java
+++ b/core/src/saros/session/ISarosSession.java
@@ -30,7 +30,6 @@ import saros.concurrent.management.ConcurrentDocumentServer;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
 import saros.net.xmpp.JID;
-import saros.preferences.IPreferenceStore;
 import saros.session.IActivityConsumer.Priority;
 import saros.session.User.Permission;
 import saros.synchronize.StopManager;
@@ -176,15 +175,6 @@ public interface ISarosSession {
    *     a JID exists in the session
    */
   public User getUser(JID jid);
-
-  /**
-   * Given a user, this method will return this users session properties.
-   *
-   * @param user the user to get the preferences for
-   * @return Properties of the given user or <code>null</code> if the user is not known to the
-   *     session
-   */
-  public IPreferenceStore getUserProperties(User user);
 
   /**
    * Given a JID (resource qualified or not), will return the resource qualified JID associated with

--- a/core/src/saros/session/User.java
+++ b/core/src/saros/session/User.java
@@ -166,17 +166,6 @@ public class User {
     return !isHost();
   }
 
-  /**
-   * FOR INTERNAL USE ONLY
-   *
-   * @param colorID
-   * @deprecated this must only be called by the component that handles color changes
-   */
-  @Deprecated
-  public void setColorID(int colorID) {
-    preferences.setValue(ColorNegotiationHook.KEY_INITIAL_COLOR, colorID);
-  }
-
   /** FOR INTERNAL USE ONLY */
   public void setInSession(boolean isInSession) {
     this.isInSession = isInSession;

--- a/core/src/saros/session/User.java
+++ b/core/src/saros/session/User.java
@@ -35,16 +35,6 @@ public class User {
   private volatile Permission permission = Permission.WRITE_ACCESS;
   private volatile boolean isInSession;
 
-  public User(JID jid, boolean isHost, boolean isLocal, int colorID, int favoriteColorID) {
-    this.jid = jid;
-    this.isHost = isHost;
-    this.isLocal = isLocal;
-
-    preferences = new PreferenceStore();
-    preferences.setValue(ColorNegotiationHook.KEY_INITIAL_COLOR, colorID);
-    preferences.setValue(ColorNegotiationHook.KEY_FAV_COLOR, favoriteColorID);
-  }
-
   public User(JID jid, boolean isHost, boolean isLocal, IPreferenceStore preferences) {
     this.jid = jid;
     this.isHost = isHost;

--- a/core/src/saros/session/User.java
+++ b/core/src/saros/session/User.java
@@ -20,6 +20,8 @@
 package saros.session;
 
 import saros.net.xmpp.JID;
+import saros.preferences.IPreferenceStore;
+import saros.preferences.PreferenceStore;
 
 /**
  * A user is a representation of a person sitting in front of an eclipse instance for the use in one
@@ -50,21 +52,32 @@ public class User {
 
   private final JID jid;
 
-  private volatile int colorID;
-
-  private final int favoriteColorID;
+  private final IPreferenceStore preferences;
 
   private volatile Permission permission = Permission.WRITE_ACCESS;
 
   private volatile boolean isInSession;
 
   public User(JID jid, boolean isHost, boolean isLocal, int colorID, int favoriteColorID) {
-
     this.jid = jid;
     this.isHost = isHost;
     this.isLocal = isLocal;
-    this.colorID = colorID;
-    this.favoriteColorID = favoriteColorID;
+
+    preferences = new PreferenceStore();
+    preferences.setValue(ColorNegotiationHook.KEY_INITIAL_COLOR, colorID);
+    preferences.setValue(ColorNegotiationHook.KEY_FAV_COLOR, favoriteColorID);
+  }
+
+  public User(JID jid, boolean isHost, boolean isLocal, IPreferenceStore preferences) {
+    this.jid = jid;
+    this.isHost = isHost;
+    this.isLocal = isLocal;
+
+    if (preferences == null) {
+      this.preferences = new PreferenceStore();
+    } else {
+      this.preferences = preferences;
+    }
   }
 
   /**
@@ -153,11 +166,11 @@ public class User {
   }
 
   public int getColorID() {
-    return colorID;
+    return preferences.getInt(ColorNegotiationHook.KEY_INITIAL_COLOR);
   }
 
   public int getFavoriteColorID() {
-    return favoriteColorID;
+    return preferences.getInt(ColorNegotiationHook.KEY_FAV_COLOR);
   }
 
   /**
@@ -194,7 +207,7 @@ public class User {
    */
   @Deprecated
   public void setColorID(int colorID) {
-    this.colorID = colorID;
+    preferences.setValue(ColorNegotiationHook.KEY_INITIAL_COLOR, colorID);
   }
 
   /** FOR INTERNAL USE ONLY */

--- a/core/src/saros/session/User.java
+++ b/core/src/saros/session/User.java
@@ -1,22 +1,3 @@
-/*
- * DPP - Serious Distributed Pair Programming
- * (c) Freie Universität Berlin - Fachbereich Mathematik und Informatik - 2006
- * (c) Riad Djemili - 2006
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 1, or (at your option)
- * any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
- */
 package saros.session;
 
 import saros.net.xmpp.JID;
@@ -46,16 +27,12 @@ public class User {
     READONLY_ACCESS
   }
 
-  private final boolean isHost;
-
-  private final boolean isLocal;
-
   private final JID jid;
-
+  private final boolean isHost;
+  private final boolean isLocal;
   private final IPreferenceStore preferences;
 
   private volatile Permission permission = Permission.WRITE_ACCESS;
-
   private volatile boolean isInSession;
 
   public User(JID jid, boolean isHost, boolean isLocal, int colorID, int favoriteColorID) {

--- a/core/src/saros/session/User.java
+++ b/core/src/saros/session/User.java
@@ -181,4 +181,8 @@ public class User {
   public void setInSession(boolean isInSession) {
     this.isInSession = isInSession;
   }
+
+  public IPreferenceStore getPreferences() {
+    return preferences;
+  }
 }

--- a/core/src/saros/session/internal/ChangeColorManager.java
+++ b/core/src/saros/session/internal/ChangeColorManager.java
@@ -19,6 +19,7 @@ import saros.editor.colorstorage.UserColorID;
 import saros.repackaged.picocontainer.Startable;
 import saros.session.AbstractActivityConsumer;
 import saros.session.AbstractActivityProducer;
+import saros.session.ColorNegotiationHook;
 import saros.session.IActivityConsumer;
 import saros.session.IActivityConsumer.Priority;
 import saros.session.ISessionListener;
@@ -130,7 +131,7 @@ public class ChangeColorManager extends AbstractActivityProducer implements Star
 
       if (!isValidColorID(colorID)) {
         colorID = getNextAvailableColorID();
-        session.getLocalUser().setColorID(colorID);
+        setUserColor(session.getLocalUser(), colorID);
       } else removeColorIdFromPool(colorID);
     } else {
       /*
@@ -223,7 +224,7 @@ public class ChangeColorManager extends AbstractActivityProducer implements Star
         removeColorIdFromPool(colorID);
 
         // this fails if a new copy is returned !
-        affected.setColorID(colorID);
+        setUserColor(affected, colorID);
       } else {
 
         assert session.isHost() : "only the session host can assign a color id";
@@ -233,7 +234,7 @@ public class ChangeColorManager extends AbstractActivityProducer implements Star
 
         addColorIdToPool(affected.getColorID());
 
-        affected.setColorID(colorID);
+        setUserColor(affected, colorID);
         fireChanges = true;
       }
     }
@@ -244,6 +245,10 @@ public class ChangeColorManager extends AbstractActivityProducer implements Star
 
     updateColorSet(currentUsers);
     session.userColorChanged(affected);
+  }
+
+  private void setUserColor(User user, int colorId) {
+    user.getPreferences().setValue(ColorNegotiationHook.KEY_INITIAL_COLOR, colorId);
   }
 
   /*
@@ -370,7 +375,7 @@ public class ChangeColorManager extends AbstractActivityProducer implements Star
 
       // make sure user uses the colorId we calculated
       User user = entry.getKey();
-      user.setColorID(colorId);
+      setUserColor(user, colorId);
     }
   }
 

--- a/core/src/saros/session/internal/SarosSession.java
+++ b/core/src/saros/session/internal/SarosSession.java
@@ -109,9 +109,6 @@ public final class SarosSession implements ISarosSession {
 
   private final ConcurrentHashMap<JID, User> participants = new ConcurrentHashMap<JID, User>();
 
-  private final ConcurrentHashMap<User, IPreferenceStore> userProperties =
-      new ConcurrentHashMap<User, IPreferenceStore>();
-
   private final SessionListenerDispatch listenerDispatch = new SessionListenerDispatch();
 
   private final User hostUser;
@@ -376,9 +373,6 @@ public final class SarosSession implements ISarosSession {
       log.error("user " + user + " added twice to SarosSession", new StackTrace());
       throw new IllegalArgumentException();
     }
-    if (this.userProperties.putIfAbsent(user, properties) != null) {
-      log.warn("user " + user + " already has properties");
-    }
 
     /*
      *
@@ -491,9 +485,6 @@ public final class SarosSession implements ISarosSession {
     if (participants.remove(jid) == null) {
       log.error("tried to remove user " + user + " who was never added to the session");
       return;
-    }
-    if (userProperties.remove(user) == null) {
-      log.error("tried to remove properties of user " + user + " that were never initialized");
     }
 
     activitySequencer.unregisterUser(user);
@@ -668,7 +659,7 @@ public final class SarosSession implements ISarosSession {
   public IPreferenceStore getUserProperties(User user) {
     if (user == null) throw new IllegalArgumentException("user is null");
 
-    return userProperties.get(user);
+    return user.getPreferences();
   }
 
   @Override
@@ -1079,14 +1070,11 @@ public final class SarosSession implements ISarosSession {
     if (host == null) {
       hostUser = localUser;
       participants.put(hostUser.getJID(), hostUser);
-      userProperties.put(hostUser, localProperties);
     } else {
       hostUser = new User(host, true, false, hostProperties);
       hostUser.setInSession(true);
       participants.put(hostUser.getJID(), hostUser);
       participants.put(localUser.getJID(), localUser);
-      userProperties.put(hostUser, hostProperties);
-      userProperties.put(localUser, localProperties);
     }
 
     sessionContainer = context.createChildContainer();

--- a/core/src/saros/session/internal/SarosSession.java
+++ b/core/src/saros/session/internal/SarosSession.java
@@ -656,13 +656,6 @@ public final class SarosSession implements ISarosSession {
   }
 
   @Override
-  public IPreferenceStore getUserProperties(User user) {
-    if (user == null) throw new IllegalArgumentException("user is null");
-
-    return user.getPreferences();
-  }
-
-  @Override
   public JID getResourceQualifiedJID(JID jid) {
 
     if (jid == null) throw new IllegalArgumentException("jid is null");

--- a/core/src/saros/session/internal/SarosSession.java
+++ b/core/src/saros/session/internal/SarosSession.java
@@ -357,7 +357,7 @@ public final class SarosSession implements ISarosSession {
    * proper initialization etc. of User objects !
    */
   @Override
-  public void addUser(final User user, IPreferenceStore properties) {
+  public void addUser(final User user) {
 
     // TODO synchronize this method !
 

--- a/core/src/saros/session/internal/SarosSession.java
+++ b/core/src/saros/session/internal/SarosSession.java
@@ -54,7 +54,6 @@ import saros.net.xmpp.XMPPConnectionService;
 import saros.preferences.IPreferenceStore;
 import saros.repackaged.picocontainer.MutablePicoContainer;
 import saros.repackaged.picocontainer.annotations.Inject;
-import saros.session.ColorNegotiationHook;
 import saros.session.IActivityConsumer;
 import saros.session.IActivityConsumer.Priority;
 import saros.session.IActivityHandlerCallback;
@@ -1074,10 +1073,7 @@ public final class SarosSession implements ISarosSession {
 
     assert localUserJID != null;
 
-    int localColorID = localProperties.getInt(ColorNegotiationHook.KEY_INITIAL_COLOR);
-    int localFavoriteColorID = localProperties.getInt(ColorNegotiationHook.KEY_FAV_COLOR);
-    localUser = new User(localUserJID, host == null, true, localColorID, localFavoriteColorID);
-
+    localUser = new User(localUserJID, host == null, true, localProperties);
     localUser.setInSession(true);
 
     if (host == null) {
@@ -1085,9 +1081,7 @@ public final class SarosSession implements ISarosSession {
       participants.put(hostUser.getJID(), hostUser);
       userProperties.put(hostUser, localProperties);
     } else {
-      int hostColorID = hostProperties.getInt(ColorNegotiationHook.KEY_INITIAL_COLOR);
-      int hostFavoriteColorID = hostProperties.getInt(ColorNegotiationHook.KEY_FAV_COLOR);
-      hostUser = new User(host, true, false, hostColorID, hostFavoriteColorID);
+      hostUser = new User(host, true, false, hostProperties);
       hostUser.setInSession(true);
       participants.put(hostUser.getJID(), hostUser);
       participants.put(localUser.getJID(), localUser);

--- a/core/src/saros/session/internal/UserInformationHandler.java
+++ b/core/src/saros/session/internal/UserInformationHandler.java
@@ -22,6 +22,7 @@ import saros.net.PacketCollector;
 import saros.net.xmpp.JID;
 import saros.preferences.PreferenceStore;
 import saros.repackaged.picocontainer.Startable;
+import saros.session.ColorNegotiationHook;
 import saros.session.ISarosSession;
 import saros.session.User;
 
@@ -293,10 +294,14 @@ public class UserInformationHandler implements Startable {
           continue;
         }
 
-        user = new User(userEntry.jid, false, false, userEntry.colorID, userEntry.favoriteColorID);
+        PreferenceStore preferences = new PreferenceStore();
+        preferences.setValue(ColorNegotiationHook.KEY_INITIAL_COLOR, userEntry.colorID);
+        preferences.setValue(ColorNegotiationHook.KEY_FAV_COLOR, userEntry.favoriteColorID);
+
+        user = new User(userEntry.jid, false, false, preferences);
 
         user.setPermission(userEntry.permission);
-        session.addUser(user, new PreferenceStore());
+        session.addUser(user, preferences);
 
       } else if ((userEntry.flags & UserListEntry.USER_REMOVED) != 0) {
         user = session.getUser(userEntry.jid);

--- a/core/src/saros/session/internal/UserInformationHandler.java
+++ b/core/src/saros/session/internal/UserInformationHandler.java
@@ -301,7 +301,7 @@ public class UserInformationHandler implements Startable {
         user = new User(userEntry.jid, false, false, preferences);
 
         user.setPermission(userEntry.permission);
-        session.addUser(user, preferences);
+        session.addUser(user);
 
       } else if ((userEntry.flags & UserListEntry.USER_REMOVED) != 0) {
         user = session.getUser(userEntry.jid);

--- a/core/test/junit/saros/activities/ActivityOptimizerTest.java
+++ b/core/test/junit/saros/activities/ActivityOptimizerTest.java
@@ -15,8 +15,8 @@ import saros.session.User;
 
 public class ActivityOptimizerTest {
 
-  private final User alice = new User(new JID("alice@junit"), true, true, 0, 0);
-  private final User bob = new User(new JID("bob@junit"), false, false, 0, 0);
+  private final User alice = new User(new JID("alice@junit"), true, true, null);
+  private final User bob = new User(new JID("bob@junit"), false, false, null);
 
   private IPath fooPath;
   private IPath barPath;

--- a/core/test/junit/saros/communication/extensions/ActivitiesExtensionProviderTest.java
+++ b/core/test/junit/saros/communication/extensions/ActivitiesExtensionProviderTest.java
@@ -15,7 +15,7 @@ public class ActivitiesExtensionProviderTest {
 
   @Test
   public void testNoPrettyPrintInMarshalledObjects() throws Exception {
-    User user = new User(new JID("alice@test"), true, true, 0, 0);
+    User user = new User(new JID("alice@test"), true, true, null);
 
     IActivity activity = new EditorActivity(user, EditorActivity.Type.ACTIVATED, null);
 

--- a/core/test/junit/saros/concurrent/jupiter/test/util/JupiterTestCase.java
+++ b/core/test/junit/saros/concurrent/jupiter/test/util/JupiterTestCase.java
@@ -63,6 +63,6 @@ public abstract class JupiterTestCase {
   }
 
   public static User createUser(String name) {
-    return new User(new JID(name + "@jabber.org"), false, true, 0, 0);
+    return new User(new JID(name + "@jabber.org"), false, true, null);
   }
 }

--- a/core/test/junit/saros/editor/colorstorage/ColorIDSetTest.java
+++ b/core/test/junit/saros/editor/colorstorage/ColorIDSetTest.java
@@ -14,6 +14,9 @@ import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 import saros.net.xmpp.JID;
+import saros.preferences.IPreferenceStore;
+import saros.preferences.PreferenceStore;
+import saros.session.ColorNegotiationHook;
 import saros.session.User;
 
 public class ColorIDSetTest {
@@ -27,10 +30,16 @@ public class ColorIDSetTest {
     userList = new ArrayList<User>();
     userMap = new HashMap<String, UserColorID>();
 
-    alice = new User(new JID("alice@saros.org"), false, false, 0, -1);
-    bob = new User(new JID("bob@saros.org"), false, false, 1, -1);
-    carl = new User(new JID("carl@lagerfeld.org"), false, false, 2, -1);
-    dave = new User(new JID("dave@saros.org"), false, false, 0, -1);
+    alice = createUser("alice@saros.org", 0);
+    bob = createUser("bob@saros.org", 1);
+    carl = createUser("carl@lagerfeld.org", 2);
+    dave = createUser("dave@saros.org", 0);
+  }
+
+  private User createUser(String jid, int color) {
+    IPreferenceStore preferences = new PreferenceStore();
+    preferences.setValue(ColorNegotiationHook.KEY_INITIAL_COLOR, color);
+    return new User(new JID(jid), false, false, preferences);
   }
 
   private ColorIDSet createColorIDSet(Collection<User> users) {

--- a/core/test/junit/saros/misc/xstream/UserConverterTest.java
+++ b/core/test/junit/saros/misc/xstream/UserConverterTest.java
@@ -20,10 +20,10 @@ public class UserConverterTest {
   @BeforeClass
   public static void prepare() {
     JID aliceJid = new JID("alice@saros-con");
-    alice = new User(aliceJid, true, true, 0, 0);
+    alice = new User(aliceJid, true, true, null);
 
     JID bobJid = new JID("bob@saros-con");
-    bob = new User(bobJid, false, false, 0, 0);
+    bob = new User(bobJid, false, false, null);
 
     /* Mocks */
     ISarosSession session = EasyMock.createMock(ISarosSession.class);

--- a/core/test/junit/saros/negotiation/SessionNegotiationTest.java
+++ b/core/test/junit/saros/negotiation/SessionNegotiationTest.java
@@ -48,8 +48,8 @@ public class SessionNegotiationTest {
   private static final JID ALICE = new JID("alice@test/Saros");
   private static final JID BOB = new JID("bob@test/Saros");
 
-  private static final User HOST = new User(ALICE, true, true, 0, 0);
-  private static final User INVITEE = new User(BOB, true, true, 0, 0);
+  private static final User HOST = new User(ALICE, true, true, null);
+  private static final User INVITEE = new User(BOB, true, true, null);
 
   private volatile Thread aliceNegotiationThread;
   private volatile Thread bobNegotiationThread;

--- a/core/test/junit/saros/negotiation/SessionNegotiationTest.java
+++ b/core/test/junit/saros/negotiation/SessionNegotiationTest.java
@@ -110,7 +110,7 @@ public class SessionNegotiationTest {
 
     aliceSession = createNiceMock(ISarosSession.class);
 
-    aliceSession.addUser(eq(INVITEE), anyObject(IPreferenceStore.class));
+    aliceSession.addUser(eq(INVITEE));
     expectLastCall().once();
 
     bobSession = createNiceMock(ISarosSession.class);

--- a/core/test/junit/saros/session/internal/ActivityQueuerTest.java
+++ b/core/test/junit/saros/session/internal/ActivityQueuerTest.java
@@ -30,8 +30,8 @@ import saros.session.User;
 
 public class ActivityQueuerTest {
 
-  private static final User ALICE = new User(new JID("Alice"), true, true, 0, 0);
-  private static final User BOB = new User(new JID("Bob"), false, false, 0, 0);
+  private static final User ALICE = new User(new JID("Alice"), true, true, null);
+  private static final User BOB = new User(new JID("Bob"), false, false, null);
 
   private static IProject SHARED_PROJECT;
   private static IProject NOT_SHARED_PROJECT;

--- a/core/test/junit/saros/session/internal/ActivitySequencerTest.java
+++ b/core/test/junit/saros/session/internal/ActivitySequencerTest.java
@@ -108,8 +108,8 @@ public class ActivitySequencerTest {
     sessionStubAlice = new SequencerSessionStub();
     sessionStubBob = new SequencerSessionStub();
 
-    aliceUser = new User(ALICE_JID, true, true, 0, 0);
-    bobUser = new User(BOB_JID, false, true, 0, 0);
+    aliceUser = new User(ALICE_JID, true, true, null);
+    bobUser = new User(BOB_JID, false, true, null);
 
     sessionStubAlice.setLocalUser(aliceUser);
     sessionStubBob.setLocalUser(bobUser);
@@ -198,7 +198,7 @@ public class ActivitySequencerTest {
 
     aliceSequencer.start();
 
-    User bobUserInAliceSession = new User(BOB_JID, false, false, 0, 0);
+    User bobUserInAliceSession = new User(BOB_JID, false, false, null);
 
     aliceSequencer.registerUser(bobUserInAliceSession);
 
@@ -225,8 +225,8 @@ public class ActivitySequencerTest {
     aliceSequencer.start();
     bobSequencer.start();
 
-    User bobUserInAliceSession = new User(BOB_JID, false, false, 0, 0);
-    User aliceUserInBobSession = new User(ALICE_JID, true, false, 0, 0);
+    User bobUserInAliceSession = new User(BOB_JID, false, false, null);
+    User aliceUserInBobSession = new User(ALICE_JID, true, false, null);
 
     sessionStubAlice.addUser(bobUserInAliceSession, new PreferenceStore());
     sessionStubBob.addUser(aliceUserInBobSession, new PreferenceStore());
@@ -261,8 +261,8 @@ public class ActivitySequencerTest {
     aliceSequencer.start();
     bobSequencer.start();
 
-    User bobUserInAliceSession = new User(BOB_JID, false, false, 0, 0);
-    User aliceUserInBobSession = new User(ALICE_JID, true, false, 0, 0);
+    User bobUserInAliceSession = new User(BOB_JID, false, false, null);
+    User aliceUserInBobSession = new User(ALICE_JID, true, false, null);
 
     sessionStubAlice.addUser(bobUserInAliceSession, new PreferenceStore());
     sessionStubBob.addUser(aliceUserInBobSession, new PreferenceStore());
@@ -293,8 +293,8 @@ public class ActivitySequencerTest {
     aliceSequencer.start();
     bobSequencer.start();
 
-    User bobUserInAliceSession = new User(BOB_JID, false, false, 0, 0);
-    User aliceUserInBobSession = new User(ALICE_JID, true, false, 0, 0);
+    User bobUserInAliceSession = new User(BOB_JID, false, false, null);
+    User aliceUserInBobSession = new User(ALICE_JID, true, false, null);
 
     sessionStubAlice.addUser(bobUserInAliceSession, new PreferenceStore());
     sessionStubBob.addUser(aliceUserInBobSession, new PreferenceStore());
@@ -326,8 +326,8 @@ public class ActivitySequencerTest {
     aliceSequencer.start();
     bobSequencer.start();
 
-    User bobUserInAliceSession = new User(BOB_JID, false, false, 0, 0);
-    User aliceUserInBobSession = new User(ALICE_JID, true, false, 0, 0);
+    User bobUserInAliceSession = new User(BOB_JID, false, false, null);
+    User aliceUserInBobSession = new User(ALICE_JID, true, false, null);
 
     sessionStubAlice.addUser(bobUserInAliceSession, new PreferenceStore());
     sessionStubBob.addUser(aliceUserInBobSession, new PreferenceStore());

--- a/core/test/junit/saros/session/internal/ActivitySequencerTest.java
+++ b/core/test/junit/saros/session/internal/ActivitySequencerTest.java
@@ -21,8 +21,6 @@ import saros.activities.NOPActivity;
 import saros.net.IReceiver;
 import saros.net.ITransmitter;
 import saros.net.xmpp.JID;
-import saros.preferences.IPreferenceStore;
-import saros.preferences.PreferenceStore;
 import saros.session.User;
 import saros.test.fakes.net.FakeConnectionFactory;
 import saros.test.fakes.net.FakeConnectionFactory.FakeConnectionFactoryResult;
@@ -54,7 +52,7 @@ public class ActivitySequencerTest {
      * needed
      */
     @Override
-    public void addUser(User user, IPreferenceStore properties) {
+    public void addUser(User user) {
       users.add(user);
     }
 
@@ -228,8 +226,8 @@ public class ActivitySequencerTest {
     User bobUserInAliceSession = new User(BOB_JID, false, false, null);
     User aliceUserInBobSession = new User(ALICE_JID, true, false, null);
 
-    sessionStubAlice.addUser(bobUserInAliceSession, new PreferenceStore());
-    sessionStubBob.addUser(aliceUserInBobSession, new PreferenceStore());
+    sessionStubAlice.addUser(bobUserInAliceSession);
+    sessionStubBob.addUser(aliceUserInBobSession);
 
     aliceSequencer.registerUser(bobUserInAliceSession);
     bobSequencer.registerUser(aliceUserInBobSession);
@@ -264,8 +262,8 @@ public class ActivitySequencerTest {
     User bobUserInAliceSession = new User(BOB_JID, false, false, null);
     User aliceUserInBobSession = new User(ALICE_JID, true, false, null);
 
-    sessionStubAlice.addUser(bobUserInAliceSession, new PreferenceStore());
-    sessionStubBob.addUser(aliceUserInBobSession, new PreferenceStore());
+    sessionStubAlice.addUser(bobUserInAliceSession);
+    sessionStubBob.addUser(aliceUserInBobSession);
 
     bobSequencer.registerUser(aliceUserInBobSession);
 
@@ -296,8 +294,8 @@ public class ActivitySequencerTest {
     User bobUserInAliceSession = new User(BOB_JID, false, false, null);
     User aliceUserInBobSession = new User(ALICE_JID, true, false, null);
 
-    sessionStubAlice.addUser(bobUserInAliceSession, new PreferenceStore());
-    sessionStubBob.addUser(aliceUserInBobSession, new PreferenceStore());
+    sessionStubAlice.addUser(bobUserInAliceSession);
+    sessionStubBob.addUser(aliceUserInBobSession);
 
     aliceSequencer.registerUser(bobUserInAliceSession);
 
@@ -329,8 +327,8 @@ public class ActivitySequencerTest {
     User bobUserInAliceSession = new User(BOB_JID, false, false, null);
     User aliceUserInBobSession = new User(ALICE_JID, true, false, null);
 
-    sessionStubAlice.addUser(bobUserInAliceSession, new PreferenceStore());
-    sessionStubBob.addUser(aliceUserInBobSession, new PreferenceStore());
+    sessionStubAlice.addUser(bobUserInAliceSession);
+    sessionStubBob.addUser(aliceUserInBobSession);
 
     aliceSequencer.registerUser(bobUserInAliceSession);
     bobSequencer.registerUser(aliceUserInBobSession);

--- a/core/test/junit/saros/session/internal/UserInformationHandlerTest.java
+++ b/core/test/junit/saros/session/internal/UserInformationHandlerTest.java
@@ -43,7 +43,7 @@ public class UserInformationHandlerTest {
 
     UserInformationHandler handler = new UserInformationHandler(session, transmitter, receiver);
 
-    User alice = new User(new JID("alice@test/Saros"), false, false, 0, 0);
+    User alice = new User(new JID("alice@test/Saros"), false, false, null);
 
     handler.start();
 
@@ -58,7 +58,7 @@ public class UserInformationHandlerTest {
 
     UserInformationHandler handler = new UserInformationHandler(session, transmitter, receiver);
 
-    User alice = new User(new JID("alice@test/Saros"), false, false, 0, 0);
+    User alice = new User(new JID("alice@test/Saros"), false, false, null);
 
     handler.start();
 
@@ -73,7 +73,7 @@ public class UserInformationHandlerTest {
 
     UserInformationHandler handler = new UserInformationHandler(session, transmitter, receiver);
 
-    User alice = new User(new JID("alice@test/Saros"), false, false, 0, 0);
+    User alice = new User(new JID("alice@test/Saros"), false, false, null);
 
     handler.start();
 
@@ -88,7 +88,7 @@ public class UserInformationHandlerTest {
 
     UserInformationHandler handler = new UserInformationHandler(session, transmitter, receiver);
 
-    User alice = new User(new JID("alice@test/Saros"), false, false, 0, 0);
+    User alice = new User(new JID("alice@test/Saros"), false, false, null);
 
     handler.start();
 
@@ -104,8 +104,8 @@ public class UserInformationHandlerTest {
 
     UserInformationHandler handler = new UserInformationHandler(session, transmitter, receiver);
 
-    User alice = new User(new JID("alice@test/Saros"), false, false, 0, 0);
-    User bob = new User(new JID("bob@test/Saros"), false, false, 0, 0);
+    User alice = new User(new JID("alice@test/Saros"), false, false, null);
+    User bob = new User(new JID("bob@test/Saros"), false, false, null);
 
     alice.setInSession(false);
 

--- a/core/test/junit/saros/synchronize/StopManagerTest.java
+++ b/core/test/junit/saros/synchronize/StopManagerTest.java
@@ -62,9 +62,9 @@ public class StopManagerTest {
             });
     alicesSession.removeActivityConsumer(isA(IActivityConsumer.class));
 
-    alicesAlice = new User(new JID("alice"), true, true, 1, -1);
-    alicesBob = new User(new JID("bob"), false, false, 2, -1);
-    alicesCarl = new User(new JID("carl"), false, false, 3, -1);
+    alicesAlice = new User(new JID("alice"), true, true, null);
+    alicesBob = new User(new JID("bob"), false, false, null);
+    alicesCarl = new User(new JID("carl"), false, false, null);
 
     alicesAlice.setInSession(true);
     alicesBob.setInSession(true);
@@ -102,9 +102,9 @@ public class StopManagerTest {
             });
     bobsSession.removeActivityConsumer(isA(IActivityConsumer.class));
 
-    bobsAlice = new User(new JID("alice"), true, false, 1, -1);
-    bobsBob = new User(new JID("bob"), false, true, 2, -1);
-    bobsCarl = new User(new JID("carl"), false, false, 3, -1);
+    bobsAlice = new User(new JID("alice"), true, false, null);
+    bobsBob = new User(new JID("bob"), false, true, null);
+    bobsCarl = new User(new JID("carl"), false, false, null);
 
     bobsAlice.setInSession(true);
     bobsBob.setInSession(true);
@@ -141,9 +141,9 @@ public class StopManagerTest {
             });
     carlsSession.removeActivityConsumer(isA(IActivityConsumer.class));
 
-    carlsAlice = new User(new JID("alice"), true, false, 1, -1);
-    carlsBob = new User(new JID("bob"), false, false, 2, -1);
-    carlsCarl = new User(new JID("carl"), false, true, 3, -1);
+    carlsAlice = new User(new JID("alice"), true, false, null);
+    carlsBob = new User(new JID("bob"), false, false, null);
+    carlsCarl = new User(new JID("carl"), false, true, null);
 
     carlsAlice.setInSession(true);
     carlsBob.setInSession(true);
@@ -536,7 +536,7 @@ public class StopManagerTest {
   }
 
   private static User rewriteUser(User user) {
-    User copy = new User(user.getJID(), user.isHost(), !user.isLocal(), user.getColorID(), -1);
+    User copy = new User(user.getJID(), user.isHost(), !user.isLocal(), null);
     copy.setInSession(true);
     return copy;
   }

--- a/core/test/junit/saros/test/stubs/SarosSessionStub.java
+++ b/core/test/junit/saros/test/stubs/SarosSessionStub.java
@@ -130,7 +130,7 @@ public class SarosSessionStub implements ISarosSession {
   }
 
   @Override
-  public void addUser(User user, IPreferenceStore properties) {
+  public void addUser(User user) {
     throw new RuntimeException("Unexpected call to Stub");
   }
 

--- a/core/test/junit/saros/test/stubs/SarosSessionStub.java
+++ b/core/test/junit/saros/test/stubs/SarosSessionStub.java
@@ -10,7 +10,6 @@ import saros.concurrent.management.ConcurrentDocumentServer;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
 import saros.net.xmpp.JID;
-import saros.preferences.IPreferenceStore;
 import saros.session.IActivityConsumer;
 import saros.session.IActivityConsumer.Priority;
 import saros.session.IActivityProducer;
@@ -66,11 +65,6 @@ public class SarosSessionStub implements ISarosSession {
 
   @Override
   public User getUser(JID jid) {
-    throw new RuntimeException("Unexpected call to Stub");
-  }
-
-  @Override
-  public IPreferenceStore getUserProperties(User user) {
     throw new RuntimeException("Unexpected call to Stub");
   }
 

--- a/eclipse/test/junit/saros/editor/internal/ContributionAnnotationManagerTest.java
+++ b/eclipse/test/junit/saros/editor/internal/ContributionAnnotationManagerTest.java
@@ -46,7 +46,7 @@ public class ContributionAnnotationManagerTest {
   @Test
   public void testHistoryRemoval() {
 
-    User alice = new User(new JID("alice@test"), false, false, 0, 0);
+    User alice = new User(new JID("alice@test"), false, false, null);
 
     AnnotationModel model = new AnnotationModel();
 
@@ -66,7 +66,7 @@ public class ContributionAnnotationManagerTest {
 
   @Test
   public void testHistoryRemovalAfterRefresh() {
-    User alice = new User(new JID("alice@test"), false, false, 0, 0);
+    User alice = new User(new JID("alice@test"), false, false, null);
 
     AnnotationModel model = new AnnotationModel();
 
@@ -85,8 +85,8 @@ public class ContributionAnnotationManagerTest {
   @Test
   public void testAnnotationSplit() {
 
-    final User alice = new User(new JID("alice@test"), false, false, 0, 0);
-    final User bob = new User(new JID("bob@test"), false, false, 0, 0);
+    final User alice = new User(new JID("alice@test"), false, false, null);
+    final User bob = new User(new JID("bob@test"), false, false, null);
 
     final AnnotationModel model = new AnnotationModel();
 

--- a/eclipse/test/junit/saros/feedback/StatisticCollectorTest.java
+++ b/eclipse/test/junit/saros/feedback/StatisticCollectorTest.java
@@ -38,8 +38,8 @@ public class StatisticCollectorTest {
 
   private static ISarosSession createSessionMock(final List<Object> sessionListeners) {
     ISarosSession session = EasyMock.createMock(ISarosSession.class);
-    final User bob = new User(new JID("bob"), false, false, 1, -1);
-    final User alice = new User(new JID("alice"), false, false, 2, -1);
+    final User bob = new User(new JID("bob"), false, false, null);
+    final User alice = new User(new JID("alice"), false, false, null);
     final List<User> participants = new LinkedList<User>();
     participants.add(bob);
     participants.add(alice);

--- a/eclipse/test/junit/saros/project/FileActivityConsumerTest.java
+++ b/eclipse/test/junit/saros/project/FileActivityConsumerTest.java
@@ -113,7 +113,7 @@ public class FileActivityConsumerTest {
 
   private FileActivity createFileActivity(IFile file, byte[] content) {
     return new FileActivity(
-        new User(new JID("foo@bar"), true, true, 0, 0),
+        new User(new JID("foo@bar"), true, true, null),
         Type.CREATED,
         Purpose.ACTIVITY,
         createPathMockForFile(file),


### PR DESCRIPTION
Integration of the User Preference Store into the User Object.
1. this removes the duplicate storage of user color
2. removing (unlikely but possible) data races where a user has already been added to a session but the preference store is not set or user already removed
3. removes some code duplication