### PR TITLE
Correctly initialize project-bound Saros UI when there is a running session

### DIFF
--- a/intellij/src/saros/intellij/ui/actions/FollowModeAction.java
+++ b/intellij/src/saros/intellij/ui/actions/FollowModeAction.java
@@ -1,12 +1,9 @@
 package saros.intellij.ui.actions;
 
-import saros.SarosPluginContext;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import saros.editor.FollowModeManager;
-import saros.repackaged.picocontainer.annotations.Inject;
 import saros.session.ISarosSession;
-import saros.session.ISarosSessionManager;
-import saros.session.ISessionLifecycleListener;
-import saros.session.SessionEndReason;
 import saros.session.User;
 import saros.ui.util.ModelFormatUtils;
 
@@ -15,47 +12,19 @@ public class FollowModeAction extends AbstractSarosAction {
 
   public static final String NAME = "follow";
 
-  @SuppressWarnings("FieldCanBeLocal")
-  private final ISessionLifecycleListener sessionLifecycleListener =
-      new ISessionLifecycleListener() {
-        @Override
-        public void sessionStarted(final ISarosSession session) {
-          FollowModeAction.this.session = session;
-          followModeManager = session.getComponent(FollowModeManager.class);
-        }
-
-        @Override
-        public void sessionEnded(ISarosSession oldSarosSession, SessionEndReason reason) {
-          session = null;
-          followModeManager = null;
-        }
-      };
-
-  @Inject private ISarosSessionManager sessionManager;
-
-  private volatile ISarosSession session;
-  private volatile FollowModeManager followModeManager;
-
-  public FollowModeAction() {
-    SarosPluginContext.initComponent(this);
-
-    sessionManager.addSessionLifecycleListener(sessionLifecycleListener);
-  }
-
   @Override
   public String getActionName() {
     return NAME;
   }
 
-  public void execute(String userName) {
-    FollowModeManager currentFollowModeManager = followModeManager;
-    User userToFollow = findUser(userName);
+  public void execute(
+      @NotNull ISarosSession session,
+      @NotNull FollowModeManager followModeManager,
+      @Nullable String userName) {
 
-    if (currentFollowModeManager == null) {
-      return;
-    }
+    User userToFollow = findUser(session, userName);
 
-    currentFollowModeManager.follow(userToFollow);
+    followModeManager.follow(userToFollow);
 
     actionPerformed();
   }
@@ -65,10 +34,8 @@ public class FollowModeAction extends AbstractSarosAction {
     // never called
   }
 
-  private User findUser(String userName) {
-    ISarosSession currentSession = session;
-
-    if (userName == null || currentSession == null) {
+  private User findUser(@NotNull ISarosSession session, @Nullable String userName) {
+    if (userName == null) {
       return null;
     }
 

--- a/intellij/src/saros/intellij/ui/actions/LeaveSessionAction.java
+++ b/intellij/src/saros/intellij/ui/actions/LeaveSessionAction.java
@@ -5,7 +5,7 @@ import saros.core.ui.util.CollaborationUtils;
 
 /** Action to leave session */
 public class LeaveSessionAction extends AbstractSarosAction {
-  private static final String NAME = "leave";
+  public static final String NAME = "leave";
 
   private final Project project;
 

--- a/intellij/src/saros/intellij/ui/tree/SessionAndContactsTreeView.java
+++ b/intellij/src/saros/intellij/ui/tree/SessionAndContactsTreeView.java
@@ -102,6 +102,7 @@ public class SessionAndContactsTreeView extends JTree {
     // show correct initial state
     renderConnectionState(
         connectionService.getConnection(), connectionService.getConnectionState());
+    sessionTreeRootNode.setInitialState();
   }
 
   private void renderConnectionState(Connection connection, ConnectionState state) {

--- a/intellij/src/saros/intellij/ui/tree/SessionTreeRootNode.java
+++ b/intellij/src/saros/intellij/ui/tree/SessionTreeRootNode.java
@@ -74,14 +74,7 @@ public class SessionTreeRootNode extends DefaultMutableTreeNode {
       new ISessionLifecycleListener() {
         @Override
         public void sessionStarted(final ISarosSession newSarosSession) {
-          UIUtil.invokeLaterIfNeeded(
-              new Runnable() {
-                @Override
-                public void run() {
-                  newSarosSession.addListener(sessionListener);
-                  createSessionNode(newSarosSession);
-                }
-              });
+          SessionTreeRootNode.this.sessionStarted(newSarosSession);
         }
 
         @Override
@@ -106,6 +99,22 @@ public class SessionTreeRootNode extends DefaultMutableTreeNode {
     setUserObject(TREE_TITLE_NO_SESSIONS);
 
     sessionManager.addSessionLifecycleListener(sessionLifecycleListener);
+  }
+
+  void setInitialState() {
+    ISarosSession session = sessionManager.getSession();
+
+    if (session != null) {
+      sessionStarted(session);
+    }
+  }
+
+  private void sessionStarted(final ISarosSession newSarosSession) {
+    UIUtil.invokeLaterIfNeeded(
+        () -> {
+          newSarosSession.addListener(sessionListener);
+          createSessionNode(newSarosSession);
+        });
   }
 
   private void createSessionNode(ISarosSession newSarosSession) {

--- a/intellij/src/saros/intellij/ui/views/buttons/AbstractSessionToolbarButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/AbstractSessionToolbarButton.java
@@ -1,0 +1,79 @@
+package saros.intellij.ui.views.buttons;
+
+import javax.swing.ImageIcon;
+import saros.SarosPluginContext;
+import saros.repackaged.picocontainer.annotations.Inject;
+import saros.session.ISarosSession;
+import saros.session.ISarosSessionManager;
+import saros.session.ISessionLifecycleListener;
+import saros.session.SessionEndReason;
+
+/**
+ * Abstract parent class representing a session toolbar button, i.e. a button that is only enabled
+ * during an active Saros session.
+ *
+ * <p>The class offers methods to react to a session starting or ending and to update the initial
+ * state of the button.
+ */
+abstract class AbstractSessionToolbarButton extends AbstractToolbarButton {
+  @Inject protected ISarosSessionManager sarosSessionManager;
+
+  @SuppressWarnings("FieldCanBeLocal")
+  private final ISessionLifecycleListener sessionLifecycleListener =
+      new ISessionLifecycleListener() {
+        @Override
+        public void sessionStarted(ISarosSession session) {
+          AbstractSessionToolbarButton.this.sessionStarted(session);
+        }
+
+        @Override
+        public void sessionEnded(ISarosSession session, SessionEndReason reason) {
+          AbstractSessionToolbarButton.this.sessionEnded(session, reason);
+        }
+      };
+
+  /**
+   * Initializes the button. Also initializes all tagged instance variables with the matching
+   * objects from the plugin context.
+   *
+   * @see AbstractToolbarButton#AbstractToolbarButton(String, String, ImageIcon)
+   * @see SarosPluginContext#initComponent(Object)
+   */
+  AbstractSessionToolbarButton(String actionCommand, String tooltipText, ImageIcon icon) {
+    super(actionCommand, tooltipText, icon);
+
+    SarosPluginContext.initComponent(this);
+
+    sarosSessionManager.addSessionLifecycleListener(sessionLifecycleListener);
+  }
+
+  /**
+   * Calls {@link #sessionStarted(ISarosSession)} if there is currently a saros session.
+   *
+   * <p>This should be called by all implementing classes as the last call of the constructor to
+   * ensure the button is correctly enabled and initialized if the class is instantiated while there
+   * is already a running session.
+   */
+  void setInitialState() {
+    ISarosSession session = sarosSessionManager.getSession();
+
+    if (session != null) {
+      sessionStarted(session);
+    }
+  }
+
+  /**
+   * Method to react to the start of a new session.
+   *
+   * @param session the started session
+   */
+  abstract void sessionStarted(final ISarosSession session);
+
+  /**
+   * Method to react to the end of the current session.
+   *
+   * @param oldSarosSession the session that just ended
+   * @param reason the reason the session ended
+   */
+  abstract void sessionEnded(ISarosSession oldSarosSession, SessionEndReason reason);
+}

--- a/intellij/src/saros/intellij/ui/views/buttons/AbstractToolbarButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/AbstractToolbarButton.java
@@ -8,14 +8,14 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 
 /** Common class for Toolbar button implementations. */
-abstract class ToolbarButton extends JButton {
+abstract class AbstractToolbarButton extends JButton {
 
   // Self-adjusting references to the current IDE color
   static final Color FOREGROUND_COLOR = JBColor.foreground();
   static final Color BACKGROUND_COLOR = JBColor.background();
 
   /** Creates a button with the specified actionCommand, Icon and toolTipText. */
-  ToolbarButton(String actionCommand, String tooltipText, ImageIcon icon) {
+  AbstractToolbarButton(String actionCommand, String tooltipText, ImageIcon icon) {
     setActionCommand(actionCommand);
     setButtonIcon(icon);
     setToolTipText(tooltipText);

--- a/intellij/src/saros/intellij/ui/views/buttons/ConnectButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/ConnectButton.java
@@ -23,7 +23,7 @@ import saros.net.xmpp.JID;
 import saros.repackaged.picocontainer.annotations.Inject;
 
 /** Implementation of connect XMPP/jabber server button */
-public class ConnectButton extends ToolbarButton {
+public class ConnectButton extends AbstractToolbarButton {
   private static final Logger LOG = Logger.getLogger(ConnectButton.class);
 
   private static final String USER_ID_SEPARATOR = "@";

--- a/intellij/src/saros/intellij/ui/views/buttons/ConsistencyButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/ConsistencyButton.java
@@ -9,7 +9,6 @@ import java.util.HashSet;
 import java.util.Set;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
-import saros.SarosPluginContext;
 import saros.activities.SPath;
 import saros.concurrent.watchdog.ConsistencyWatchdogClient;
 import saros.concurrent.watchdog.IsInconsistentObservable;
@@ -22,8 +21,6 @@ import saros.intellij.ui.util.NotificationPanel;
 import saros.observables.ValueChangeListener;
 import saros.repackaged.picocontainer.annotations.Inject;
 import saros.session.ISarosSession;
-import saros.session.ISarosSessionManager;
-import saros.session.ISessionLifecycleListener;
 import saros.session.SessionEndReason;
 
 /**
@@ -32,7 +29,7 @@ import saros.session.SessionEndReason;
  *
  * <p>FIXME: Remove awkward session handling together with UI components created with session.
  */
-public class ConsistencyButton extends AbstractToolbarButton {
+public class ConsistencyButton extends AbstractSessionToolbarButton {
   private static final Logger LOG = Logger.getLogger(ConsistencyButton.class);
 
   private boolean previouslyInConsistentState = true;
@@ -68,34 +65,9 @@ public class ConsistencyButton extends AbstractToolbarButton {
         }
       };
 
-  @SuppressWarnings("FieldCanBeLocal")
-  private final ISessionLifecycleListener sessionLifecycleListener =
-      new ISessionLifecycleListener() {
-        @Override
-        public void sessionStarted(ISarosSession newSarosSession) {
-          if (!newSarosSession.isHost()) {
-            setSarosSession(newSarosSession);
-          }
-
-          setToolTipText(Messages.ConsistencyButton_tooltip_no_inconsistency);
-        }
-
-        @Override
-        public void sessionEnded(ISarosSession oldSarosSession, SessionEndReason reason) {
-          if (!oldSarosSession.isHost()) {
-            setSarosSession(null);
-          }
-
-          setEnabledFromUIThread(false);
-          setToolTipText(Messages.ConsistencyButton_tooltip_functionality);
-        }
-      };
-
   private final ValueChangeListener<Boolean> isConsistencyListener = this::handleConsistencyChange;
 
   private final Project project;
-
-  @Inject private ISarosSessionManager sessionManager;
 
   @Inject private IsInconsistentObservable inconsistentObservable;
 
@@ -108,15 +80,36 @@ public class ConsistencyButton extends AbstractToolbarButton {
         Messages.ConsistencyButton_tooltip_functionality,
         IconManager.IN_SYNC_ICON);
 
-    SarosPluginContext.initComponent(this);
-
     this.project = project;
 
-    setSarosSession(sessionManager.getSession());
-    sessionManager.addSessionLifecycleListener(sessionLifecycleListener);
+    setSarosSession(sarosSessionManager.getSession());
 
     addActionListener(actionListener);
     setEnabled(false);
+
+    setInitialState();
+  }
+
+  @Override
+  void sessionStarted(ISarosSession newSarosSession) {
+    setToolTipText(Messages.ConsistencyButton_tooltip_no_inconsistency);
+
+    if (!newSarosSession.isHost()) {
+      setSarosSession(newSarosSession);
+
+      Boolean isInconsistent = inconsistentObservable.getValue();
+      if (isInconsistent != null && isInconsistent) handleConsistencyChange(Boolean.TRUE);
+    }
+  }
+
+  @Override
+  void sessionEnded(ISarosSession oldSarosSession, SessionEndReason reason) {
+    if (!oldSarosSession.isHost()) {
+      setSarosSession(null);
+    }
+
+    setEnabledFromUIThread(false);
+    setToolTipText(Messages.ConsistencyButton_tooltip_functionality);
   }
 
   private class SessionInconsistencyState {
@@ -177,7 +170,7 @@ public class ConsistencyButton extends AbstractToolbarButton {
    * displays a tooltip.
    */
   private void handleConsistencyChange(final Boolean isInconsistent) {
-    if (sessionManager.getSession() == null) {
+    if (sarosSessionManager.getSession() == null) {
       return;
     }
 

--- a/intellij/src/saros/intellij/ui/views/buttons/ConsistencyButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/ConsistencyButton.java
@@ -32,7 +32,7 @@ import saros.session.SessionEndReason;
  *
  * <p>FIXME: Remove awkward session handling together with UI components created with session.
  */
-public class ConsistencyButton extends ToolbarButton {
+public class ConsistencyButton extends AbstractToolbarButton {
   private static final Logger LOG = Logger.getLogger(ConsistencyButton.class);
 
   private boolean previouslyInConsistentState = true;

--- a/intellij/src/saros/intellij/ui/views/buttons/FollowButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/FollowButton.java
@@ -134,7 +134,7 @@ public class FollowButton extends AbstractToolbarButton {
     leaveItem.setForeground(FOREGROUND_COLOR);
     leaveItem.setBackground(BACKGROUND_COLOR);
 
-    leaveItem.addActionListener(e -> followModeAction.execute(null));
+    leaveItem.addActionListener(e -> followModeAction.execute(session, followModeManager, null));
     leaveItem.setEnabled(currentFollowModeManager.getFollowedUser() != null);
 
     popupMenu.add(leaveItem);
@@ -169,7 +169,9 @@ public class FollowButton extends AbstractToolbarButton {
     }
 
     menuItem.setActionCommand(userName);
-    menuItem.addActionListener(e -> followModeAction.execute(e.getActionCommand()));
+    menuItem.addActionListener(
+        e -> followModeAction.execute(session, followModeManager, e.getActionCommand()));
+
     return menuItem;
   }
 

--- a/intellij/src/saros/intellij/ui/views/buttons/FollowButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/FollowButton.java
@@ -21,7 +21,7 @@ import saros.session.User;
 import saros.ui.util.ModelFormatUtils;
 
 /** Button to follow a user. Displays a PopupMenu containing all session users to choose from. */
-public class FollowButton extends ToolbarButton {
+public class FollowButton extends AbstractToolbarButton {
   private JPopupMenu popupMenu;
   private final FollowModeAction followModeAction;
 

--- a/intellij/src/saros/intellij/ui/views/buttons/LeaveSessionButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/LeaveSessionButton.java
@@ -1,43 +1,33 @@
 package saros.intellij.ui.views.buttons;
 
 import com.intellij.openapi.project.Project;
-import saros.SarosPluginContext;
 import saros.intellij.ui.actions.LeaveSessionAction;
 import saros.intellij.ui.util.IconManager;
-import saros.repackaged.picocontainer.annotations.Inject;
 import saros.session.ISarosSession;
-import saros.session.ISarosSessionManager;
-import saros.session.ISessionLifecycleListener;
 import saros.session.SessionEndReason;
 
-public class LeaveSessionButton extends SimpleButton {
-
-  @SuppressWarnings("FieldCanBeLocal")
-  private final ISessionLifecycleListener sessionLifecycleListener =
-      new ISessionLifecycleListener() {
-        @Override
-        public void sessionStarted(ISarosSession newSarosSession) {
-          setEnabledFromUIThread(true);
-        }
-
-        @Override
-        public void sessionEnded(ISarosSession oldSarosSession, SessionEndReason reason) {
-
-          setEnabledFromUIThread(false);
-        }
-      };
-
-  @Inject private ISarosSessionManager sessionManager;
-
+public class LeaveSessionButton extends AbstractSessionToolbarButton {
   /**
    * Creates a LeaveSessionButton and registers the sessionListener.
    *
    * <p>LeaveSessionButton is created as disabled.
    */
   public LeaveSessionButton(Project project) {
-    super(new LeaveSessionAction(project), "Leave session", IconManager.LEAVE_SESSION_ICON);
-    SarosPluginContext.initComponent(this);
-    sessionManager.addSessionLifecycleListener(sessionLifecycleListener);
+    super(LeaveSessionAction.NAME, "Leave session", IconManager.LEAVE_SESSION_ICON);
+
+    addActionListener(actionEvent -> new LeaveSessionAction(project).execute());
     setEnabled(false);
+
+    setInitialState();
+  }
+
+  @Override
+  void sessionStarted(ISarosSession newSarosSession) {
+    setEnabledFromUIThread(true);
+  }
+
+  @Override
+  void sessionEnded(ISarosSession oldSarosSession, SessionEndReason reason) {
+    setEnabledFromUIThread(false);
   }
 }

--- a/intellij/src/saros/intellij/ui/views/buttons/SimpleButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/SimpleButton.java
@@ -4,7 +4,7 @@ import javax.swing.ImageIcon;
 import saros.intellij.ui.actions.AbstractSarosAction;
 
 /** Simple button used to create actions that just call {@link AbstractSarosAction#execute()}. */
-public class SimpleButton extends ToolbarButton {
+public class SimpleButton extends AbstractToolbarButton {
   private AbstractSarosAction action;
 
   /** Creates a button that executes action.execute() when clicked. */


### PR DESCRIPTION
This fixes the first half (initialization) of #572.

#### [REFACTOR][I] Rename ToolbarButton to AbstractToolbarButton

#### [REFACTOR][I] Remove session lifecycle listener from FollowModeAction

Removes the session lifecycle listener from the FollowModeAction.
Instead, the needed session components are now passed to the execute
command.

This was done to reduce the complexity of the action and remove the
state held by the action, which led to unexpected behaviors.

#### [INTERNAL][I] Add AbstractSessionToolbarButton

Adds AbstractSessionToolbarButton to avoid code duplication. The class
can be used by all session buttons.

Also offers the functionality to set the initial state of the button in
case there is already a running session when the button is instantiated.
This is needed as such a case is not covered by the session lifecycle
listener.

#### [FIX][I] #572 Set initial state for session buttons

Uses AbstractSessionToolbarButtons for all session buttons.

Adds the call to set the initial button state to the button CTORs.

#### [FIX][I] #572 Set initial state for session tree

Sets the initial state for the session tree contained in the Saros view
when it is instantiated. This is needed to correctly handle case where
the UI is initialized while there is already a running session.