### PR TITLE
[UI][E] Moves information from EnterXMPPAccountWizardPage

### DIFF
--- a/eclipse/src/saros/ui/wizards/ConfigurationWizard.java
+++ b/eclipse/src/saros/ui/wizards/ConfigurationWizard.java
@@ -1,9 +1,14 @@
 package saros.ui.wizards;
 
+import java.util.Arrays;
 import org.bitlet.weupnp.GatewayDevice;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.wizard.Wizard;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
 import saros.SarosPluginContext;
 import saros.account.XMPPAccount;
 import saros.account.XMPPAccountStore;
@@ -17,6 +22,7 @@ import saros.repackaged.picocontainer.annotations.Inject;
 import saros.ui.ImageManager;
 import saros.ui.Messages;
 import saros.ui.util.XMPPConnectionSupport;
+import saros.ui.widgets.SimpleNoteComposite;
 import saros.ui.wizards.pages.ColorChooserWizardPage;
 import saros.ui.wizards.pages.ConfigurationSettingsWizardPage;
 import saros.ui.wizards.pages.ConfigurationSummaryWizardPage;
@@ -30,7 +36,37 @@ import saros.ui.wizards.pages.EnterXMPPAccountWizardPage;
 public class ConfigurationWizard extends Wizard {
 
   private final EnterXMPPAccountWizardPage enterXMPPAccountWizardPage =
-      new EnterXMPPAccountWizardPage();
+      new EnterXMPPAccountWizardPage() {
+        /*
+         *  Note this is more like a hack as we know how the original page is created.
+         *  As this information contained in the SimpleNoteComposite below is only displayed in
+         *  the context of this Wizard it is not worth to add logic to the EnterXMPPAccountWizardPage
+         *  that should decide if this Note is displayed at all. So do it the dirty way and inject the SimpleNoteComposite
+         *  that it is the first widget displayed in this page.
+         */
+
+        @Override
+        public void createControl(final Composite parent) {
+          super.createControl(parent);
+
+          final Composite composite = (Composite) getControl();
+
+          final Control controlToMoveAbove =
+              Arrays.asList(composite.getChildren()).stream().findFirst().orElse(null);
+
+          SimpleNoteComposite noteComposite =
+              new SimpleNoteComposite(
+                  composite,
+                  SWT.BORDER,
+                  SWT.ICON_INFORMATION,
+                  Messages.EnterXMPPAccountWizardPage_info_already_created_account);
+
+          noteComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+          noteComposite.setSpacing(8);
+
+          if (controlToMoveAbove != null) noteComposite.moveAbove(controlToMoveAbove);
+        }
+      };
 
   private final ConfigurationSettingsWizardPage configurationSettingsWizardPage =
       new ConfigurationSettingsWizardPage();

--- a/eclipse/src/saros/ui/wizards/pages/EnterXMPPAccountWizardPage.java
+++ b/eclipse/src/saros/ui/wizards/pages/EnterXMPPAccountWizardPage.java
@@ -15,7 +15,6 @@ import saros.account.XMPPAccountStore;
 import saros.net.xmpp.JID;
 import saros.repackaged.picocontainer.annotations.Inject;
 import saros.ui.Messages;
-import saros.ui.widgets.SimpleNoteComposite;
 import saros.ui.widgets.wizard.EnterXMPPAccountComposite;
 
 /**
@@ -66,19 +65,9 @@ public class EnterXMPPAccountWizardPage extends WizardPage {
 
     composite.setLayout(new GridLayout(1, false));
 
-    SimpleNoteComposite noteComposite =
-        new SimpleNoteComposite(
-            composite,
-            SWT.BORDER,
-            SWT.ICON_INFORMATION,
-            Messages.EnterXMPPAccountWizardPage_info_already_created_account);
-
-    noteComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
-    noteComposite.setSpacing(8);
-
     enterXMPPAccountComposite = new EnterXMPPAccountComposite(composite, SWT.NONE);
 
-    enterXMPPAccountComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, false, false));
+    enterXMPPAccountComposite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
     enterXMPPAccountComposite.setUsingTLS(true);
     enterXMPPAccountComposite.setUsingSASL(true);


### PR DESCRIPTION
[UI][E] Moves information from ENterXMPPAccountWizardPage

This information is only needed for the configuration wizard. It is very
confusing if you open the page in stand-alone mode and reading "If you
already have a XMPP account ..." 

I am guessing I would have used Create-Account instead of Add-Account if
I do not own a XMPP account.