### PR TITLE
Dispose project-bound Saros UI to avoid memory leaks

### DIFF
--- a/intellij/src/saros/intellij/ui/tree/ContactTreeRootNode.java
+++ b/intellij/src/saros/intellij/ui/tree/ContactTreeRootNode.java
@@ -14,6 +14,7 @@ import org.jivesoftware.smack.RosterEntry;
 import org.jivesoftware.smack.packet.Presence;
 import saros.SarosPluginContext;
 import saros.intellij.ui.util.IconManager;
+import saros.intellij.ui.views.SarosMainPanelView;
 import saros.net.xmpp.JID;
 import saros.net.xmpp.roster.IRosterListener;
 import saros.net.xmpp.roster.RosterTracker;
@@ -24,6 +25,9 @@ import saros.repackaged.picocontainer.annotations.Inject;
  *
  * <p>It registers as {@link IRosterListener} and keeps the displayed contacts in sync with the
  * server.
+ *
+ * <p><b>NOTE:</b>This component and any component added here must be correctly torn down when the
+ * project the components belong to is closed. See {@link SarosMainPanelView}.
  */
 
 /*

--- a/intellij/src/saros/intellij/ui/tree/ContactTreeRootNode.java
+++ b/intellij/src/saros/intellij/ui/tree/ContactTreeRootNode.java
@@ -1,5 +1,7 @@
 package saros.intellij.ui.tree;
 
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.util.ui.UIUtil;
 import java.util.Collection;
 import java.util.HashMap;
@@ -29,7 +31,8 @@ import saros.repackaged.picocontainer.annotations.Inject;
  * the same issue as the Eclipse counterpart, it cannot
  * handle multiple JIDs with different resources
  */
-public class ContactTreeRootNode extends DefaultMutableTreeNode implements IRosterListener {
+public class ContactTreeRootNode extends DefaultMutableTreeNode
+    implements IRosterListener, Disposable {
 
   private static final long serialVersionUID = 1L;
 
@@ -48,6 +51,9 @@ public class ContactTreeRootNode extends DefaultMutableTreeNode implements IRost
 
   public ContactTreeRootNode(SessionAndContactsTreeView treeView) {
     super(treeView);
+
+    Disposer.register(treeView, this);
+
     SarosPluginContext.initComponent(this);
 
     this.treeView = treeView;
@@ -56,6 +62,11 @@ public class ContactTreeRootNode extends DefaultMutableTreeNode implements IRost
 
     rosterTracker.addRosterListener(this);
     rosterChanged(rosterTracker.getRoster());
+  }
+
+  @Override
+  public void dispose() {
+    rosterTracker.removeRosterListener(this);
   }
 
   /**

--- a/intellij/src/saros/intellij/ui/tree/SessionAndContactsTreeView.java
+++ b/intellij/src/saros/intellij/ui/tree/SessionAndContactsTreeView.java
@@ -17,13 +17,19 @@ import org.jivesoftware.smack.Connection;
 import saros.SarosPluginContext;
 import saros.account.XMPPAccountStore;
 import saros.intellij.ui.util.IconManager;
+import saros.intellij.ui.views.SarosMainPanelView;
 import saros.net.ConnectionState;
 import saros.net.xmpp.IConnectionListener;
 import saros.net.xmpp.JID;
 import saros.net.xmpp.XMPPConnectionService;
 import saros.repackaged.picocontainer.annotations.Inject;
 
-/** Saros tree view for contacts and sessions. */
+/**
+ * Saros tree view for contacts and sessions.
+ *
+ * <p><b>NOTE:</b>This component and any component added here must be correctly torn down when the
+ * project the components belong to is closed. See {@link SarosMainPanelView}.
+ */
 public class SessionAndContactsTreeView extends JTree implements Disposable {
 
   private final SessionTreeRootNode sessionTreeRootNode;

--- a/intellij/src/saros/intellij/ui/tree/SessionAndContactsTreeView.java
+++ b/intellij/src/saros/intellij/ui/tree/SessionAndContactsTreeView.java
@@ -1,5 +1,8 @@
 package saros.intellij.ui.tree;
 
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.util.ui.UIUtil;
 import java.awt.Component;
 import javax.swing.JTree;
@@ -9,6 +12,7 @@ import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreeCellRenderer;
 import javax.swing.tree.TreePath;
 import javax.swing.tree.TreeSelectionModel;
+import org.jetbrains.annotations.NotNull;
 import org.jivesoftware.smack.Connection;
 import saros.SarosPluginContext;
 import saros.account.XMPPAccountStore;
@@ -20,7 +24,7 @@ import saros.net.xmpp.XMPPConnectionService;
 import saros.repackaged.picocontainer.annotations.Inject;
 
 /** Saros tree view for contacts and sessions. */
-public class SessionAndContactsTreeView extends JTree {
+public class SessionAndContactsTreeView extends JTree implements Disposable {
 
   private final SessionTreeRootNode sessionTreeRootNode;
   private final ContactTreeRootNode contactTreeRootNode;
@@ -83,8 +87,11 @@ public class SessionAndContactsTreeView extends JTree {
         }
       };
 
-  public SessionAndContactsTreeView() {
+  public SessionAndContactsTreeView(@NotNull Project project) {
     super(new SarosTreeRootNode());
+
+    Disposer.register(project, this);
+
     SarosPluginContext.initComponent(this);
 
     sessionTreeRootNode = new SessionTreeRootNode(this);
@@ -103,6 +110,11 @@ public class SessionAndContactsTreeView extends JTree {
     renderConnectionState(
         connectionService.getConnection(), connectionService.getConnectionState());
     sessionTreeRootNode.setInitialState();
+  }
+
+  @Override
+  public void dispose() {
+    connectionService.removeListener(connectionStateListener);
   }
 
   private void renderConnectionState(Connection connection, ConnectionState state) {

--- a/intellij/src/saros/intellij/ui/tree/SessionTreeRootNode.java
+++ b/intellij/src/saros/intellij/ui/tree/SessionTreeRootNode.java
@@ -13,6 +13,7 @@ import saros.SarosPluginContext;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
 import saros.intellij.ui.util.IconManager;
+import saros.intellij.ui.views.SarosMainPanelView;
 import saros.repackaged.picocontainer.annotations.Inject;
 import saros.session.ISarosSession;
 import saros.session.ISarosSessionManager;
@@ -22,7 +23,12 @@ import saros.session.SessionEndReason;
 import saros.session.User;
 import saros.ui.util.ModelFormatUtils;
 
-/** Session tree root node. */
+/**
+ * Session tree root node.
+ *
+ * <p><b>NOTE:</b>This component and any component added here must be correctly torn down when the
+ * project the components belong to is closed. See {@link SarosMainPanelView}.
+ */
 public class SessionTreeRootNode extends DefaultMutableTreeNode implements Disposable {
   public static final String TREE_TITLE = "Session";
   public static final String TREE_TITLE_NO_SESSIONS = "No Session Running";

--- a/intellij/src/saros/intellij/ui/views/SarosMainPanelView.java
+++ b/intellij/src/saros/intellij/ui/views/SarosMainPanelView.java
@@ -1,6 +1,8 @@
 package saros.intellij.ui.views;
 
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.ui.components.JBScrollPane;
 import java.awt.BorderLayout;
 import java.awt.Container;
@@ -16,6 +18,13 @@ import saros.intellij.ui.tree.SessionAndContactsTreeView;
 /**
  * Saros main panel view containing the {@link SessionAndContactsTreeView}, the {@link SarosToolbar}
  * and empty space for future components.
+ *
+ * <p><b>NOTE:</b> Any component added to the main view must be correctly torn down (i.e. dropping
+ * any references that would keep the object from being garbage collected) when the project is
+ * disposed to avoid memory leaks. To tear down a component when the project is disposed, implement
+ * {@link Disposable} and register it to a suitable parent (either the project or another disposable
+ * component registered with the project) using {@link Disposer#register(Disposable, Disposable)}.
+ * This will cause {@link Disposable#dispose()} to be called when the parent is disposed.
  */
 public class SarosMainPanelView extends JPanel {
 

--- a/intellij/src/saros/intellij/ui/views/SarosMainPanelView.java
+++ b/intellij/src/saros/intellij/ui/views/SarosMainPanelView.java
@@ -25,7 +25,7 @@ public class SarosMainPanelView extends JPanel {
    */
   public SarosMainPanelView(@NotNull Project project) throws HeadlessException {
     super(new BorderLayout());
-    SessionAndContactsTreeView sarosTree = new SessionAndContactsTreeView();
+    SessionAndContactsTreeView sarosTree = new SessionAndContactsTreeView(project);
     SarosToolbar sarosToolbar = new SarosToolbar(project);
 
     JScrollPane treeScrollPane = new JBScrollPane(sarosTree);

--- a/intellij/src/saros/intellij/ui/views/SarosToolbar.java
+++ b/intellij/src/saros/intellij/ui/views/SarosToolbar.java
@@ -16,6 +16,9 @@ import saros.intellij.ui.views.buttons.SimpleButton;
 /**
  * Saros toolbar. Displays several buttons for interacting with Saros.
  *
+ * <p><b>NOTE:</b>This component and any component added here must be correctly torn down when the
+ * project the components belong to is closed. See {@link SarosMainPanelView}.
+ *
  * <p>FIXME: Replace by IDEA toolbar class.
  */
 class SarosToolbar extends JToolBar {

--- a/intellij/src/saros/intellij/ui/views/SarosToolbar.java
+++ b/intellij/src/saros/intellij/ui/views/SarosToolbar.java
@@ -67,7 +67,7 @@ class SarosToolbar extends JToolBar {
               IconManager.OPEN_PREFERENCES_ICON));
     }
 
-    add(new FollowButton());
+    add(new FollowButton(project));
 
     add(new ConsistencyButton(project));
 

--- a/intellij/src/saros/intellij/ui/views/buttons/AbstractSessionToolbarButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/AbstractSessionToolbarButton.java
@@ -7,6 +7,7 @@ import javax.swing.ImageIcon;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import saros.SarosPluginContext;
+import saros.intellij.ui.views.SarosMainPanelView;
 import saros.repackaged.picocontainer.annotations.Inject;
 import saros.session.ISarosSession;
 import saros.session.ISarosSessionManager;
@@ -19,6 +20,10 @@ import saros.session.SessionEndReason;
  *
  * <p>The class offers methods to react to a session starting or ending and to update the initial
  * state of the button.
+ *
+ * <p><b>NOTE:</b>This component and any component added here must be correctly torn down when the
+ * project the components belong to is closed. See {@link SarosMainPanelView}. This class offers the
+ * method {@link #disposeComponents()} for such a purpose.
  */
 abstract class AbstractSessionToolbarButton extends AbstractToolbarButton implements Disposable {
   protected final Project project;

--- a/intellij/src/saros/intellij/ui/views/buttons/ConsistencyButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/ConsistencyButton.java
@@ -67,8 +67,6 @@ public class ConsistencyButton extends AbstractSessionToolbarButton {
 
   private final ValueChangeListener<Boolean> isConsistencyListener = this::handleConsistencyChange;
 
-  private final Project project;
-
   @Inject private IsInconsistentObservable inconsistentObservable;
 
   private volatile SessionInconsistencyState sessionInconsistencyState;
@@ -76,11 +74,10 @@ public class ConsistencyButton extends AbstractSessionToolbarButton {
   /** Creates a Consistency button, adds a sessionListener and disables the button. */
   public ConsistencyButton(@NotNull Project project) {
     super(
+        project,
         ConsistencyAction.NAME,
         Messages.ConsistencyButton_tooltip_functionality,
         IconManager.IN_SYNC_ICON);
-
-    this.project = project;
 
     setSarosSession(sarosSessionManager.getSession());
 
@@ -88,6 +85,11 @@ public class ConsistencyButton extends AbstractSessionToolbarButton {
     setEnabled(false);
 
     setInitialState();
+  }
+
+  @Override
+  void disposeComponents() {
+    inconsistentObservable.remove(isConsistencyListener);
   }
 
   @Override

--- a/intellij/src/saros/intellij/ui/views/buttons/ConsistencyButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/ConsistencyButton.java
@@ -24,8 +24,11 @@ import saros.session.ISarosSession;
 import saros.session.SessionEndReason;
 
 /**
- * Button for triggering a {@link ConsistencyAction}. Displays a different symbol when state is
- * inconsistent or not.
+ * Session button for triggering a {@link ConsistencyAction}. Displays a different symbol when state
+ * is inconsistent or not.
+ *
+ * <p><b>NOTE:</b>This component and any component added here must be correctly torn down when the
+ * project the components belong to is closed. See {@link AbstractSessionToolbarButton}.
  *
  * <p>FIXME: Remove awkward session handling together with UI components created with session.
  */

--- a/intellij/src/saros/intellij/ui/views/buttons/FollowButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/FollowButton.java
@@ -19,7 +19,12 @@ import saros.session.SessionEndReason;
 import saros.session.User;
 import saros.ui.util.ModelFormatUtils;
 
-/** Button to follow a user. Displays a PopupMenu containing all session users to choose from. */
+/**
+ * Button to follow a user. Displays a PopupMenu containing all session users to choose from.
+ *
+ * <p><b>NOTE:</b>This component and any component added here must be correctly torn down when the
+ * project the components belong to is closed. See {@link AbstractSessionToolbarButton}.
+ */
 public class FollowButton extends AbstractSessionToolbarButton {
   private JPopupMenu popupMenu;
   private final FollowModeAction followModeAction;
@@ -55,11 +60,7 @@ public class FollowButton extends AbstractSessionToolbarButton {
   private volatile ISarosSession session;
   private volatile FollowModeManager followModeManager;
 
-  /**
-   * Creates a Follow button with a JPopupMenu, registers session listeners and editor listeners.
-   *
-   * <p>The FollowButton is created as disabled.
-   */
+  /** Session button to follow other participants or leave the follow mode. */
   public FollowButton(@NotNull Project project) {
     super(project, FollowModeAction.NAME, Messages.FollowButton_tooltip, IconManager.FOLLOW_ICON);
 

--- a/intellij/src/saros/intellij/ui/views/buttons/FollowButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/FollowButton.java
@@ -1,11 +1,13 @@
 package saros.intellij.ui.views.buttons;
 
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.JBMenuItem;
 import com.intellij.openapi.ui.JBPopupMenu;
 import com.intellij.util.ui.UIUtil;
 import javax.swing.JButton;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
+import org.jetbrains.annotations.NotNull;
 import saros.editor.FollowModeManager;
 import saros.editor.IFollowModeListener;
 import saros.intellij.ui.Messages;
@@ -58,8 +60,8 @@ public class FollowButton extends AbstractSessionToolbarButton {
    *
    * <p>The FollowButton is created as disabled.
    */
-  public FollowButton() {
-    super(FollowModeAction.NAME, Messages.FollowButton_tooltip, IconManager.FOLLOW_ICON);
+  public FollowButton(@NotNull Project project) {
+    super(project, FollowModeAction.NAME, Messages.FollowButton_tooltip, IconManager.FOLLOW_ICON);
 
     followModeAction = new FollowModeAction();
 
@@ -71,6 +73,19 @@ public class FollowButton extends AbstractSessionToolbarButton {
         ev -> popupMenu.show(button, 0, button.getBounds().y + button.getBounds().height));
 
     setInitialState();
+  }
+
+  @Override
+  void disposeComponents() {
+    ISarosSession currentSession = session;
+    if (currentSession != null) {
+      currentSession.removeListener(sessionListener);
+    }
+
+    FollowModeManager currentFollowModeManager = followModeManager;
+    if (currentFollowModeManager != null) {
+      currentFollowModeManager.removeListener(followModeListener);
+    }
   }
 
   @Override

--- a/intellij/src/saros/intellij/ui/views/buttons/LeaveSessionButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/LeaveSessionButton.java
@@ -7,6 +7,12 @@ import saros.intellij.ui.util.IconManager;
 import saros.session.ISarosSession;
 import saros.session.SessionEndReason;
 
+/**
+ * Session button to leave the current session.
+ *
+ * <p><b>NOTE:</b>This component and any component added here must be correctly torn down when the
+ * project the components belong to is closed. See {@link AbstractSessionToolbarButton}.
+ */
 public class LeaveSessionButton extends AbstractSessionToolbarButton {
   /**
    * Creates a LeaveSessionButton and registers the sessionListener.

--- a/intellij/src/saros/intellij/ui/views/buttons/LeaveSessionButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/LeaveSessionButton.java
@@ -15,6 +15,7 @@ public class LeaveSessionButton extends AbstractSessionToolbarButton {
    */
   public LeaveSessionButton(Project project) {
     super(
+        project,
         LeaveSessionAction.NAME,
         Messages.LeaveSessionButton_tooltip,
         IconManager.LEAVE_SESSION_ICON);
@@ -23,6 +24,11 @@ public class LeaveSessionButton extends AbstractSessionToolbarButton {
     setEnabled(false);
 
     setInitialState();
+  }
+
+  @Override
+  void disposeComponents() {
+    // NOP
   }
 
   @Override


### PR DESCRIPTION
Correctly disposes the project-bound Saros UI so that it can be garbage collected after the project was closed.

The objects are correctly garbage collected after this change (tested with looking at the heap with the debugger).

This fixes the second half of #572.

#### [FIX][I] #572 Add logic to dispose project-bound buttons

Makes AbstractSessionToolbarButton implement Disposable (IntelliJ
interface, not PicoContainer).

The basic logic to dispose the abstract button just removes the session
lifecycle listener. The class also offers an abstract method to allow
sub-classes to disposing their components when the button is disposed.

Registers the button to be disposed when its project is disposed.

#### [FIX][I] #572 Add logic to dispose project-bound tree view

Adjusts SessionAndContactsTreeView and its components to be disposed
when their project is disposed.

#### [DOC][I] Add teardown javadoc to project-bound UI

Adds javadoc to SarosMainPanelView stating and explaining the need to
correctly tear down contained UI components in order to avoid memory
leaks.

Adds references to this javadoc to all project-bound UI components to
(hopefully) ensure that this fact is not missed when implementing future
changes.