### PR TITLE
[FIX][E] #28 Make Balloons not overlap editorparts

### DIFF
--- a/eclipse/src/saros/ui/BalloonNotification.java
+++ b/eclipse/src/saros/ui/BalloonNotification.java
@@ -45,14 +45,18 @@ public class BalloonNotification {
    *
    * <p>The window will be hidden automatically after the value specified in the timeout expires
    *
+   * <p><b>Note:</b> The balloon window is always anchored to the given control at position (0,0).
+   * Specifying the balloon window anchor is relative to this point.
+   *
    * <p>TODO wrap the contents so the balloon notification does not expand across two screens for a
    * long text. OR even better: do not show long notifications. users tend to ignore them anyway!
    *
    * @param control the control, next to where the widget will appear
+   * @param anchor the anchor of the balloon window
    * @param title the title of the balloon
    * @param text the text to display as contents
    */
-  public static void showNotification(Control control, String title, String text) {
+  public static void showNotification(Control control, int anchor, String title, String text) {
 
     if (control != null && control.isDisposed()) {
       control = null;
@@ -73,7 +77,7 @@ public class BalloonNotification {
         new BalloonWindow(
             control != null ? control.getShell() : null, SWT.NO_FOCUS | SWT.TOOL | SWT.TITLE);
 
-    window.setAnchor(SWT.LEFT | SWT.BOTTOM);
+    window.setAnchor(anchor);
     windows.add(window);
     /*
      * Note: if you add SWT.CLOSE to the style of the BalloonWindow, it will

--- a/eclipse/src/saros/ui/views/SarosView.java
+++ b/eclipse/src/saros/ui/views/SarosView.java
@@ -24,6 +24,8 @@ import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
@@ -238,6 +240,8 @@ public class SarosView extends ViewPart {
 
   private static volatile boolean showBalloonNotifications;
 
+  private Composite notificationAnchor;
+
   /**
    * Stores actions by their {@link IAction#getId() ID}, so they can (1) be {@linkplain
    * #getAction(String) retrieved} and (2) {@linkplain Disposable#dispose() disposed} when and if
@@ -276,10 +280,20 @@ public class SarosView extends ViewPart {
   @Override
   public void createPartControl(Composite parent) {
 
-    parent.setLayout(new FillLayout());
+    GridData gridData;
+
+    final GridLayout layout = new GridLayout(1, false);
+
+    layout.horizontalSpacing = 0;
+    layout.verticalSpacing = 0;
+
+    parent.setLayout(layout);
 
     final SashForm baseSashForm = new SashForm(parent, SWT.SMOOTH);
 
+    gridData = new GridData(SWT.FILL, SWT.FILL, true, true);
+
+    baseSashForm.setLayoutData(gridData);
     /*
      * LEFT COLUMN
      */
@@ -358,6 +372,14 @@ public class SarosView extends ViewPart {
     baseSashForm.setWeights(weights);
 
     chatRooms = new ChatRoomsComposite(rightComposite, SWT.NONE, rosterTracker);
+
+    notificationAnchor = new Composite(parent, SWT.NONE);
+
+    gridData = new GridData(SWT.BEGINNING, SWT.BEGINNING, false, false);
+    gridData.heightHint = 0;
+
+    notificationAnchor.setLayoutData(gridData);
+    notificationAnchor.setVisible(false);
 
     /**
      * @JTourBusStop 3, The Interface Tour:
@@ -589,26 +611,29 @@ public class SarosView extends ViewPart {
           @Override
           public void run() {
 
-            if (control != null) {
-              BalloonNotification.showNotification(control, title, text);
+            Control attachToControl = control;
+
+            if (attachToControl != null) {
+              BalloonNotification.showNotification(
+                  attachToControl, SWT.LEFT | SWT.BOTTOM, title, text);
               return;
             }
 
             IViewPart sarosView = SWTUtils.findView(SarosView.ID);
+
             /*
              * If no session view is open then show the balloon notification
              * in the control which has the keyboard focus
              */
 
-            Control sarosViewControl;
-
             if (sarosView != null) {
-              sarosViewControl = ((SarosView) sarosView).leftComposite;
+              attachToControl = ((SarosView) sarosView).notificationAnchor;
             } else {
-              sarosViewControl = Display.getDefault().getFocusControl();
+              attachToControl = Display.getCurrent().getFocusControl();
             }
 
-            BalloonNotification.showNotification(sarosViewControl, title, text);
+            BalloonNotification.showNotification(
+                attachToControl, SWT.LEFT | SWT.BOTTOM, title, text);
           }
         });
   }


### PR DESCRIPTION
This fixes issue #28.

The popups are now displayed at the bottom of the view. As there was not
functionality to specify the "hooking point" an invisble widget was
added to the bottom of the view which is used as reference point.