### PR TITLE
Introducing EclipseReferencePointManager

### DIFF
--- a/eclipse/src/saros/SarosEclipseContextFactory.java
+++ b/eclipse/src/saros/SarosEclipseContextFactory.java
@@ -16,6 +16,7 @@ import saros.context.IContextKeyBindings;
 import saros.editor.EditorManager;
 import saros.editor.IEditorManager;
 import saros.filesystem.EclipsePathFactory;
+import saros.filesystem.EclipseReferencePointManager;
 import saros.filesystem.EclipseWorkspaceImpl;
 import saros.filesystem.EclipseWorkspaceRootImpl;
 import saros.filesystem.FileContentNotifierBridge;
@@ -62,6 +63,9 @@ public class SarosEclipseContextFactory extends AbstractContextFactory {
    */
   private final Component[] getContextComponents() {
     return new Component[] {
+      // ReferencePointManager
+      Component.create(EclipseReferencePointManager.class),
+
       // Core Managers
       Component.create(IEditorManager.class, EditorManager.class),
       Component.create(saros.preferences.Preferences.class, EclipsePreferences.class),

--- a/eclipse/src/saros/filesystem/EclipseReferencePointManager.java
+++ b/eclipse/src/saros/filesystem/EclipseReferencePointManager.java
@@ -1,0 +1,239 @@
+package saros.filesystem;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IPath;
+import saros.activities.SPath;
+
+/**
+ * The EclipseReferencePointManager maps an {@link IReferencePoint} reference point to {@link
+ * IProject} project
+ */
+public class EclipseReferencePointManager {
+
+  ConcurrentHashMap<IReferencePoint, IProject> referencePointToProjectMapper;
+
+  public EclipseReferencePointManager() {
+    referencePointToProjectMapper = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * Creates and returns the {@link IReferencePoint} reference point of given {@link IResource}
+   * resource, or null if the given {@link IResource} resource is null. The reference point points
+   * on the resource's project full path.
+   *
+   * @param resource for which the reference point should be created
+   * @return the reference point of given resource
+   */
+  public static IReferencePoint create(IResource resource) {
+    if (resource == null) return null;
+
+    IProject project = resource.getProject();
+    saros.filesystem.IPath path = ResourceAdapterFactory.create(project.getFullPath());
+
+    return new ReferencePointImpl(path);
+  }
+
+  /**
+   * Inserts a pair of {@link IReferencePoint} reference point and {@link IProject} project. The
+   * reference point will be created from the project's relative path by
+   * {#putIfAbsent(IReferencePoint referencePoint, IProject project) putIfAbsent} .
+   *
+   * @param project the {@link IProject} project for which a reference point is created and are
+   *     inserted.
+   * @exception IllegalArgumentException if {@link IProject} project is null
+   */
+  public void putIfAbsent(IProject project) {
+    checkArgument(project, "Project is null");
+
+    IReferencePoint referencePoint = create(project);
+
+    putIfAbsent(referencePoint, project);
+  }
+
+  /**
+   * Insert a pair of {@link IReferencePoint} reference point and {@link IProject} project
+   *
+   * @param referencePoint the key of the pair
+   * @param project the value of the pair
+   * @exception IllegalArgumentException if {@link IProject} project or {@link IReferencePoint}
+   *     reference point is null
+   */
+  public void putIfAbsent(IReferencePoint referencePoint, IProject project) {
+    checkArgument(referencePoint, "Reference point is null");
+    checkArgument(project, "Project is null");
+
+    referencePointToProjectMapper.putIfAbsent(referencePoint, project);
+  }
+
+  /**
+   * Returns the {@link IProject} project given by the {@link IReferencePoint} reference point
+   *
+   * @param referencePoint the key for which the IProject should be returned
+   * @return the IProject given by referencePoint
+   * @exception IllegalArgumentException if {@link IReferencePoint} reference point is null
+   */
+  public IProject getProject(IReferencePoint referencePoint) {
+    checkArgument(referencePoint, "Reference point is null");
+
+    return referencePointToProjectMapper.get(referencePoint);
+  }
+
+  /**
+   * Returns the {@link IResource} resource in combination of the {@link IReferencePoint} reference
+   * point and the {@link IPath} relative path from the {@link IReferencePoint} reference point to
+   * the {@link IResource} resource, or null if the resource does not exist
+   *
+   * @param referencePoint The {@link IReferencePoint} reference point, on which the {@link
+   *     IResource} resource belongs to
+   * @param referencePointRelativePath the {@link IPath} relative path from the {@link
+   *     IReferencePoint} reference point to the {@link IResource} resource
+   * @return the resource of the {@link IReferencePoint} reference point from {@link IPath}
+   *     referencePointRelativePath or null if resource does not exist.
+   * @exception IllegalArgumentException if {@link IReferencePoint} reference point or {@link IPath}
+   *     referencePointRelativePath is null
+   * @exception NullPointerException if the given {@link IReferencePoint} reference point does't
+   *     exist an {@link IProject} project
+   */
+  public IResource findMember(IReferencePoint referencePoint, IPath referencePointRelativePath) {
+    checkArgument(referencePoint, "Reference point is null");
+    checkArgument(referencePointRelativePath, "ReferencePointsRelativePath is null");
+
+    IProject project = Objects.requireNonNull(getProject(referencePoint));
+
+    return project.findMember(referencePointRelativePath);
+  }
+
+  /**
+   * Returns the {@link IResource} resource represented by this {@link SPath} SPath, or null if the
+   * resource does not exist
+   *
+   * @param path the {@link SPath} SPath which represents the {@link IResource} resource
+   * @return the resource of the {@link IReferencePoint} reference point from {@link IPath}
+   *     referencePointRelativePath or null if resource does not exist.
+   * @exception IllegalArgumentException if {@link SPath} path is null
+   * @exception NullPointerException if the given {@link SPath} path does contain an {@link
+   *     IReferencePoint} reference point
+   * @exception NullPointerException if the given {@link SPath} path does contain an {@link IPath}
+   *     referencePointRelativePath
+   */
+  public IResource findMember(SPath path) {
+    checkArgument(path, "SPath is null");
+
+    IReferencePoint referencePoint = Objects.requireNonNull(path.getReferencePoint());
+    saros.filesystem.IPath referencePointRelativePath =
+        Objects.requireNonNull(path.getProjectRelativePath());
+
+    IPath eclipsePath = ((EclipsePathImpl) referencePointRelativePath).getDelegate();
+
+    return findMember(referencePoint, eclipsePath);
+  }
+
+  /**
+   * Returns a handle to the {@link IFile} file identified by the given {@link IPath} path and
+   * {@link IReferencePoint} reference point
+   *
+   * @param referencePoint The {@link IReferencePoint} reference point, on which the {@link IFile}
+   *     file belongs to
+   * @param referencePointRelativePath the relative {@link IPath} path from the {@link
+   *     IReferencePoint} reference point to the {@link IFile} file
+   * @return a handle to the {@link IFile} file
+   * @exception IllegalArgumentException if {@link IReferencePoint} reference point or {@link IPath}
+   *     referencePointRelativePath is null
+   * @exception NullPointerException if the given {@link IReferencePoint} reference point does't
+   *     exist an {@link IProject} project
+   */
+  public IFile getFile(IReferencePoint referencePoint, IPath referencePointRelativePath) {
+    checkArgument(referencePoint, "Reference point is null");
+    checkArgument(referencePointRelativePath, "ReferencePointsRelativePath is null");
+
+    IProject project = Objects.requireNonNull(getProject(referencePoint));
+
+    return project.getFile(referencePointRelativePath);
+  }
+
+  /**
+   * Returns a handle to the {@link IFile} file represented by this {@link SPath} SPath
+   *
+   * @param path the {@link SPath} SPath which represents the {@link IFile} file
+   * @return a handle to the {@link IFile} file
+   * @exception IllegalArgumentException if {@link SPath} path is null
+   * @exception NullPointerException if the given {@link SPath} path does contain an {@link
+   *     IReferencePoint} reference point
+   * @exception NullPointerException if the given {@link SPath} path does contain an {@link IPath}
+   *     referencePointRelativePath
+   */
+  public IFile getFile(SPath path) {
+    checkArgument(path, "SPath is null");
+
+    IReferencePoint referencePoint = Objects.requireNonNull(path.getReferencePoint());
+    saros.filesystem.IPath referencePointRelativePath =
+        Objects.requireNonNull(path.getProjectRelativePath());
+
+    IPath eclipsePath = ((EclipsePathImpl) referencePointRelativePath).getDelegate();
+
+    return getFile(referencePoint, eclipsePath);
+  }
+
+  /**
+   * Returns a handle to the {@link IFolder} folder identified by the given {@link IPath} path and
+   * {@link IReferencePoint} reference point
+   *
+   * @param referencePoint The {@link IReferencePoint} reference point, on which the {@link IFolder}
+   *     folder belongs to
+   * @param referencePointRelativePath the {@link IPath} relative path from the {@link
+   *     IReferencePoint} reference point to the {@link IFolder} folder
+   * @return a handle to the {@link IFolder} folder
+   * @exception IllegalArgumentException if {@link IReferencePoint} reference point or {@link IPath}
+   *     referencePointRelativePath is null
+   * @exception NullPointerException if the given {@link IReferencePoint} reference point does't
+   *     exist an {@link IProject} project
+   */
+  public IFolder getFolder(IReferencePoint referencePoint, IPath referencePointRelativePath) {
+    checkArgument(referencePoint, "Reference point is null");
+    checkArgument(referencePointRelativePath, "ReferencePointsRelativePath is null");
+
+    IProject project = Objects.requireNonNull(getProject(referencePoint));
+
+    return project.getFolder(referencePointRelativePath);
+  }
+
+  /**
+   * Returns a handle to the {@link IFolder} folder represented by this {@link SPath} SPath
+   *
+   * @param path the {@link SPath} SPath which represents the {@link IFolder} folder
+   * @return a handle to the {@link IFolder} folder
+   * @exception IllegalArgumentException if {@link SPath} path is null
+   * @exception NullPointerException if the given {@link SPath} path does contain an {@link
+   *     IReferencePoint} reference point
+   * @exception NullPointerException if the given {@link SPath} path does contain an {@link IPath}
+   *     referencePointRelativePath
+   */
+  public IFolder getFolder(SPath path) {
+    checkArgument(path, "SPath is null");
+
+    IReferencePoint referencePoint = Objects.requireNonNull(path.getReferencePoint());
+    saros.filesystem.IPath referencePointRelativePath =
+        Objects.requireNonNull(path.getProjectRelativePath());
+
+    IPath eclipsePath = ((EclipsePathImpl) referencePointRelativePath).getDelegate();
+
+    return getFolder(referencePoint, eclipsePath);
+  }
+
+  /**
+   * Check, if the given argument is null
+   *
+   * @param argument which is checked for null
+   * @param <T> Type of argument parameter (like {@link IReferencePoint reference point})
+   * @param message message for the IllegalArgumentException
+   * @exception IllegalArgumentException if given argument is null
+   */
+  private <T> void checkArgument(T argument, String message) {
+    if (argument == null) throw new IllegalArgumentException(message);
+  }
+}

--- a/eclipse/src/saros/ui/util/CollaborationUtils.java
+++ b/eclipse/src/saros/ui/util/CollaborationUtils.java
@@ -29,6 +29,7 @@ import saros.Saros;
 import saros.SarosPluginContext;
 import saros.filesystem.CoreReferencePointManager;
 import saros.filesystem.EclipseProjectImpl;
+import saros.filesystem.EclipseReferencePointManager;
 import saros.filesystem.IReferencePointManager;
 import saros.filesystem.ResourceAdapterFactory;
 import saros.net.xmpp.JID;
@@ -53,6 +54,8 @@ public class CollaborationUtils {
   private static final Logger LOG = Logger.getLogger(CollaborationUtils.class);
 
   @Inject private static ISarosSessionManager sessionManager;
+
+  @Inject private static EclipseReferencePointManager eclipseReferencePointManager;
 
   static {
     SarosPluginContext.initComponent(new CollaborationUtils());
@@ -86,9 +89,7 @@ public class CollaborationUtils {
 
               IReferencePointManager coreReferencePointManager = new CoreReferencePointManager();
 
-              fillReferencePointManager(
-                  coreReferencePointManager,
-                  convertToProjectResourceMapping(newResources).keySet());
+              fillReferencePointManager(coreReferencePointManager, newResources.keySet());
 
               sessionManager.startSession(
                   convertToReferencePointResourceMapping(newResources), coreReferencePointManager);
@@ -221,8 +222,7 @@ public class CollaborationUtils {
             IReferencePointManager referencePointManager =
                 session.getComponent(IReferencePointManager.class);
 
-            fillReferencePointManager(
-                referencePointManager, convertToProjectResourceMapping(projectResources).keySet());
+            fillReferencePointManager(referencePointManager, projectResources.keySet());
 
             sessionManager.addReferencePointResources(
                 convertToReferencePointResourceMapping(projectResources));
@@ -502,7 +502,13 @@ public class CollaborationUtils {
   }
 
   private static void fillReferencePointManager(
-      IReferencePointManager referencePointManager, Set<saros.filesystem.IProject> projects) {
-    referencePointManager.putSetOfProjects(projects);
+      IReferencePointManager referencePointManager, Set<IProject> projects) {
+
+    projects.forEach(
+        project -> {
+          eclipseReferencePointManager.putIfAbsent(project);
+          referencePointManager.putIfAbsent(
+              EclipseReferencePointManager.create(project), ResourceAdapterFactory.create(project));
+        });
   }
 }

--- a/eclipse/src/saros/ui/wizards/AddProjectToSessionWizard.java
+++ b/eclipse/src/saros/ui/wizards/AddProjectToSessionWizard.java
@@ -40,6 +40,7 @@ import org.eclipse.ui.IFileEditorInput;
 import saros.Saros;
 import saros.SarosPluginContext;
 import saros.editor.internal.EditorAPI;
+import saros.filesystem.EclipseReferencePointManager;
 import saros.filesystem.IChecksumCache;
 import saros.filesystem.IReferencePoint;
 import saros.filesystem.IReferencePointManager;
@@ -87,6 +88,8 @@ public class AddProjectToSessionWizard extends Wizard {
   @Inject private Preferences preferences;
 
   @Inject private ISarosSessionManager sessionManager;
+
+  @Inject private EclipseReferencePointManager eclipseReferencePointManager;
 
   private static class OverwriteErrorDialog extends ErrorDialog {
 
@@ -313,12 +316,11 @@ public class AddProjectToSessionWizard extends Wizard {
                   new HashMap<String, IReferencePoint>();
 
               for (final Entry<String, IProject> entry : targetProjectMapping.entrySet()) {
-                saros.filesystem.IProject sarosProject =
-                    ResourceAdapterFactory.create(entry.getValue());
+                IProject project = entry.getValue();
 
-                convertedMapping.put(entry.getKey(), sarosProject.getReferencePoint());
+                convertedMapping.put(entry.getKey(), EclipseReferencePointManager.create(project));
 
-                fillReferencePointManager(sessionManager.getSession(), sarosProject);
+                fillReferencePointManager(sessionManager.getSession(), project);
               }
 
               final ProjectNegotiation.Status status =
@@ -551,7 +553,7 @@ public class AddProjectToSessionWizard extends Wizard {
       final saros.filesystem.IProject adaptedProject =
           ResourceAdapterFactory.create(entry.getValue());
 
-      fillReferencePointManager(session, adaptedProject);
+      fillReferencePointManager(session, project);
 
       /*
        * do not refresh already partially shared projects as this may
@@ -679,10 +681,14 @@ public class AddProjectToSessionWizard extends Wizard {
     }
   }
 
-  private void fillReferencePointManager(ISarosSession session, saros.filesystem.IProject project) {
+  private void fillReferencePointManager(ISarosSession session, IProject project) {
     IReferencePointManager referencePointManager =
         session.getComponent(IReferencePointManager.class);
 
-    referencePointManager.putIfAbsent(project.getReferencePoint(), project);
+    saros.filesystem.IProject sarosProject = ResourceAdapterFactory.create(project);
+    IReferencePoint referencePoint = EclipseReferencePointManager.create(project);
+
+    eclipseReferencePointManager.putIfAbsent(referencePoint, project);
+    referencePointManager.putIfAbsent(referencePoint, sarosProject);
   }
 }

--- a/eclipse/test/junit/saros/filesystem/EclipseReferencePointManagerTest.java
+++ b/eclipse/test/junit/saros/filesystem/EclipseReferencePointManagerTest.java
@@ -1,0 +1,235 @@
+package saros.filesystem;
+
+import org.easymock.EasyMock;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IPath;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import saros.activities.SPath;
+
+public class EclipseReferencePointManagerTest {
+
+  IReferencePoint referencePoint;
+  EclipseReferencePointManager eclipseReferencePointManager;
+
+  @Before
+  public void prepare() {
+    referencePoint = EasyMock.createMock(IReferencePoint.class);
+    EasyMock.replay(referencePoint);
+
+    eclipseReferencePointManager = new EclipseReferencePointManager();
+  }
+
+  @Test
+  public void testPutIfAbsent() {
+    IProject project = createProjectMock();
+    EasyMock.replay(project);
+
+    eclipseReferencePointManager.putIfAbsent(referencePoint, project);
+
+    IProject projectFromReferencePointManager =
+        eclipseReferencePointManager.getProject(referencePoint);
+
+    Assert.assertNotNull(projectFromReferencePointManager);
+    Assert.assertEquals(project, projectFromReferencePointManager);
+  }
+
+  @Test
+  public void testFindMember() {
+    IResource resource = createResourceMock();
+    IPath projectRelativePath = createRelativePathMock();
+    IProject project = createProjectMock();
+    EasyMock.expect(project.findMember(projectRelativePath)).andStubReturn(resource);
+    EasyMock.replay(project);
+
+    eclipseReferencePointManager.putIfAbsent(referencePoint, project);
+
+    IResource resourceFromReferencePointManager =
+        eclipseReferencePointManager.findMember(referencePoint, projectRelativePath);
+
+    Assert.assertNotNull(resource);
+    Assert.assertEquals(resource, resourceFromReferencePointManager);
+  }
+
+  @Test
+  public void testFindMemberWithSPath() {
+    IResource resource = createResourceMock();
+    IPath projectRelativePath = createRelativePathMock();
+    IProject project = createProjectMock();
+    EasyMock.expect(project.findMember(projectRelativePath)).andStubReturn(resource);
+    EasyMock.replay(project);
+    SPath sPath = createSPathMock(projectRelativePath);
+
+    eclipseReferencePointManager.putIfAbsent(referencePoint, project);
+
+    IResource resourceFromReferencePointManager = eclipseReferencePointManager.findMember(sPath);
+
+    Assert.assertNotNull(resourceFromReferencePointManager);
+    Assert.assertEquals(resource, resourceFromReferencePointManager);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetResourceWithNullReferencePoint() {
+    eclipseReferencePointManager.findMember(null, createRelativePathMock());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetResourceWithNullRelativePath() {
+    eclipseReferencePointManager.findMember(referencePoint, null);
+  }
+
+  @Test
+  public void testGetFile() {
+    IFile file = createFileMock();
+    IPath projectRelativePath = createRelativePathMock();
+    IProject project = createProjectMock();
+    EasyMock.expect(project.getFile(projectRelativePath)).andStubReturn(file);
+    EasyMock.replay(project);
+
+    eclipseReferencePointManager.putIfAbsent(referencePoint, project);
+
+    IFile fileFromReferencePointManager =
+        eclipseReferencePointManager.getFile(referencePoint, projectRelativePath);
+
+    Assert.assertNotNull(fileFromReferencePointManager);
+    Assert.assertEquals(file, fileFromReferencePointManager);
+  }
+
+  @Test
+  public void testGetFileWithSPath() {
+    IFile file = createFileMock();
+    IPath projectRelativePath = createRelativePathMock();
+    IProject project = createProjectMock();
+    EasyMock.expect(project.getFile(projectRelativePath)).andStubReturn(file);
+    EasyMock.replay(project);
+    SPath sPath = createSPathMock(projectRelativePath);
+
+    eclipseReferencePointManager.putIfAbsent(referencePoint, project);
+
+    IFile fileFromReferencePointManager = eclipseReferencePointManager.getFile(sPath);
+
+    Assert.assertNotNull(fileFromReferencePointManager);
+    Assert.assertEquals(file, fileFromReferencePointManager);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetFileWithNullReferencePoint() {
+    eclipseReferencePointManager.getFile(null, createRelativePathMock());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetFileWithNullRelativePath() {
+    eclipseReferencePointManager.getFile(referencePoint, null);
+  }
+
+  @Test
+  public void testGetFolder() {
+    IFolder folder = createFolderMock();
+    IPath projectRelativePath = createRelativePathMock();
+    IProject project = createProjectMock();
+    EasyMock.expect(project.getFolder(projectRelativePath)).andStubReturn(folder);
+    EasyMock.replay(project);
+
+    eclipseReferencePointManager.putIfAbsent(referencePoint, project);
+
+    IFolder folderFromReferencePointManager =
+        eclipseReferencePointManager.getFolder(referencePoint, projectRelativePath);
+
+    Assert.assertNotNull(folderFromReferencePointManager);
+    Assert.assertEquals(folder, folderFromReferencePointManager);
+  }
+
+  @Test
+  public void testGetFolderWithSPath() {
+    IFolder folder = createFolderMock();
+    IPath projectRelativePath = createRelativePathMock();
+    IProject project = createProjectMock();
+    EasyMock.expect(project.getFolder(projectRelativePath)).andStubReturn(folder);
+    EasyMock.replay(project);
+    SPath sPath = createSPathMock(projectRelativePath);
+
+    eclipseReferencePointManager.putIfAbsent(referencePoint, project);
+
+    IFolder folderFromReferencePointManager = eclipseReferencePointManager.getFolder(sPath);
+
+    Assert.assertNotNull(folderFromReferencePointManager);
+    Assert.assertEquals(folder, folderFromReferencePointManager);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetFolderWithNullReferencePoint() {
+    eclipseReferencePointManager.getFolder(null, createRelativePathMock());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetFolderWithNullRelativePath() {
+    eclipseReferencePointManager.getFolder(referencePoint, null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testGetFolderWithSPathWithNullRelativePath() {
+    SPath path = EasyMock.createMock(SPath.class);
+
+    EasyMock.expect(path.getReferencePoint()).andStubReturn(referencePoint);
+    EasyMock.expect(path.getProjectRelativePath()).andStubReturn(null);
+    EasyMock.replay(path);
+
+    eclipseReferencePointManager.getFolder(path);
+  }
+
+  private IFile createFileMock() {
+    IFile file = EasyMock.createMock(IFile.class);
+    EasyMock.replay(file);
+
+    return file;
+  }
+
+  private IFolder createFolderMock() {
+    IFolder folder = EasyMock.createMock(IFolder.class);
+    EasyMock.replay(folder);
+
+    return folder;
+  }
+
+  private IResource createResourceMock() {
+    IResource resource = EasyMock.createMock(IResource.class);
+    EasyMock.replay(resource);
+
+    return resource;
+  }
+
+  private IProject createProjectMock() {
+    IProject project = EasyMock.createMock(IProject.class);
+
+    return project;
+  }
+
+  private IPath createRelativePathMock() {
+    IPath relativePath = EasyMock.createMock(IPath.class);
+    EasyMock.replay(relativePath);
+
+    return relativePath;
+  }
+
+  private SPath createSPathMock(IPath projectRelativePath) {
+    SPath sPath = EasyMock.createMock(SPath.class);
+    EasyMock.expect(sPath.getReferencePoint()).andStubReturn(referencePoint);
+    EasyMock.expect(sPath.getProjectRelativePath())
+        .andStubReturn(createSarosIPathMock(projectRelativePath));
+    EasyMock.replay(sPath);
+
+    return sPath;
+  }
+
+  private EclipsePathImpl createSarosIPathMock(IPath projectRelativePath) {
+    EclipsePathImpl path = EasyMock.createMock(EclipsePathImpl.class);
+    EasyMock.expect(path.getDelegate()).andStubReturn(projectRelativePath);
+    EasyMock.replay(path);
+
+    return path;
+  }
+}


### PR DESCRIPTION
In Saros/E the EclipseReferencePointManager is used for mapping reference points to eclipse projects and also determining eclipse resources given by reference point and relative paths, or SPath.
This PR contains the implementation of the EclipseReferencePointManager and unit tests. The EclipseReferencePointManager is created by the eclipse plugin context and will be filled with eclipse projects and reference points, when a Saros Session is started, like the CoreReferencePointManager.

Features:
- Creates ReferencePoints, given by eclipse projects
- Maps ReferencePoints to eclipse projects
- Returns eclipse projects, given by ReferencePoints
- Returns eclipse resources (IResource, IFile, IFolder),
  given by ReferencePoints and ReferencePointRelativePath or SPaths