### PR TITLE
[BUILD] Skip documentation and markdown during build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,15 @@ sudo: enabled
 git:
   depth: false
 
-# Override the install default behavior that calls gradle assemble
+# Override the install default behavior to terminate the build
+# if only markdown files are changed or files within the docs dir
 install:
-- true
+- |
+    if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(.md$)|(^docs/)'
+    then
+      echo "Only docs were updated, not running the CI."
+      exit
+    fi
 
 notifications:
   email:


### PR DESCRIPTION
Each documentation change triggers a ~7min gradle build
and format check. This change skips the build in the earliest
phase of each stage if: only markdown files (with extension .md)
or files in the docs directory are changed.