### PR TITLE
[INTERNAL][E] Adds central connection access point for the UI

### DIFF
--- a/eclipse/src/saros/SarosEclipseContextFactory.java
+++ b/eclipse/src/saros/SarosEclipseContextFactory.java
@@ -45,6 +45,7 @@ import saros.ui.eventhandler.SessionStatusRequestHandler;
 import saros.ui.eventhandler.SessionViewOpener;
 import saros.ui.eventhandler.UserStatusChangeHandler;
 import saros.ui.eventhandler.XMPPAuthorizationHandler;
+import saros.ui.util.XMPPConnectionSupport;
 
 /**
  * Factory used for creating the Saros context when running as Eclipse plugin.
@@ -106,7 +107,9 @@ public class SarosEclipseContextFactory extends AbstractContextFactory {
           IRemoteProgressIndicatorFactory.class, EclipseRemoteProgressIndicatorFactoryImpl.class),
       Component.create(MUCNegotiationManager.class),
       Component.create(SkypeManager.class),
-      Component.create(AwarenessInformationCollector.class)
+      Component.create(AwarenessInformationCollector.class),
+      // Central connect/disconnect access point for the UI
+      Component.create(XMPPConnectionSupport.class)
     };
   }
 

--- a/eclipse/src/saros/StartupSaros.java
+++ b/eclipse/src/saros/StartupSaros.java
@@ -8,7 +8,6 @@ import org.eclipse.ui.IStartup;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.intro.IIntroManager;
 import org.eclipse.ui.intro.IIntroPart;
-import saros.account.XMPPAccount;
 import saros.account.XMPPAccountStore;
 import saros.annotations.Component;
 import saros.communication.connection.ConnectionHandler;
@@ -19,7 +18,7 @@ import saros.repackaged.picocontainer.annotations.Inject;
 import saros.ui.commandHandlers.GettingStartedHandler;
 import saros.ui.util.SWTUtils;
 import saros.ui.util.ViewUtils;
-import saros.util.ThreadUtils;
+import saros.ui.util.XMPPConnectionSupport;
 
 /**
  * An instance of this class is instantiated when Eclipse starts, after the Saros plugin has been
@@ -89,18 +88,7 @@ public class StartupSaros implements IStartup {
 
         if (!preferences.isAutoConnecting() || xmppAccountStore.isEmpty()) return;
 
-        final XMPPAccount account = xmppAccountStore.getActiveAccount();
-
-        ThreadUtils.runSafeAsync(
-            "dpp-connect-auto",
-            LOG,
-            new Runnable() {
-              @Override
-              public void run() {
-                // avoid error popups
-                connectionHandler.connect(account, true);
-              }
-            });
+        SWTUtils.runSafeSWTAsync(LOG, () -> XMPPConnectionSupport.getInstance().connect(true));
       }
     }
   }

--- a/eclipse/src/saros/ui/util/XMPPConnectionSupport.java
+++ b/eclipse/src/saros/ui/util/XMPPConnectionSupport.java
@@ -1,0 +1,178 @@
+package saros.ui.util;
+
+import org.apache.log4j.Logger;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTException;
+import org.eclipse.swt.widgets.Display;
+import saros.account.XMPPAccount;
+import saros.account.XMPPAccountStore;
+import saros.communication.connection.ConnectionHandler;
+import saros.session.ISarosSessionManager;
+import saros.util.ThreadUtils;
+
+/** Central access point for the UI to connect and disconnect to an XMPP server. */
+public class XMPPConnectionSupport {
+
+  private static final Logger log = Logger.getLogger(XMPPConnectionSupport.class);
+
+  private static XMPPConnectionSupport instance;
+
+  private final XMPPAccountStore store;
+
+  private final ISarosSessionManager sessionManager;
+
+  private final ConnectionHandler connectionHandler;
+
+  public static XMPPConnectionSupport getInstance() {
+    return instance;
+  }
+
+  private volatile boolean isConnecting = false;
+  private volatile boolean isDisconnecting = false;
+
+  public XMPPConnectionSupport(
+      final XMPPAccountStore store,
+      final ConnectionHandler connectionHandler,
+      final ISarosSessionManager sessionManager) {
+    this.store = store;
+    this.connectionHandler = connectionHandler;
+    this.sessionManager = sessionManager;
+    instance = this;
+  }
+
+  /**
+   * Connects with the current active / default account.
+   *
+   * @param failSilently if <code>true</code> suppresses any further error handling
+   */
+  public void connect(boolean failSilently) {
+    connect(null, false);
+  }
+
+  /**
+   * Connects with given account. If the given account is <code>null<code> the active / default one will be used.
+   * @param account the account to use
+   * @param failSilently if <code>true</code> suppresses any further error handling
+   */
+  public void connect(final XMPPAccount account, boolean failSilently) {
+    connect(account, false, failSilently);
+  }
+
+  /**
+   * Connects with given account. If the given account is <code>null<code> the active / default one will be used.
+   * @param account the account to use
+   * @param setAsDefault if <code>true</code> the account is set as the default one
+   * @param failSilently if <code>true</code> suppresses any further error handling
+   */
+  public void connect(final XMPPAccount account, boolean setAsDefault, boolean failSilently) {
+    if (Display.getCurrent() == null) throw new SWTException(SWT.ERROR_THREAD_INVALID_ACCESS);
+
+    if (isConnecting || isDisconnecting && failSilently) return;
+
+    if (isConnecting || isDisconnecting) {
+      MessageDialog.openWarning(
+          SWTUtils.getShell(),
+          "Error",
+          "A connection attempt is already in progress. Please try again.");
+      return;
+    }
+
+    isConnecting = true;
+
+    if (connectionHandler.isConnected() && failSilently) {
+      isConnecting = false;
+      return;
+    }
+
+    if (sessionManager.getSession() != null && failSilently) {
+      isConnecting = false;
+      return;
+    }
+
+    boolean mustDisconnect = false;
+
+    if (sessionManager.getSession() != null) {
+
+      final boolean disconnectFromSession =
+          MessageDialog.openQuestion(
+              SWTUtils.getShell(),
+              "Disconnecting from the current Saros Session",
+              "Connecting with a different account will disconnect you from your current Saros session. Do you wish to continue ?");
+
+      if (!disconnectFromSession) {
+        isConnecting = false;
+        return;
+      }
+
+      mustDisconnect = true;
+    }
+
+    if (connectionHandler.isConnected()) {
+      final boolean reconnect =
+          MessageDialog.openQuestion(
+              SWTUtils.getShell(),
+              "Already connected",
+              "Do you want to reconnect as "
+                  + account.getUsername()
+                  + "@"
+                  + account.getDomain()
+                  + " ?");
+
+      if (!reconnect) {
+        isConnecting = false;
+        return;
+      }
+
+      mustDisconnect = true;
+    }
+
+    final XMPPAccount accountToConnect;
+
+    if (account == null && !store.isEmpty()) accountToConnect = store.getActiveAccount();
+    else if (account != null) accountToConnect = account;
+    else accountToConnect = null;
+
+    /*
+     * some magic, if we connect with null we will trigger an exception that is processed by
+     * the ConnectingFailureHandler which in turn will open the ConfigurationWizard
+     */
+    if (setAsDefault && accountToConnect != null) {
+      store.setAccountActive(accountToConnect);
+    }
+
+    final boolean disconnectFirst = mustDisconnect;
+
+    ThreadUtils.runSafeAsync(
+        "dpp-connect-xmpp",
+        log,
+        () -> {
+          if (disconnectFirst) connectionHandler.disconnect();
+          try {
+            connectionHandler.connect(accountToConnect, failSilently);
+          } finally {
+            isConnecting = false;
+          }
+        });
+  }
+
+  /** Disconnects the currently connected account. */
+  public void disconnect() {
+    if (Display.getCurrent() == null) throw new SWTException(SWT.ERROR_THREAD_INVALID_ACCESS);
+
+    if (isConnecting || isDisconnecting) return;
+
+    isDisconnecting = true;
+
+    ThreadUtils.runSafeAsync(
+        "dpp-disconnect-xmpp",
+        log,
+        () -> {
+          try {
+            connectionHandler.disconnect();
+          } finally {
+            isDisconnecting = false;
+          }
+        });
+  }
+}

--- a/eclipse/src/saros/ui/wizards/CreateXMPPAccountWizard.java
+++ b/eclipse/src/saros/ui/wizards/CreateXMPPAccountWizard.java
@@ -16,9 +16,9 @@ import saros.net.util.XMPPUtils;
 import saros.repackaged.picocontainer.annotations.Inject;
 import saros.ui.ImageManager;
 import saros.ui.Messages;
-import saros.ui.util.DialogUtils;
+import saros.ui.util.SWTUtils;
+import saros.ui.util.XMPPConnectionSupport;
 import saros.ui.wizards.pages.CreateXMPPAccountWizardPage;
-import saros.util.ThreadUtils;
 
 /**
  * @JTourBusStop 4, The Interface Tour:
@@ -142,30 +142,9 @@ public class CreateXMPPAccountWizard extends Wizard {
         accountStore.createAccount(
             cachedUsername, cachedPassword, cachedServer.toLowerCase(), "", 0, true, true);
 
-    // reconnect if user wishes
-    if (createXMPPAccountPage.useNow()) {
-      boolean reconnect = true;
-      if (connectionHandler.isConnected()) {
-        reconnect =
-            DialogUtils.openQuestionMessageDialog(
-                getShell(),
-                Messages.CreateXMPPAccountWizard_already_connected,
-                Messages.CreateXMPPAccountWizard_already_connected_text);
-      }
-
-      if (reconnect) {
-        accountStore.setAccountActive(createdXMPPAccount);
-        ThreadUtils.runSafeAsync(
-            "dpp-connect-demand",
-            log,
-            new Runnable() {
-              @Override
-              public void run() {
-                connectionHandler.connect(createdXMPPAccount, false);
-              }
-            });
-      }
-    }
+    if (createXMPPAccountPage.useNow())
+      SWTUtils.runSafeSWTAsync(
+          log, () -> XMPPConnectionSupport.getInstance().connect(createdXMPPAccount, true, false));
 
     return true;
   }


### PR DESCRIPTION
Adds a central class that is now responsible for connection attempts.

This should help to prevent certain misuse, e.g disconnecting an active
session without any warning.

In addition this patch removes the inheritance between the
XMPPAddAccountWizard and the SarosConfigurationWizard.