### PR TITLE
[INTERNAL][CORE] Removes deprecated methods from XMPPAccountStore

### DIFF
--- a/core/src/saros/account/XMPPAccount.java
+++ b/core/src/saros/account/XMPPAccount.java
@@ -51,6 +51,9 @@ public final class XMPPAccount implements Serializable {
     if (!domain.toLowerCase().equals(domain))
       throw new IllegalArgumentException("domain url must be in lower case letters");
 
+    // FIXME see https://tools.ietf.org/html/rfc6122#section-2 - the localpart/username is also
+    // case-insensitive
+
     if (port < 0 || port >= 65536) throw new IllegalArgumentException("port number is not valid");
 
     if ((server.trim().length() != 0 && port == 0) || (server.trim().length() == 0 && port != 0))

--- a/core/test/junit/saros/account/XMPPAccountStoreTest.java
+++ b/core/test/junit/saros/account/XMPPAccountStoreTest.java
@@ -2,6 +2,7 @@ package saros.account;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -30,11 +31,6 @@ public class XMPPAccountStoreTest {
   @Test
   public void testWithNoAccountFile() {
     assertTrue(store.isEmpty());
-  }
-
-  @Test(expected = IllegalStateException.class)
-  public void testActiveAccountWithEmptyAccountStore() {
-    store.getActiveAccount();
   }
 
   /*
@@ -73,57 +69,20 @@ public class XMPPAccountStoreTest {
     assertTrue(store.existsAccount("anotherAccount1", "anotherdomain1", "anotherserver1", 1));
     assertTrue(store.existsAccount("anotherAccount2", "anotherdomain2", "anotherserver2", 2));
 
-    assertEquals("activeAccount", store.getActiveAccount().getUsername());
-  }
-
-  private void writeAccountFile(File accountFile, String key, String content) throws Exception {
-    final FileOutputStream dataOut = new FileOutputStream(accountFile);
-    final byte[] encryptedXmlContent = XMPPAccountStore.Crypto.encrypt(content.getBytes(), key);
-
-    try {
-      dataOut.write(encryptedXmlContent);
-      dataOut.flush();
-    } finally {
-      IOUtils.closeQuietly(dataOut);
-    }
-  }
-
-  private String createAccountFileContent(
-      XMPPAccount activeAccount, ArrayList<XMPPAccount> configuredAccounts) {
-
-    int index = configuredAccounts.indexOf(activeAccount);
-    StringBuilder xmlContent =
-        new StringBuilder()
-            .append("<accounts>\n")
-            .append(String.format("  <activeAccountIndex>%d</activeAccountIndex>\n", index));
-
-    xmlContent.append("  <configuredAccounts>\n");
-    for (XMPPAccount acc : configuredAccounts) {
-      xmlContent
-          .append("    <xmppAccount>\n")
-          .append(String.format("    <username>%s</username>\n", acc.getUsername()))
-          .append(String.format("    <password>%s</password>\n", acc.getPassword()))
-          .append(String.format("    <domain>%s</domain>\n", acc.getDomain()))
-          .append(String.format("    <server>%s</server>\n", acc.getServer()))
-          .append(String.format("    <port>%d</port>\n", acc.getPort()))
-          .append(String.format("    <useTLS>%s</useTLS>\n", acc.useTLS()))
-          .append(String.format("    <useSASL>%s</useSASL>\n", acc.useSASL()))
-          .append("    </xmppAccount>\n");
-    }
-    xmlContent.append("  </configuredAccounts>\n").append("</accounts>");
-
-    return xmlContent.toString();
+    assertEquals("activeAccount", store.getDefaultAccount().getUsername());
   }
 
   @Test
-  public void testAutoActivation() throws Exception {
+  public void testGetDefaultOnAccountCreationInEmptyStore() throws Exception {
     store.createAccount("a", "a", "a", "a", 1, true, true);
     assertFalse(store.isEmpty());
-    assertEquals("a", store.getActiveAccount().getUsername());
+    assertNotNull(store.getDefaultAccount());
+
+    assertEquals("a", store.getDefaultAccount().getUsername());
 
     // only the first account must be auto activated
     store.createAccount("b", "b", "b", "b", 1, true, true);
-    assertEquals("a", store.getActiveAccount().getUsername());
+    assertEquals("a", store.getDefaultAccount().getUsername());
   }
 
   @Test
@@ -159,10 +118,11 @@ public class XMPPAccountStoreTest {
   }
 
   @Test
-  public void deleteDefaultAccount() {
+  public void testDeleteDefaultAccount() {
     store.createAccount("a", "a", "a", "a", 1, true, true);
     store.deleteAccount(store.getDefaultAccount());
     assertNull(store.getDefaultAccount());
+    assertTrue(store.isEmpty());
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -172,19 +132,19 @@ public class XMPPAccountStoreTest {
   }
 
   @Test
-  public void setAccountActive() {
+  public void setAccountAsDefaultAccount() {
     store.createAccount("a", "a", "a", "a", 1, true, true);
     XMPPAccount account = store.createAccount("b", "a", "a", "a", 1, true, true);
-    store.setAccountActive(account);
-    assertEquals(account, store.getActiveAccount());
+    store.setDefaultAccount(account);
+    assertEquals(account, store.getDefaultAccount());
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void setNonExistingAccountActive() {
+  public void setNonExistingAccountAsDefault() {
     store.createAccount("a", "a", "a", "a", 1, true, true);
     XMPPAccount account = store.createAccount("b", "a", "a", "a", 1, true, true);
     store.deleteAccount(account);
-    store.setAccountActive(account);
+    store.setDefaultAccount(account);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -197,9 +157,9 @@ public class XMPPAccountStoreTest {
   @Test
   public void testChangeAccountData() {
     store.createAccount("a", "a", "a", "a", 1, true, true);
-    store.changeAccountData(store.getActiveAccount(), "b", "b", "b", "b", 5, false, false);
+    store.changeAccountData(store.getDefaultAccount(), "b", "b", "b", "b", 5, false, false);
 
-    XMPPAccount account = store.getActiveAccount();
+    XMPPAccount account = store.getDefaultAccount();
 
     assertEquals("b", account.getPassword());
     assertEquals("b", account.getServer());
@@ -263,47 +223,17 @@ public class XMPPAccountStoreTest {
   }
 
   @Test
-  public void testAccountexists() {
+  public void testAccountExists() {
     store.createAccount("alice", "alice", "b", "b", 1, true, true);
 
     assertTrue(store.existsAccount("alice", "b", "b", 1));
-    assertFalse(store.existsAccount("Alice", "b", "b", 1));
     assertFalse(store.existsAccount("alice", "a", "b", 1));
     assertFalse(store.existsAccount("alice", "b", "a", 1));
     assertFalse(store.existsAccount("alice", "b", "b", 5));
   }
 
   @Test
-  public void testChangeAccountDataAndActiveAccountAfterDeserialization() throws IOException {
-
-    File tmpAccountFile = tmpFolder.newFile("saros_account.dat");
-
-    store.setAccountFile(tmpAccountFile, null);
-
-    store.createAccount("alice", "alice", "b", "b", 1, true, true);
-
-    store = new XMPPAccountStore();
-    store.setAccountFile(tmpAccountFile, null);
-
-    XMPPAccount account = store.getActiveAccount();
-
-    XMPPAccount another = store.getAllAccounts().get(0);
-
-    store.changeAccountData(
-        another,
-        another.getUsername(),
-        another.getPassword(),
-        another.getDomain(),
-        "",
-        0,
-        true,
-        true);
-
-    assertEquals(another, account);
-  }
-
-  @Test
-  public void testChangeAccountAfterDeserialization() throws IOException {
+  public void testDefaultAccountIsModifiedCorrectlyAfterLoading() throws IOException {
 
     File tmpAccountFile = tmpFolder.newFile("saros_account.dat");
 
@@ -332,7 +262,7 @@ public class XMPPAccountStoreTest {
   }
 
   @Test
-  public void testSetDefaultToNullAndThenDeserializeAgain() throws IOException {
+  public void testSetDefaultToNullThenSaveAndLoadAgain() throws IOException {
     File tmpAccountFile = tmpFolder.newFile("saros_account.dat");
 
     XMPPAccount defaultAccount;
@@ -340,6 +270,7 @@ public class XMPPAccountStoreTest {
     store.setAccountFile(tmpAccountFile, null);
 
     assertEquals(0, store.getAllAccounts().size());
+
     // this is the default one
     defaultAccount = store.createAccount("alice", "alice", "b", "b", 1, true, true);
     store.createAccount("bob", "bob", "b", "b", 1, true, true);
@@ -358,36 +289,72 @@ public class XMPPAccountStoreTest {
   }
 
   @Test
-  public void testFindsExistingAccount() {
+  public void testGetExistingAccount() {
     XMPPAccount created =
         store.createAccount("alice", "alice", "domain", "server", 12345, true, true);
 
-    XMPPAccount found = store.findAccount("alice@domain");
+    XMPPAccount found = store.getAccount("alice", "domain");
     assertEquals(created, found);
   }
 
   @Test
-  public void testUnsuccessfulFindAccount() {
-    XMPPAccount found = store.findAccount("alice@domain");
+  public void testGetNonExistingAccount() {
+    XMPPAccount found = store.getAccount("i_want_to_win", "the_lottery");
     assertNull(found);
   }
 
   @Test
-  public void testFindAccountIgnoresCase() {
+  public void testGetExisingAccountIgnoresCase() {
     XMPPAccount created =
         store.createAccount("alice", "alice", "domain", "server", 12345, true, true);
-    XMPPAccount found = store.findAccount("Alice@Domain");
+
+    XMPPAccount found = store.getAccount("AlIcE", "DoMaIn");
     assertEquals(created, found);
   }
 
-  @Test(expected = NullPointerException.class)
-  public void testFindAccountWithNull() {
-    store.findAccount(null);
+  @Test
+  public void testFindAccountWithEmptyStringOrNull() {
+    assertNull(store.getAccount("", ""));
+    assertNull(store.getAccount(null, null));
   }
 
-  @Test
-  public void testFindAccountWithEmptyString() {
-    XMPPAccount found = store.findAccount("");
-    assertNull(found);
+  private static void writeAccountFile(File accountFile, String key, String content)
+      throws Exception {
+    final FileOutputStream dataOut = new FileOutputStream(accountFile);
+    final byte[] encryptedXmlContent = XMPPAccountStore.Crypto.encrypt(content.getBytes(), key);
+
+    try {
+      dataOut.write(encryptedXmlContent);
+      dataOut.flush();
+    } finally {
+      IOUtils.closeQuietly(dataOut);
+    }
+  }
+
+  private static String createAccountFileContent(
+      XMPPAccount activeAccount, ArrayList<XMPPAccount> configuredAccounts) {
+
+    int index = configuredAccounts.indexOf(activeAccount);
+    StringBuilder xmlContent =
+        new StringBuilder()
+            .append("<accounts>\n")
+            .append(String.format("  <activeAccountIndex>%d</activeAccountIndex>\n", index));
+
+    xmlContent.append("  <configuredAccounts>\n");
+    for (XMPPAccount acc : configuredAccounts) {
+      xmlContent
+          .append("    <xmppAccount>\n")
+          .append(String.format("    <username>%s</username>\n", acc.getUsername()))
+          .append(String.format("    <password>%s</password>\n", acc.getPassword()))
+          .append(String.format("    <domain>%s</domain>\n", acc.getDomain()))
+          .append(String.format("    <server>%s</server>\n", acc.getServer()))
+          .append(String.format("    <port>%d</port>\n", acc.getPort()))
+          .append(String.format("    <useTLS>%s</useTLS>\n", acc.useTLS()))
+          .append(String.format("    <useSASL>%s</useSASL>\n", acc.useSASL()))
+          .append("    </xmppAccount>\n");
+    }
+    xmlContent.append("  </configuredAccounts>\n").append("</accounts>");
+
+    return xmlContent.toString();
   }
 }


### PR DESCRIPTION
[INTERNAL][CORE] Removes deprecated methods from XMPPAccountStore

This patch also fixes an issue in the getAccountsMethods so they lookup
the account correctly by ignoring the case sensitivity of the username.

Adds a FIXME to the XMPPAccount class regarding RFC 6122