### PR TITLE
[REFACTOR] Replace deprecated ObjectUtils methods

### DIFF
--- a/core/src/saros/activities/AbstractActivity.java
+++ b/core/src/saros/activities/AbstractActivity.java
@@ -1,7 +1,7 @@
 package saros.activities;
 
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import saros.session.User;
 
 public abstract class AbstractActivity implements IActivity {
@@ -40,7 +40,7 @@ public abstract class AbstractActivity implements IActivity {
 
   @Override
   public int hashCode() {
-    return ObjectUtils.hashCode(source);
+    return Objects.hashCode(source);
   }
 
   @Override
@@ -51,7 +51,7 @@ public abstract class AbstractActivity implements IActivity {
 
     AbstractActivity other = (AbstractActivity) obj;
 
-    if (!ObjectUtils.equals(this.source, other.source)) return false;
+    if (!Objects.equals(this.source, other.source)) return false;
 
     return true;
   }

--- a/core/src/saros/activities/AbstractResourceActivity.java
+++ b/core/src/saros/activities/AbstractResourceActivity.java
@@ -1,7 +1,7 @@
 package saros.activities;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import saros.session.User;
 
 public abstract class AbstractResourceActivity extends AbstractActivity
@@ -35,7 +35,7 @@ public abstract class AbstractResourceActivity extends AbstractActivity
   public int hashCode() {
     final int prime = 31;
     int result = super.hashCode();
-    result = prime * result + ObjectUtils.hashCode(path);
+    result = prime * result + Objects.hashCode(path);
     return result;
   }
 
@@ -47,7 +47,7 @@ public abstract class AbstractResourceActivity extends AbstractActivity
 
     AbstractResourceActivity other = (AbstractResourceActivity) obj;
 
-    if (!ObjectUtils.equals(this.path, other.path)) return false;
+    if (!Objects.equals(this.path, other.path)) return false;
 
     return true;
   }

--- a/core/src/saros/activities/ChecksumActivity.java
+++ b/core/src/saros/activities/ChecksumActivity.java
@@ -2,7 +2,7 @@ package saros.activities;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import saros.concurrent.jupiter.Timestamp;
 import saros.session.User;
 
@@ -83,7 +83,7 @@ public class ChecksumActivity extends AbstractResourceActivity {
     int result = super.hashCode();
     result = prime * result + (int) (hash ^ (hash >>> 32));
     result = prime * result + (int) (length ^ (length >>> 32));
-    result = prime * result + ObjectUtils.hashCode(jupiterTimestamp);
+    result = prime * result + Objects.hashCode(jupiterTimestamp);
     return result;
   }
 
@@ -97,7 +97,7 @@ public class ChecksumActivity extends AbstractResourceActivity {
 
     if (this.hash != other.hash) return false;
     if (this.length != other.length) return false;
-    if (!ObjectUtils.equals(this.jupiterTimestamp, other.jupiterTimestamp)) return false;
+    if (!Objects.equals(this.jupiterTimestamp, other.jupiterTimestamp)) return false;
 
     return true;
   }

--- a/core/src/saros/activities/ChecksumErrorActivity.java
+++ b/core/src/saros/activities/ChecksumErrorActivity.java
@@ -23,7 +23,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 import java.util.List;
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import saros.session.User;
 
 /**
@@ -76,9 +76,9 @@ public class ChecksumErrorActivity extends AbstractActivity implements ITargeted
   public int hashCode() {
     final int prime = 31;
     int result = super.hashCode();
-    result = prime * result + ObjectUtils.hashCode(paths);
-    result = prime * result + ObjectUtils.hashCode(recoveryID);
-    result = prime * result + ObjectUtils.hashCode(target);
+    result = prime * result + Objects.hashCode(paths);
+    result = prime * result + Objects.hashCode(recoveryID);
+    result = prime * result + Objects.hashCode(target);
     return result;
   }
 
@@ -90,9 +90,9 @@ public class ChecksumErrorActivity extends AbstractActivity implements ITargeted
 
     ChecksumErrorActivity other = (ChecksumErrorActivity) obj;
 
-    if (!ObjectUtils.equals(this.recoveryID, other.recoveryID)) return false;
-    if (!ObjectUtils.equals(this.paths, other.paths)) return false;
-    if (!ObjectUtils.equals(this.target, other.target)) return false;
+    if (!Objects.equals(this.recoveryID, other.recoveryID)) return false;
+    if (!Objects.equals(this.paths, other.paths)) return false;
+    if (!Objects.equals(this.target, other.target)) return false;
 
     return true;
   }

--- a/core/src/saros/activities/EditorActivity.java
+++ b/core/src/saros/activities/EditorActivity.java
@@ -21,7 +21,7 @@ package saros.activities;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import saros.session.User;
 
 /**
@@ -79,7 +79,7 @@ public class EditorActivity extends AbstractResourceActivity {
   public int hashCode() {
     final int prime = 31;
     int result = super.hashCode();
-    result = prime * result + ObjectUtils.hashCode(type);
+    result = prime * result + Objects.hashCode(type);
     return result;
   }
 

--- a/core/src/saros/activities/FileActivity.java
+++ b/core/src/saros/activities/FileActivity.java
@@ -3,7 +3,7 @@ package saros.activities;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 import java.util.Arrays;
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import saros.session.User;
 
 @XStreamAlias("fileActivity")
@@ -136,9 +136,9 @@ public class FileActivity extends AbstractResourceActivity
     final int prime = 31;
     int result = super.hashCode();
     result = prime * result + Arrays.hashCode(content);
-    result = prime * result + ObjectUtils.hashCode(oldPath);
-    result = prime * result + ObjectUtils.hashCode(type);
-    result = prime * result + ObjectUtils.hashCode(purpose);
+    result = prime * result + Objects.hashCode(oldPath);
+    result = prime * result + Objects.hashCode(type);
+    result = prime * result + Objects.hashCode(purpose);
     return result;
   }
 
@@ -156,11 +156,11 @@ public class FileActivity extends AbstractResourceActivity
 
     if (purpose != other.purpose) return false;
 
-    if (!ObjectUtils.equals(oldPath, other.oldPath)) return false;
+    if (!Objects.equals(oldPath, other.oldPath)) return false;
 
     if (!Arrays.equals(content, other.content)) return false;
 
-    return ObjectUtils.equals(encoding, other.encoding);
+    return Objects.equals(encoding, other.encoding);
   }
 
   @Override

--- a/core/src/saros/activities/JupiterActivity.java
+++ b/core/src/saros/activities/JupiterActivity.java
@@ -1,7 +1,7 @@
 package saros.activities;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import saros.concurrent.jupiter.Operation;
 import saros.concurrent.jupiter.Timestamp;
 import saros.session.User;
@@ -41,8 +41,8 @@ public class JupiterActivity extends AbstractResourceActivity {
 
     JupiterActivity other = (JupiterActivity) obj;
 
-    if (!ObjectUtils.equals(this.operation, other.operation)) return false;
-    if (!ObjectUtils.equals(this.timestamp, other.timestamp)) return false;
+    if (!Objects.equals(this.operation, other.operation)) return false;
+    if (!Objects.equals(this.timestamp, other.timestamp)) return false;
 
     return true;
   }
@@ -51,8 +51,8 @@ public class JupiterActivity extends AbstractResourceActivity {
   public int hashCode() {
     final int prime = 31;
     int result = super.hashCode();
-    result = prime * result + ObjectUtils.hashCode(operation);
-    result = prime * result + ObjectUtils.hashCode(timestamp);
+    result = prime * result + Objects.hashCode(operation);
+    result = prime * result + Objects.hashCode(timestamp);
     return result;
   }
 

--- a/core/src/saros/activities/ProgressActivity.java
+++ b/core/src/saros/activities/ProgressActivity.java
@@ -2,7 +2,7 @@ package saros.activities;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import saros.session.User;
 
 /** A {@link ProgressActivity} is used for controlling a progress bar at a remote peer. */
@@ -116,10 +116,10 @@ public class ProgressActivity extends AbstractActivity implements ITargetedActiv
   public int hashCode() {
     final int prime = 31;
     int result = super.hashCode();
-    result = prime * result + ObjectUtils.hashCode(action);
-    result = prime * result + ObjectUtils.hashCode(progressID);
-    result = prime * result + ObjectUtils.hashCode(taskName);
-    result = prime * result + ObjectUtils.hashCode(target);
+    result = prime * result + Objects.hashCode(action);
+    result = prime * result + Objects.hashCode(progressID);
+    result = prime * result + Objects.hashCode(taskName);
+    result = prime * result + Objects.hashCode(target);
     result = prime * result + workCurrent;
     result = prime * result + workTotal;
 
@@ -137,9 +137,9 @@ public class ProgressActivity extends AbstractActivity implements ITargetedActiv
     if (this.workCurrent != other.workCurrent) return false;
     if (this.workTotal != other.workTotal) return false;
     if (this.action != other.action) return false;
-    if (!ObjectUtils.equals(this.progressID, other.progressID)) return false;
-    if (!ObjectUtils.equals(this.taskName, other.taskName)) return false;
-    if (!ObjectUtils.equals(this.target, other.target)) return false;
+    if (!Objects.equals(this.progressID, other.progressID)) return false;
+    if (!Objects.equals(this.taskName, other.taskName)) return false;
+    if (!Objects.equals(this.target, other.target)) return false;
 
     return true;
   }

--- a/core/src/saros/activities/SPath.java
+++ b/core/src/saros/activities/SPath.java
@@ -1,7 +1,7 @@
 package saros.activities;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import saros.filesystem.IFile;
 import saros.filesystem.IFolder;
 import saros.filesystem.IPath;
@@ -112,8 +112,8 @@ public class SPath {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + ObjectUtils.hashCode(project);
-    result = prime * result + ObjectUtils.hashCode(projectRelativePath);
+    result = prime * result + Objects.hashCode(project);
+    result = prime * result + Objects.hashCode(projectRelativePath);
     return result;
   }
 
@@ -127,8 +127,8 @@ public class SPath {
 
     SPath other = (SPath) obj;
 
-    return ObjectUtils.equals(project, other.project)
-        && ObjectUtils.equals(projectRelativePath, other.projectRelativePath);
+    return Objects.equals(project, other.project)
+        && Objects.equals(projectRelativePath, other.projectRelativePath);
   }
 
   @Override

--- a/core/src/saros/activities/StopActivity.java
+++ b/core/src/saros/activities/StopActivity.java
@@ -2,7 +2,7 @@ package saros.activities;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import saros.session.User;
 
 /**
@@ -72,11 +72,11 @@ public class StopActivity extends AbstractActivity implements ITargetedActivity 
   public int hashCode() {
     final int prime = 31;
     int result = super.hashCode();
-    result = prime * result + ObjectUtils.hashCode(initiator);
-    result = prime * result + ObjectUtils.hashCode(state);
-    result = prime * result + ObjectUtils.hashCode(stopActivityID);
-    result = prime * result + ObjectUtils.hashCode(type);
-    result = prime * result + ObjectUtils.hashCode(affected);
+    result = prime * result + Objects.hashCode(initiator);
+    result = prime * result + Objects.hashCode(state);
+    result = prime * result + Objects.hashCode(stopActivityID);
+    result = prime * result + Objects.hashCode(type);
+    result = prime * result + Objects.hashCode(affected);
     return result;
   }
 
@@ -90,9 +90,9 @@ public class StopActivity extends AbstractActivity implements ITargetedActivity 
 
     if (this.state != other.state) return false;
     if (this.type != other.type) return false;
-    if (!ObjectUtils.equals(this.stopActivityID, other.stopActivityID)) return false;
-    if (!ObjectUtils.equals(this.initiator, other.initiator)) return false;
-    if (!ObjectUtils.equals(this.affected, other.affected)) return false;
+    if (!Objects.equals(this.stopActivityID, other.stopActivityID)) return false;
+    if (!Objects.equals(this.initiator, other.initiator)) return false;
+    if (!Objects.equals(this.affected, other.affected)) return false;
 
     return true;
   }

--- a/core/src/saros/activities/TextEditActivity.java
+++ b/core/src/saros/activities/TextEditActivity.java
@@ -19,7 +19,7 @@
  */
 package saros.activities;
 
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
@@ -97,8 +97,8 @@ public class TextEditActivity extends AbstractResourceActivity {
     final int prime = 31;
     int result = super.hashCode();
     result = prime * result + offset;
-    result = prime * result + ObjectUtils.hashCode(replacedText);
-    result = prime * result + ObjectUtils.hashCode(text);
+    result = prime * result + Objects.hashCode(replacedText);
+    result = prime * result + Objects.hashCode(text);
     return result;
   }
 
@@ -111,8 +111,8 @@ public class TextEditActivity extends AbstractResourceActivity {
     TextEditActivity other = (TextEditActivity) obj;
 
     if (this.offset != other.offset) return false;
-    if (!ObjectUtils.equals(this.replacedText, other.replacedText)) return false;
-    if (!ObjectUtils.equals(this.text, other.text)) return false;
+    if (!Objects.equals(this.replacedText, other.replacedText)) return false;
+    if (!Objects.equals(this.text, other.text)) return false;
 
     return true;
   }

--- a/core/src/saros/concurrent/management/TransformationResult.java
+++ b/core/src/saros/concurrent/management/TransformationResult.java
@@ -3,7 +3,7 @@ package saros.concurrent.management;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import saros.activities.IActivity;
 import saros.activities.QueueItem;
 import saros.session.User;
@@ -36,7 +36,7 @@ public class TransformationResult {
   public List<QueueItem> sendToPeers = new ArrayList<QueueItem>();
 
   public void addAll(TransformationResult other) {
-    if (!ObjectUtils.equals(other.localUser, this.localUser)) {
+    if (!Objects.equals(other.localUser, this.localUser)) {
       throw new IllegalArgumentException(
           "can only merge two transformation result objects if they are managing the same local user");
     }

--- a/core/src/saros/misc/xstream/XStreamExtensionProvider.java
+++ b/core/src/saros/misc/xstream/XStreamExtensionProvider.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import org.apache.log4j.Logger;
 import org.jivesoftware.smack.filter.PacketExtensionFilter;
 import org.jivesoftware.smack.filter.PacketFilter;
@@ -235,8 +235,8 @@ public class XStreamExtensionProvider<T> implements PacketExtensionProvider, IQP
 
     /** Returns whether this XStreamPacketExtension is compatible with the given provider */
     public boolean accept(XStreamExtensionProvider<?> provider) {
-      return ObjectUtils.equals(getElementName(), provider.getElementName())
-          && ObjectUtils.equals(getNamespace(), provider.getNamespace());
+      return Objects.equals(getElementName(), provider.getElementName())
+          && Objects.equals(getNamespace(), provider.getNamespace());
     }
 
     @Override

--- a/core/src/saros/negotiation/FileList.java
+++ b/core/src/saros/negotiation/FileList.java
@@ -26,8 +26,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
-import org.apache.commons.lang3.ObjectUtils;
 
 /**
  * A FileList is a list of resources -- files and folders -- which belong to the same project.
@@ -238,10 +238,10 @@ public class FileList {
     public int hashCode() {
       final int prime = 31;
       int result = 1;
-      result = prime * result + ObjectUtils.hashCode(files);
+      result = prime * result + Objects.hashCode(files);
       result = prime * result + (isDirectory ? 1231 : 1237);
-      result = prime * result + ObjectUtils.hashCode(metaData);
-      result = prime * result + ObjectUtils.hashCode(path);
+      result = prime * result + Objects.hashCode(metaData);
+      result = prime * result + Objects.hashCode(path);
       return result;
     }
 
@@ -255,9 +255,9 @@ public class FileList {
 
       if (isDirectory != other.isDirectory) return false;
 
-      if (!ObjectUtils.equals(path, other.path)) return false;
-      if (!ObjectUtils.equals(metaData, other.metaData)) return false;
-      if (!ObjectUtils.equals(files, other.files)) return false;
+      if (!Objects.equals(path, other.path)) return false;
+      if (!Objects.equals(metaData, other.metaData)) return false;
+      if (!Objects.equals(files, other.files)) return false;
 
       return true;
     }
@@ -277,7 +277,7 @@ public class FileList {
 
       MetaData other = (MetaData) o;
 
-      if (!ObjectUtils.equals(checksum, other.checksum)) return false;
+      if (!Objects.equals(checksum, other.checksum)) return false;
 
       return true;
     }

--- a/eclipse/src/saros/concurrent/undo/UndoManager.java
+++ b/eclipse/src/saros/concurrent/undo/UndoManager.java
@@ -2,7 +2,7 @@ package saros.concurrent.undo;
 
 import java.util.LinkedList;
 import java.util.List;
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import org.apache.log4j.Logger;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.operations.AbstractOperation;
@@ -266,7 +266,7 @@ public class UndoManager extends AbstractActivityConsumer implements Disposable 
         @Override
         public void editorActivated(User user, SPath newActiveEditor) {
 
-          if (!user.isLocal() || ObjectUtils.equals(currentActiveEditor, newActiveEditor)) return;
+          if (!user.isLocal() || Objects.equals(currentActiveEditor, newActiveEditor)) return;
 
           updateCurrentLocalAtomicOperation(null);
           storeCurrentLocalOperation();
@@ -275,7 +275,7 @@ public class UndoManager extends AbstractActivityConsumer implements Disposable 
 
         @Override
         public void editorClosed(User user, SPath closedEditor) {
-          if (ObjectUtils.equals(currentActiveEditor, closedEditor)) {
+          if (Objects.equals(currentActiveEditor, closedEditor)) {
             updateCurrentLocalAtomicOperation(null);
             storeCurrentLocalOperation();
             currentActiveEditor = null;

--- a/eclipse/src/saros/editor/EditorManager.java
+++ b/eclipse/src/saros/editor/EditorManager.java
@@ -3,9 +3,9 @@ package saros.editor;
 import java.io.FileNotFoundException;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IFile;
@@ -575,7 +575,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
     for (IEditorPart editor : editorPool.getAllEditors()) {
       IEditorInput input = editor.getEditorInput();
 
-      if (ObjectUtils.equals(EditorAPI.getDocumentProvider(input).getDocument(input), document)) {
+      if (Objects.equals(EditorAPI.getDocumentProvider(input).getDocument(input), document)) {
         changedEditor = editor;
         break;
       }

--- a/eclipse/src/saros/monitoring/remote/EclipseRemoteProgressIndicatorImpl.java
+++ b/eclipse/src/saros/monitoring/remote/EclipseRemoteProgressIndicatorImpl.java
@@ -1,8 +1,8 @@
 package saros.monitoring.remote;
 
+import java.util.Objects;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.log4j.Logger;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -205,8 +205,8 @@ final class EclipseRemoteProgressIndicatorImpl implements IRemoteProgressIndicat
 
     if (!(obj instanceof EclipseRemoteProgressIndicatorImpl)) return false;
 
-    return ObjectUtils.equals(
+    return Objects.equals(
             remoteProgressID, ((EclipseRemoteProgressIndicatorImpl) obj).remoteProgressID)
-        && ObjectUtils.equals(remoteUser, ((EclipseRemoteProgressIndicatorImpl) obj).remoteUser);
+        && Objects.equals(remoteUser, ((EclipseRemoteProgressIndicatorImpl) obj).remoteUser);
   }
 }

--- a/eclipse/src/saros/ui/model/session/SessionHeaderElement.java
+++ b/eclipse/src/saros/ui/model/session/SessionHeaderElement.java
@@ -2,7 +2,7 @@ package saros.ui.model.session;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.lang3.ObjectUtils;
+import java.util.Objects;
 import org.eclipse.jface.viewers.StyledString;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.Image;
@@ -74,7 +74,7 @@ public class SessionHeaderElement extends HeaderElement {
 
   @Override
   public int hashCode() {
-    return ObjectUtils.hashCode(sessionInput);
+    return Objects.hashCode(sessionInput);
   }
 
   @Override
@@ -86,6 +86,6 @@ public class SessionHeaderElement extends HeaderElement {
     if (getClass() != obj.getClass()) return false;
 
     SessionHeaderElement other = (SessionHeaderElement) obj;
-    return ObjectUtils.equals(sessionInput, other.sessionInput);
+    return Objects.equals(sessionInput, other.sessionInput);
   }
 }

--- a/intellij/src/saros/core/monitoring/remote/IntelliJRemoteProgressIndicatorImpl.java
+++ b/intellij/src/saros/core/monitoring/remote/IntelliJRemoteProgressIndicatorImpl.java
@@ -1,8 +1,8 @@
 package saros.core.monitoring.remote;
 
+import java.util.Objects;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.log4j.Logger;
 import saros.activities.ProgressActivity;
 import saros.activities.ProgressActivity.ProgressAction;
@@ -203,8 +203,8 @@ final class IntelliJRemoteProgressIndicatorImpl implements IRemoteProgressIndica
 
     if (!(obj instanceof IntelliJRemoteProgressIndicatorImpl)) return false;
 
-    return ObjectUtils.equals(
+    return Objects.equals(
             remoteProgressID, ((IntelliJRemoteProgressIndicatorImpl) obj).remoteProgressID)
-        && ObjectUtils.equals(remoteUser, ((IntelliJRemoteProgressIndicatorImpl) obj).remoteUser);
+        && Objects.equals(remoteUser, ((IntelliJRemoteProgressIndicatorImpl) obj).remoteUser);
   }
 }


### PR DESCRIPTION
The hashCode and equals method in the ObjectUtils class from Apache
Commons was marked deprecated and they advise to use the methods from
Java standard libary introduced in Java 7. This replacement was done
using a shell script.