### PR TITLE
[BUILD][I] Remove build classpath workaround

### DIFF
--- a/intellij/build.gradle
+++ b/intellij/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.3.4"
+    classpath "gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.4.8"
   }
 }
 
@@ -71,14 +71,13 @@ intellij {
   if (project.hasProperty('intellijHome')) {
     localPath = intellijHome
   } else {
-    version = 'IC-2018.2.6'
+    version = 'IC-2019.1.2'
   }
 
   // don't overwrite the version compatibility defined in the plugin.xml
   updateSinceUntilBuild = false
 
   pluginName 'Saros'
-  configureDefaultDependencies = false
 
   // determine new sandbox dir that is not locked
   Integer sandboxCount = 1
@@ -111,7 +110,7 @@ runIde.finalizedBy(unlockIntellijSandbox)
 
 afterEvaluate {
   dependencies {
-    compile intellij {exclude 'junit*.jar'}
+    compile intellij {}
   }
 }
 

--- a/intellij/build.gradle
+++ b/intellij/build.gradle
@@ -68,7 +68,7 @@ intellij {
   }
 
   // Download intellij only if the home property is not set
-  if (project.hasProperty('intellijHome')) {
+  if (intellijHome) {
     localPath = intellijHome
   } else {
     version = 'IC-2019.1.2'


### PR DESCRIPTION
Removes the workaround adjusting the build classpath used by gradle.
This workaround is no longer necessary as the library conflicts with
JUnit and PicoContainer have been resolved.

Updates the IntelliJ version used when no local installation is provided
to 2019.1.2 (the latest release at the time of writing).

Updates the used version of 'gradle-intellij-plugin' to 0.4.8 as the
current version has issues functioning with IntelliJ versions newer than
2019.1.