### PR TITLE
Prepare to remove project from plugin context (5 of X)

### DIFF
--- a/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
+++ b/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
@@ -7,7 +7,6 @@ import saros.communication.connection.NullProxyResolver;
 import saros.context.AbstractContextFactory;
 import saros.context.IContextKeyBindings;
 import saros.core.monitoring.remote.IntelliJRemoteProgressIndicatorFactoryImpl;
-import saros.core.project.internal.SarosIntellijSessionContextFactory;
 import saros.core.ui.eventhandler.NegotiationHandler;
 import saros.core.ui.eventhandler.UserStatusChangeHandler;
 import saros.core.ui.eventhandler.XMPPAuthorizationHandler;

--- a/intellij/src/saros/intellij/context/SarosIntellijSessionContextFactory.java
+++ b/intellij/src/saros/intellij/context/SarosIntellijSessionContextFactory.java
@@ -1,4 +1,4 @@
-package saros.core.project.internal;
+package saros.intellij.context;
 
 import saros.intellij.editor.LocalEditorHandler;
 import saros.intellij.editor.LocalEditorManipulator;


### PR DESCRIPTION
Continuation of #451, #452, #453, and #510.

#### [REFACTOR][I] Move session context factory to intellij package

Moves SarosIntellijSessionContextFactory to the package
'intellij.context'. This was done as the class contains Saros/I specific
dependencies, meaning it can not be moved to the core. For this reason,
it should not remain in the 'core' package.