### PR TITLE
Prepare to remove project from plugin context (7 of 7)

### DIFF
--- a/intellij/src/saros/intellij/context/SarosIntellijSessionContextFactory.java
+++ b/intellij/src/saros/intellij/context/SarosIntellijSessionContextFactory.java
@@ -7,7 +7,6 @@ import saros.intellij.editor.SelectedEditorStateSnapshotFactory;
 import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.eventhandler.ApplicationEventHandlersFactory;
 import saros.intellij.eventhandler.ProjectEventHandlersFactory;
-import saros.intellij.filesystem.VirtualFileConverter;
 import saros.intellij.followmode.FollowModeNotificationDispatcher;
 import saros.intellij.project.SharedResourcesManager;
 import saros.intellij.project.filesystem.ModuleInitialization;
@@ -45,8 +44,5 @@ public class SarosIntellijSessionContextFactory extends SarosCoreSessionContextF
 
     // User notifications
     container.addComponent(FollowModeNotificationDispatcher.class);
-
-    // Utility
-    container.addComponent(VirtualFileConverter.class);
   }
 }

--- a/intellij/src/saros/intellij/context/SarosIntellijSessionContextFactory.java
+++ b/intellij/src/saros/intellij/context/SarosIntellijSessionContextFactory.java
@@ -2,7 +2,6 @@ package saros.intellij.context;
 
 import saros.intellij.editor.LocalEditorHandler;
 import saros.intellij.editor.LocalEditorManipulator;
-import saros.intellij.editor.ProjectAPI;
 import saros.intellij.editor.SelectedEditorStateSnapshotFactory;
 import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.eventhandler.ApplicationEventHandlersFactory;
@@ -24,9 +23,6 @@ public class SarosIntellijSessionContextFactory extends SarosCoreSessionContextF
     container.addComponent(SharedIDEContext.class);
     container.addComponent(ApplicationEventHandlersFactory.class);
     container.addComponent(ProjectEventHandlersFactory.class);
-
-    // Project interaction
-    container.addComponent(ProjectAPI.class);
 
     // Editor interaction
     container.addComponent(LocalEditorHandler.class);

--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.event.SelectionEvent;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -36,6 +37,7 @@ import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.eventhandler.IProjectEventHandler.ProjectEventHandlerType;
 import saros.intellij.eventhandler.editor.editorstate.ViewportAdjustmentExecutor;
 import saros.intellij.filesystem.Filesystem;
+import saros.intellij.filesystem.IntelliJProjectImpl;
 import saros.intellij.filesystem.VirtualFileConverter;
 import saros.observables.FileReplacementInProgressObservable;
 import saros.session.AbstractActivityConsumer;
@@ -251,7 +253,9 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
           Set<String> visibleFilePaths = new HashSet<>();
 
-          for (VirtualFile virtualFile : projectAPI.getSelectedFiles()) {
+          Project project = sharedIDEContext.getProject();
+
+          for (VirtualFile virtualFile : ProjectAPI.getSelectedFiles(project)) {
             visibleFilePaths.add(virtualFile.getPath());
           }
 
@@ -266,7 +270,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
                     sendSelectionInformation(localUser, path, editor);
                   });
 
-          Editor activeEditor = projectAPI.getActiveEditor();
+          Editor activeEditor = ProjectAPI.getActiveEditor(project);
 
           SPath activeEditorPath;
 
@@ -371,7 +375,9 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
    * @param project the added project
    */
   private void addProjectResources(IProject project) {
-    VirtualFile[] openFiles = projectAPI.getOpenFiles();
+    Project intellijProject = project.adaptTo(IntelliJProjectImpl.class).getModule().getProject();
+
+    VirtualFile[] openFiles = ProjectAPI.getOpenFiles(intellijProject);
 
     SelectedEditorStateSnapshot selectedEditorStateSnapshot =
         selectedEditorStateSnapshotFactory.capturedState();
@@ -425,8 +431,6 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
           userEditorStateManager = session.getComponent(UserEditorStateManager.class);
 
-          projectAPI = sarosSession.getComponent(ProjectAPI.class);
-
           localEditorHandler = sarosSession.getComponent(LocalEditorHandler.class);
           localEditorManipulator = sarosSession.getComponent(LocalEditorManipulator.class);
 
@@ -444,8 +448,6 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
           session = null;
 
           userEditorStateManager = null;
-
-          projectAPI = null;
 
           localEditorHandler = null;
           localEditorManipulator = null;
@@ -492,7 +494,6 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
   /* Session Components */
   private UserEditorStateManager userEditorStateManager;
   private ISarosSession session;
-  private ProjectAPI projectAPI;
   private LocalEditorHandler localEditorHandler;
   private LocalEditorManipulator localEditorManipulator;
   private AnnotationManager annotationManager;
@@ -873,7 +874,9 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
     Set<String> visibleFilePaths = new HashSet<>();
 
-    for (VirtualFile virtualFile : projectAPI.getSelectedFiles()) {
+    Project project = path.getProject().adaptTo(IntelliJProjectImpl.class).getModule().getProject();
+
+    for (VirtualFile virtualFile : ProjectAPI.getSelectedFiles(project)) {
       visibleFilePaths.add(virtualFile.getPath());
     }
 

--- a/intellij/src/saros/intellij/editor/LocalEditorHandler.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorHandler.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.Nullable;
 import saros.activities.SPath;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
+import saros.intellij.filesystem.IntelliJProjectImpl;
 import saros.intellij.filesystem.VirtualFileConverter;
 import saros.session.ISarosSession;
 
@@ -21,17 +22,13 @@ public class LocalEditorHandler {
 
   private static final Logger LOG = Logger.getLogger(LocalEditorHandler.class);
 
-  private final ProjectAPI projectAPI;
   private final EditorManager manager;
   private final ISarosSession sarosSession;
 
   /** This is just a reference to {@link EditorManager}'s editorPool and not a separate pool. */
   private final EditorPool editorPool;
 
-  public LocalEditorHandler(
-      ProjectAPI projectAPI, EditorManager editorManager, ISarosSession sarosSession) {
-
-    this.projectAPI = projectAPI;
+  public LocalEditorHandler(EditorManager editorManager, ISarosSession sarosSession) {
     this.manager = editorManager;
     this.sarosSession = sarosSession;
 
@@ -133,7 +130,9 @@ public class LocalEditorHandler {
       return null;
     }
 
-    Editor editor = projectAPI.openEditor(virtualFile, activate);
+    Project project = path.getProject().adaptTo(IntelliJProjectImpl.class).getModule().getProject();
+
+    Editor editor = ProjectAPI.openEditor(project, virtualFile, activate);
 
     editorPool.add(path, editor);
     manager.startEditor(editor);
@@ -245,6 +244,8 @@ public class LocalEditorHandler {
       return false;
     }
 
-    return projectAPI.isOpen(doc);
+    Project project = path.getProject().adaptTo(IntelliJProjectImpl.class).getModule().getProject();
+
+    return ProjectAPI.isOpen(project, doc);
   }
 }

--- a/intellij/src/saros/intellij/editor/LocalEditorHandler.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorHandler.java
@@ -2,6 +2,7 @@ package saros.intellij.editor;
 
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -23,21 +24,16 @@ public class LocalEditorHandler {
   private final ProjectAPI projectAPI;
   private final EditorManager manager;
   private final ISarosSession sarosSession;
-  private final VirtualFileConverter virtualFileConverter;
 
   /** This is just a reference to {@link EditorManager}'s editorPool and not a separate pool. */
   private final EditorPool editorPool;
 
   public LocalEditorHandler(
-      ProjectAPI projectAPI,
-      EditorManager editorManager,
-      ISarosSession sarosSession,
-      VirtualFileConverter virtualFileConverter) {
+      ProjectAPI projectAPI, EditorManager editorManager, ISarosSession sarosSession) {
 
     this.projectAPI = projectAPI;
     this.manager = editorManager;
     this.sarosSession = sarosSession;
-    this.virtualFileConverter = virtualFileConverter;
 
     this.editorPool = manager.getEditorPool();
   }
@@ -48,19 +44,21 @@ public class LocalEditorHandler {
    *
    * <p><b>Note:</b> This only works for shared resources.
    *
+   * @param project the project in which to open the editor
    * @param virtualFile path of the file to open
    * @param activate activate editor after opening
    * @return the opened <code>Editor</code> or <code>null</code> if the given file does not belong
    *     to a shared module
    */
   @Nullable
-  public Editor openEditor(@NotNull VirtualFile virtualFile, boolean activate) {
+  public Editor openEditor(
+      @NotNull Project project, @NotNull VirtualFile virtualFile, boolean activate) {
 
     if (!manager.hasSession()) {
       return null;
     }
 
-    SPath path = virtualFileConverter.convertToSPath(virtualFile);
+    SPath path = VirtualFileConverter.convertToSPath(project, virtualFile);
 
     if (path == null || !sarosSession.isShared(path.getResource())) {
       LOG.debug(
@@ -148,10 +146,11 @@ public class LocalEditorHandler {
   /**
    * Removes a file from the editorPool and calls {@link EditorManager#generateEditorClosed(SPath)}
    *
-   * @param virtualFile
+   * @param project the project in which to close the editor
+   * @param virtualFile the file for which to close the editor
    */
-  public void closeEditor(@NotNull VirtualFile virtualFile) {
-    SPath path = virtualFileConverter.convertToSPath(virtualFile);
+  public void closeEditor(@NotNull Project project, @NotNull VirtualFile virtualFile) {
+    SPath path = VirtualFileConverter.convertToSPath(project, virtualFile);
 
     if (path != null && sarosSession.isShared(path.getResource())) {
       editorPool.removeEditor(path);
@@ -206,9 +205,10 @@ public class LocalEditorHandler {
    * outside the editor package. If you still need to access this method, please consider whether
    * your class should rather be located in the editor package.
    *
+   * @param project the project in which to activate the editor
    * @param file the file whose editor was activated or <code>null</code> if there is no editor open
    */
-  public void activateEditor(@Nullable VirtualFile file) {
+  public void activateEditor(@NotNull Project project, @Nullable VirtualFile file) {
     if (file == null) {
 
       if (manager.hasSession()) {
@@ -218,7 +218,7 @@ public class LocalEditorHandler {
       return;
     }
 
-    SPath path = virtualFileConverter.convertToSPath(file);
+    SPath path = VirtualFileConverter.convertToSPath(project, file);
 
     if (path != null && sarosSession.isShared(path.getResource())) {
       manager.generateEditorActivated(path);

--- a/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
@@ -29,7 +29,6 @@ public class LocalEditorManipulator {
 
   private static final Logger LOG = Logger.getLogger(LocalEditorManipulator.class);
 
-  private final ProjectAPI projectAPI;
   private final AnnotationManager annotationManager;
   private final ISarosSession sarosSession;
 
@@ -39,12 +38,10 @@ public class LocalEditorManipulator {
   private EditorManager manager;
 
   public LocalEditorManipulator(
-      ProjectAPI projectAPI,
       AnnotationManager annotationManager,
       EditorManager editorManager,
       ISarosSession sarosSession) {
 
-    this.projectAPI = projectAPI;
     this.annotationManager = annotationManager;
     this.manager = editorManager;
     this.sarosSession = sarosSession;
@@ -82,7 +79,9 @@ public class LocalEditorManipulator {
       return null;
     }
 
-    Editor editor = projectAPI.openEditor(virtualFile, activate);
+    Project project = path.getProject().adaptTo(IntelliJProjectImpl.class).getModule().getProject();
+
+    Editor editor = ProjectAPI.openEditor(project, virtualFile, activate);
 
     manager.startEditor(editor);
     editorPool.add(path, editor);
@@ -114,8 +113,10 @@ public class LocalEditorManipulator {
       return;
     }
 
-    if (projectAPI.isOpen(virtualFile)) {
-      projectAPI.closeEditor(virtualFile);
+    Project project = path.getProject().adaptTo(IntelliJProjectImpl.class).getModule().getProject();
+
+    if (ProjectAPI.isOpen(project, virtualFile)) {
+      ProjectAPI.closeEditor(project, virtualFile);
     }
 
     LOG.debug("Closed editor for file " + virtualFile);
@@ -366,8 +367,8 @@ public class LocalEditorManipulator {
     }
 
     Editor editor = null;
-    if (projectAPI.isOpen(virtualFile)) {
-      editor = projectAPI.openEditor(virtualFile, false);
+    if (ProjectAPI.isOpen(project, virtualFile)) {
+      editor = ProjectAPI.openEditor(project, virtualFile, false);
     }
 
     annotationManager.addContributionAnnotation(source, file, 0, documentLength, editor);

--- a/intellij/src/saros/intellij/editor/ProjectAPI.java
+++ b/intellij/src/saros/intellij/editor/ProjectAPI.java
@@ -6,91 +6,104 @@ import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
 import saros.intellij.filesystem.Filesystem;
 
-/** Wrapper for interacting with the project-level Intellij editor API. */
+/** Static utility class for interacting with the project-level Intellij editor API. */
 public class ProjectAPI {
-  private Project project;
-  private FileEditorManager editorFileManager;
-
-  public ProjectAPI(Project project) {
-    this.project = project;
-
-    this.editorFileManager = FileEditorManager.getInstance(project);
+  private ProjectAPI() {
+    // NOP
   }
 
   /**
    * Returns whether there is an open editor for the given file.
    *
+   * @param project the project in which to check
    * @param virtualFile the file to check
    * @return whether there is an open editor for the given file
    */
-  public boolean isOpen(VirtualFile virtualFile) {
-    return editorFileManager.isFileOpen(virtualFile);
+  public static boolean isOpen(@NotNull Project project, @NotNull VirtualFile virtualFile) {
+    return getFileEditorManager(project).isFileOpen(virtualFile);
   }
 
   /**
    * Returns whether there is an open editor for the given document.
    *
+   * @param project the project in which to check
    * @param document the document to check
    * @return Returns whether there is an open editor for the given document.
    */
-  public boolean isOpen(Document document) {
+  public static boolean isOpen(@NotNull Project project, @NotNull Document document) {
     VirtualFile file = DocumentAPI.getVirtualFile(document);
 
-    return isOpen(file);
+    if (file == null) {
+      throw new IllegalStateException(
+          "Could not retrieve the document for the given document " + document);
+    }
+
+    return isOpen(project, file);
   }
 
   /**
    * Opens an editor for the given file in the UI thread.
    *
+   * @param project the project in which to open the editor
    * @param virtualFile file for which to open an editor
    * @param activate activate editor after opening
    * @return Editor managing the passed file
    */
-  public Editor openEditor(final VirtualFile virtualFile, final boolean activate) {
+  public static Editor openEditor(
+      @NotNull Project project, @NotNull VirtualFile virtualFile, final boolean activate) {
     return Filesystem.runReadAction(
         () ->
-            editorFileManager.openTextEditor(
-                new OpenFileDescriptor(project, virtualFile), activate));
+            getFileEditorManager(project)
+                .openTextEditor(new OpenFileDescriptor(project, virtualFile), activate));
   }
 
   /**
    * Closes the editor for the given file in the UI thread.
    *
+   * @param project the project in which to close the editor
    * @param virtualFile the file whose editor to close
    */
-  public void closeEditor(final VirtualFile virtualFile) {
-
-    Filesystem.runReadAction(() -> editorFileManager.closeFile(virtualFile));
+  public static void closeEditor(@NotNull Project project, @NotNull final VirtualFile virtualFile) {
+    Filesystem.runReadAction(() -> getFileEditorManager(project).closeFile(virtualFile));
   }
 
   /**
    * Returns an array containing the files of all currently open editors. It is sorted by the order
    * of the editor tabs.
    *
+   * @param project the project whose open editors to return
    * @return array containing the files of all currently open editors
    */
-  public VirtualFile[] getOpenFiles() {
-    return editorFileManager.getOpenFiles();
+  public static VirtualFile[] getOpenFiles(@NotNull Project project) {
+    return getFileEditorManager(project).getOpenFiles();
   }
 
   /**
    * Returns the currently selected editor.
    *
+   * @param project the project whose open editor to return
    * @return the currently selected editor
    */
-  public Editor getActiveEditor() {
-    return editorFileManager.getSelectedTextEditor();
+  public static Editor getActiveEditor(@NotNull Project project) {
+    return getFileEditorManager(project).getSelectedTextEditor();
   }
 
   /**
    * Returns an array containing the files of all currently active editors. It is sorted by time of
    * last activation, starting with the most recent one.
    *
+   * @param project the project whose selected files to return
    * @return an array containing the files of all currently active editors
    */
-  public VirtualFile[] getSelectedFiles() {
-    return editorFileManager.getSelectedFiles();
+  public static VirtualFile[] getSelectedFiles(@NotNull Project project) {
+    return getFileEditorManager(project).getSelectedFiles();
+  }
+
+  @NotNull
+  private static FileEditorManager getFileEditorManager(@NotNull Project project) {
+    return FileEditorManager.getInstance(project);
   }
 }

--- a/intellij/src/saros/intellij/editor/SelectedEditorStateSnapshotFactory.java
+++ b/intellij/src/saros/intellij/editor/SelectedEditorStateSnapshotFactory.java
@@ -1,5 +1,7 @@
 package saros.intellij.editor;
 
+import saros.intellij.context.SharedIDEContext;
+
 /**
  * Factory class that can be used to create and obtain snapshots of the current selected editor
  * state.
@@ -8,11 +10,12 @@ package saros.intellij.editor;
  */
 public class SelectedEditorStateSnapshotFactory {
 
-  private final ProjectAPI projectAPI;
+  private final SharedIDEContext sharedIDEContext;
   private final EditorManager editorManager;
 
-  public SelectedEditorStateSnapshotFactory(ProjectAPI projectAPI, EditorManager editorManager) {
-    this.projectAPI = projectAPI;
+  public SelectedEditorStateSnapshotFactory(
+      SharedIDEContext sharedIDEContext, EditorManager editorManager) {
+    this.sharedIDEContext = sharedIDEContext;
     this.editorManager = editorManager;
   }
 
@@ -23,6 +26,6 @@ public class SelectedEditorStateSnapshotFactory {
    * @see SelectedEditorStateSnapshot
    */
   public SelectedEditorStateSnapshot capturedState() {
-    return new SelectedEditorStateSnapshot(projectAPI, editorManager);
+    return new SelectedEditorStateSnapshot(sharedIDEContext, editorManager);
   }
 }

--- a/intellij/src/saros/intellij/eventhandler/ApplicationEventHandlersFactory.java
+++ b/intellij/src/saros/intellij/eventhandler/ApplicationEventHandlersFactory.java
@@ -6,7 +6,6 @@ import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 import saros.intellij.editor.EditorManager;
 import saros.intellij.editor.LocalEditorHandler;
-import saros.intellij.editor.ProjectAPI;
 import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.eventhandler.filesystem.LocalFilesystemModificationHandler;
 import saros.observables.FileReplacementInProgressObservable;
@@ -18,7 +17,6 @@ public class ApplicationEventHandlersFactory {
   private final EditorManager editorManager;
   private final ISarosSession sarosSession;
   private final FileReplacementInProgressObservable fileReplacementInProgressObservable;
-  private final ProjectAPI projectAPI;
   private final AnnotationManager annotationManager;
   private final LocalEditorHandler localEditorHandler;
 
@@ -26,14 +24,12 @@ public class ApplicationEventHandlersFactory {
       EditorManager editorManager,
       ISarosSession sarosSession,
       FileReplacementInProgressObservable fileReplacementInProgressObservable,
-      ProjectAPI projectAPI,
       AnnotationManager annotationManager,
       LocalEditorHandler localEditorHandler) {
 
     this.editorManager = editorManager;
     this.sarosSession = sarosSession;
     this.fileReplacementInProgressObservable = fileReplacementInProgressObservable;
-    this.projectAPI = projectAPI;
     this.annotationManager = annotationManager;
     this.localEditorHandler = localEditorHandler;
   }
@@ -71,7 +67,6 @@ public class ApplicationEventHandlersFactory {
             editorManager,
             sarosSession,
             fileReplacementInProgressObservable,
-            projectAPI,
             annotationManager,
             localEditorHandler));
 

--- a/intellij/src/saros/intellij/eventhandler/ApplicationEventHandlersFactory.java
+++ b/intellij/src/saros/intellij/eventhandler/ApplicationEventHandlersFactory.java
@@ -9,7 +9,6 @@ import saros.intellij.editor.LocalEditorHandler;
 import saros.intellij.editor.ProjectAPI;
 import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.eventhandler.filesystem.LocalFilesystemModificationHandler;
-import saros.intellij.filesystem.VirtualFileConverter;
 import saros.observables.FileReplacementInProgressObservable;
 import saros.session.ISarosSession;
 
@@ -22,7 +21,6 @@ public class ApplicationEventHandlersFactory {
   private final ProjectAPI projectAPI;
   private final AnnotationManager annotationManager;
   private final LocalEditorHandler localEditorHandler;
-  private final VirtualFileConverter virtualFileConverter;
 
   public ApplicationEventHandlersFactory(
       EditorManager editorManager,
@@ -30,8 +28,7 @@ public class ApplicationEventHandlersFactory {
       FileReplacementInProgressObservable fileReplacementInProgressObservable,
       ProjectAPI projectAPI,
       AnnotationManager annotationManager,
-      LocalEditorHandler localEditorHandler,
-      VirtualFileConverter virtualFileConverter) {
+      LocalEditorHandler localEditorHandler) {
 
     this.editorManager = editorManager;
     this.sarosSession = sarosSession;
@@ -39,7 +36,6 @@ public class ApplicationEventHandlersFactory {
     this.projectAPI = projectAPI;
     this.annotationManager = annotationManager;
     this.localEditorHandler = localEditorHandler;
-    this.virtualFileConverter = virtualFileConverter;
   }
 
   /**
@@ -71,14 +67,13 @@ public class ApplicationEventHandlersFactory {
      */
     applicationEventHandlers.add(
         new LocalFilesystemModificationHandler(
+            project,
             editorManager,
             sarosSession,
             fileReplacementInProgressObservable,
             projectAPI,
             annotationManager,
-            project,
-            localEditorHandler,
-            virtualFileConverter));
+            localEditorHandler));
 
     return new ApplicationEventHandlers(applicationEventHandlers);
   }

--- a/intellij/src/saros/intellij/eventhandler/ProjectEventHandlersFactory.java
+++ b/intellij/src/saros/intellij/eventhandler/ProjectEventHandlersFactory.java
@@ -7,7 +7,6 @@ import org.jetbrains.annotations.NotNull;
 import saros.intellij.editor.EditorManager;
 import saros.intellij.editor.LocalEditorHandler;
 import saros.intellij.editor.LocalEditorManipulator;
-import saros.intellij.editor.ProjectAPI;
 import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.eventhandler.editor.document.LocalClosedEditorModificationHandler;
 import saros.intellij.eventhandler.editor.document.LocalDocumentModificationHandler;
@@ -24,7 +23,6 @@ public class ProjectEventHandlersFactory {
 
   private final EditorManager editorManager;
   private final ISarosSession sarosSession;
-  private final ProjectAPI projectAPI;
   private final AnnotationManager annotationManager;
   private final LocalEditorHandler localEditorHandler;
   private final LocalEditorManipulator localEditorManipulator;
@@ -32,14 +30,12 @@ public class ProjectEventHandlersFactory {
   public ProjectEventHandlersFactory(
       EditorManager editorManager,
       ISarosSession sarosSession,
-      ProjectAPI projectAPI,
       AnnotationManager annotationManager,
       LocalEditorHandler localEditorHandler,
       LocalEditorManipulator localEditorManipulator) {
 
     this.editorManager = editorManager;
     this.sarosSession = sarosSession;
-    this.projectAPI = projectAPI;
     this.annotationManager = annotationManager;
     this.localEditorHandler = localEditorHandler;
     this.localEditorManipulator = localEditorManipulator;
@@ -65,7 +61,7 @@ public class ProjectEventHandlersFactory {
      */
     projectEventHandlers.add(
         new LocalClosedEditorModificationHandler(
-            project, editorManager, sarosSession, projectAPI, annotationManager));
+            project, editorManager, sarosSession, annotationManager));
 
     projectEventHandlers.add(
         new LocalDocumentModificationHandler(project, editorManager, sarosSession));
@@ -82,8 +78,7 @@ public class ProjectEventHandlersFactory {
         new PreexistingSelectionDispatcher(
             project, editorManager, localEditorHandler, sarosSession));
 
-    projectEventHandlers.add(
-        new ViewportAdjustmentExecutor(project, projectAPI, localEditorManipulator));
+    projectEventHandlers.add(new ViewportAdjustmentExecutor(project, localEditorManipulator));
 
     /*
      * editor selection change handlers

--- a/intellij/src/saros/intellij/eventhandler/ProjectEventHandlersFactory.java
+++ b/intellij/src/saros/intellij/eventhandler/ProjectEventHandlersFactory.java
@@ -17,14 +17,12 @@ import saros.intellij.eventhandler.editor.editorstate.PreexistingSelectionDispat
 import saros.intellij.eventhandler.editor.editorstate.ViewportAdjustmentExecutor;
 import saros.intellij.eventhandler.editor.selection.LocalTextSelectionChangeHandler;
 import saros.intellij.eventhandler.editor.viewport.LocalViewPortChangeHandler;
-import saros.intellij.filesystem.VirtualFileConverter;
 import saros.session.ISarosSession;
 
 /** Factory to instantiate {@link ProjectEventHandlers} objects. */
 public class ProjectEventHandlersFactory {
 
   private final EditorManager editorManager;
-  private final VirtualFileConverter virtualFileConverter;
   private final ISarosSession sarosSession;
   private final ProjectAPI projectAPI;
   private final AnnotationManager annotationManager;
@@ -33,7 +31,6 @@ public class ProjectEventHandlersFactory {
 
   public ProjectEventHandlersFactory(
       EditorManager editorManager,
-      VirtualFileConverter virtualFileConverter,
       ISarosSession sarosSession,
       ProjectAPI projectAPI,
       AnnotationManager annotationManager,
@@ -41,7 +38,6 @@ public class ProjectEventHandlersFactory {
       LocalEditorManipulator localEditorManipulator) {
 
     this.editorManager = editorManager;
-    this.virtualFileConverter = virtualFileConverter;
     this.sarosSession = sarosSession;
     this.projectAPI = projectAPI;
     this.annotationManager = annotationManager;
@@ -69,23 +65,22 @@ public class ProjectEventHandlersFactory {
      */
     projectEventHandlers.add(
         new LocalClosedEditorModificationHandler(
-            editorManager, virtualFileConverter, sarosSession, projectAPI, annotationManager));
+            project, editorManager, sarosSession, projectAPI, annotationManager));
 
     projectEventHandlers.add(
-        new LocalDocumentModificationHandler(editorManager, sarosSession, virtualFileConverter));
+        new LocalDocumentModificationHandler(project, editorManager, sarosSession));
 
     /*
      * editor state change handlers
      */
     projectEventHandlers.add(
-        new AnnotationUpdater(
-            project, annotationManager, localEditorHandler, sarosSession, virtualFileConverter));
+        new AnnotationUpdater(project, annotationManager, localEditorHandler, sarosSession));
 
     projectEventHandlers.add(new EditorStatusChangeActivityDispatcher(project, localEditorHandler));
 
     projectEventHandlers.add(
         new PreexistingSelectionDispatcher(
-            project, editorManager, localEditorHandler, sarosSession, virtualFileConverter));
+            project, editorManager, localEditorHandler, sarosSession));
 
     projectEventHandlers.add(
         new ViewportAdjustmentExecutor(project, projectAPI, localEditorManipulator));

--- a/intellij/src/saros/intellij/eventhandler/editor/document/LocalClosedEditorModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/document/LocalClosedEditorModificationHandler.java
@@ -3,13 +3,13 @@ package saros.intellij.eventhandler.editor.document;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.event.DocumentEvent;
 import com.intellij.openapi.editor.event.DocumentListener;
+import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 import saros.activities.SPath;
 import saros.filesystem.IFile;
 import saros.intellij.editor.EditorManager;
 import saros.intellij.editor.ProjectAPI;
 import saros.intellij.editor.annotations.AnnotationManager;
-import saros.intellij.filesystem.VirtualFileConverter;
 import saros.session.ISarosSession;
 
 /**
@@ -31,13 +31,13 @@ public class LocalClosedEditorModificationHandler extends AbstractLocalDocumentM
       };
 
   public LocalClosedEditorModificationHandler(
+      Project project,
       EditorManager editorManager,
-      VirtualFileConverter virtualFileConverter,
       ISarosSession sarosSession,
       ProjectAPI projectAPI,
       AnnotationManager annotationManager) {
 
-    super(editorManager, sarosSession, virtualFileConverter);
+    super(project, editorManager, sarosSession);
 
     this.projectAPI = projectAPI;
     this.annotationManager = annotationManager;

--- a/intellij/src/saros/intellij/eventhandler/editor/document/LocalClosedEditorModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/document/LocalClosedEditorModificationHandler.java
@@ -19,7 +19,6 @@ import saros.session.ISarosSession;
  * @see com.intellij.openapi.editor.event.DocumentListener
  */
 public class LocalClosedEditorModificationHandler extends AbstractLocalDocumentModificationHandler {
-  private final ProjectAPI projectAPI;
   private final AnnotationManager annotationManager;
 
   private final DocumentListener documentListener =
@@ -34,12 +33,10 @@ public class LocalClosedEditorModificationHandler extends AbstractLocalDocumentM
       Project project,
       EditorManager editorManager,
       ISarosSession sarosSession,
-      ProjectAPI projectAPI,
       AnnotationManager annotationManager) {
 
     super(project, editorManager, sarosSession);
 
-    this.projectAPI = projectAPI;
     this.annotationManager = annotationManager;
   }
 
@@ -64,7 +61,7 @@ public class LocalClosedEditorModificationHandler extends AbstractLocalDocumentM
     String newText = event.getNewFragment().toString();
     String replacedText = event.getOldFragment().toString();
 
-    if (!projectAPI.isOpen(document)) {
+    if (!ProjectAPI.isOpen(project, document)) {
       IFile file = path.getFile();
 
       int replacedTextLength = replacedText.length();

--- a/intellij/src/saros/intellij/eventhandler/editor/document/LocalDocumentModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/document/LocalDocumentModificationHandler.java
@@ -3,10 +3,10 @@ package saros.intellij.eventhandler.editor.document;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.event.DocumentEvent;
 import com.intellij.openapi.editor.event.DocumentListener;
+import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 import saros.activities.SPath;
 import saros.intellij.editor.EditorManager;
-import saros.intellij.filesystem.VirtualFileConverter;
 import saros.session.ISarosSession;
 
 /**
@@ -26,11 +26,9 @@ public class LocalDocumentModificationHandler extends AbstractLocalDocumentModif
       };
 
   public LocalDocumentModificationHandler(
-      EditorManager editorManager,
-      ISarosSession sarosSession,
-      VirtualFileConverter virtualFileConverter) {
+      Project project, EditorManager editorManager, ISarosSession sarosSession) {
 
-    super(editorManager, sarosSession, virtualFileConverter);
+    super(project, editorManager, sarosSession);
   }
 
   /**

--- a/intellij/src/saros/intellij/eventhandler/editor/editorstate/AbstractLocalEditorStatusChangeHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/editorstate/AbstractLocalEditorStatusChangeHandler.java
@@ -20,7 +20,7 @@ import saros.intellij.eventhandler.IProjectEventHandler;
  */
 public abstract class AbstractLocalEditorStatusChangeHandler implements IProjectEventHandler {
 
-  private final Project project;
+  protected final Project project;
 
   private boolean enabled;
   private boolean disposed;

--- a/intellij/src/saros/intellij/eventhandler/editor/editorstate/AnnotationUpdater.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/editorstate/AnnotationUpdater.java
@@ -23,7 +23,6 @@ public class AnnotationUpdater extends AbstractLocalEditorStatusChangeHandler {
   private final AnnotationManager annotationManager;
   private final LocalEditorHandler localEditorHandler;
   private final ISarosSession sarosSession;
-  private final VirtualFileConverter virtualFileConverter;
 
   private final FileEditorManagerListener fileEditorManagerListener =
       new FileEditorManagerListener() {
@@ -50,15 +49,13 @@ public class AnnotationUpdater extends AbstractLocalEditorStatusChangeHandler {
       Project project,
       AnnotationManager annotationManager,
       LocalEditorHandler localEditorHandler,
-      ISarosSession sarosSession,
-      VirtualFileConverter virtualFileConverter) {
+      ISarosSession sarosSession) {
 
     super(project);
 
     this.annotationManager = annotationManager;
     this.localEditorHandler = localEditorHandler;
     this.sarosSession = sarosSession;
-    this.virtualFileConverter = virtualFileConverter;
   }
 
   /**
@@ -69,9 +66,9 @@ public class AnnotationUpdater extends AbstractLocalEditorStatusChangeHandler {
    * @see FileEditorManagerListener#fileOpened(FileEditorManager, VirtualFile)
    */
   private void setUpOpenedEditor(@NotNull VirtualFile virtualFile) {
-    Editor editor = localEditorHandler.openEditor(virtualFile, false);
+    Editor editor = localEditorHandler.openEditor(project, virtualFile, false);
 
-    SPath sPath = virtualFileConverter.convertToSPath(virtualFile);
+    SPath sPath = VirtualFileConverter.convertToSPath(project, virtualFile);
 
     if (sPath == null || editor == null) {
       return;
@@ -91,7 +88,7 @@ public class AnnotationUpdater extends AbstractLocalEditorStatusChangeHandler {
    * @see FileEditorManagerListener.Before#beforeFileClosed(FileEditorManager, VirtualFile)
    */
   private void cleanUpAnnotations(@NotNull VirtualFile virtualFile) {
-    SPath sPath = virtualFileConverter.convertToSPath(virtualFile);
+    SPath sPath = VirtualFileConverter.convertToSPath(project, virtualFile);
 
     if (sPath == null) {
       return;

--- a/intellij/src/saros/intellij/eventhandler/editor/editorstate/EditorStatusChangeActivityDispatcher.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/editorstate/EditorStatusChangeActivityDispatcher.java
@@ -43,23 +43,23 @@ public class EditorStatusChangeActivityDispatcher extends AbstractLocalEditorSta
   }
 
   /**
-   * Calls {@link LocalEditorHandler#closeEditor(VirtualFile)}.
+   * Calls {@link LocalEditorHandler#closeEditor(Project, VirtualFile)}.
    *
    * @param virtualFile the file whose editor was closed
    * @see FileEditorManagerListener#fileClosed(FileEditorManager, VirtualFile)
    */
   private void generateEditorClosedActivity(@NotNull VirtualFile virtualFile) {
-    localEditorHandler.closeEditor(virtualFile);
+    localEditorHandler.closeEditor(project, virtualFile);
   }
 
   /**
-   * Calls {@link LocalEditorHandler#activateEditor(VirtualFile)}.
+   * Calls {@link LocalEditorHandler#activateEditor(Project, VirtualFile)}.
    *
    * @param event the event to react to
    * @see FileEditorManagerListener#selectionChanged(FileEditorManagerEvent)
    */
   private void generateEditorActivatedActivity(@NotNull FileEditorManagerEvent event) {
-    localEditorHandler.activateEditor(event.getNewFile());
+    localEditorHandler.activateEditor(project, event.getNewFile());
   }
 
   @Override

--- a/intellij/src/saros/intellij/eventhandler/editor/editorstate/PreexistingSelectionDispatcher.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/editorstate/PreexistingSelectionDispatcher.java
@@ -27,7 +27,6 @@ public class PreexistingSelectionDispatcher extends AbstractLocalEditorStatusCha
   private final EditorManager editorManager;
   private final LocalEditorHandler localEditorHandler;
   private final ISarosSession sarosSession;
-  private final VirtualFileConverter virtualFileConverter;
 
   private final FileEditorManagerListener fileEditorManagerListener =
       new FileEditorManagerListener() {
@@ -43,15 +42,13 @@ public class PreexistingSelectionDispatcher extends AbstractLocalEditorStatusCha
       Project project,
       EditorManager editorManager,
       LocalEditorHandler localEditorHandler,
-      ISarosSession sarosSession,
-      VirtualFileConverter virtualFileConverter) {
+      ISarosSession sarosSession) {
 
     super(project);
 
     this.editorManager = editorManager;
     this.localEditorHandler = localEditorHandler;
     this.sarosSession = sarosSession;
-    this.virtualFileConverter = virtualFileConverter;
   }
 
   /**
@@ -62,9 +59,9 @@ public class PreexistingSelectionDispatcher extends AbstractLocalEditorStatusCha
    * @param virtualFile the file to send the current selection information for
    */
   private void sendExistingSelection(@NotNull VirtualFile virtualFile) {
-    Editor editor = localEditorHandler.openEditor(virtualFile, false);
+    Editor editor = localEditorHandler.openEditor(project, virtualFile, false);
 
-    SPath sPath = virtualFileConverter.convertToSPath(virtualFile);
+    SPath sPath = VirtualFileConverter.convertToSPath(project, virtualFile);
 
     if (sPath != null && sarosSession.isShared(sPath.getResource()) && editor != null) {
       editorManager.sendExistingSelection(sPath, editor);

--- a/intellij/src/saros/intellij/eventhandler/editor/editorstate/ViewportAdjustmentExecutor.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/editorstate/ViewportAdjustmentExecutor.java
@@ -21,7 +21,6 @@ import saros.intellij.editor.ProjectAPI;
  * adjustment once the corresponding editor is selected.
  */
 public class ViewportAdjustmentExecutor extends AbstractLocalEditorStatusChangeHandler {
-  private final ProjectAPI projectAPI;
   private final LocalEditorManipulator localEditorManipulator;
 
   private static final Map<String, QueuedViewPortChange> queuedViewPortChanges =
@@ -38,11 +37,10 @@ public class ViewportAdjustmentExecutor extends AbstractLocalEditorStatusChangeH
       };
 
   public ViewportAdjustmentExecutor(
-      Project project, ProjectAPI projectAPI, LocalEditorManipulator localEditorManipulator) {
+      Project project, LocalEditorManipulator localEditorManipulator) {
 
     super(project);
 
-    this.projectAPI = projectAPI;
     this.localEditorManipulator = localEditorManipulator;
   }
 
@@ -79,7 +77,7 @@ public class ViewportAdjustmentExecutor extends AbstractLocalEditorStatusChangeH
       editor = queuedEditor;
 
     } else {
-      editor = projectAPI.openEditor(virtualFile, false);
+      editor = ProjectAPI.openEditor(project, virtualFile, false);
     }
 
     ApplicationManager.getApplication()

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -59,15 +59,15 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
   private static final Logger LOG = Logger.getLogger(LocalFilesystemModificationHandler.class);
 
+  private final Project project;
+
   private final EditorManager editorManager;
   private final ISarosSession session;
   private final LocalFileSystem localFileSystem;
   private final FileReplacementInProgressObservable fileReplacementInProgressObservable;
   private final ProjectAPI projectAPI;
   private final AnnotationManager annotationManager;
-  private final Project project;
   private final LocalEditorHandler localEditorHandler;
-  private final VirtualFileConverter virtualFileConverter;
 
   private boolean enabled;
   private boolean disposed;
@@ -172,23 +172,22 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
    * @see #dispose()
    */
   public LocalFilesystemModificationHandler(
+      Project project,
       EditorManager editorManager,
       ISarosSession session,
       FileReplacementInProgressObservable fileReplacementInProgressObservable,
       ProjectAPI projectAPI,
       AnnotationManager annotationManager,
-      Project project,
-      LocalEditorHandler localEditorHandler,
-      VirtualFileConverter virtualFileConverter) {
+      LocalEditorHandler localEditorHandler) {
+
+    this.project = project;
 
     this.editorManager = editorManager;
     this.session = session;
     this.fileReplacementInProgressObservable = fileReplacementInProgressObservable;
     this.projectAPI = projectAPI;
     this.annotationManager = annotationManager;
-    this.project = project;
     this.localEditorHandler = localEditorHandler;
-    this.virtualFileConverter = virtualFileConverter;
 
     this.enabled = false;
     this.disposed = false;
@@ -213,7 +212,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
       LOG.trace("Reacting before resource contents changed: " + file);
     }
 
-    SPath path = virtualFileConverter.convertToSPath(file);
+    SPath path = VirtualFileConverter.convertToSPath(project, file);
 
     if (path == null || !session.isShared(path.getResource())) {
       if (LOG.isTraceEnabled()) {
@@ -271,7 +270,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
       LOG.trace("Reacting to resource creation: " + createdVirtualFile);
     }
 
-    SPath path = virtualFileConverter.convertToSPath(createdVirtualFile);
+    SPath path = VirtualFileConverter.convertToSPath(project, createdVirtualFile);
 
     if (path == null || !session.isShared(path.getResource())) {
       if (LOG.isTraceEnabled()) {
@@ -331,7 +330,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
               + copy);
     }
 
-    SPath copyPath = virtualFileConverter.convertToSPath(copy);
+    SPath copyPath = VirtualFileConverter.convertToSPath(project, copy);
 
     if (copyPath == null || !session.isShared(copyPath.getResource())) {
       if (LOG.isTraceEnabled()) {
@@ -371,7 +370,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
       LOG.trace("Reacting before resource deletion: " + deletedVirtualFile);
     }
 
-    SPath path = virtualFileConverter.convertToSPath(deletedVirtualFile);
+    SPath path = VirtualFileConverter.convertToSPath(project, deletedVirtualFile);
 
     if (path == null || !session.isShared(path.getResource())) {
       if (LOG.isTraceEnabled()) {
@@ -477,8 +476,8 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
     String folderName = newFolderName != null ? newFolderName : oldFile.getName();
 
-    SPath oldPath = virtualFileConverter.convertToSPath(oldFile);
-    SPath newParentPath = virtualFileConverter.convertToSPath(newParent);
+    SPath oldPath = VirtualFileConverter.convertToSPath(project, oldFile);
+    SPath newParentPath = VirtualFileConverter.convertToSPath(project, newParent);
 
     User user = session.getLocalUser();
 
@@ -618,8 +617,8 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
     String encoding = oldFile.getCharset().name();
 
-    SPath oldFilePath = virtualFileConverter.convertToSPath(oldFile);
-    SPath newParentPath = virtualFileConverter.convertToSPath(newBaseParent);
+    SPath oldFilePath = VirtualFileConverter.convertToSPath(project, oldFile);
+    SPath newParentPath = VirtualFileConverter.convertToSPath(project, newBaseParent);
 
     User user = session.getLocalUser();
 
@@ -785,7 +784,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
         if (parent == null) {
 
-          SPath path = virtualFileConverter.convertToSPath(file);
+          SPath path = VirtualFileConverter.convertToSPath(project, file);
 
           if (path != null && session.isShared(path.getResource())) {
             LOG.error(

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -65,7 +65,6 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
   private final ISarosSession session;
   private final LocalFileSystem localFileSystem;
   private final FileReplacementInProgressObservable fileReplacementInProgressObservable;
-  private final ProjectAPI projectAPI;
   private final AnnotationManager annotationManager;
   private final LocalEditorHandler localEditorHandler;
 
@@ -176,7 +175,6 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
       EditorManager editorManager,
       ISarosSession session,
       FileReplacementInProgressObservable fileReplacementInProgressObservable,
-      ProjectAPI projectAPI,
       AnnotationManager annotationManager,
       LocalEditorHandler localEditorHandler) {
 
@@ -185,7 +183,6 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
     this.editorManager = editorManager;
     this.session = session;
     this.fileReplacementInProgressObservable = fileReplacementInProgressObservable;
-    this.projectAPI = projectAPI;
     this.annotationManager = annotationManager;
     this.localEditorHandler = localEditorHandler;
 
@@ -626,7 +623,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
     boolean newPathIsShared =
         newParentPath != null && session.isShared(newParentPath.getResource());
 
-    boolean fileIsOpen = projectAPI.isOpen(oldFile);
+    boolean fileIsOpen = ProjectAPI.isOpen(project, oldFile);
 
     IPath relativePath = getRelativePath(oldBaseParent, oldFile);
 
@@ -687,7 +684,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
               encoding);
 
       if (fileIsOpen) {
-        Editor editor = projectAPI.openEditor(oldFile, false);
+        Editor editor = ProjectAPI.openEditor(project, oldFile, false);
 
         editorManager.addEditorMapping(newFilePath, editor);
       }

--- a/intellij/src/saros/intellij/filesystem/VirtualFileConverter.java
+++ b/intellij/src/saros/intellij/filesystem/VirtualFileConverter.java
@@ -19,15 +19,15 @@ public class VirtualFileConverter {
 
   private static final Logger log = Logger.getLogger(VirtualFileConverter.class);
 
-  private final Project project;
-
-  public VirtualFileConverter(Project project) {
-    this.project = project;
+  private VirtualFileConverter() {
+    // NOP
   }
 
   /**
-   * Returns an <code>SPath</code> representing the given file.
+   * Returns an <code>SPath</code> representing the given file. Uses the given project to try to
+   * obtain a valid module for the given file.
    *
+   * @param project the project to use for the conversion
    * @param virtualFile file to get the <code>SPath</code> for
    * @return an <code>SPath</code> representing the given file or <code>null</code> if given file
    *     does not exist, no module could be found for the file or the found module can not be shared
@@ -35,16 +35,18 @@ public class VirtualFileConverter {
    *     constructed
    */
   @Nullable
-  public SPath convertToSPath(@NotNull VirtualFile virtualFile) {
+  public static SPath convertToSPath(@NotNull Project project, @NotNull VirtualFile virtualFile) {
 
-    IResource resource = convertToResource(virtualFile);
+    IResource resource = convertToResource(project, virtualFile);
 
     return resource == null ? null : new SPath(resource);
   }
 
   /**
-   * Returns an <code>IResource</code> representing the given <code>VirtualFile</code>.
+   * Returns an <code>IResource</code> representing the given <code>VirtualFile</code>. Uses the
+   * given project to try to obtain a valid module for the given file.
    *
+   * @param project the project to use for the conversion
    * @param virtualFile file to get the <code>IResource</code> for
    * @return an <code>IResource</code> representing the given file or <code>null</code> if given
    *     file does not exist, no module could be found for the file or the found module can not be
@@ -52,7 +54,8 @@ public class VirtualFileConverter {
    *     be constructed
    */
   @Nullable
-  public IResource convertToResource(@NotNull VirtualFile virtualFile) {
+  public static IResource convertToResource(
+      @NotNull Project project, @NotNull VirtualFile virtualFile) {
 
     Module module = ModuleUtil.findModuleForFile(virtualFile, project);
 

--- a/intellij/test/junit/saros/intellij/eventhandler/editor/document/LocalDocumentModificationHandlerTest.java
+++ b/intellij/test/junit/saros/intellij/eventhandler/editor/document/LocalDocumentModificationHandlerTest.java
@@ -29,7 +29,7 @@ public class LocalDocumentModificationHandlerTest {
   public void before() {
     mockEditorFactory();
     localDocumentModificationHandler =
-        new LocalDocumentModificationHandler(dummyEditorManager(), null, null);
+        new LocalDocumentModificationHandler(null, dummyEditorManager(), null);
     listening = false;
   }
 


### PR DESCRIPTION
Removes the last references to the project object held in the session context. This basically marks the end of the refactoring to remove the project object from the plugin context. The rest if just a minor refactoring that can be done when the UI stuff is merged as well.

The PR should by reviewed by going through the commits. Each commit features a commit message giving more details about the content.