### PR TITLE
Move Saros/I to application context

### DIFF
--- a/intellij/resources/META-INF/plugin.xml
+++ b/intellij/resources/META-INF/plugin.xml
@@ -34,15 +34,12 @@
     -->
 
     <application-components>
-        <!-- Add your application components here -->
-    </application-components>
-
-    <project-components>
         <component>
-            <implementation-class>saros.intellij.SarosComponent
+            <implementation-class>
+                saros.intellij.SarosComponent
             </implementation-class>
         </component>
-    </project-components>
+    </application-components>
 
     <actions>
         <group keep-content="true" compact="false" popup="true"

--- a/intellij/src/saros/intellij/IntellijProjectLifecycle.java
+++ b/intellij/src/saros/intellij/IntellijProjectLifecycle.java
@@ -1,6 +1,5 @@
 package saros.intellij;
 
-import com.intellij.openapi.project.Project;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -26,28 +25,24 @@ public class IntellijProjectLifecycle extends AbstractContextLifecycle {
   private static IntellijProjectLifecycle instance;
 
   /**
-   * Creates a new IntellijProjectLifecycle singleton instance from a project.
+   * Returns the current intellij project lifecycle instance. The returned instance is singleton. If
+   * no instance is present, a new instance is instantiated.
    *
-   * @param project
-   * @return
+   * @return the current intellij project lifecycle instance
    */
-  public static synchronized IntellijProjectLifecycle getInstance(Project project) {
-    instance = new IntellijProjectLifecycle(project);
+  public static synchronized IntellijProjectLifecycle getInstance() {
+    if (instance == null) {
+      instance = new IntellijProjectLifecycle();
+    }
 
     return instance;
-  }
-
-  private Project project;
-
-  private IntellijProjectLifecycle(Project project) {
-    this.project = project;
   }
 
   @Override
   protected Collection<IContextFactory> additionalContextFactories() {
     List<IContextFactory> nonCoreFactories = new ArrayList<>();
 
-    nonCoreFactories.add(new SarosIntellijContextFactory(project));
+    nonCoreFactories.add(new SarosIntellijContextFactory());
 
     if (SarosComponent.isSwtBrowserEnabled()) {
       SwtLibLoader.loadSwtLib();

--- a/intellij/src/saros/intellij/SarosComponent.java
+++ b/intellij/src/saros/intellij/SarosComponent.java
@@ -3,19 +3,17 @@ package saros.intellij;
 import com.intellij.openapi.actionSystem.KeyboardShortcut;
 import com.intellij.openapi.keymap.Keymap;
 import com.intellij.openapi.keymap.KeymapManager;
-import com.intellij.openapi.project.Project;
 import java.awt.event.KeyEvent;
 import java.io.InputStream;
 import javax.swing.KeyStroke;
 import org.apache.log4j.PropertyConfigurator;
 import org.apache.log4j.helpers.LogLog;
-import org.jetbrains.annotations.NotNull;
 
 /**
- * Component that is initalized when a project is loaded. It initializes the logging, shortcuts and
+ * Component that is initialized when a project is loaded. It initializes the logging, shortcuts and
  * the {@link IntellijProjectLifecycle} singleton.
  */
-public class SarosComponent implements com.intellij.openapi.components.ProjectComponent {
+public class SarosComponent {
 
   /**
    * This is the plugin ID that identifies the saros plugin in the IDEA ecosystem. It is set in
@@ -23,7 +21,7 @@ public class SarosComponent implements com.intellij.openapi.components.ProjectCo
    */
   public static final String PLUGIN_ID = "saros";
 
-  public SarosComponent(final Project project) {
+  public SarosComponent() {
     loadLoggers();
 
     Keymap keymap = KeymapManager.getInstance().getActiveKeymap();
@@ -50,7 +48,7 @@ public class SarosComponent implements com.intellij.openapi.components.ProjectCo
       LogLog.error("could not load saros property file 'saros.properties'", e);
     }
 
-    IntellijProjectLifecycle.getInstance(project).start();
+    IntellijProjectLifecycle.getInstance().start();
   }
 
   public static boolean isSwtBrowserEnabled() {
@@ -72,31 +70,5 @@ public class SarosComponent implements com.intellij.openapi.components.ProjectCo
     } finally {
       Thread.currentThread().setContextClassLoader(contextClassLoader);
     }
-  }
-
-  @Override
-  public void initComponent() {
-    // NOP
-  }
-
-  @Override
-  public void disposeComponent() {
-    // NOP
-  }
-
-  @NotNull
-  @Override
-  public String getComponentName() {
-    return "Saros";
-  }
-
-  @Override
-  public void projectOpened() {
-    // TODO: Update project
-  }
-
-  @Override
-  public void projectClosed() {
-    // TODO: Update project
   }
 }

--- a/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
+++ b/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
@@ -1,6 +1,5 @@
 package saros.intellij.context;
 
-import com.intellij.openapi.project.Project;
 import java.util.Arrays;
 import saros.communication.connection.IProxyResolver;
 import saros.communication.connection.NullProxyResolver;
@@ -80,19 +79,12 @@ public class SarosIntellijContextFactory extends AbstractContextFactory {
     };
   }
 
-  private Project project;
-
-  public SarosIntellijContextFactory(Project project) {
-    this.project = project;
-  }
-
   @Override
   public void createComponents(MutablePicoContainer container) {
 
     // Saros Core PathIntl Support
     container.addComponent(IPathFactory.class, new PathFactory());
 
-    container.addComponent(Project.class, project);
     container.addComponent(IWorkspace.class, IntelliJWorkspaceImpl.class);
 
     for (Component component : Arrays.asList(getContextComponents())) {

--- a/intellij/src/saros/intellij/context/SharedIDEContext.java
+++ b/intellij/src/saros/intellij/context/SharedIDEContext.java
@@ -36,17 +36,13 @@ public class SharedIDEContext implements Disposable {
 
   public SharedIDEContext(
       ApplicationEventHandlersFactory applicationEventHandlersFactory,
-      ProjectEventHandlersFactory projectEventHandlersFactory,
-      Project project) {
+      ProjectEventHandlersFactory projectEventHandlersFactory) {
 
     this.applicationEventHandlersFactory = applicationEventHandlersFactory;
     this.projectEventHandlersFactory = projectEventHandlersFactory;
 
     if (preregisteredProject != null) {
       startProjectComponents(preregisteredProject);
-    } else {
-      // TODO remove this workaround once the shared project object is correctly initialized
-      startProjectComponents(project);
     }
   }
 

--- a/intellij/src/saros/intellij/ui/menu/ShareWithUserAction.java
+++ b/intellij/src/saros/intellij/ui/menu/ShareWithUserAction.java
@@ -13,6 +13,7 @@ import java.util.List;
 import org.apache.log4j.Logger;
 import saros.core.ui.util.CollaborationUtils;
 import saros.filesystem.IResource;
+import saros.intellij.context.SharedIDEContext;
 import saros.intellij.filesystem.IntelliJProjectImpl;
 import saros.intellij.ui.Messages;
 import saros.intellij.ui.util.IconManager;
@@ -46,17 +47,25 @@ public class ShareWithUserAction extends AnAction {
 
   @Override
   public void actionPerformed(AnActionEvent e) {
-    VirtualFile virtFile = e.getData(CommonDataKeys.VIRTUAL_FILE);
-    if (virtFile == null) {
-      return;
+    Project project = e.getProject();
+    if (project == null) {
+      throw new IllegalStateException(
+          "Unable to start session - could not determine project for highlighted resource.");
+    }
+
+    VirtualFile virtualFile = e.getData(CommonDataKeys.VIRTUAL_FILE);
+    if (virtualFile == null) {
+      throw new IllegalStateException(
+          "Unable to start session - could not determine virtual file for highlighted resource.");
     }
 
     // We allow only completely shared projects, so no need to check
     // for partially shared ones.
-    List<IResource> resources = Arrays.asList(getModuleFromVirtFile(virtFile, e.getProject()));
+    List<IResource> resources = Arrays.asList(getModuleFromVirtFile(virtualFile, e.getProject()));
 
     List<JID> contacts = Arrays.asList(userJID);
 
+    SharedIDEContext.preregisterProject(project);
     CollaborationUtils.startSession(resources, contacts);
   }
 

--- a/intellij/src/saros/intellij/ui/wizards/AddProjectToSessionWizard.java
+++ b/intellij/src/saros/intellij/ui/wizards/AddProjectToSessionWizard.java
@@ -32,6 +32,7 @@ import org.jetbrains.annotations.Nullable;
 import saros.SarosPluginContext;
 import saros.filesystem.IChecksumCache;
 import saros.filesystem.IProject;
+import saros.intellij.context.SharedIDEContext;
 import saros.intellij.editor.DocumentAPI;
 import saros.intellij.filesystem.Filesystem;
 import saros.intellij.filesystem.IntelliJProjectImpl;
@@ -75,7 +76,6 @@ import saros.util.ThreadUtils;
  */
 
 //  FIXME: Add facility for more than one project.
-
 public class AddProjectToSessionWizard extends Wizard {
   private static final Logger LOG = Logger.getLogger(AddProjectToSessionWizard.class);
 
@@ -137,6 +137,8 @@ public class AddProjectToSessionWizard extends Wizard {
           }
 
           Project project = moduleSelectionResult.getProject();
+
+          sessionManager.getSession().getComponent(SharedIDEContext.class).setProject(project);
 
           switch (moduleSelectionResult.getLocalRepresentationOption()) {
             case CREATE_NEW_MODULE:

--- a/intellij/test/junit/saros/intellij/context/AbstractContextTest.java
+++ b/intellij/test/junit/saros/intellij/context/AbstractContextTest.java
@@ -4,7 +4,6 @@ import static saros.intellij.test.IntellijMocker.mockStaticGetInstance;
 
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.module.ModuleTypeManager;
-import com.intellij.openapi.project.Project;
 import org.easymock.EasyMock;
 import org.junit.Before;
 import org.junit.runner.RunWith;
@@ -19,7 +18,6 @@ import saros.test.mocks.ContextMocker;
 public class AbstractContextTest {
 
   MutablePicoContainer container;
-  Project project;
 
   @Before
   public void setup() {
@@ -28,10 +26,6 @@ public class AbstractContextTest {
     // mock IntelliJ dependencies
     mockStaticGetInstance(PropertiesComponent.class, null);
     mockStaticGetInstance(ModuleTypeManager.class, null);
-
-    project = EasyMock.createNiceMock(Project.class);
-
-    EasyMock.replay(project);
 
     // mock IntelliJ dependent calls to get current IDE and plugin version
     PowerMock.mockStaticPartial(

--- a/intellij/test/junit/saros/intellij/context/SarosIntellijContextFactoryTest.java
+++ b/intellij/test/junit/saros/intellij/context/SarosIntellijContextFactoryTest.java
@@ -24,7 +24,7 @@ public class SarosIntellijContextFactoryTest extends AbstractContextTest {
 
   @Test
   public void testCreateComponents() {
-    IContextFactory factory = new SarosIntellijContextFactory(project);
+    IContextFactory factory = new SarosIntellijContextFactory();
 
     factory.createComponents(container);
     container.start();

--- a/intellij/test/junit/saros/intellij/context/SarosIntellijContextTest.java
+++ b/intellij/test/junit/saros/intellij/context/SarosIntellijContextTest.java
@@ -27,7 +27,7 @@ public class SarosIntellijContextTest extends AbstractContextTest {
   public void createComponentsWithoutSWT() {
     List<IContextFactory> factories = new ArrayList<>();
 
-    factories.add(new SarosIntellijContextFactory(project));
+    factories.add(new SarosIntellijContextFactory());
     factories.add(new CoreContextFactory());
 
     for (IContextFactory factory : factories) {
@@ -43,7 +43,7 @@ public class SarosIntellijContextTest extends AbstractContextTest {
   public void createComponentsWithSWT() {
     List<IContextFactory> factories = new ArrayList<>();
 
-    factories.add(new SarosIntellijContextFactory(project));
+    factories.add(new SarosIntellijContextFactory());
     factories.add(new CoreContextFactory());
     factories.add(new HTMLUIContextFactory());
 


### PR DESCRIPTION
#### [INTERNAL][I] Add shared project to SharedIDEContext

Adjusts the existing logic to add the needed shared project object to
the SharedIDEContext when a session is started.

Subsequently removes the workaround adding the plugin context project
object to the SharedIDEContext if no other project object is given. The
workaround is no longer needed as all necessary calls starting a session
now correctly set the shared project object.

#### [INTERNAL][I] Move plugin to application context

Makes the Saros/I plugin an application level plugin, meaning a single
instance will be loaded when the application is started. This plugin
instance is shared by all open projects.

Fixes #76. Fixes #394.

Also makes the IntellijProjectLifecycle really a singleton and removes
the project object from the lifecycle.

Subsequently removes the project object from the plugin context as this
is now completely handled by the SharedIDEContext. Also removes the
project object from the affected test cases.