### PR TITLE
Fix initial user editor state

### DIFF
--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -290,56 +290,6 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
           sendEditorOpenInformation(localUser, activeEditorPath);
         }
-
-        private void sendEditorOpenInformation(@NotNull User user, @Nullable SPath path) {
-          EditorActivity activateEditor =
-              new EditorActivity(user, EditorActivity.Type.ACTIVATED, path);
-
-          fireActivity(activateEditor);
-        }
-
-        /**
-         * Sends the viewport information for the given editor if it is currently visible.
-         *
-         * @param user the local user
-         * @param path the path of the editor
-         * @param editor the editor to send the viewport for
-         * @param visibleFilePaths the paths of all currently visible editors
-         */
-        private void sendViewPortInformation(
-            @NotNull User user,
-            @NotNull SPath path,
-            @NotNull Editor editor,
-            @NotNull Set<String> visibleFilePaths) {
-
-          VirtualFile fileForEditor = DocumentAPI.getVirtualFile(editor.getDocument());
-
-          if (fileForEditor == null) {
-            LOG.warn(
-                "Encountered editor without valid virtual file representation - path held in editor pool: "
-                    + path);
-
-            return;
-          }
-
-          if (!visibleFilePaths.contains(fileForEditor.getPath())) {
-            LOG.debug(
-                "Ignoring "
-                    + path
-                    + " while sending viewport awareness information as the editor is not currently visible.");
-
-            return;
-          }
-
-          LineRange localViewPort = EditorAPI.getLocalViewPortRange(editor);
-          int viewPortStartLine = localViewPort.getStartLine();
-          int viewPortLength = localViewPort.getNumberOfLines();
-
-          ViewportActivity setViewPort =
-              new ViewportActivity(user, viewPortStartLine, viewPortLength, path);
-
-          fireActivity(setViewPort);
-        }
       };
 
   /**
@@ -362,6 +312,55 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
     User localUser = session.getLocalUser();
 
     sendSelectionInformation(localUser, path, editor);
+  }
+
+  private void sendEditorOpenInformation(@NotNull User user, @Nullable SPath path) {
+    EditorActivity activateEditor = new EditorActivity(user, EditorActivity.Type.ACTIVATED, path);
+
+    fireActivity(activateEditor);
+  }
+
+  /**
+   * Sends the viewport information for the given editor if it is currently visible.
+   *
+   * @param user the local user
+   * @param path the path of the editor
+   * @param editor the editor to send the viewport for
+   * @param visibleFilePaths the paths of all currently visible editors
+   */
+  private void sendViewPortInformation(
+      @NotNull User user,
+      @NotNull SPath path,
+      @NotNull Editor editor,
+      @NotNull Set<String> visibleFilePaths) {
+
+    VirtualFile fileForEditor = DocumentAPI.getVirtualFile(editor.getDocument());
+
+    if (fileForEditor == null) {
+      LOG.warn(
+          "Encountered editor without valid virtual file representation - path held in editor pool: "
+              + path);
+
+      return;
+    }
+
+    if (!visibleFilePaths.contains(fileForEditor.getPath())) {
+      LOG.debug(
+          "Ignoring "
+              + path
+              + " while sending viewport awareness information as the editor is not currently visible.");
+
+      return;
+    }
+
+    LineRange localViewPort = EditorAPI.getLocalViewPortRange(editor);
+    int viewPortStartLine = localViewPort.getStartLine();
+    int viewPortLength = localViewPort.getNumberOfLines();
+
+    ViewportActivity setViewPort =
+        new ViewportActivity(user, viewPortStartLine, viewPortLength, path);
+
+    fireActivity(setViewPort);
   }
 
   private void sendSelectionInformation(

--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -283,17 +283,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
                     sendSelectionInformation(localUser, path, editor);
                   });
 
-          Editor activeEditor = ProjectAPI.getActiveEditor(project);
-
-          SPath activeEditorPath;
-
-          if (activeEditor != null) {
-            activeEditorPath = editorPool.getFile(activeEditor.getDocument());
-          } else {
-            activeEditorPath = null;
-          }
-
-          sendEditorOpenInformation(localUser, activeEditorPath);
+          sendActiveEditorInformation(localUser, project);
         }
       };
 
@@ -382,6 +372,30 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
   }
 
   /**
+   * Sends an editor activation activity for the active editor. This should be done after sending
+   * user editor state information about other editors to ensure that the correct editor is still
+   * set as the active editor in the user editor state held by the other participants.
+   *
+   * @param localUser the local user
+   * @param project the shared project
+   * @see ProjectAPI#getActiveEditor(Project)
+   */
+  private void sendActiveEditorInformation(@NotNull User localUser, @NotNull Project project) {
+
+    Editor activeEditor = ProjectAPI.getActiveEditor(project);
+
+    SPath activeEditorPath;
+
+    if (activeEditor != null) {
+      activeEditorPath = editorPool.getFile(activeEditor.getDocument());
+    } else {
+      activeEditorPath = null;
+    }
+
+    sendEditorOpenInformation(localUser, activeEditorPath);
+  }
+
+  /**
    * Adds all currently open editors belonging to the passed project to the pool of open editors.
    *
    * @param project the added project
@@ -446,6 +460,8 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
           sendSelectionInformation(localUser, path, editor);
         });
+
+    sendActiveEditorInformation(localUser, intellijProject);
   }
 
   @SuppressWarnings("FieldCanBeLocal")

--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -226,7 +226,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
         @Override
         public void userFinishedProjectNegotiation(User user) {
-          sendAwarenessInformation();
+          sendAwarenessInformation(user);
         }
 
         @Override
@@ -240,16 +240,24 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
         }
 
         /**
-         * Sends awareness information to populate the UserEditorState of the participant that
-         * joined the session.
+         * Sends the awareness information for all open shared editors. This is done to populate the
+         * UserEditorState of the participant that finished the project negotiation.
          *
          * <p>This is done by first sending the needed state for all locally open editors. After the
          * awareness information for all locally open editors (including the active editor) has been
          * transmitted, a second editor activated activity is send for the locally active editor to
          * correctly set the active editor in the remote user editor state for the local user.
+         *
+         * <p>This will not be executed for the user that finished the project negotiation as their
+         * user editor state will be propagated through {@link #resourcesAdded(IProject)} when the
+         * shared resources are initially added.
          */
-        private void sendAwarenessInformation() {
+        private void sendAwarenessInformation(@NotNull User user) {
           User localUser = session.getLocalUser();
+
+          if (localUser.equals(user)) {
+            return;
+          }
 
           Set<String> visibleFilePaths = new HashSet<>();
 


### PR DESCRIPTION
#### [FIX][I] #581 Only send user editor state when other user joined

Adjusts the logic to send the current user editor state to no longer
send the state of the joined user. This was done as the session of the
joined user might not have been set up completely at this point.

Instead, the state of the joined user will be send as part of the
resources added call. This change is made in a separate commit.

#### [REFACTOR][I] Move methods to send user editor state out of listener

Moves the methods to send the user editor state out of the session
listener as they are now also needed outside the listener.

#### [FIX][I] #581 Send user editor state when resource is added to session

Adjusts the logic of EditorManager#addProjectResources(IProject) to also
send the user editor state for any editors belonging to the added
module.

Fixes #581.

#### [INTERNAL][I] Correctly set active editor in user editor state

Ensures that the correct active editor is set after initializing the
user editor state for added modules.