### PR TITLE
[INTERNAL][E] Removes static ImageDescriptos from ImageManager

### DIFF
--- a/eclipse/src/saros/ui/ImageManager.java
+++ b/eclipse/src/saros/ui/ImageManager.java
@@ -1,5 +1,6 @@
 package saros.ui;
 
+import org.apache.log4j.Logger;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.DecorationOverlayIcon;
 import org.eclipse.jface.viewers.IDecoration;
@@ -9,106 +10,134 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 import saros.Saros;
 
 /** Handles references to all used images throughout this plug-in. */
+/*
+ * Please do NOT add ImageDescriptors here !
+ */
 public class ImageManager {
+
+  private static final Logger log = Logger.getLogger(ImageManager.class);
 
   /*
    * overlays
    */
-  public static final ImageDescriptor OVERLAY_FOLLOWMODE =
-      getImageDescriptor("icons/ovr16/followmode.png"); // $NON-NLS-1$
-  public static final ImageDescriptor OVERLAY_READONLY =
-      getImageDescriptor("icons/ovr16/readonly.png"); // $NON-NLS-1$
-  public static final ImageDescriptor OVERLAY_AWAY =
-      getImageDescriptor("icons/ovr16/away.png"); // $NON-NLS-1$
+  public static final Image OVERLAY_FOLLOWMODE =
+      getImage("icons/ovr16/followmode.png"); // $NON-NLS-1$
+  public static final Image OVERLAY_READONLY = getImage("icons/ovr16/readonly.png"); // $NON-NLS-1$
+
+  public static final Image OVERLAY_AWAY = getImage("icons/ovr16/away.png"); // $NON-NLS-1$
 
   /*
    * wizard banners
    */
-  public static final ImageDescriptor WIZBAN_CONFIGURATION =
-      getImageDescriptor("icons/wizban/configuration_wiz.gif"); // $NON-NLS-1$
-  public static final ImageDescriptor WIZBAN_CREATE_XMPP_ACCOUNT =
-      getImageDescriptor("icons/wizban/xmpp_create_account_wiz.gif"); // $NON-NLS-1$
-  public static final ImageDescriptor WIZBAN_EDIT_XMPP_ACCOUNT =
-      getImageDescriptor("icons/wizban/xmpp_edit_account_wiz.gif"); // $NON-NLS-1$
-  public static final ImageDescriptor WIZBAN_ADD_CONTACT =
-      getImageDescriptor("icons/wizban/add_contact_wiz.gif"); // $NON-NLS-1$
-  public static final ImageDescriptor WIZBAN_SESSION_INCOMING =
-      getImageDescriptor("icons/wizban/session_incoming_wiz.gif"); // $NON-NLS-1$
-  public static final ImageDescriptor WIZBAN_SESSION_OUTGOING =
-      getImageDescriptor("icons/wizban/session_outgoing_wiz.gif"); // $NON-NLS-1$
-  public static final ImageDescriptor WIZBAN_SESSION_ADD_PROJECTS =
-      getImageDescriptor("icons/wizban/session_add_projects_wiz.gif"); // $NON-NLS-1$
-  public static final ImageDescriptor WIZBAN_SESSION_ADD_CONTACTS =
-      getImageDescriptor("icons/wizban/session_add_contacts_wiz.gif"); // $NON-NLS-1$
+  public static final Image WIZBAN_CONFIGURATION =
+      getImage("icons/wizban/configuration_wiz.gif"); // $NON-NLS-1$
+
+  public static final Image WIZBAN_CREATE_XMPP_ACCOUNT =
+      getImage("icons/wizban/xmpp_create_account_wiz.gif"); // $NON-NLS-1$
+
+  public static final Image WIZBAN_EDIT_XMPP_ACCOUNT =
+      getImage("icons/wizban/xmpp_edit_account_wiz.gif"); // $NON-NLS-1$
+
+  public static final Image WIZBAN_ADD_CONTACT =
+      getImage("icons/wizban/add_contact_wiz.gif"); // $NON-NLS-1$
+
+  public static final Image WIZBAN_SESSION_INCOMING =
+      getImage("icons/wizban/session_incoming_wiz.gif"); // $NON-NLS-1$
+
+  public static final Image WIZBAN_SESSION_OUTGOING =
+      getImage("icons/wizban/session_outgoing_wiz.gif"); // $NON-NLS-1$
+
+  public static final Image WIZBAN_SESSION_ADD_PROJECTS =
+      getImage("icons/wizban/session_add_projects_wiz.gif"); // $NON-NLS-1$
+
+  public static final Image WIZBAN_SESSION_ADD_CONTACTS =
+      getImage("icons/wizban/session_add_contacts_wiz.gif"); // $NON-NLS-1$
 
   /*
    * tool bar
    */
   public static final Image ETOOL_STATISTIC =
       getImage("icons/etool16/statistic_misc.png"); // $NON-NLS-1$
+
   public static final Image DTOOL_STATISTIC =
       getImage("icons/dtool16/statistic_misc.png"); // $NON-NLS-1$
+
   public static final Image ETOOL_CRASH_REPORT =
       getImage("icons/etool16/crash_report_misc.png"); // $NON-NLS-1$
+
   public static final Image DTOOL_CRASH_REPORT =
       getImage("icons/dtool16/crash_report_misc.png"); // $NON-NLS-1$
+
   public static final Image ETOOL_NEW_PROJECT =
       getImage("icons/etool16/new_project.gif"); // $NON-NLS-1$
+
   public static final ImageDescriptor ETOOL_EDIT =
       getImageDescriptor("icons/etool16/edit.gif"); // $NON-NLS-1$
-  public static final ImageDescriptor ETOOL_TEST_CONNECTION =
-      getImageDescriptor("icons/etool16/test_con.gif"); // $NON-NLS-1$
 
   /*
    * local tool bar
    */
   public static final Image ELCL_SPACER = getImage("icons/elcl16/spacer.png"); // $NON-NLS-1$
+
   public static final Image DLCL_SPACER = getImage("icons/dlcl16/spacer.png"); // $NON-NLS-1$
+
   public static final Image ELCL_PREFERENCES_OPEN =
       getImage("icons/elcl16/preferences_open_tsk.png"); // $NON-NLS-1$
+
   public static final Image ELCL_XMPP_CONNECTED =
       getImage("icons/elcl16/xmpp_disconnect_tsk.png"); // $NON-NLS-1$
+
   public static final Image DLCL_XMPP_CONNECTED =
       getImage("icons/dlcl16/xmpp_disconnect_tsk.png"); // $NON-NLS-1$
+
   public static final Image ELCL_CONTACT_SKYPE_CALL =
       getImage("icons/elcl16/contact_skype_call_tsk.png"); // $NON-NLS-1$
+
   public static final Image DLCL_CONTACT_SKYPE_CALL =
       getImage("icons/dlcl16/contact_skype_call_tsk.png"); // $NON-NLS-1$
+
   public static final Image ELCL_CONTACT_ADD =
       getImage("icons/elcl16/contact_add_tsk.png"); // $NON-NLS-1$
+
   public static final Image DLCL_CONTACT_ADD =
       getImage("icons/dlcl16/contact_add_tsk.png"); // $NON-NLS-1$
 
   public static final Image ELCL_SESSION = getImage("icons/elcl16/session_tsk.png"); // $NON-NLS-1$
-  public static final ImageDescriptor ELCL_SESSION__DESCRIPTOR =
-      getImageDescriptor("icons/elcl16/session_tsk.png"); // $NON-NLS-1$
 
   public static final Image DLCL_SESSION = getImage("icons/dlcl16/session_tsk.png"); // $NON-NLS-1$
 
   public static final Image ELCL_SESSION_LEAVE =
       getImage("icons/elcl16/session_leave_tsk.png"); // $NON-NLS-1$
+
   public static final Image DLCL_SESSION_LEAVE =
       getImage("icons/dlcl16/session_leave_tsk.png"); // $NON-NLS-1$
+
   public static final Image ELCL_SESSION_TERMINATE =
       getImage("icons/elcl16/session_terminate_tsk.png"); // $NON-NLS-1$
+
   public static final Image DLCL_SESSION_TERMINATE =
       getImage("icons/dlcl16/session_terminate_tsk.png"); // $NON-NLS-1$
+
   public static final Image ELCL_SESSION_ADD_PROJECTS =
       getImage("icons/elcl16/session_add_projects_tsk.png"); // $NON-NLS-1$
+
   public static final Image DLCL_SESSION_ADD_PROJECTS =
       getImage("icons/dlcl16/session_add_projects_tsk.png"); // $NON-NLS-1$
+
   public static final Image ELCL_SESSION_ADD_CONTACTS =
       getImage("icons/elcl16/session_add_contacts_tsk.png"); // $NON-NLS-1$
+
   public static final Image DLCL_SESSION_ADD_CONTACTS =
       getImage("icons/dlcl16/session_add_contacts_tsk.png"); // $NON-NLS-1$
+
   public static final Image ELCL_SAROS_SESSION_STOP_PROCESS =
       getImage("icons/elcl16/saros_session_stop_process_tsk.png"); // $NON-NLS-1$
+
   public static final Image DLCL_SAROS_SESSION_STOP_PROCESS =
       getImage("icons/dlcl16/saros_session_stop_process_tsk.png"); // $NON-NLS-1$
+
   public static final Image ELCL_DIALOG = getImage("icons/elcl16/dialog.gif"); // $NON-NLS-1$
   public static final Image ELCL_DELETE = getImage("icons/btn/deleteaccount.png"); // $NON-NLS-1$
-  public static final ImageDescriptor ELCL_OPEN_PREFERENCES =
-      getImageDescriptor("icons/elcl16/preferences_open_tsk.png"); // $NON-NLS-1$
 
   /*
    * objects
@@ -116,50 +145,44 @@ public class ImageManager {
   public static final Image ICON_UPNP = getImage("icons/obj16/upnp_obj.png"); // $NON-NLS-1$
 
   public static final Image ICON_GROUP = getImage("icons/obj16/group_obj.png"); // $NON-NLS-1$
+
   public static final Image ICON_CONTACT = getImage("icons/obj16/contact_obj.png"); // $NON-NLS-1$
+
   public static final Image ICON_CONTACT_OFFLINE =
       getImage("icons/obj16/contact_offline_obj.png"); // $NON-NLS-1$
-  public static final Image ICON_CONTACT_AWAY =
-      new DecorationOverlayIcon(ICON_CONTACT, OVERLAY_AWAY, IDecoration.TOP_RIGHT).createImage();
 
   public static final Image ICON_CONTACT_SAROS_SUPPORT =
       getImage("icons/obj16/contact_saros_obj.png"); // $NON-NLS-1$
 
+  public static final Image ICON_CONTACT_AWAY =
+      createImageWithOverlay(ICON_CONTACT, OVERLAY_AWAY, IDecoration.TOP_RIGHT);
+
   public static final Image ICON_USER_SAROS_FOLLOWMODE =
-      new DecorationOverlayIcon(
-              ICON_CONTACT_SAROS_SUPPORT, OVERLAY_FOLLOWMODE, IDecoration.TOP_LEFT)
-          .createImage();
+      createImageWithOverlay(ICON_CONTACT_SAROS_SUPPORT, OVERLAY_FOLLOWMODE, IDecoration.TOP_LEFT);
 
   public static final Image ICON_USER_SAROS_FOLLOWMODE_DISABLED =
-      new DecorationOverlayIcon(ICON_CONTACT_OFFLINE, OVERLAY_FOLLOWMODE, IDecoration.TOP_LEFT)
-          .createImage();
+      createImageWithOverlay(ICON_CONTACT_OFFLINE, OVERLAY_FOLLOWMODE, IDecoration.TOP_LEFT);
 
   public static final Image ICON_USER_SAROS_FOLLOWMODE_READONLY =
-      new DecorationOverlayIcon(
-              ICON_USER_SAROS_FOLLOWMODE, OVERLAY_READONLY, IDecoration.BOTTOM_RIGHT)
-          .createImage();
+      createImageWithOverlay(
+          ICON_USER_SAROS_FOLLOWMODE, OVERLAY_READONLY, IDecoration.BOTTOM_RIGHT);
 
   public static final Image ICON_USER_SAROS_FOLLOWMODE_READONLY_AWAY =
-      new DecorationOverlayIcon(
-              ICON_USER_SAROS_FOLLOWMODE_READONLY, OVERLAY_AWAY, IDecoration.TOP_RIGHT)
-          .createImage();
+      createImageWithOverlay(
+          ICON_USER_SAROS_FOLLOWMODE_READONLY, OVERLAY_AWAY, IDecoration.TOP_RIGHT);
 
   public static final Image ICON_USER_SAROS_FOLLOWMODE_AWAY =
-      new DecorationOverlayIcon(ICON_USER_SAROS_FOLLOWMODE, OVERLAY_AWAY, IDecoration.TOP_RIGHT)
-          .createImage();
+      createImageWithOverlay(ICON_USER_SAROS_FOLLOWMODE, OVERLAY_AWAY, IDecoration.TOP_RIGHT);
 
   public static final Image ICON_USER_SAROS_READONLY =
-      new DecorationOverlayIcon(
-              ICON_CONTACT_SAROS_SUPPORT, OVERLAY_READONLY, IDecoration.BOTTOM_RIGHT)
-          .createImage();
+      createImageWithOverlay(
+          ICON_CONTACT_SAROS_SUPPORT, OVERLAY_READONLY, IDecoration.BOTTOM_RIGHT);
 
   public static final Image ICON_USER_SAROS_READONLY_AWAY =
-      new DecorationOverlayIcon(ICON_USER_SAROS_READONLY, OVERLAY_AWAY, IDecoration.TOP_RIGHT)
-          .createImage();
+      createImageWithOverlay(ICON_USER_SAROS_READONLY, OVERLAY_AWAY, IDecoration.TOP_RIGHT);
 
   public static final Image ICON_USER_SAROS_AWAY =
-      new DecorationOverlayIcon(ICON_CONTACT_SAROS_SUPPORT, OVERLAY_AWAY, IDecoration.TOP_RIGHT)
-          .createImage();
+      createImageWithOverlay(ICON_CONTACT_SAROS_SUPPORT, OVERLAY_AWAY, IDecoration.TOP_RIGHT);
 
   /**
    * Returns an image from the file at the given plug-in relative path.
@@ -167,8 +190,18 @@ public class ImageManager {
    * @param path
    * @return image; the returned image <b>MUST be disposed after usage</b> to free up memory
    */
-  public static Image getImage(String path) {
-    return new Image(Display.getDefault(), getImageDescriptor(path).getImageData());
+  public static Image getImage(final String path) {
+    ImageDescriptor descriptor = getImageDescriptor(path);
+
+    if (descriptor == null) {
+      log.warn(
+          "could not create image for path '"
+              + path
+              + "', either the file does not exists or the format is not supported");
+      descriptor = ImageDescriptor.getMissingImageDescriptor();
+    }
+
+    return new Image(Display.getDefault(), descriptor.getImageData());
   }
 
   /**
@@ -177,7 +210,22 @@ public class ImageManager {
    * @param path the path
    * @return the image descriptor
    */
-  public static ImageDescriptor getImageDescriptor(String path) {
+  public static ImageDescriptor getImageDescriptor(final String path) {
     return AbstractUIPlugin.imageDescriptorFromPlugin(Saros.PLUGIN_ID, path);
+  }
+
+  /**
+   * Returns an image descriptor for the given image.
+   *
+   * @param image image to obtain the image descriptor for, not <code>null</code>
+   * @return the image descriptor
+   */
+  public static ImageDescriptor getImageDescriptor(final Image image) {
+    return ImageDescriptor.createFromImage(image);
+  }
+
+  private static Image createImageWithOverlay(Image image, Image overlay, int quadrant) {
+    return new DecorationOverlayIcon(image, getImageDescriptor(overlay), quadrant)
+        .createImage(true);
   }
 }

--- a/eclipse/src/saros/ui/actions/OpenPreferencesAction.java
+++ b/eclipse/src/saros/ui/actions/OpenPreferencesAction.java
@@ -18,20 +18,19 @@ public class OpenPreferencesAction extends Action {
 
     setId(ACTION_ID);
     setToolTipText(Messages.OpenPreferencesAction_tooltip);
-    setImageDescriptor(ImageManager.ELCL_OPEN_PREFERENCES);
+    setImageDescriptor(ImageManager.getImageDescriptor(ImageManager.ELCL_PREFERENCES_OPEN));
     setEnabled(true);
   }
 
   @Override
   public void run() {
     IHandlerService service =
-        (IHandlerService)
-            PlatformUI.getWorkbench()
-                .getActiveWorkbenchWindow()
-                .getActivePage()
-                .getActivePart()
-                .getSite()
-                .getService(IHandlerService.class);
+        PlatformUI.getWorkbench()
+            .getActiveWorkbenchWindow()
+            .getActivePage()
+            .getActivePart()
+            .getSite()
+            .getService(IHandlerService.class);
     try {
       service.executeCommand(
           "saros.ui.commands.OpenSarosPreferences", //$NON-NLS-1$

--- a/eclipse/src/saros/ui/views/SarosView.java
+++ b/eclipse/src/saros/ui/views/SarosView.java
@@ -438,7 +438,7 @@ public class SarosView extends ViewPart {
               MenuManager shareProjectSubMenu =
                   new MenuManager(
                       "Share Project(s)...",
-                      ImageManager.ELCL_SESSION__DESCRIPTOR,
+                      ImageManager.getImageDescriptor(ImageManager.ELCL_SESSION),
                       "Share_Project");
 
               shareProjectSubMenu.add(new StartSessionWithProjects());

--- a/eclipse/src/saros/ui/wizards/AddContactWizard.java
+++ b/eclipse/src/saros/ui/wizards/AddContactWizard.java
@@ -6,7 +6,6 @@ import java.util.concurrent.CancellationException;
 import org.apache.log4j.Logger;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jface.operation.IRunnableWithProgress;
-import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.jface.wizard.WizardPage;
 import org.jivesoftware.smack.Connection;
@@ -34,7 +33,6 @@ public class AddContactWizard extends Wizard {
   private static final Logger log = Logger.getLogger(AddContactWizard.class);
 
   public static final String TITLE = Messages.AddContactWizard_title;
-  public static final ImageDescriptor IMAGE = ImageManager.WIZBAN_ADD_CONTACT;
 
   @Inject protected XMPPConnectionService connectionService;
 
@@ -71,7 +69,7 @@ public class AddContactWizard extends Wizard {
   public AddContactWizard() {
     SarosPluginContext.initComponent(this);
     setWindowTitle(TITLE);
-    setDefaultPageImageDescriptor(IMAGE);
+    setDefaultPageImageDescriptor(ImageManager.getImageDescriptor(ImageManager.WIZBAN_ADD_CONTACT));
     setNeedsProgressMonitor(true);
   }
 

--- a/eclipse/src/saros/ui/wizards/AddContactsToSessionWizard.java
+++ b/eclipse/src/saros/ui/wizards/AddContactsToSessionWizard.java
@@ -1,7 +1,6 @@
 package saros.ui.wizards;
 
 import java.util.List;
-import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.wizard.Wizard;
 import saros.net.xmpp.JID;
 import saros.ui.ImageManager;
@@ -16,14 +15,14 @@ import saros.ui.wizards.pages.ContactSelectionWizardPage;
  */
 public class AddContactsToSessionWizard extends Wizard {
   public static final String TITLE = Messages.SessionAddContactsWizard_title;
-  public static final ImageDescriptor IMAGE = ImageManager.WIZBAN_SESSION_ADD_CONTACTS;
 
   private final ContactSelectionWizardPage contactSelectionWizardPage =
       new ContactSelectionWizardPage();
 
   public AddContactsToSessionWizard() {
     setWindowTitle(TITLE);
-    setDefaultPageImageDescriptor(IMAGE);
+    setDefaultPageImageDescriptor(
+        ImageManager.getImageDescriptor(ImageManager.WIZBAN_SESSION_ADD_CONTACTS));
     setHelpAvailable(false);
   }
 

--- a/eclipse/src/saros/ui/wizards/AddResourcesToSessionWizard.java
+++ b/eclipse/src/saros/ui/wizards/AddResourcesToSessionWizard.java
@@ -3,7 +3,6 @@ package saros.ui.wizards;
 import java.util.Collection;
 import java.util.List;
 import org.eclipse.core.resources.IResource;
-import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.Wizard;
 import saros.ui.ImageManager;
@@ -19,14 +18,14 @@ import saros.ui.wizards.pages.ResourceSelectionWizardPage;
  */
 public class AddResourcesToSessionWizard extends Wizard {
   public static final String TITLE = Messages.SessionAddProjectsWizard_title;
-  public static final ImageDescriptor IMAGE = ImageManager.WIZBAN_SESSION_ADD_PROJECTS;
 
   private final ResourceSelectionWizardPage resourceSelectionWizardPage;
 
   /** @param preselectedResources resources that should be preselected or <code>null</code> */
   public AddResourcesToSessionWizard(final Collection<IResource> preselectedResources) {
     setWindowTitle(TITLE);
-    setDefaultPageImageDescriptor(IMAGE);
+    setDefaultPageImageDescriptor(
+        ImageManager.getImageDescriptor(ImageManager.WIZBAN_SESSION_ADD_PROJECTS));
     setHelpAvailable(false);
     resourceSelectionWizardPage = new ResourceSelectionWizardPage(preselectedResources);
   }

--- a/eclipse/src/saros/ui/wizards/AddXMPPAccountWizard.java
+++ b/eclipse/src/saros/ui/wizards/AddXMPPAccountWizard.java
@@ -39,7 +39,8 @@ public class AddXMPPAccountWizard extends Wizard {
     setWindowTitle(Messages.AddXMPPAccountWizard_title);
     setHelpAvailable(false);
     setNeedsProgressMonitor(false);
-    setDefaultPageImageDescriptor(ImageManager.WIZBAN_CONFIGURATION);
+    setDefaultPageImageDescriptor(
+        ImageManager.getImageDescriptor(ImageManager.WIZBAN_CONFIGURATION));
   }
 
   @Override

--- a/eclipse/src/saros/ui/wizards/ColorChooserWizard.java
+++ b/eclipse/src/saros/ui/wizards/ColorChooserWizard.java
@@ -13,7 +13,8 @@ public class ColorChooserWizard extends Wizard {
     setWindowTitle(Messages.ChangeColorWizard_title);
     setHelpAvailable(false);
     setNeedsProgressMonitor(false);
-    setDefaultPageImageDescriptor(ImageManager.WIZBAN_CONFIGURATION);
+    setDefaultPageImageDescriptor(
+        ImageManager.getImageDescriptor(ImageManager.WIZBAN_CONFIGURATION));
 
     colorChooserWizardPage.setTitle(Messages.ChangeColorWizardPage_title);
     colorChooserWizardPage.setDescription(Messages.ChangeColorWizardPage_description);

--- a/eclipse/src/saros/ui/wizards/ConfigurationWizard.java
+++ b/eclipse/src/saros/ui/wizards/ConfigurationWizard.java
@@ -37,7 +37,8 @@ public class ConfigurationWizard extends AddXMPPAccountWizard {
     SarosPluginContext.initComponent(this);
 
     setWindowTitle("Saros Configuration");
-    setDefaultPageImageDescriptor(ImageManager.WIZBAN_CONFIGURATION);
+    setDefaultPageImageDescriptor(
+        ImageManager.getImageDescriptor(ImageManager.WIZBAN_CONFIGURATION));
     colorChooserWizardPage.setTitle(Messages.ChangeColorWizardPage_configuration_mode_title);
 
     colorChooserWizardPage.setDescription(

--- a/eclipse/src/saros/ui/wizards/CreateXMPPAccountWizard.java
+++ b/eclipse/src/saros/ui/wizards/CreateXMPPAccountWizard.java
@@ -62,7 +62,8 @@ public class CreateXMPPAccountWizard extends Wizard {
     SarosPluginContext.initComponent(this);
 
     setWindowTitle(Messages.CreateXMPPAccountWizard_title);
-    setDefaultPageImageDescriptor(ImageManager.WIZBAN_CREATE_XMPP_ACCOUNT);
+    setDefaultPageImageDescriptor(
+        ImageManager.getImageDescriptor(ImageManager.WIZBAN_CREATE_XMPP_ACCOUNT));
 
     this.createXMPPAccountPage = new CreateXMPPAccountWizardPage(showUseNowButton);
     setNeedsProgressMonitor(true);

--- a/eclipse/src/saros/ui/wizards/EditXMPPAccountWizard.java
+++ b/eclipse/src/saros/ui/wizards/EditXMPPAccountWizard.java
@@ -1,6 +1,5 @@
 package saros.ui.wizards;
 
-import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.wizard.Wizard;
 import saros.SarosPluginContext;
 import saros.account.XMPPAccount;
@@ -18,7 +17,6 @@ import saros.ui.wizards.pages.EditXMPPAccountWizardPage;
  */
 public class EditXMPPAccountWizard extends Wizard {
   public static final String TITLE = Messages.EditXMPPAccountWizard_title;
-  public static final ImageDescriptor IMAGE = ImageManager.WIZBAN_EDIT_XMPP_ACCOUNT;
 
   @Inject XMPPAccountStore xmppAccountStore;
   XMPPAccount account;
@@ -30,7 +28,8 @@ public class EditXMPPAccountWizard extends Wizard {
 
     SarosPluginContext.initComponent(this);
     this.setWindowTitle(TITLE);
-    this.setDefaultPageImageDescriptor(IMAGE);
+    this.setDefaultPageImageDescriptor(
+        ImageManager.getImageDescriptor(ImageManager.WIZBAN_EDIT_XMPP_ACCOUNT));
 
     this.setNeedsProgressMonitor(false);
 

--- a/eclipse/src/saros/ui/wizards/StartSessionWizard.java
+++ b/eclipse/src/saros/ui/wizards/StartSessionWizard.java
@@ -3,7 +3,6 @@ package saros.ui.wizards;
 import java.util.Collection;
 import java.util.List;
 import org.eclipse.core.resources.IResource;
-import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.Wizard;
 import saros.SarosPluginContext;
@@ -26,7 +25,6 @@ import saros.ui.wizards.pages.ResourceSelectionWizardPage;
 public class StartSessionWizard extends Wizard {
 
   public static final String TITLE = Messages.SessionStartWizard_title;
-  public static final ImageDescriptor IMAGE = ImageManager.WIZBAN_SESSION_OUTGOING;
 
   private final ResourceSelectionWizardPage resourceSelectionWizardPage;
   private final ContactSelectionWizardPage contactSelectionWizardPage;
@@ -35,7 +33,8 @@ public class StartSessionWizard extends Wizard {
   public StartSessionWizard(final Collection<IResource> preselectedResources) {
     SarosPluginContext.initComponent(this);
     setWindowTitle(TITLE);
-    setDefaultPageImageDescriptor(IMAGE);
+    setDefaultPageImageDescriptor(
+        ImageManager.getImageDescriptor(ImageManager.WIZBAN_SESSION_OUTGOING));
     setNeedsProgressMonitor(true);
     setHelpAvailable(false);
 


### PR DESCRIPTION
Such ImageDescriptors can be generated as needed so there is no need to
store them somewhere. 

In addition when an image cannot be found a default one is returned in
addition with a warning message in the log file. This fixes the issue
where Eclipse will not even start when an image is missing due to an NPE
in the static initializer on some classes (in this case some Chat
Stuff).