### PR TITLE
Upgrade to IntelliJ 2019.2

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/intellij/build.gradle
+++ b/intellij/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.4.8"
+    classpath "gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.4.9"
   }
 }
 
@@ -71,7 +71,7 @@ intellij {
   if (intellijHome) {
     localPath = intellijHome
   } else {
-    version = 'IC-2019.1.2'
+    version = 'IC-2019.2'
   }
 
   // don't overwrite the version compatibility defined in the plugin.xml

--- a/intellij/src/saros/intellij/ui/menu/SarosFileShareGroup.java
+++ b/intellij/src/saros/intellij/ui/menu/SarosFileShareGroup.java
@@ -3,7 +3,7 @@ package saros.intellij.ui.menu;
 import com.intellij.openapi.actionSystem.ActionGroup;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.DataKeys;
+import com.intellij.openapi.actionSystem.LangDataKeys;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import java.util.ArrayList;
@@ -77,12 +77,12 @@ public class SarosFileShareGroup extends ActionGroup {
   private boolean isSharableResource(AnActionEvent e) {
     // FIXME also returns null when a module with multiple roots is selected
     // Don't allow to share any file or folder other than a module
-    if (e.getDataContext().getData(DataKeys.MODULE_CONTEXT.getName()) == null) {
+    if (e.getDataContext().getData(LangDataKeys.MODULE_CONTEXT.getName()) == null) {
       return false;
     }
 
-    Project project = e.getData(DataKeys.PROJECT);
-    Module module = e.getData(DataKeys.MODULE);
+    Project project = e.getData(LangDataKeys.PROJECT);
+    Module module = e.getData(LangDataKeys.MODULE);
 
     if (project == null || module == null || project.getName().equalsIgnoreCase(module.getName())) {
 

--- a/intellij/src/saros/intellij/ui/util/UIProjectUtils.java
+++ b/intellij/src/saros/intellij/ui/util/UIProjectUtils.java
@@ -2,7 +2,7 @@ package saros.intellij.ui.util;
 
 import com.intellij.ide.DataManager;
 import com.intellij.openapi.actionSystem.DataContext;
-import com.intellij.openapi.actionSystem.DataKeys;
+import com.intellij.openapi.actionSystem.LangDataKeys;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -97,7 +97,7 @@ public class UIProjectUtils {
 
     Promise<DataContext> promisedDataContext =
         DataManager.getInstance().getDataContextFromFocusAsync();
-    Promise<Project> promisedProject = promisedDataContext.then(DataKeys.PROJECT::getData);
+    Promise<Project> promisedProject = promisedDataContext.then(LangDataKeys.PROJECT::getData);
 
     promisedProject.onProcessed(projectRunner::run);
   }


### PR DESCRIPTION
#### [I] Commit automatic config changes for IntelliJ 2019.2

#### [FIX][I] Replace usage of DataKeys with LangDataKeys

Replaces the usage of DataKeys with LangDataKeys. This is necessary as
IntelliJ 2019.2 deprecates the class and largely removes its contents.

#### [BUILD][I] Update to IntelliJ 2019.2

Updates the version to build the plugin against to 2019.2.

Subsequently updates the gradle-intellij-plugin to the latest version.

The switch to 2019.2 causes an illegal reflexive access warning to be
displayed when running the plugin locally using 'runIDE'. This seems to
be an issue with IntelliJ and does not seem to influence our plugin.