### PR TITLE
[INTERNAL][I] Remove implementation of IWorkspace implementation

### DIFF
--- a/core/src/saros/filesystem/IWorkspace.java
+++ b/core/src/saros/filesystem/IWorkspace.java
@@ -35,7 +35,19 @@ public interface IWorkspace {
   public void run(IWorkspaceRunnable runnable, IResource[] resources)
       throws IOException, OperationCanceledException;
 
+  /**
+   * @deprecated the concept of a central workspace for the IDE instance does not apply to all IDE
+   *     models (see the IntelliJ project/module model). This method will be removed from the
+   *     interface in a future patch.
+   */
+  @Deprecated
   public IProject getProject(String project);
 
+  /**
+   * @deprecated the concept of a central workspace for the IDE instance does not apply to all IDE
+   *     models (see the IntelliJ project/module model). This method will be removed from the
+   *     interface in a future patch.
+   */
+  @Deprecated
   public IPath getLocation();
 }

--- a/eclipse/src/saros/filesystem/EclipseWorkspaceImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseWorkspaceImpl.java
@@ -118,12 +118,16 @@ public class EclipseWorkspaceImpl implements IWorkspace {
     }
   }
 
+  /** @deprecated See {@link IWorkspace}. */
   @Override
+  @Deprecated
   public IProject getProject(String project) {
     return ResourceAdapterFactory.create(delegate.getRoot().getProject(project));
   }
 
+  /** @deprecated See {@link IWorkspace}. */
   @Override
+  @Deprecated
   public IPath getLocation() {
     return ResourceAdapterFactory.create(delegate.getRoot().getLocation());
   }

--- a/intellij/src/saros/intellij/project/filesystem/IntelliJWorkspaceImpl.java
+++ b/intellij/src/saros/intellij/project/filesystem/IntelliJWorkspaceImpl.java
@@ -1,9 +1,5 @@
 package saros.intellij.project.filesystem;
 
-import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleManager;
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.Computable;
 import java.io.IOException;
 import org.apache.log4j.Logger;
 import saros.exceptions.OperationCanceledException;
@@ -12,18 +8,10 @@ import saros.filesystem.IProject;
 import saros.filesystem.IResource;
 import saros.filesystem.IWorkspace;
 import saros.filesystem.IWorkspaceRunnable;
-import saros.intellij.filesystem.Filesystem;
-import saros.intellij.filesystem.IntelliJProjectImpl;
 import saros.monitoring.NullProgressMonitor;
 
 public class IntelliJWorkspaceImpl implements IWorkspace {
   public static final Logger LOG = Logger.getLogger(IntelliJWorkspaceImpl.class);
-
-  private Project project;
-
-  public IntelliJWorkspaceImpl(Project project) {
-    this.project = project;
-  }
 
   @Override
   public void run(IWorkspaceRunnable procedure) throws IOException, OperationCanceledException {
@@ -36,22 +24,42 @@ public class IntelliJWorkspaceImpl implements IWorkspace {
     run(runnable);
   }
 
+  /**
+   * This method always throws an <code>UnsupportedOperationException</code>.
+   *
+   * <p>In Intellij, module names can not be used to uniquely identify modules in an application
+   * context. There can be any number of open project that can each contain a module with the same
+   * name. This makes it impossible to implement a general method that just uses the module name.
+   *
+   * @param moduleName the name of the module to instantiate an <code>IProject</code> object for
+   * @return nothing as it always throws an <code>UnsupportedOperationException</code>
+   * @throws UnsupportedOperationException always
+   * @deprecated does not make sense in the context of Intellij IDEA
+   */
+  @Deprecated
   @Override
   public IProject getProject(final String moduleName) {
-    Module module =
-        Filesystem.runReadAction(
-            new Computable<Module>() {
-              @Override
-              public Module compute() {
-                return ModuleManager.getInstance(project).findModuleByName(moduleName);
-              }
-            });
-
-    return module != null ? new IntelliJProjectImpl(module) : null;
+    throw new UnsupportedOperationException(
+        "Modules names can not be used to uniquely identify modules in Intellij in an application context.");
   }
 
+  /**
+   * This method always throws an <code>UnsupportedOperationException</code>.
+   *
+   * <p>In Intellij, there is no such concept as a centralized workspace directory for the IDE. Each
+   * Intellij application can have any number of projects open which each can have any number of
+   * modules. Each module in turn can have any number of content roots which define the content of
+   * the module. In the filesystem, there is no correlation between the location of any of the above
+   * mentioned parts. This makes it impossible to determine a general workspace directory.
+   *
+   * @return nothing as it always throws an <code>UnsupportedOperationException</code>
+   * @throws UnsupportedOperationException always
+   * @deprecated does not make sense in the context of Intellij IDEA
+   */
+  @Deprecated
   @Override
   public IPath getLocation() {
-    return IntelliJPathImpl.fromString(project.getBasePath());
+    throw new UnsupportedOperationException(
+        "There is no such concept as a centralized workspace directory for Intellij.");
   }
 }

--- a/server/src/saros/server/filesystem/ServerWorkspaceImpl.java
+++ b/server/src/saros/server/filesystem/ServerWorkspaceImpl.java
@@ -23,12 +23,16 @@ public class ServerWorkspaceImpl implements IWorkspace {
     this.location = location;
   }
 
+  /** @deprecated See {@link IWorkspace}. */
   @Override
+  @Deprecated
   public IPath getLocation() {
     return location;
   }
 
+  /** @deprecated See {@link IWorkspace}. */
   @Override
+  @Deprecated
   public IProject getProject(String name) {
     return new ServerProjectImpl(this, name);
   }


### PR DESCRIPTION
Removes the implementation of IntelliJWorkspaceImpl.getProject(String)
and IntelliJWorkspaceImpl.getLocation() as they don't make sense in an
IntelliJ context. Replaces them with throwing an unsupported operation
exception and detailed explanations as part of the javadoc. Also marks
the methods as deprecated.