### PR TITLE
[FIX][E] #32 Splitting annotations do not honor the history

### DIFF
--- a/eclipse/test/junit/saros/editor/internal/ContributionAnnotationManagerTest.java
+++ b/eclipse/test/junit/saros/editor/internal/ContributionAnnotationManagerTest.java
@@ -2,16 +2,21 @@ package saros.editor.internal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.PreferenceStore;
 import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.AnnotationModel;
+import org.eclipse.jface.text.source.IAnnotationModel;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,24 +26,48 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import saros.net.xmpp.JID;
 import saros.preferences.EclipsePreferenceConstants;
 import saros.session.ISarosSession;
+import saros.session.ISessionListener;
 import saros.session.User;
-import saros.test.util.EclipseMemoryPreferenceStore;
+import saros.ui.util.SWTUtils;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(User.class)
+@PrepareForTest(SWTUtils.class)
 public class ContributionAnnotationManagerTest {
 
   private ContributionAnnotationManager manager;
   private ISarosSession sessionMock;
   private IPreferenceStore store;
 
+  private Capture<ISessionListener> sessionListenerCapture;
+
   @Before
   public void setUp() {
-    store = new EclipseMemoryPreferenceStore();
+    store = new PreferenceStore();
     store.setValue(EclipsePreferenceConstants.SHOW_CONTRIBUTION_ANNOTATIONS, true);
 
+    sessionListenerCapture = EasyMock.newCapture();
+
     sessionMock = EasyMock.createNiceMock(ISarosSession.class);
-    PowerMock.replay(sessionMock);
+
+    sessionMock.addListener(EasyMock.capture(sessionListenerCapture));
+
+    EasyMock.expectLastCall().once();
+
+    PowerMock.mockStatic(SWTUtils.class);
+
+    final Capture<Runnable> capture = EasyMock.newCapture();
+
+    SWTUtils.runSafeSWTAsync(EasyMock.anyObject(), EasyMock.capture(capture));
+
+    EasyMock.expectLastCall()
+        .andAnswer(
+            () -> {
+              capture.getValue().run();
+              return null;
+            })
+        .anyTimes();
+
+    PowerMock.replayAll(sessionMock);
 
     manager = new ContributionAnnotationManager(sessionMock, store);
   }
@@ -83,6 +112,47 @@ public class ContributionAnnotationManagerTest {
   }
 
   @Test
+  public void testHistoryAfterSplit() {
+
+    final User alice = new User(new JID("alice@test"), false, false, null);
+    final User bob = new User(new JID("bob@test"), false, false, null);
+
+    final AnnotationModel model = new AnnotationModel();
+
+    manager.insertAnnotation(model, 5, 7, alice);
+    manager.insertAnnotation(model, 2, 15, bob);
+
+    manager.splitAnnotation(model, 9);
+
+    assertEquals("split does not affected all annotations", 4, getAnnotationCount(model));
+
+    int startIndex = 100;
+
+    for (int i = 0; i < ContributionAnnotationManager.MAX_HISTORY_LENGTH - 1; i++, startIndex++)
+      manager.insertAnnotation(model, startIndex, 1, alice);
+
+    assertEquals(
+        "splitted annotions should count as one annotion for the history",
+        4 + ContributionAnnotationManager.MAX_HISTORY_LENGTH - 1,
+        getAnnotationCount(model));
+
+    manager.insertAnnotation(model, startIndex++, 1, alice);
+
+    assertEquals(
+        "splitted annotions are not correctly removed from the history",
+        4 + ContributionAnnotationManager.MAX_HISTORY_LENGTH - 1 - 1,
+        getAnnotationCount(model));
+
+    for (int i = 0; i < ContributionAnnotationManager.MAX_HISTORY_LENGTH; i++, startIndex++)
+      manager.insertAnnotation(model, startIndex, 1, bob);
+
+    assertEquals(
+        "splitted annotions are not correctly removed from the history",
+        2 * ContributionAnnotationManager.MAX_HISTORY_LENGTH,
+        getAnnotationCount(model));
+  }
+
+  @Test
   public void testAnnotationSplit() {
 
     final User alice = new User(new JID("alice@test"), false, false, null);
@@ -110,8 +180,101 @@ public class ContributionAnnotationManagerTest {
     assertTrue("expected annotation region not found: " + expectB1, positions.contains(expectB1));
   }
 
-  @SuppressWarnings("unchecked")
-  private int getAnnotationCount(AnnotationModel model) {
+  @Test
+  public void testRemoveAllAnnotationsBySwitchingProperty() {
+
+    final List<User> users =
+        Arrays.asList(
+            new User(new JID("alice@test"), false, false, null),
+            new User(new JID("bob@test"), false, false, null),
+            new User(new JID("carl@test"), false, false, null),
+            new User(new JID("dave@test"), false, false, null));
+
+    int idx = 0;
+
+    final AnnotationModel model = new AnnotationModel();
+
+    for (final User user : users)
+      for (int i = 0; i < ContributionAnnotationManager.MAX_HISTORY_LENGTH; i++, idx++)
+        manager.insertAnnotation(model, idx, 1, user);
+
+    assertEquals(
+        ContributionAnnotationManager.MAX_HISTORY_LENGTH * users.size(), getAnnotationCount(model));
+
+    store.setValue(EclipsePreferenceConstants.SHOW_CONTRIBUTION_ANNOTATIONS, false);
+
+    assertEquals(0, getAnnotationCount(model));
+  }
+
+  @Test
+  public void testRemoveAnnotationsWhenUserLeaves() {
+
+    final List<User> users = new ArrayList<>();
+
+    users.add(new User(new JID("alice@test"), false, false, null));
+    users.add(new User(new JID("bob@test"), false, false, null));
+
+    int idx = 0;
+
+    final AnnotationModel model = new AnnotationModel();
+
+    for (final User user : users)
+      for (int i = 0; i < ContributionAnnotationManager.MAX_HISTORY_LENGTH; i++, idx++)
+        manager.insertAnnotation(model, idx, 1, user);
+
+    assertEquals(
+        ContributionAnnotationManager.MAX_HISTORY_LENGTH * users.size(), getAnnotationCount(model));
+
+    final ISessionListener sessionListener = sessionListenerCapture.getValue();
+
+    assertNotNull(sessionListener);
+
+    while (!users.isEmpty()) {
+      sessionListener.userLeft(users.remove(0));
+
+      assertEquals(
+          ContributionAnnotationManager.MAX_HISTORY_LENGTH * users.size(),
+          getAnnotationCount(model));
+    }
+  }
+
+  public void testInsertWhileNotEnable() {
+    store.setValue(EclipsePreferenceConstants.SHOW_CONTRIBUTION_ANNOTATIONS, false);
+
+    final User alice = new User(new JID("alice@test"), false, false, null);
+
+    final AnnotationModel model = new AnnotationModel();
+
+    manager.insertAnnotation(model, 5, 7, alice);
+
+    assertEquals(0, getAnnotationCount(model));
+  }
+
+  @Test
+  public void testDispose() {
+
+    final List<User> users = new ArrayList<>();
+
+    users.add(new User(new JID("alice@test"), false, false, null));
+    users.add(new User(new JID("bob@test"), false, false, null));
+
+    int idx = 0;
+
+    final AnnotationModel model = new AnnotationModel();
+
+    for (final User user : users)
+      for (int i = 0; i < ContributionAnnotationManager.MAX_HISTORY_LENGTH; i++, idx++)
+        manager.insertAnnotation(model, idx, 1, user);
+
+    assertEquals(
+        ContributionAnnotationManager.MAX_HISTORY_LENGTH * users.size(), getAnnotationCount(model));
+
+    manager.dispose();
+
+    assertEquals(0, getAnnotationCount(model));
+  }
+
+  private int getAnnotationCount(IAnnotationModel model) {
     int count = 0;
 
     Iterator<Annotation> it = model.getAnnotationIterator();
@@ -124,7 +287,6 @@ public class ContributionAnnotationManagerTest {
     return count;
   }
 
-  @SuppressWarnings("unchecked")
   private List<Position> getAnnotationPositions(AnnotationModel model) {
 
     List<Position> positions = new ArrayList<Position>();


### PR DESCRIPTION
This patch fixes the last outstanding issues regarding #32.

Annotations that were split are now correctly inserted to the history
and so correctly removed.

This patch introduces a new method to the annotation helper as well as
it reduces LOC in the ContributionAnnotationManager.