### PR TITLE
Fix issues with SharedIDEContext.dispose()

### DIFF
--- a/intellij/src/saros/intellij/context/SharedIDEContext.java
+++ b/intellij/src/saros/intellij/context/SharedIDEContext.java
@@ -137,7 +137,8 @@ public class SharedIDEContext implements Disposable {
   /**
    * {@inheritDoc}
    *
-   * <p>Stops and disposes all registered application- and project-level event handlers.
+   * <p>Stops and disposes all registered application- and project-level event handlers and resets
+   * the preregistered project.
    *
    * @see IEventHandler#dispose()
    */
@@ -145,6 +146,8 @@ public class SharedIDEContext implements Disposable {
   public void dispose() {
     applicationEventHandlers.stop();
     projectEventHandlers.stop();
+
+    preregisteredProject = null;
   }
 
   /**

--- a/intellij/src/saros/intellij/context/SharedIDEContext.java
+++ b/intellij/src/saros/intellij/context/SharedIDEContext.java
@@ -144,8 +144,13 @@ public class SharedIDEContext implements Disposable {
    */
   @Override
   public void dispose() {
-    applicationEventHandlers.stop();
-    projectEventHandlers.stop();
+    if (applicationEventHandlers != null) {
+      applicationEventHandlers.stop();
+    }
+
+    if (projectEventHandlers != null) {
+      projectEventHandlers.stop();
+    }
 
     preregisteredProject = null;
   }


### PR DESCRIPTION
#### [FIX][I] Drop preregistered project object on session end

Adjusts SharedIDEContext to drop the held preregistered project object.
Otherwise, starting a second session after the first session ended
causes an erroneous warning on the host side as the preregistered
project of the first session is still present.

#### [FIX][I] Add null check to SharedIDEContext.dispose()

Adds a null check for applicationEventHandlers and projectEventHandlers
to SharedIDEContext.dispose(). This check is needed as the context can
be disposed without the handlers being initialized when the project
negotiation was canceled on the client side.