### PR TITLE
[BUILD][CORE] Upgrade EasyMock, PowerMock and jUnit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ configure(projectsToConfigure) { projectToConf ->
     }
   }
 
-  projectToConf.ext.junitVersion = 'junit:junit:4.11'
+  projectToConf.ext.junitVersion = 'junit:junit:4.12'
   projectToConf.ext.log4jVersion = 'log4j:log4j:1.2.15'
 
   dependencies {
@@ -110,8 +110,10 @@ configure(projectsToConfigure) { projectToConf ->
     }
 
     testConfig junitVersion
-    testConfig 'org.easymock:easymock:3.1'
-    testConfig 'org.powermock:powermock-easymock-release-full:1.5.1'
+    testConfig 'org.easymock:easymock:3.5.1'
+    testConfig 'org.powermock:powermock-core:2.0.0'
+    testConfig 'org.powermock:powermock-module-junit4:2.0.0'
+    testConfig 'org.powermock:powermock-api-easymock:2.0.0'
   }
 
   // generate lib directory that contains all release dependencies

--- a/core/test/junit/saros/net/RosterTrackerTest.java
+++ b/core/test/junit/saros/net/RosterTrackerTest.java
@@ -53,7 +53,7 @@ public class RosterTrackerTest {
 
   private XMPPConnectionService connectionServiceMock;
 
-  private Capture<IConnectionListener> connectionListener = new Capture<IConnectionListener>();
+  private Capture<IConnectionListener> connectionListener = Capture.newInstance();
 
   private XMPPConnectionService createXMPPConnectionServiceMock(
       Capture<IConnectionListener> connectionListener) {

--- a/core/test/junit/saros/net/internal/DataTransferManagerTest.java
+++ b/core/test/junit/saros/net/internal/DataTransferManagerTest.java
@@ -174,7 +174,7 @@ public class DataTransferManagerTest {
 
   private XMPPConnectionService connectionServiceStub;
 
-  private Capture<IConnectionListener> connectionListener = new Capture<IConnectionListener>();
+  private Capture<IConnectionListener> connectionListener = Capture.newInstance();
 
   private Connection connectionMock;
 

--- a/eclipse/test/junit/saros/filesystem/IResourceTest.java
+++ b/eclipse/test/junit/saros/filesystem/IResourceTest.java
@@ -13,7 +13,7 @@ public class IResourceTest {
     org.eclipse.core.resources.IFolder folder =
         EasyMock.createMock(org.eclipse.core.resources.IFolder.class);
 
-    Capture<Class<Object>> mappedAdapterClassCapture = new Capture<Class<Object>>();
+    Capture<Class<Object>> mappedAdapterClassCapture = Capture.newInstance();
 
     EasyMock.expect(folder.getAdapter(EasyMock.capture(mappedAdapterClassCapture)))
         .andStubReturn(folder);


### PR DESCRIPTION
Update to PowerMock 2.0.0. This should theoretically add support for
java 9, but from initial testing it looks like the java 9 support is
still a bit buggy.

Updates EasyMock to 3.5.1 as this is the latest release officially
supported by PowerMock 2.0.0.

Subsequently updates jUnit to 4.12. This could not be done previously as
the old mocking libraries required 4.11 or earlier.

Adjusts the test logic initializing Capture objects as they now require
a 'newInstance()' call instead of calling the CTOR.