### PR TITLE
[DOC] Remove reference to section 'naming conventions'

### DIFF
--- a/docs/contribute/best-practices.md
+++ b/docs/contribute/best-practices.md
@@ -59,8 +59,6 @@ is not acceptable to make a member part of a package's API
     of your interface will not want to implement all methods. Also it
     helps to improve ability to change the program, as methods can be
     added to the interface more easily.
-    *   see [Naming Conventions](../index.md#naming_conventions) for
-        more information
 *   Do not implement more than one listener interface per class,
     especially if using a top level class, because it makes the code
     much less readable and makes you more likely to forget unregistering


### PR DESCRIPTION
Removes a reference to the section 'naming conventions' as the section
does not exist in the current documentation.