### PR TITLE
Adjusting SPath references in Saros/E with EclipseReferencePointManager

### DIFF
--- a/core/src/saros/activities/SPath.java
+++ b/core/src/saros/activities/SPath.java
@@ -96,7 +96,10 @@ public class SPath {
    * Returns a handle for an IFolder represented by this SPath.
    *
    * @return the IFolder contained in the associated IProject for the given project relative path
+   * @deprecated this method will be removed when SPath completely based on {@link IReferencePoint}
+   *     reference points and {@link IPath} relative path to resource
    */
+  @Deprecated
   public IFolder getFolder() {
     return project.getFolder(projectRelativePath);
   }

--- a/core/src/saros/activities/SPath.java
+++ b/core/src/saros/activities/SPath.java
@@ -72,7 +72,10 @@ public class SPath {
    * Returns a handle for an IFile represented by this SPath.
    *
    * @return the IFile contained in the associated IProject for the given project relative path
+   * @deprecated this method will be removed when SPath completely based on {@link IReferencePoint}
+   *     reference points and {@link IPath} relative path to resource
    */
+  @Deprecated
   public IFile getFile() {
     return project.getFile(projectRelativePath);
   }

--- a/core/src/saros/activities/SPath.java
+++ b/core/src/saros/activities/SPath.java
@@ -87,7 +87,10 @@ public class SPath {
    *
    * @return the resource represented by this SPath or <code>null</code> if such or resource does
    *     not exist
+   * @deprecated this method will be removed when SPath completely based on {@link IReferencePoint}
+   *     reference points and {@link IPath} relative path to resource
    */
+  @Deprecated
   public IResource getResource() {
     return project.findMember(projectRelativePath);
   }

--- a/eclipse/src/saros/SarosEclipseContextFactory.java
+++ b/eclipse/src/saros/SarosEclipseContextFactory.java
@@ -16,6 +16,7 @@ import saros.context.IContextKeyBindings;
 import saros.editor.EditorManager;
 import saros.editor.IEditorManager;
 import saros.filesystem.EclipsePathFactory;
+import saros.filesystem.EclipseReferencePointManager;
 import saros.filesystem.EclipseWorkspaceImpl;
 import saros.filesystem.EclipseWorkspaceRootImpl;
 import saros.filesystem.FileContentNotifierBridge;
@@ -62,6 +63,9 @@ public class SarosEclipseContextFactory extends AbstractContextFactory {
    */
   private final Component[] getContextComponents() {
     return new Component[] {
+      // ReferencePointManager
+      Component.create(EclipseReferencePointManager.class),
+
       // Core Managers
       Component.create(IEditorManager.class, EditorManager.class),
       Component.create(saros.preferences.Preferences.class, EclipsePreferences.class),

--- a/eclipse/src/saros/concurrent/undo/UndoManager.java
+++ b/eclipse/src/saros/concurrent/undo/UndoManager.java
@@ -40,7 +40,7 @@ import saros.concurrent.undo.OperationHistory.Type;
 import saros.editor.EditorManager;
 import saros.editor.ISharedEditorListener;
 import saros.editor.internal.EditorAPI;
-import saros.filesystem.EclipseFileImpl;
+import saros.filesystem.EclipseReferencePointManager;
 import saros.preferences.Preferences;
 import saros.repackaged.picocontainer.Disposable;
 import saros.repackaged.picocontainer.annotations.Inject;
@@ -95,6 +95,8 @@ public class UndoManager extends AbstractActivityConsumer implements Disposable 
   protected EditorManager editorManager;
 
   protected SPath currentActiveEditor = null;
+
+  private EclipseReferencePointManager eclipseReferencePointManager;
 
   /** This UndoManager is disabled when not in a Saros session. */
   protected boolean enabled;
@@ -368,7 +370,10 @@ public class UndoManager extends AbstractActivityConsumer implements Disposable 
         }
       };
 
-  public UndoManager(ISarosSessionManager sessionManager, EditorManager editorManager) {
+  public UndoManager(
+      ISarosSessionManager sessionManager,
+      EditorManager editorManager,
+      EclipseReferencePointManager eclipseReferencePointManager) {
 
     if (log.isDebugEnabled()) DefaultOperationHistory.DEBUG_OPERATION_HISTORY_APPROVAL = true;
 
@@ -379,6 +384,7 @@ public class UndoManager extends AbstractActivityConsumer implements Disposable 
 
     editorManager.addActivityListener(this.activityListener);
     this.editorManager = editorManager;
+    this.eclipseReferencePointManager = eclipseReferencePointManager;
 
     editorManager.addSharedEditorListener(sharedEditorListener);
   }
@@ -489,7 +495,7 @@ public class UndoManager extends AbstractActivityConsumer implements Disposable 
 
     List<ITextOperation> textOps = activity.toOperation().getTextOperations();
 
-    IFile file = ((EclipseFileImpl) currentActiveEditor.getFile()).getDelegate();
+    IFile file = eclipseReferencePointManager.getFile(currentActiveEditor);
 
     FileEditorInput input = new FileEditorInput(file);
     IDocumentProvider provider = EditorAPI.connect(input);

--- a/eclipse/src/saros/editor/EditorManager.java
+++ b/eclipse/src/saros/editor/EditorManager.java
@@ -490,7 +490,12 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
     this.locallyActiveEditor = path;
 
-    if (path != null && session.isShared(path.getResource())) openEditorPaths.add(path);
+    if (path != null) {
+      IResource eclipseResource = eclipseReferencePointManager.findMember(path);
+      saros.filesystem.IResource sarosResource = ResourceAdapterFactory.create(eclipseResource);
+
+      if (session.isShared(sarosResource)) openEditorPaths.add(path);
+    }
 
     editorListenerDispatch.editorActivated(session.getLocalUser(), path);
 
@@ -1377,7 +1382,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
       if (resource == null) continue;
 
-      if (ResourceAdapterFactory.create(resource).equals(path.getResource())) return true;
+      if (resource.equals(eclipseReferencePointManager.findMember(path))) return true;
     }
 
     return false;

--- a/eclipse/src/saros/editor/RemoteWriteAccessManager.java
+++ b/eclipse/src/saros/editor/RemoteWriteAccessManager.java
@@ -11,7 +11,7 @@ import org.eclipse.ui.part.FileEditorInput;
 import saros.activities.EditorActivity;
 import saros.activities.SPath;
 import saros.editor.internal.EditorAPI;
-import saros.filesystem.EclipseFileImpl;
+import saros.filesystem.EclipseReferencePointManager;
 import saros.session.AbstractActivityConsumer;
 import saros.session.IActivityConsumer;
 import saros.session.ISarosSession;
@@ -47,9 +47,13 @@ public class RemoteWriteAccessManager extends AbstractActivityConsumer {
 
   protected ISarosSession sarosSession;
 
-  public RemoteWriteAccessManager(final ISarosSession sarosSession) {
+  private EclipseReferencePointManager eclipseReferencePointManager;
+
+  public RemoteWriteAccessManager(
+      final ISarosSession sarosSession, EclipseReferencePointManager eclipseReferencePointManager) {
     this.sarosSession = sarosSession;
     this.sarosSession.addListener(sessionListener);
+    this.eclipseReferencePointManager = eclipseReferencePointManager;
   }
 
   /** This method is called from the shared project when a new Activity arrives */
@@ -131,7 +135,7 @@ public class RemoteWriteAccessManager extends AbstractActivityConsumer {
 
     assert !connectedUserWithWriteAccessFiles.contains(path);
 
-    IFile file = ((EclipseFileImpl) path.getFile()).getDelegate();
+    IFile file = eclipseReferencePointManager.getFile(path);
     if (!file.exists()) {
       log.error(
           "Attempting to connect to file which" + " is not available locally: " + path,
@@ -154,7 +158,7 @@ public class RemoteWriteAccessManager extends AbstractActivityConsumer {
 
     connectedUserWithWriteAccessFiles.remove(path);
 
-    IFile file = ((EclipseFileImpl) path.getFile()).getDelegate();
+    IFile file = eclipseReferencePointManager.getFile(path);
     EditorAPI.disconnect(new FileEditorInput(file));
   }
 

--- a/eclipse/src/saros/editor/internal/EditorAPI.java
+++ b/eclipse/src/saros/editor/internal/EditorAPI.java
@@ -37,7 +37,7 @@ import org.eclipse.ui.texteditor.ITextEditorActionConstants;
 import saros.activities.SPath;
 import saros.editor.text.LineRange;
 import saros.editor.text.TextSelection;
-import saros.filesystem.EclipseFileImpl;
+import saros.filesystem.EclipseReferencePointManager;
 import saros.filesystem.ResourceAdapterFactory;
 import saros.ui.dialogs.WarningMessageDialog;
 import saros.ui.util.SWTUtils;
@@ -96,10 +96,12 @@ public class EditorAPI {
    * Opens the editor with given path. Needs to be called from an UI thread.
    *
    * @param activate <code>true</code>, if editor should get focus, otherwise <code>false</code>
+   * @param eclipseReferencePointManager which determine the file
    * @return the opened editor or <code>null</code> if the editor couldn't be opened.
    */
-  public static IEditorPart openEditor(SPath path, boolean activate) {
-    IFile file = ((EclipseFileImpl) path.getFile()).getDelegate();
+  public static IEditorPart openEditor(
+      SPath path, boolean activate, EclipseReferencePointManager eclipseReferencePointManager) {
+    IFile file = eclipseReferencePointManager.getFile(path);
 
     if (!file.exists()) {
       LOG.error("EditorAPI cannot open file which does not exist: " + file, new StackTrace());

--- a/eclipse/src/saros/filesystem/EclipseReferencePointManager.java
+++ b/eclipse/src/saros/filesystem/EclipseReferencePointManager.java
@@ -1,0 +1,239 @@
+package saros.filesystem;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IPath;
+import saros.activities.SPath;
+
+/**
+ * The EclipseReferencePointManager maps an {@link IReferencePoint} reference point to {@link
+ * IProject} project
+ */
+public class EclipseReferencePointManager {
+
+  ConcurrentHashMap<IReferencePoint, IProject> referencePointToProjectMapper;
+
+  public EclipseReferencePointManager() {
+    referencePointToProjectMapper = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * Creates and returns the {@link IReferencePoint} reference point of given {@link IResource}
+   * resource, or null if the given {@link IResource} resource is null. The reference point points
+   * on the resource's project full path.
+   *
+   * @param resource for which the reference point should be created
+   * @return the reference point of given resource
+   */
+  public static IReferencePoint create(IResource resource) {
+    if (resource == null) return null;
+
+    IProject project = resource.getProject();
+    saros.filesystem.IPath path = ResourceAdapterFactory.create(project.getFullPath());
+
+    return new ReferencePointImpl(path);
+  }
+
+  /**
+   * Inserts a pair of {@link IReferencePoint} reference point and {@link IProject} project. The
+   * reference point will be created from the project's relative path by
+   * {#putIfAbsent(IReferencePoint referencePoint, IProject project) putIfAbsent} .
+   *
+   * @param project the {@link IProject} project for which a reference point is created and are
+   *     inserted.
+   * @exception IllegalArgumentException if {@link IProject} project is null
+   */
+  public void putIfAbsent(IProject project) {
+    checkArgument(project, "Project is null");
+
+    IReferencePoint referencePoint = create(project);
+
+    putIfAbsent(referencePoint, project);
+  }
+
+  /**
+   * Insert a pair of {@link IReferencePoint} reference point and {@link IProject} project
+   *
+   * @param referencePoint the key of the pair
+   * @param project the value of the pair
+   * @exception IllegalArgumentException if {@link IProject} project or {@link IReferencePoint}
+   *     reference point is null
+   */
+  public void putIfAbsent(IReferencePoint referencePoint, IProject project) {
+    checkArgument(referencePoint, "Reference point is null");
+    checkArgument(project, "Project is null");
+
+    referencePointToProjectMapper.putIfAbsent(referencePoint, project);
+  }
+
+  /**
+   * Returns the {@link IProject} project given by the {@link IReferencePoint} reference point
+   *
+   * @param referencePoint the key for which the IProject should be returned
+   * @return the IProject given by referencePoint
+   * @exception IllegalArgumentException if {@link IReferencePoint} reference point is null
+   */
+  public IProject getProject(IReferencePoint referencePoint) {
+    checkArgument(referencePoint, "Reference point is null");
+
+    return referencePointToProjectMapper.get(referencePoint);
+  }
+
+  /**
+   * Returns the {@link IResource} resource in combination of the {@link IReferencePoint} reference
+   * point and the {@link IPath} relative path from the {@link IReferencePoint} reference point to
+   * the {@link IResource} resource, or null if the resource does not exist
+   *
+   * @param referencePoint The {@link IReferencePoint} reference point, on which the {@link
+   *     IResource} resource belongs to
+   * @param referencePointRelativePath the {@link IPath} relative path from the {@link
+   *     IReferencePoint} reference point to the {@link IResource} resource
+   * @return the resource of the {@link IReferencePoint} reference point from {@link IPath}
+   *     referencePointRelativePath or null if resource does not exist.
+   * @exception IllegalArgumentException if {@link IReferencePoint} reference point or {@link IPath}
+   *     referencePointRelativePath is null
+   * @exception NullPointerException if the given {@link IReferencePoint} reference point does't
+   *     exist an {@link IProject} project
+   */
+  public IResource findMember(IReferencePoint referencePoint, IPath referencePointRelativePath) {
+    checkArgument(referencePoint, "Reference point is null");
+    checkArgument(referencePointRelativePath, "ReferencePointsRelativePath is null");
+
+    IProject project = Objects.requireNonNull(getProject(referencePoint));
+
+    return project.findMember(referencePointRelativePath);
+  }
+
+  /**
+   * Returns the {@link IResource} resource represented by this {@link SPath} SPath, or null if the
+   * resource does not exist
+   *
+   * @param path the {@link SPath} SPath which represents the {@link IResource} resource
+   * @return the resource of the {@link IReferencePoint} reference point from {@link IPath}
+   *     referencePointRelativePath or null if resource does not exist.
+   * @exception IllegalArgumentException if {@link SPath} path is null
+   * @exception NullPointerException if the given {@link SPath} path does contain an {@link
+   *     IReferencePoint} reference point
+   * @exception NullPointerException if the given {@link SPath} path does contain an {@link IPath}
+   *     referencePointRelativePath
+   */
+  public IResource findMember(SPath path) {
+    checkArgument(path, "SPath is null");
+
+    IReferencePoint referencePoint = Objects.requireNonNull(path.getReferencePoint());
+    saros.filesystem.IPath referencePointRelativePath =
+        Objects.requireNonNull(path.getProjectRelativePath());
+
+    IPath eclipsePath = ((EclipsePathImpl) referencePointRelativePath).getDelegate();
+
+    return findMember(referencePoint, eclipsePath);
+  }
+
+  /**
+   * Returns a handle to the {@link IFile} file identified by the given {@link IPath} path and
+   * {@link IReferencePoint} reference point
+   *
+   * @param referencePoint The {@link IReferencePoint} reference point, on which the {@link IFile}
+   *     file belongs to
+   * @param referencePointRelativePath the relative {@link IPath} path from the {@link
+   *     IReferencePoint} reference point to the {@link IFile} file
+   * @return a handle to the {@link IFile} file
+   * @exception IllegalArgumentException if {@link IReferencePoint} reference point or {@link IPath}
+   *     referencePointRelativePath is null
+   * @exception NullPointerException if the given {@link IReferencePoint} reference point does't
+   *     exist an {@link IProject} project
+   */
+  public IFile getFile(IReferencePoint referencePoint, IPath referencePointRelativePath) {
+    checkArgument(referencePoint, "Reference point is null");
+    checkArgument(referencePointRelativePath, "ReferencePointsRelativePath is null");
+
+    IProject project = Objects.requireNonNull(getProject(referencePoint));
+
+    return project.getFile(referencePointRelativePath);
+  }
+
+  /**
+   * Returns a handle to the {@link IFile} file represented by this {@link SPath} SPath
+   *
+   * @param path the {@link SPath} SPath which represents the {@link IFile} file
+   * @return a handle to the {@link IFile} file
+   * @exception IllegalArgumentException if {@link SPath} path is null
+   * @exception NullPointerException if the given {@link SPath} path does contain an {@link
+   *     IReferencePoint} reference point
+   * @exception NullPointerException if the given {@link SPath} path does contain an {@link IPath}
+   *     referencePointRelativePath
+   */
+  public IFile getFile(SPath path) {
+    checkArgument(path, "SPath is null");
+
+    IReferencePoint referencePoint = Objects.requireNonNull(path.getReferencePoint());
+    saros.filesystem.IPath referencePointRelativePath =
+        Objects.requireNonNull(path.getProjectRelativePath());
+
+    IPath eclipsePath = ((EclipsePathImpl) referencePointRelativePath).getDelegate();
+
+    return getFile(referencePoint, eclipsePath);
+  }
+
+  /**
+   * Returns a handle to the {@link IFolder} folder identified by the given {@link IPath} path and
+   * {@link IReferencePoint} reference point
+   *
+   * @param referencePoint The {@link IReferencePoint} reference point, on which the {@link IFolder}
+   *     folder belongs to
+   * @param referencePointRelativePath the {@link IPath} relative path from the {@link
+   *     IReferencePoint} reference point to the {@link IFolder} folder
+   * @return a handle to the {@link IFolder} folder
+   * @exception IllegalArgumentException if {@link IReferencePoint} reference point or {@link IPath}
+   *     referencePointRelativePath is null
+   * @exception NullPointerException if the given {@link IReferencePoint} reference point does't
+   *     exist an {@link IProject} project
+   */
+  public IFolder getFolder(IReferencePoint referencePoint, IPath referencePointRelativePath) {
+    checkArgument(referencePoint, "Reference point is null");
+    checkArgument(referencePointRelativePath, "ReferencePointsRelativePath is null");
+
+    IProject project = Objects.requireNonNull(getProject(referencePoint));
+
+    return project.getFolder(referencePointRelativePath);
+  }
+
+  /**
+   * Returns a handle to the {@link IFolder} folder represented by this {@link SPath} SPath
+   *
+   * @param path the {@link SPath} SPath which represents the {@link IFolder} folder
+   * @return a handle to the {@link IFolder} folder
+   * @exception IllegalArgumentException if {@link SPath} path is null
+   * @exception NullPointerException if the given {@link SPath} path does contain an {@link
+   *     IReferencePoint} reference point
+   * @exception NullPointerException if the given {@link SPath} path does contain an {@link IPath}
+   *     referencePointRelativePath
+   */
+  public IFolder getFolder(SPath path) {
+    checkArgument(path, "SPath is null");
+
+    IReferencePoint referencePoint = Objects.requireNonNull(path.getReferencePoint());
+    saros.filesystem.IPath referencePointRelativePath =
+        Objects.requireNonNull(path.getProjectRelativePath());
+
+    IPath eclipsePath = ((EclipsePathImpl) referencePointRelativePath).getDelegate();
+
+    return getFolder(referencePoint, eclipsePath);
+  }
+
+  /**
+   * Check, if the given argument is null
+   *
+   * @param argument which is checked for null
+   * @param <T> Type of argument parameter (like {@link IReferencePoint reference point})
+   * @param message message for the IllegalArgumentException
+   * @exception IllegalArgumentException if given argument is null
+   */
+  private <T> void checkArgument(T argument, String message) {
+    if (argument == null) throw new IllegalArgumentException(message);
+  }
+}

--- a/eclipse/src/saros/ui/decorators/SharedProjectFileDecorator.java
+++ b/eclipse/src/saros/ui/decorators/SharedProjectFileDecorator.java
@@ -26,7 +26,7 @@ import saros.annotations.Component;
 import saros.editor.EditorManager;
 import saros.editor.ISharedEditorListener;
 import saros.editor.annotations.SarosAnnotation;
-import saros.filesystem.ResourceAdapterFactory;
+import saros.filesystem.EclipseReferencePointManager;
 import saros.repackaged.picocontainer.annotations.Inject;
 import saros.session.ISarosSession;
 import saros.session.ISarosSessionManager;
@@ -83,6 +83,8 @@ public class SharedProjectFileDecorator implements ILightweightLabelDecorator {
   @Inject private EditorManager editorManager;
 
   @Inject private ISarosSessionManager sessionManager;
+
+  @Inject private EclipseReferencePointManager eclipseReferencePointManager;
 
   private static class MemoryImageDescriptor extends ImageDescriptor {
 
@@ -148,7 +150,7 @@ public class SharedProjectFileDecorator implements ILightweightLabelDecorator {
 
           if (filePath != null) {
 
-            IResource resource = ResourceAdapterFactory.convertBack(filePath.getResource());
+            IResource resource = eclipseReferencePointManager.findMember(filePath);
 
             if (resource != null) activeEditorResources.put(user, getResources(resource));
             else LOG.warn("resource for editor " + filePath + " does not exist locally");

--- a/eclipse/src/saros/ui/model/session/AwarenessInformationTreeElement.java
+++ b/eclipse/src/saros/ui/model/session/AwarenessInformationTreeElement.java
@@ -112,7 +112,7 @@ public class AwarenessInformationTreeElement extends TreeElement {
       details.add(
           activeFile.getProject().getName()
               + ": "
-              + activeFile.getFile().getProjectRelativePath().toString());
+              + activeFile.getProjectRelativePath().toString());
     }
 
     return details;

--- a/eclipse/src/saros/ui/util/CollaborationUtils.java
+++ b/eclipse/src/saros/ui/util/CollaborationUtils.java
@@ -29,6 +29,7 @@ import saros.Saros;
 import saros.SarosPluginContext;
 import saros.filesystem.CoreReferencePointManager;
 import saros.filesystem.EclipseProjectImpl;
+import saros.filesystem.EclipseReferencePointManager;
 import saros.filesystem.IReferencePointManager;
 import saros.filesystem.ResourceAdapterFactory;
 import saros.net.xmpp.JID;
@@ -53,6 +54,8 @@ public class CollaborationUtils {
   private static final Logger LOG = Logger.getLogger(CollaborationUtils.class);
 
   @Inject private static ISarosSessionManager sessionManager;
+
+  @Inject private static EclipseReferencePointManager eclipseReferencePointManager;
 
   static {
     SarosPluginContext.initComponent(new CollaborationUtils());
@@ -86,9 +89,7 @@ public class CollaborationUtils {
 
               IReferencePointManager coreReferencePointManager = new CoreReferencePointManager();
 
-              fillReferencePointManager(
-                  coreReferencePointManager,
-                  convertToProjectResourceMapping(newResources).keySet());
+              fillReferencePointManager(coreReferencePointManager, newResources.keySet());
 
               sessionManager.startSession(
                   convertToReferencePointResourceMapping(newResources), coreReferencePointManager);
@@ -221,8 +222,7 @@ public class CollaborationUtils {
             IReferencePointManager referencePointManager =
                 session.getComponent(IReferencePointManager.class);
 
-            fillReferencePointManager(
-                referencePointManager, convertToProjectResourceMapping(projectResources).keySet());
+            fillReferencePointManager(referencePointManager, projectResources.keySet());
 
             sessionManager.addReferencePointResources(
                 convertToReferencePointResourceMapping(projectResources));
@@ -502,7 +502,13 @@ public class CollaborationUtils {
   }
 
   private static void fillReferencePointManager(
-      IReferencePointManager referencePointManager, Set<saros.filesystem.IProject> projects) {
-    referencePointManager.putSetOfProjects(projects);
+      IReferencePointManager referencePointManager, Set<IProject> projects) {
+
+    projects.forEach(
+        project -> {
+          eclipseReferencePointManager.putIfAbsent(project);
+          referencePointManager.putIfAbsent(
+              EclipseReferencePointManager.create(project), ResourceAdapterFactory.create(project));
+        });
   }
 }

--- a/eclipse/src/saros/ui/wizards/AddProjectToSessionWizard.java
+++ b/eclipse/src/saros/ui/wizards/AddProjectToSessionWizard.java
@@ -40,6 +40,7 @@ import org.eclipse.ui.IFileEditorInput;
 import saros.Saros;
 import saros.SarosPluginContext;
 import saros.editor.internal.EditorAPI;
+import saros.filesystem.EclipseReferencePointManager;
 import saros.filesystem.IChecksumCache;
 import saros.filesystem.IReferencePoint;
 import saros.filesystem.IReferencePointManager;
@@ -87,6 +88,8 @@ public class AddProjectToSessionWizard extends Wizard {
   @Inject private Preferences preferences;
 
   @Inject private ISarosSessionManager sessionManager;
+
+  @Inject private EclipseReferencePointManager eclipseReferencePointManager;
 
   private static class OverwriteErrorDialog extends ErrorDialog {
 
@@ -313,12 +316,11 @@ public class AddProjectToSessionWizard extends Wizard {
                   new HashMap<String, IReferencePoint>();
 
               for (final Entry<String, IProject> entry : targetProjectMapping.entrySet()) {
-                saros.filesystem.IProject sarosProject =
-                    ResourceAdapterFactory.create(entry.getValue());
+                IProject project = entry.getValue();
 
-                convertedMapping.put(entry.getKey(), sarosProject.getReferencePoint());
+                convertedMapping.put(entry.getKey(), EclipseReferencePointManager.create(project));
 
-                fillReferencePointManager(sessionManager.getSession(), sarosProject);
+                fillReferencePointManager(sessionManager.getSession(), project);
               }
 
               final ProjectNegotiation.Status status =
@@ -551,7 +553,7 @@ public class AddProjectToSessionWizard extends Wizard {
       final saros.filesystem.IProject adaptedProject =
           ResourceAdapterFactory.create(entry.getValue());
 
-      fillReferencePointManager(session, adaptedProject);
+      fillReferencePointManager(session, project);
 
       /*
        * do not refresh already partially shared projects as this may
@@ -679,10 +681,14 @@ public class AddProjectToSessionWizard extends Wizard {
     }
   }
 
-  private void fillReferencePointManager(ISarosSession session, saros.filesystem.IProject project) {
+  private void fillReferencePointManager(ISarosSession session, IProject project) {
     IReferencePointManager referencePointManager =
         session.getComponent(IReferencePointManager.class);
 
-    referencePointManager.putIfAbsent(project.getReferencePoint(), project);
+    saros.filesystem.IProject sarosProject = ResourceAdapterFactory.create(project);
+    IReferencePoint referencePoint = EclipseReferencePointManager.create(project);
+
+    eclipseReferencePointManager.putIfAbsent(referencePoint, project);
+    referencePointManager.putIfAbsent(referencePoint, sarosProject);
   }
 }

--- a/eclipse/test/junit/saros/filesystem/EclipseReferencePointManagerTest.java
+++ b/eclipse/test/junit/saros/filesystem/EclipseReferencePointManagerTest.java
@@ -1,0 +1,235 @@
+package saros.filesystem;
+
+import org.easymock.EasyMock;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IPath;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import saros.activities.SPath;
+
+public class EclipseReferencePointManagerTest {
+
+  IReferencePoint referencePoint;
+  EclipseReferencePointManager eclipseReferencePointManager;
+
+  @Before
+  public void prepare() {
+    referencePoint = EasyMock.createMock(IReferencePoint.class);
+    EasyMock.replay(referencePoint);
+
+    eclipseReferencePointManager = new EclipseReferencePointManager();
+  }
+
+  @Test
+  public void testPutIfAbsent() {
+    IProject project = createProjectMock();
+    EasyMock.replay(project);
+
+    eclipseReferencePointManager.putIfAbsent(referencePoint, project);
+
+    IProject projectFromReferencePointManager =
+        eclipseReferencePointManager.getProject(referencePoint);
+
+    Assert.assertNotNull(projectFromReferencePointManager);
+    Assert.assertEquals(project, projectFromReferencePointManager);
+  }
+
+  @Test
+  public void testFindMember() {
+    IResource resource = createResourceMock();
+    IPath projectRelativePath = createRelativePathMock();
+    IProject project = createProjectMock();
+    EasyMock.expect(project.findMember(projectRelativePath)).andStubReturn(resource);
+    EasyMock.replay(project);
+
+    eclipseReferencePointManager.putIfAbsent(referencePoint, project);
+
+    IResource resourceFromReferencePointManager =
+        eclipseReferencePointManager.findMember(referencePoint, projectRelativePath);
+
+    Assert.assertNotNull(resource);
+    Assert.assertEquals(resource, resourceFromReferencePointManager);
+  }
+
+  @Test
+  public void testFindMemberWithSPath() {
+    IResource resource = createResourceMock();
+    IPath projectRelativePath = createRelativePathMock();
+    IProject project = createProjectMock();
+    EasyMock.expect(project.findMember(projectRelativePath)).andStubReturn(resource);
+    EasyMock.replay(project);
+    SPath sPath = createSPathMock(projectRelativePath);
+
+    eclipseReferencePointManager.putIfAbsent(referencePoint, project);
+
+    IResource resourceFromReferencePointManager = eclipseReferencePointManager.findMember(sPath);
+
+    Assert.assertNotNull(resourceFromReferencePointManager);
+    Assert.assertEquals(resource, resourceFromReferencePointManager);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetResourceWithNullReferencePoint() {
+    eclipseReferencePointManager.findMember(null, createRelativePathMock());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetResourceWithNullRelativePath() {
+    eclipseReferencePointManager.findMember(referencePoint, null);
+  }
+
+  @Test
+  public void testGetFile() {
+    IFile file = createFileMock();
+    IPath projectRelativePath = createRelativePathMock();
+    IProject project = createProjectMock();
+    EasyMock.expect(project.getFile(projectRelativePath)).andStubReturn(file);
+    EasyMock.replay(project);
+
+    eclipseReferencePointManager.putIfAbsent(referencePoint, project);
+
+    IFile fileFromReferencePointManager =
+        eclipseReferencePointManager.getFile(referencePoint, projectRelativePath);
+
+    Assert.assertNotNull(fileFromReferencePointManager);
+    Assert.assertEquals(file, fileFromReferencePointManager);
+  }
+
+  @Test
+  public void testGetFileWithSPath() {
+    IFile file = createFileMock();
+    IPath projectRelativePath = createRelativePathMock();
+    IProject project = createProjectMock();
+    EasyMock.expect(project.getFile(projectRelativePath)).andStubReturn(file);
+    EasyMock.replay(project);
+    SPath sPath = createSPathMock(projectRelativePath);
+
+    eclipseReferencePointManager.putIfAbsent(referencePoint, project);
+
+    IFile fileFromReferencePointManager = eclipseReferencePointManager.getFile(sPath);
+
+    Assert.assertNotNull(fileFromReferencePointManager);
+    Assert.assertEquals(file, fileFromReferencePointManager);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetFileWithNullReferencePoint() {
+    eclipseReferencePointManager.getFile(null, createRelativePathMock());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetFileWithNullRelativePath() {
+    eclipseReferencePointManager.getFile(referencePoint, null);
+  }
+
+  @Test
+  public void testGetFolder() {
+    IFolder folder = createFolderMock();
+    IPath projectRelativePath = createRelativePathMock();
+    IProject project = createProjectMock();
+    EasyMock.expect(project.getFolder(projectRelativePath)).andStubReturn(folder);
+    EasyMock.replay(project);
+
+    eclipseReferencePointManager.putIfAbsent(referencePoint, project);
+
+    IFolder folderFromReferencePointManager =
+        eclipseReferencePointManager.getFolder(referencePoint, projectRelativePath);
+
+    Assert.assertNotNull(folderFromReferencePointManager);
+    Assert.assertEquals(folder, folderFromReferencePointManager);
+  }
+
+  @Test
+  public void testGetFolderWithSPath() {
+    IFolder folder = createFolderMock();
+    IPath projectRelativePath = createRelativePathMock();
+    IProject project = createProjectMock();
+    EasyMock.expect(project.getFolder(projectRelativePath)).andStubReturn(folder);
+    EasyMock.replay(project);
+    SPath sPath = createSPathMock(projectRelativePath);
+
+    eclipseReferencePointManager.putIfAbsent(referencePoint, project);
+
+    IFolder folderFromReferencePointManager = eclipseReferencePointManager.getFolder(sPath);
+
+    Assert.assertNotNull(folderFromReferencePointManager);
+    Assert.assertEquals(folder, folderFromReferencePointManager);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetFolderWithNullReferencePoint() {
+    eclipseReferencePointManager.getFolder(null, createRelativePathMock());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetFolderWithNullRelativePath() {
+    eclipseReferencePointManager.getFolder(referencePoint, null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testGetFolderWithSPathWithNullRelativePath() {
+    SPath path = EasyMock.createMock(SPath.class);
+
+    EasyMock.expect(path.getReferencePoint()).andStubReturn(referencePoint);
+    EasyMock.expect(path.getProjectRelativePath()).andStubReturn(null);
+    EasyMock.replay(path);
+
+    eclipseReferencePointManager.getFolder(path);
+  }
+
+  private IFile createFileMock() {
+    IFile file = EasyMock.createMock(IFile.class);
+    EasyMock.replay(file);
+
+    return file;
+  }
+
+  private IFolder createFolderMock() {
+    IFolder folder = EasyMock.createMock(IFolder.class);
+    EasyMock.replay(folder);
+
+    return folder;
+  }
+
+  private IResource createResourceMock() {
+    IResource resource = EasyMock.createMock(IResource.class);
+    EasyMock.replay(resource);
+
+    return resource;
+  }
+
+  private IProject createProjectMock() {
+    IProject project = EasyMock.createMock(IProject.class);
+
+    return project;
+  }
+
+  private IPath createRelativePathMock() {
+    IPath relativePath = EasyMock.createMock(IPath.class);
+    EasyMock.replay(relativePath);
+
+    return relativePath;
+  }
+
+  private SPath createSPathMock(IPath projectRelativePath) {
+    SPath sPath = EasyMock.createMock(SPath.class);
+    EasyMock.expect(sPath.getReferencePoint()).andStubReturn(referencePoint);
+    EasyMock.expect(sPath.getProjectRelativePath())
+        .andStubReturn(createSarosIPathMock(projectRelativePath));
+    EasyMock.replay(sPath);
+
+    return sPath;
+  }
+
+  private EclipsePathImpl createSarosIPathMock(IPath projectRelativePath) {
+    EclipsePathImpl path = EasyMock.createMock(EclipsePathImpl.class);
+    EasyMock.expect(path.getDelegate()).andStubReturn(projectRelativePath);
+    EasyMock.replay(path);
+
+    return path;
+  }
+}

--- a/eclipse/test/junit/saros/project/FileActivityConsumerTest.java
+++ b/eclipse/test/junit/saros/project/FileActivityConsumerTest.java
@@ -99,8 +99,15 @@ public class FileActivityConsumerTest {
     expectLastCall().andStubThrow(new AssertionError("file was written unnecessarily"));
 
     replay(file);
+    SPath path = createPathMockForFile(file);
 
-    IActivity activity = createFileActivity(file, INCOMING_SAME_CONTENT);
+    createReferencePointManagerMock(referencePoint, project, file, path);
+
+    IActivity activity = createFileActivity(path, INCOMING_SAME_CONTENT);
+
+    consumer =
+        new FileActivityConsumer(null, resourceChangeListener, null, eclipseReferencePointManager);
+
     consumer.exec(activity);
 
     verify(file);
@@ -116,7 +123,14 @@ public class FileActivityConsumerTest {
 
     replay(file);
 
-    IActivity activity = createFileActivity(file, INCOMING_DIFFERENT_CONTENT);
+    SPath path = createPathMockForFile(file);
+
+    createReferencePointManagerMock(referencePoint, project, file, path);
+
+    IActivity activity = createFileActivity(path, INCOMING_DIFFERENT_CONTENT);
+
+    consumer =
+        new FileActivityConsumer(null, resourceChangeListener, null, eclipseReferencePointManager);
 
     consumer.exec(activity);
 
@@ -131,24 +145,24 @@ public class FileActivityConsumerTest {
     expect(path.getProjectRelativePath()).andStubReturn(ResourceAdapterFactory.create(this.path));
     replay(path);
 
+    return path;
+  }
+
+  private void createReferencePointManagerMock(
+      IReferencePoint referencePoint, IProject project, IFile file, SPath path) {
     eclipseReferencePointManager = createMock(EclipseReferencePointManager.class);
     expect(eclipseReferencePointManager.getProject(referencePoint)).andStubReturn(project);
     expect(eclipseReferencePointManager.getFile(path)).andStubReturn(file);
 
     replay(eclipseReferencePointManager);
-
-    consumer =
-        new FileActivityConsumer(null, resourceChangeListener, null, eclipseReferencePointManager);
-
-    return path;
   }
 
-  private FileActivity createFileActivity(IFile file, byte[] content) {
+  private FileActivity createFileActivity(SPath path, byte[] content) {
     return new FileActivity(
         new User(new JID("foo@bar"), true, true, 0, 0),
         Type.CREATED,
         Purpose.ACTIVITY,
-        createPathMockForFile(file),
+        path,
         null,
         content,
         null);

--- a/eclipse/test/junit/saros/session/internal/SarosSessionTest.java
+++ b/eclipse/test/junit/saros/session/internal/SarosSessionTest.java
@@ -44,6 +44,7 @@ import saros.editor.EditorManager;
 import saros.feedback.FeedbackManager;
 import saros.feedback.FeedbackPreferences;
 import saros.feedback.StatisticManager;
+import saros.filesystem.EclipseReferencePointManager;
 import saros.filesystem.IPathFactory;
 import saros.filesystem.IReferencePointManager;
 import saros.net.IConnectionManager;
@@ -319,6 +320,7 @@ public class SarosSessionTest {
 
     addMockedComponent(IPathFactory.class);
     addMockedComponent(ISarosSessionManager.class);
+    addMockedComponent(EclipseReferencePointManager.class);
 
     container.start();
   }


### PR DESCRIPTION
This PR contains adjustings of SPath references in Saros/E, because the SPath class can't only return the IReferencePoint and the relative path to the saros resource, but also the saros resources itself (like IFolder, IFile, ...). 
The idea is, that the EclipseReferencePointManager gets the SPath object and determinates Eclipse resources (because in Saros/E the Eclipse resource is determined from the SPath object).
The FileActivityConsumerTest had also to be adjusted.

IMPORTANT: 
Because the PR https://github.com/saros-project/saros/pull/551 has not been merged to the BasedOnReferencePoints branch yet, so this PR shows the Commit (b42539e) "[E] IntroducingReferencePointManager". So please ignore this commit.
