### PR TITLE
[INTERNAL][E] Adds comments regarding Preferences

### DIFF
--- a/eclipse/src/saros/Saros.java
+++ b/eclipse/src/saros/Saros.java
@@ -166,7 +166,7 @@ public class Saros extends AbstractUIPlugin {
   public synchronized Preferences getGlobalPreferences() {
     // TODO Singleton-Pattern code smell: ConfigPrefs should be a @component
     if (globalPreferences == null) {
-      globalPreferences = new ConfigurationScope().getNode(PLUGIN_ID);
+      globalPreferences = ConfigurationScope.INSTANCE.getNode(PLUGIN_ID);
     }
     return globalPreferences;
   }

--- a/eclipse/src/saros/preferences/EclipsePreferenceInitializer.java
+++ b/eclipse/src/saros/preferences/EclipsePreferenceInitializer.java
@@ -26,13 +26,23 @@ public class EclipsePreferenceInitializer extends AbstractPreferenceInitializer 
   @Override
   public void initializeDefaultPreferences() {
     LOG.info("initializing preference default values");
-    setPreferences(new DefaultScope().getNode(Saros.PLUGIN_ID));
+    setPreferences(DefaultScope.INSTANCE.getNode(Saros.PLUGIN_ID));
   }
 
+  /**
+   * Do not call. Should only be used for testing purposes.
+   *
+   * @param preferences
+   */
   public static void setPreferences(Preferences preferences) {
     setPreferences(new OSGiPreferencesAccessAdapter(preferences));
   }
 
+  /**
+   * Do not call. Should only be used for testing purposes.
+   *
+   * @param preferenceStore
+   */
   public static void setPreferences(IPreferenceStore preferenceStore) {
     setPreferences(new IPreferenceStoreAccessAdapter(preferenceStore));
   }
@@ -145,22 +155,22 @@ public class EclipsePreferenceInitializer extends AbstractPreferenceInitializer 
 
     @Override
     public void setDefault(String key, int value) {
-      preferenceStore.setValue(key, value);
+      preferenceStore.setDefault(key, value);
     }
 
     @Override
     public void setDefault(String key, long value) {
-      preferenceStore.setValue(key, value);
+      preferenceStore.setDefault(key, value);
     }
 
     @Override
     public void setDefault(String key, boolean value) {
-      preferenceStore.setValue(key, value);
+      preferenceStore.setDefault(key, value);
     }
 
     @Override
     public void setDefault(String key, String value) {
-      preferenceStore.setValue(key, value);
+      preferenceStore.setDefault(key, value);
     }
   }
 

--- a/eclipse/test/junit/saros/feedback/StatisticCollectorTest.java
+++ b/eclipse/test/junit/saros/feedback/StatisticCollectorTest.java
@@ -18,6 +18,7 @@ import saros.editor.FollowModeManager;
 import saros.net.IConnectionManager;
 import saros.net.internal.DataTransferManager;
 import saros.net.xmpp.JID;
+import saros.preferences.EclipsePreferenceConstants;
 import saros.repackaged.picocontainer.BindKey;
 import saros.repackaged.picocontainer.MutablePicoContainer;
 import saros.repackaged.picocontainer.PicoBuilder;
@@ -105,6 +106,10 @@ public class StatisticCollectorTest {
 
     IPreferenceStore store = EclipseMocker.initPreferenceStore(container);
     Preferences preferences = EclipseMocker.initPreferences();
+
+    // triggers SWTUtils if not disabled and causes issues
+    preferences.putInt(
+        EclipsePreferenceConstants.FEEDBACK_SURVEY_DISABLED, FeedbackManager.FEEDBACK_DISABLED);
 
     EclipseMocker.mockSarosWithPreferences(container, store, preferences);
 

--- a/eclipse/test/junit/saros/session/internal/SarosSessionTest.java
+++ b/eclipse/test/junit/saros/session/internal/SarosSessionTest.java
@@ -51,6 +51,7 @@ import saros.net.PacketCollector;
 import saros.net.internal.BinaryXMPPExtension;
 import saros.net.xmpp.JID;
 import saros.net.xmpp.XMPPConnectionService;
+import saros.preferences.EclipsePreferenceConstants;
 import saros.preferences.EclipsePreferences;
 import saros.preferences.PreferenceStore;
 import saros.project.internal.SarosEclipseSessionContextFactory;
@@ -278,6 +279,10 @@ public class SarosSessionTest {
     final IPreferenceStore store = EclipseMocker.initPreferenceStore(container);
 
     final Preferences preferences = EclipseMocker.initPreferences();
+
+    // triggers SWTUtils if not disabled and causes issues
+    preferences.putInt(
+        EclipsePreferenceConstants.FEEDBACK_SURVEY_DISABLED, FeedbackManager.FEEDBACK_DISABLED);
 
     // Init Feedback
     FeedbackPreferences.setPreferences(preferences);


### PR DESCRIPTION
Preferences in Eclipse are quite complex. Without going too deep in
detail we have an issue regarding the preference scope in Eclipse. It is
currently scoped to the workspace and not the application.

This commit also fixes an issue with test cases that will fail if
assertions are enabled.
