### PR TITLE
[INTERNAL][I] Show non-shareable modules in contact pop menu

### DIFF
--- a/intellij/src/saros/intellij/ui/Messages.java
+++ b/intellij/src/saros/intellij/ui/Messages.java
@@ -92,16 +92,17 @@ public class Messages {
   public static String Contact_saros_message_conditional;
 
   public static String ContactPopMenu_root_popup_text;
+  public static String ContactPopMenu_menu_tooltip_share_module;
+  public static String ContactPopMenu_menu_tooltip_project_module;
+  public static String ContactPopMenu_menu_tooltip_invalid_module;
+  public static String ContactPopMenu_menu_tooltip_error_module;
+  public static String ContactPopMenu_menu_entry_error_processing_project;
   public static String ContactPopMenu_menu_entry_no_modules_found;
   public static String ContactPopMenu_menu_entry_no_valid_modules_found;
   public static String ContactPopMenu_unsupported_ide_title;
   public static String ContactPopMenu_unsupported_ide_message_condition;
   public static String ContactPopMenu_module_not_found_title;
   public static String ContactPopMenu_module_not_found_message_condition;
-  public static String ContactPopMenu_invalid_module_title;
-  public static String ContactPopMenu_invalid_module_message_condition;
-  public static String ContactPopMenu_error_creating_module_object_title;
-  public static String ContactPopMenu_error_creating_module_object_message;
 
   public static String ShareWithUserAction_description;
 

--- a/intellij/src/saros/intellij/ui/messages.properties
+++ b/intellij/src/saros/intellij/ui/messages.properties
@@ -79,16 +79,17 @@ ConnectButton_connect_to_new_account_message=Connect to the created Account?\nNO
 Contact_saros_message_conditional={0}, please contact the Saros development team. You can reach us by writing to our mailing list (<a href=\"https://groups.google.com/forum/#!forum/saros-devel\">forum</a>, <a href=\"mailto:saros-devel@googlegroups.com\">mailto</a>).
 
 ContactPopMenu_root_popup_text=Work together on...
+ContactPopMenu_menu_tooltip_share_module=Share this module through Saros.
+ContactPopMenu_menu_tooltip_project_module=Project modules currently can not be shared through Saros/I.
+ContactPopMenu_menu_tooltip_invalid_module=Module can not be shared as it does not match the current module restrictions.
+ContactPopMenu_menu_tooltip_error_module=Saros encountered an error while trying to process the module.
+ContactPopMenu_menu_entry_error_processing_project=Saros encountered an error while trying to process the project.
 ContactPopMenu_menu_entry_no_modules_found=No modules found!
 ContactPopMenu_menu_entry_no_valid_modules_found=No modules complying with our current release restrictions found!
 ContactPopMenu_unsupported_ide_title=Unsupported IDE
 ContactPopMenu_unsupported_ide_message_condition=The local module manager could not be found. This most likely means that you are not using IntelliJ IDEA or are using an unsupported version. If you are using a supported version of IntelliJ IDEA
 ContactPopMenu_module_not_found_title=Module not found - Project sharing aborted
 ContactPopMenu_module_not_found_message_condition=Saros could not find the chosen module {0}. Please make sure that the module is correctly configured in the current project and exists on disk.\nIf there seems to be no problem with the module
-ContactPopMenu_invalid_module_title=Invalid modules not shown
-ContactPopMenu_invalid_module_message_condition=The module(s) {0} can not be shared through Saros and are therefore not shown. This is probably due to the modules not meeting the current restrictions. Modules should have exactly one content root that is located in the project root directory.\nIf these modules do meets the given restrictions
-ContactPopMenu_error_creating_module_object_title=Problem while handling the module "{0}"
-ContactPopMenu_error_creating_module_object_message=Saros encountered an error while trying to handle the module "{0}". Please make sure that the module is configured correctly.\n{1}
 
 ShareWithUserAction_description=Share this module with {0}
 


### PR DESCRIPTION
Adjusts ContactPopMenu to also show non-shareable modules. Such modules
are disabled in the menu and are displayed in a separate group.
Furthermore, the carry a tooltip explaining that/why they can't be
shared.

Subsequently removes the user notification when encountering a
non-shareable module.

This re-structuring was done to avoid annoying the user with unnecessary
notifications.