### PR TITLE
Prepare to remove project from plugin context (4 of X)

### DIFF
--- a/intellij/src/saros/core/project/internal/SarosIntellijSessionContextFactory.java
+++ b/intellij/src/saros/core/project/internal/SarosIntellijSessionContextFactory.java
@@ -1,6 +1,5 @@
 package saros.core.project.internal;
 
-import saros.intellij.editor.EditorAPI;
 import saros.intellij.editor.LocalEditorHandler;
 import saros.intellij.editor.LocalEditorManipulator;
 import saros.intellij.editor.ProjectAPI;
@@ -33,7 +32,6 @@ public class SarosIntellijSessionContextFactory extends SarosCoreSessionContextF
     container.addComponent(ProjectAPI.class);
 
     // Editor interaction
-    container.addComponent(EditorAPI.class);
     container.addComponent(LocalEditorHandler.class);
     container.addComponent(LocalEditorManipulator.class);
     container.addComponent(SelectedEditorStateSnapshotFactory.class);

--- a/intellij/src/saros/intellij/editor/EditorAPI.java
+++ b/intellij/src/saros/intellij/editor/EditorAPI.java
@@ -3,19 +3,14 @@ package saros.intellij.editor;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
-import com.intellij.openapi.command.CommandProcessor;
-import com.intellij.openapi.command.UndoConfirmationPolicy;
-import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.LogicalPosition;
 import com.intellij.openapi.editor.ScrollType;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
 import java.awt.Point;
 import java.awt.Rectangle;
 import org.jetbrains.annotations.NotNull;
 import saros.editor.text.LineRange;
-import saros.intellij.filesystem.Filesystem;
 
 /**
  * IntellJ editor API. An Editor is a window for editing source files.
@@ -25,12 +20,10 @@ import saros.intellij.filesystem.Filesystem;
 public class EditorAPI {
 
   private Application application;
-  private CommandProcessor commandProcessor;
 
   /** Creates an EditorAPI with the current Project and initializes Fields. */
   public EditorAPI() {
     this.application = ApplicationManager.getApplication();
-    this.commandProcessor = CommandProcessor.getInstance();
   }
 
   /**
@@ -135,79 +128,5 @@ public class EditorAPI {
     int rangeLength = endLine - startLine;
 
     return new LineRange(startLine, rangeLength);
-  }
-
-  /**
-   * Inserts the specified text at the specified offset in the document. Line breaks in the inserted
-   * text must be normalized as '\n'.
-   *
-   * <p>The insertion will be wrapped in a command processor action. The action will be assigned to
-   * the passed project. This means the action will be registered with the undo-buffer of the given
-   * project.
-   *
-   * @param project the project to assign the resulting insertion action to
-   * @param document the document to insert the text into
-   * @param offset the offset to insert the text at
-   * @param text the text to insert
-   * @see Document#insertString(int, CharSequence)
-   * @see CommandProcessor
-   */
-  void insertText(
-      @NotNull Project project,
-      @NotNull final Document document,
-      final int offset,
-      final String text) {
-
-    Runnable insertCommand =
-        () -> {
-          Runnable insertString = () -> document.insertString(offset, text);
-
-          String commandName = "Saros text insertion at index " + offset + " of \"" + text + "\"";
-
-          commandProcessor.executeCommand(
-              project,
-              insertString,
-              commandName,
-              commandProcessor.getCurrentCommandGroupId(),
-              UndoConfirmationPolicy.REQUEST_CONFIRMATION,
-              document);
-        };
-
-    Filesystem.runWriteAction(insertCommand, ModalityState.defaultModalityState());
-  }
-
-  /**
-   * Deletes the specified range of text from the given document.
-   *
-   * <p>The deletion will be wrapped in a command processor action. The action will be assigned to
-   * the passed project. This means the action will be registered with the undo-buffer of the given
-   * project.
-   *
-   * @param project the project to assign the resulting deletion action to
-   * @param doc the document to delete text from
-   * @param start the start offset of the range to delete
-   * @param end the end offset of the range to delete
-   * @see Document#deleteString(int, int)
-   * @see CommandProcessor
-   */
-  void deleteText(
-      @NotNull Project project, @NotNull final Document doc, final int start, final int end) {
-
-    Runnable deletionCommand =
-        () -> {
-          Runnable deleteRange = () -> doc.deleteString(start, end);
-
-          String commandName = "Saros text deletion from index " + start + " to " + end;
-
-          commandProcessor.executeCommand(
-              project,
-              deleteRange,
-              commandName,
-              commandProcessor.getCurrentCommandGroupId(),
-              UndoConfirmationPolicy.REQUEST_CONFIRMATION,
-              doc);
-        };
-
-    Filesystem.runWriteAction(deletionCommand, ModalityState.defaultModalityState());
   }
 }

--- a/intellij/src/saros/intellij/editor/EditorAPI.java
+++ b/intellij/src/saros/intellij/editor/EditorAPI.java
@@ -27,11 +27,8 @@ public class EditorAPI {
   private Application application;
   private CommandProcessor commandProcessor;
 
-  private Project project;
-
   /** Creates an EditorAPI with the current Project and initializes Fields. */
-  public EditorAPI(Project project) {
-    this.project = project;
+  public EditorAPI() {
     this.application = ApplicationManager.getApplication();
     this.commandProcessor = CommandProcessor.getInstance();
   }
@@ -142,14 +139,24 @@ public class EditorAPI {
 
   /**
    * Inserts the specified text at the specified offset in the document. Line breaks in the inserted
-   * text must be normalized as \n.
+   * text must be normalized as '\n'.
    *
+   * <p>The insertion will be wrapped in a command processor action. The action will be assigned to
+   * the passed project. This means the action will be registered with the undo-buffer of the given
+   * project.
+   *
+   * @param project the project to assign the resulting insertion action to
    * @param document the document to insert the text into
    * @param offset the offset to insert the text at
    * @param text the text to insert
    * @see Document#insertString(int, CharSequence)
+   * @see CommandProcessor
    */
-  void insertText(@NotNull final Document document, final int offset, final String text) {
+  void insertText(
+      @NotNull Project project,
+      @NotNull final Document document,
+      final int offset,
+      final String text) {
 
     Runnable insertCommand =
         () -> {
@@ -172,12 +179,20 @@ public class EditorAPI {
   /**
    * Deletes the specified range of text from the given document.
    *
+   * <p>The deletion will be wrapped in a command processor action. The action will be assigned to
+   * the passed project. This means the action will be registered with the undo-buffer of the given
+   * project.
+   *
+   * @param project the project to assign the resulting deletion action to
    * @param doc the document to delete text from
    * @param start the start offset of the range to delete
    * @param end the end offset of the range to delete
    * @see Document#deleteString(int, int)
+   * @see CommandProcessor
    */
-  void deleteText(@NotNull final Document doc, final int start, final int end) {
+  void deleteText(
+      @NotNull Project project, @NotNull final Document doc, final int start, final int end) {
+
     Runnable deletionCommand =
         () -> {
           Runnable deleteRange = () -> doc.deleteString(start, end);

--- a/intellij/src/saros/intellij/editor/EditorAPI.java
+++ b/intellij/src/saros/intellij/editor/EditorAPI.java
@@ -19,11 +19,10 @@ import saros.editor.text.LineRange;
  */
 public class EditorAPI {
 
-  private Application application;
+  private static final Application application = ApplicationManager.getApplication();
 
-  /** Creates an EditorAPI with the current Project and initializes Fields. */
-  public EditorAPI() {
-    this.application = ApplicationManager.getApplication();
+  private EditorAPI() {
+    // NOP
   }
 
   /**
@@ -40,7 +39,7 @@ public class EditorAPI {
    * @param line the line to scroll to
    * @see LogicalPosition
    */
-  void scrollToViewPortCenter(final Editor editor, final int line) {
+  static void scrollToViewPortCenter(final Editor editor, final int line) {
     application.invokeAndWait(
         () -> {
           LogicalPosition logicalPosition = new LogicalPosition(line, 0);
@@ -62,7 +61,7 @@ public class EditorAPI {
    * @see LogicalPosition
    */
   @NotNull
-  LineRange getLocalViewPortRange(@NotNull Editor editor) {
+  static LineRange getLocalViewPortRange(@NotNull Editor editor) {
     Rectangle visibleAreaRectangle = editor.getScrollingModel().getVisibleAreaOnScrollingFinished();
 
     return getLocalViewPortRange(editor, visibleAreaRectangle);
@@ -76,7 +75,7 @@ public class EditorAPI {
    * @return the logical line range of the local viewport for the given editor
    * @see LogicalPosition
    */
-  public LineRange getLocalViewPortRange(
+  public static LineRange getLocalViewPortRange(
       @NotNull Editor editor, @NotNull Rectangle visibleAreaRectangle) {
     int basePos = visibleAreaRectangle.y;
     int endPos = visibleAreaRectangle.y + visibleAreaRectangle.height;
@@ -98,7 +97,7 @@ public class EditorAPI {
    * @return a Pair containing the local selection offset and length for the given editor.
    */
   @NotNull
-  Pair<Integer, Integer> getLocalSelectionOffsets(@NotNull Editor editor) {
+  static Pair<Integer, Integer> getLocalSelectionOffsets(@NotNull Editor editor) {
     int selectionStartOffset = editor.getSelectionModel().getSelectionStart();
     int selectionEndOffset = editor.getSelectionModel().getSelectionEnd();
 
@@ -119,7 +118,7 @@ public class EditorAPI {
    * @see LogicalPosition
    */
   @NotNull
-  LineRange getLineRange(@NotNull Editor editor, int startOffset, int endOffset) {
+  static LineRange getLineRange(@NotNull Editor editor, int startOffset, int endOffset) {
     assert startOffset <= endOffset;
 
     int startLine = editor.offsetToLogicalPosition(startOffset).line;

--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -324,7 +324,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
             return;
           }
 
-          LineRange localViewPort = editorAPI.getLocalViewPortRange(editor);
+          LineRange localViewPort = EditorAPI.getLocalViewPortRange(editor);
           int viewPortStartLine = localViewPort.getStartLine();
           int viewPortLength = localViewPort.getNumberOfLines();
 
@@ -360,7 +360,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
   private void sendSelectionInformation(
       @NotNull User user, @NotNull SPath path, @NotNull Editor editor) {
 
-    Pair<Integer, Integer> localSelectionOffsets = editorAPI.getLocalSelectionOffsets(editor);
+    Pair<Integer, Integer> localSelectionOffsets = EditorAPI.getLocalSelectionOffsets(editor);
     int selectionStartOffset = localSelectionOffsets.first;
     int selectionLength = localSelectionOffsets.second;
 
@@ -432,7 +432,6 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
           projectAPI = sarosSession.getComponent(ProjectAPI.class);
 
-          editorAPI = sarosSession.getComponent(EditorAPI.class);
           localEditorHandler = sarosSession.getComponent(LocalEditorHandler.class);
           localEditorManipulator = sarosSession.getComponent(LocalEditorManipulator.class);
 
@@ -465,7 +464,6 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
           projectAPI = null;
 
-          editorAPI = null;
           localEditorHandler = null;
           localEditorManipulator = null;
 
@@ -524,7 +522,6 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
   private UserEditorStateManager userEditorStateManager;
   private ISarosSession session;
   private ProjectAPI projectAPI;
-  private EditorAPI editorAPI;
   private LocalEditorHandler localEditorHandler;
   private LocalEditorManipulator localEditorManipulator;
   private AnnotationManager annotationManager;

--- a/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
@@ -177,14 +177,14 @@ public class LocalEditorManipulator {
 
       for (ITextOperation op : operations.getTextOperations()) {
         if (op instanceof DeleteOperation) {
-          editorAPI.deleteText(
+          DocumentAPI.deleteText(
               project, doc, op.getPosition(), op.getPosition() + op.getTextLength());
         } else {
           boolean writePermission = doc.isWritable();
           if (!writePermission) {
             doc.setReadOnly(false);
           }
-          editorAPI.insertText(project, doc, op.getPosition(), op.getText());
+          DocumentAPI.insertText(project, doc, op.getPosition(), op.getText());
           if (!writePermission) {
             doc.setReadOnly(true);
           }
@@ -354,8 +354,8 @@ public class LocalEditorManipulator {
         manager.setLocalDocumentModificationHandlersEnabled(false);
       }
 
-      editorAPI.deleteText(project, document, 0, documentLength);
-      editorAPI.insertText(project, document, 0, text);
+      DocumentAPI.deleteText(project, document, 0, documentLength);
+      DocumentAPI.insertText(project, document, 0, text);
 
     } finally {
 

--- a/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
@@ -30,7 +30,6 @@ public class LocalEditorManipulator {
   private static final Logger LOG = Logger.getLogger(LocalEditorManipulator.class);
 
   private final ProjectAPI projectAPI;
-  private final EditorAPI editorAPI;
   private final AnnotationManager annotationManager;
   private final ISarosSession sarosSession;
 
@@ -41,13 +40,11 @@ public class LocalEditorManipulator {
 
   public LocalEditorManipulator(
       ProjectAPI projectAPI,
-      EditorAPI editorAPI,
       AnnotationManager annotationManager,
       EditorManager editorManager,
       ISarosSession sarosSession) {
 
     this.projectAPI = projectAPI;
-    this.editorAPI = editorAPI;
     this.annotationManager = annotationManager;
     this.manager = editorManager;
     this.sarosSession = sarosSession;
@@ -224,7 +221,7 @@ public class LocalEditorManipulator {
       return;
     }
 
-    LineRange localViewport = editorAPI.getLocalViewPortRange(editor);
+    LineRange localViewport = EditorAPI.getLocalViewPortRange(editor);
 
     int localStartLine = localViewport.getStartLine();
     int localEndLine = localViewport.getStartLine() + localViewport.getNumberOfLines();
@@ -240,7 +237,7 @@ public class LocalEditorManipulator {
       int startOffset = selection.getOffset();
       int endOffset = selection.getOffset() + selection.getLength();
 
-      LineRange selectionRange = editorAPI.getLineRange(editor, startOffset, endOffset);
+      LineRange selectionRange = EditorAPI.getLineRange(editor, startOffset, endOffset);
 
       remoteStartLine = selectionRange.getStartLine();
       remoteEndLine = selectionRange.getStartLine() + selectionRange.getNumberOfLines();
@@ -265,7 +262,7 @@ public class LocalEditorManipulator {
 
     int remoteViewPortCenter = findCenter(remoteStartLine, remoteEndLine);
 
-    editorAPI.scrollToViewPortCenter(editor, remoteViewPortCenter);
+    EditorAPI.scrollToViewPortCenter(editor, remoteViewPortCenter);
   }
 
   /**

--- a/intellij/src/saros/intellij/eventhandler/editor/viewport/LocalViewPortChangeHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/viewport/LocalViewPortChangeHandler.java
@@ -22,7 +22,6 @@ public class LocalViewPortChangeHandler implements DisableableHandler, Startable
   private static final Logger log = Logger.getLogger(LocalViewPortChangeHandler.class);
 
   private final EditorManager editorManager;
-  private final EditorAPI editorAPI;
 
   private final VisibleAreaListener visibleAreaListener = this::generateViewportActivity;
 
@@ -35,9 +34,8 @@ public class LocalViewPortChangeHandler implements DisableableHandler, Startable
    *
    * @param editorManager the EditorManager instance
    */
-  public LocalViewPortChangeHandler(EditorManager editorManager, EditorAPI editorAPI) {
+  public LocalViewPortChangeHandler(EditorManager editorManager) {
     this.editorManager = editorManager;
-    this.editorAPI = editorAPI;
 
     this.enabled = false;
     this.disposed = false;
@@ -104,7 +102,7 @@ public class LocalViewPortChangeHandler implements DisableableHandler, Startable
       return;
     }
 
-    LineRange newVisibleLineRange = editorAPI.getLocalViewPortRange(editor, newVisibleRectangle);
+    LineRange newVisibleLineRange = EditorAPI.getLocalViewPortRange(editor, newVisibleRectangle);
 
     editorManager.generateViewport(path, newVisibleLineRange);
   }


### PR DESCRIPTION
Continuation of #451, #452, and #453.

#### [INTERNAL][I] Remove EditorAPI dependency on the shared project

Adjusts the EditorAPI methods used to modify editor contents to use the
passed project reference for the command processor instead of the
project object held by the session context.

Adjusts the usage of the adjusted methods to request the matching
project object from the module the resource belongs to.

#### [REFACTOR][I] Move document modification methods to DocumentAPI

#### [REFACTOR][I] Make EditorAPI static
Makes the class EditorAPI static as it is only a utility class that does
not hold a state. Subsequently removes the class from the session
context.