### PR TITLE
Add a Gradle property to exclude STF self-tests from the test runner

### DIFF
--- a/.idea/runConfigurations/saros__runIde_.xml
+++ b/.idea/runConfigurations/saros__runIde_.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="saros [runIde]" type="GradleRunConfiguration" factoryName="Gradle" singleton="false">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="runIde" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <GradleScriptDebugEnabled>true</GradleScriptDebugEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/saros__test_.xml
+++ b/.idea/runConfigurations/saros__test_.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="saros [test]" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-PskipTestSuites=true -PskipSTFTests=true" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="test" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <GradleScriptDebugEnabled>true</GradleScriptDebugEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/saros__test__rerun_tasks.xml
+++ b/.idea/runConfigurations/saros__test__rerun_tasks.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="saros [test] rerun-tasks" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-PskipTestSuites=true -PskipSTFTests=true --rerun-tasks" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="test" />
+        </list>
+      </option>
+      <option name="vmOptions" value="" />
+    </ExternalSystemSettings>
+    <GradleScriptDebugEnabled>true</GradleScriptDebugEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,16 @@ configure(projectsToConfigure) { project ->
     if (project.hasProperty('skipTestSuites') && skipTestSuites.equalsIgnoreCase("true")) {
       exclude '**/*TestSuite*'
     }
+
+    /*
+     * Exclude STF tests if property is set. Otherwise the STF self-tests (which are reliant on test
+     * workers to function properly) are also run when executing the 'test' task to run all Saros
+     * test.
+     */
+    if (project.hasProperty('skipSTFTests') && skipSTFTests.equalsIgnoreCase("true")) {
+      exclude 'saros/stf/test/stf/*'
+    }
+
     exclude '**/Abstract*'
 
     testLogging {


### PR DESCRIPTION
#### [BUILD] Add a property to exclude STF self-tests

Adds a gradle property to exclude STF self-tests from the test-runner.
This can be useful when trying to use the default 'test' task to run the
tests of all Saros components.

#### [BUILD][I] Add some run configurations

Adds some useful run configurations that are automatically loaded by
IntelliJ on loading the project:
 - Adds a "runIDE" config that can be run in parallel
 - Adds a "test" config that excludes TestSuites and STF self-tests
 - Adds a "test" config that excludes TestSuites and STF self-tests and
   always re-runs all test tasks independently of the gradle cache