### PR TITLE
[FIX] #98 UPnPTest#testDispose() Fails if Assertions are Enabled

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -49,9 +49,8 @@ jar {
 }
 
 
-// Avoid issue GH issue #98
 tasks.withType(Test) {
-  enableAssertions = false
+  enableAssertions = true
 }
 
 task testJar(type: Jar) {

--- a/eclipse/build.gradle
+++ b/eclipse/build.gradle
@@ -67,7 +67,7 @@ dependencies {
 }
 
 tasks.withType(Test) {
-  enableAssertions = false
+  enableAssertions = true
 }
 
 compileJava.dependsOn rootProject.mavenizeP2Repository


### PR DESCRIPTION
This fixes #98 by implementing the missing functionality to handle
multiple IGD that support lease durations.

This patch also fixes and issue I have found using a FritzBox. It seems
that the Fritzbox is renaming the MappingDescription and so we would
face problems if want to apply the mapping again without removing it
first (e.g due program crash).
