### PR TITLE
[FIX][E] Fixes #469 by reintroduces missing context menu

### DIFF
--- a/eclipse/plugin.xml
+++ b/eclipse/plugin.xml
@@ -1002,6 +1002,7 @@
       <menuContribution
             allPopups="false"
             locationURI="popup:org.eclipse.ui.popup.any?before=menustart">
+         <!-- See SarosView, the context menu is created manually 
          <command
                commandId="saros.ui.commands.ShareResource"
                disabledIcon="icons/dlcl16/spacer.png"
@@ -1023,6 +1024,7 @@
                </and>
             </visibleWhen>
          </command>
+         -->
          <command
                commandId="saros.ui.commands.SessionAddSelectedContacts"
                disabledIcon="icons/dlcl16/session_add_contacts_tsk.png"

--- a/eclipse/src/saros/ui/ImageManager.java
+++ b/eclipse/src/saros/ui/ImageManager.java
@@ -78,8 +78,13 @@ public class ImageManager {
       getImage("icons/elcl16/contact_add_tsk.png"); // $NON-NLS-1$
   public static final Image DLCL_CONTACT_ADD =
       getImage("icons/dlcl16/contact_add_tsk.png"); // $NON-NLS-1$
+
   public static final Image ELCL_SESSION = getImage("icons/elcl16/session_tsk.png"); // $NON-NLS-1$
+  public static final ImageDescriptor ELCL_SESSION__DESCRIPTOR =
+      getImageDescriptor("icons/elcl16/session_tsk.png"); // $NON-NLS-1$
+
   public static final Image DLCL_SESSION = getImage("icons/dlcl16/session_tsk.png"); // $NON-NLS-1$
+
   public static final Image ELCL_SESSION_LEAVE =
       getImage("icons/elcl16/session_leave_tsk.png"); // $NON-NLS-1$
   public static final Image DLCL_SESSION_LEAVE =

--- a/eclipse/src/saros/ui/views/SarosView.java
+++ b/eclipse/src/saros/ui/views/SarosView.java
@@ -54,6 +54,7 @@ import saros.session.ISessionLifecycleListener;
 import saros.session.SessionEndReason;
 import saros.session.User;
 import saros.ui.BalloonNotification;
+import saros.ui.ImageManager;
 import saros.ui.Messages;
 import saros.ui.actions.ChangeColorAction;
 import saros.ui.actions.ChangeWriteAccessAction;
@@ -73,6 +74,7 @@ import saros.ui.actions.RenameContactAction;
 import saros.ui.actions.RequestSessionInviteAction;
 import saros.ui.actions.SendFileAction;
 import saros.ui.actions.SkypeAction;
+import saros.ui.menuContributions.StartSessionWithProjects;
 import saros.ui.model.roster.RosterEntryElement;
 import saros.ui.sounds.SoundPlayer;
 import saros.ui.sounds.Sounds;
@@ -432,6 +434,17 @@ public class SarosView extends ViewPart {
                 SelectionRetrieverFactory.getSelectionRetriever(JID.class).getSelection();
             if (contacts.size() == 0) return;
 
+            if (sarosSessionManager.getSession() == null) {
+              MenuManager shareProjectSubMenu =
+                  new MenuManager(
+                      "Share Project(s)...",
+                      ImageManager.ELCL_SESSION__DESCRIPTOR,
+                      "Share_Project");
+
+              shareProjectSubMenu.add(new StartSessionWithProjects());
+              // TODO it seems it not that trivial to add tooltips to these entries
+              manager.add(shareProjectSubMenu);
+            }
             /*
              * disabled because feature does not work properly(current
              * version 14.1.31)


### PR DESCRIPTION
This time without the plugin.xml magic. The context menu was only shown
when a JID was selected which is only the case when you select something
in the Saros View, to be more specific in the roster.

Restores the original behavior, the only thing that is missing is the
tooltip for the menu entry.