### PR TITLE
[FIX][E] #65 Warning dialog upon reusing an existing project is

### DIFF
--- a/eclipse/src/saros/ui/messages.properties
+++ b/eclipse/src/saros/ui/messages.properties
@@ -172,7 +172,7 @@ AddProjectToSessionWizard_invitation_canceled_text2=Your invitation has been can
 AddProjectToSessionWizard_invitation_canceled_text3=Your invitation has been canceled remotely by {0}\!
 AddProjectToSessionWizard_leave_session=Leaving the Session
 AddProjectToSessionWizard_leave_session_text=The session participants must remain synchronized at all times. Declining an invitation will therefore eject you from the session. Are you sure you want to leave?
-AddProjectToSessionWizard_synchronize_projects=Each project you are accepting will be synchronized with the inviter's copy. It has been found that some of your local files differ from those of the inviter.\n\n All local differences will be overwritten\!\n\n Press "No" and then select "Create copy..." if you are unsure.\n Press "Details" to find out what changes will occur if you proceed.\n\n Do you want to proceed?
+AddProjectToSessionWizard_synchronize_projects=Each project you are accepting will be synchronized with the inviter's copy. It has been found that some of your local files differ from those of the inviter.\n\n All local differences will be overwritten\!\n\n Press "No" and then select "Create new project" for the affected project(s) if you are unsure.\n Press "Details" to find out what changes will occur if you proceed.\n\n Do you want to proceed?
 AddProjectToSessionWizard_synchronize_finished_notification_title=Synchronization finished
 AddProjectToSessionWizard_synchronize_finished_notification_text=You can now start working on the following project(s): {0}
 


### PR DESCRIPTION
misleading

Fixes issue #65. Took only several years to change a string after a
feature got removed because it was not working as intended.