### PR TITLE
Fix theme-dependent UI inconsistencies

### DIFF
--- a/intellij/src/saros/intellij/ui/views/buttons/ConnectButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/ConnectButton.java
@@ -1,6 +1,8 @@
 package saros.intellij.ui.views.buttons;
 
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.JBMenuItem;
+import com.intellij.openapi.ui.JBPopupMenu;
 import java.util.Scanner;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
@@ -29,7 +31,7 @@ public class ConnectButton extends ToolbarButton {
   private static final boolean ENABLE_CONFIGURE_ACCOUNTS =
       Boolean.getBoolean("saros.intellij.ENABLE_CONFIGURE_ACCOUNTS");
 
-  private JPopupMenu popupMenu = new JPopupMenu();
+  private final JPopupMenu popupMenu;
   private JMenuItem menuItemAdd;
   private JMenuItem configure;
   private JMenuItem disconnect;
@@ -50,6 +52,11 @@ public class ConnectButton extends ToolbarButton {
 
     disconnectAction = new DisconnectServerAction(project);
     connectAction = new ConnectServerAction(project);
+
+    popupMenu = new JBPopupMenu();
+
+    popupMenu.setForeground(FOREGROUND_COLOR);
+    popupMenu.setBackground(BACKGROUND_COLOR);
 
     configureAccounts = new NotImplementedAction("configure accounts");
 
@@ -99,24 +106,40 @@ public class ConnectButton extends ToolbarButton {
   }
 
   private JMenuItem createMenuItemForUser(final String userName) {
-    JMenuItem accountItem = new JMenuItem(userName);
+    JMenuItem accountItem = new JBMenuItem(userName);
+
+    accountItem.setForeground(FOREGROUND_COLOR);
+    accountItem.setBackground(BACKGROUND_COLOR);
+
     accountItem.addActionListener(actionEvent -> connectAction.executeWithUser(userName));
 
     return accountItem;
   }
 
   private void createDisconnectMenuItem() {
-    disconnect = new JMenuItem("Disconnect server");
+    disconnect = new JBMenuItem("Disconnect server");
+
+    disconnect.setForeground(FOREGROUND_COLOR);
+    disconnect.setBackground(BACKGROUND_COLOR);
+
     disconnect.addActionListener(actionEvent -> disconnectAction.execute());
   }
 
   private void createConfigureAccountMenuItem() {
-    configure = new JMenuItem("Configure accounts...");
+    configure = new JBMenuItem("Configure accounts...");
+
+    configure.setForeground(FOREGROUND_COLOR);
+    configure.setBackground(BACKGROUND_COLOR);
+
     configure.addActionListener(actionEvent -> configureAccounts.execute());
   }
 
   private void createAddAccountMenuItem() {
-    menuItemAdd = new JMenuItem("Add account...");
+    menuItemAdd = new JBMenuItem("Add account...");
+
+    menuItemAdd.setForeground(FOREGROUND_COLOR);
+    menuItemAdd.setBackground(BACKGROUND_COLOR);
+
     menuItemAdd.addActionListener(
         actionEvent -> {
           XMPPAccount account = createNewAccount();

--- a/intellij/src/saros/intellij/ui/views/buttons/FollowButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/FollowButton.java
@@ -1,5 +1,7 @@
 package saros.intellij.ui.views.buttons;
 
+import com.intellij.openapi.ui.JBMenuItem;
+import com.intellij.openapi.ui.JBPopupMenu;
 import com.intellij.util.ui.UIUtil;
 import javax.swing.JButton;
 import javax.swing.JMenuItem;
@@ -106,7 +108,10 @@ public class FollowButton extends ToolbarButton {
   }
 
   private void createMenu() {
-    popupMenu = new JPopupMenu();
+    popupMenu = new JBPopupMenu();
+
+    popupMenu.setForeground(FOREGROUND_COLOR);
+    popupMenu.setBackground(BACKGROUND_COLOR);
 
     menuItemPrefix = "Follow ";
 
@@ -124,7 +129,11 @@ public class FollowButton extends ToolbarButton {
 
     popupMenu.addSeparator();
 
-    JMenuItem leaveItem = new JMenuItem("Leave follow mode");
+    JMenuItem leaveItem = new JBMenuItem("Leave follow mode");
+
+    leaveItem.setForeground(FOREGROUND_COLOR);
+    leaveItem.setBackground(BACKGROUND_COLOR);
+
     leaveItem.addActionListener(e -> followModeAction.execute(null));
     leaveItem.setEnabled(currentFollowModeManager.getFollowedUser() != null);
 
@@ -139,7 +148,10 @@ public class FollowButton extends ToolbarButton {
       userNameShort = userNameShort.substring(0, index);
     }
 
-    JMenuItem menuItem = new JMenuItem(menuItemPrefix + userNameShort);
+    JMenuItem menuItem = new JBMenuItem(menuItemPrefix + userNameShort);
+
+    menuItem.setForeground(FOREGROUND_COLOR);
+    menuItem.setBackground(BACKGROUND_COLOR);
 
     FollowModeManager currentFollowModeManager = followModeManager;
 

--- a/intellij/src/saros/intellij/ui/views/buttons/ToolbarButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/ToolbarButton.java
@@ -19,6 +19,8 @@ abstract class ToolbarButton extends JButton {
     setActionCommand(actionCommand);
     setButtonIcon(icon);
     setToolTipText(tooltipText);
+
+    setBorder(BorderFactory.createLineBorder(JBColor.border(), 1, true));
   }
 
   /** calls {@link #setEnabled(boolean)} from the UI thread. */

--- a/intellij/src/saros/intellij/ui/views/buttons/ToolbarButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/ToolbarButton.java
@@ -1,11 +1,18 @@
 package saros.intellij.ui.views.buttons;
 
+import com.intellij.ui.JBColor;
 import com.intellij.util.ui.UIUtil;
+import java.awt.Color;
+import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 
 /** Common class for Toolbar button implementations. */
 abstract class ToolbarButton extends JButton {
+
+  // Self-adjusting references to the current IDE color
+  static final Color FOREGROUND_COLOR = JBColor.foreground();
+  static final Color BACKGROUND_COLOR = JBColor.background();
 
   /** Creates a button with the specified actionCommand, Icon and toolTipText. */
   ToolbarButton(String actionCommand, String tooltipText, ImageIcon icon) {


### PR DESCRIPTION
#### [FIX][I] #550 Add workaround for toolbar popup menu color

Manually sets the color of the Saros toolbar popup menu and its entries
using the correct dynamic color references. This reference automatically
changes when the IDE theme is changes, thereby causing the menu color to
change as well.

Also replaces the usage of default swing components in this context with
the jetbrains wrapper, as recommended in the IntelliJ platform SDK.

Fixes #550.

#### [FIX][I] #569 Add default border for toolbar buttons

Adds a default border to the Saros toolbar buttons. The color of the
border is determined by the current IDE theme.

Fixes #569.