### PR TITLE
End session when project of shared module is closed

### DIFF
--- a/core/src/saros/session/ISarosSession.java
+++ b/core/src/saros/session/ISarosSession.java
@@ -152,6 +152,23 @@ public interface ISarosSession {
   public void removeListener(ISessionListener listener);
 
   /**
+   * Enables or disables the execution of received activities for the given project. If the
+   * execution is disabled, activities for resources of the given projects will be dropped without
+   * being applied.
+   *
+   * <p>This method can be used to disable the execution of received activities for projects that
+   * are no longer available (i.e. are no longer part of the session or are no longer
+   * present/accessible locally).
+   *
+   * @param project the shared project to enable or disable the activity execution for
+   * @param enabled <code>true</code> to enable or <code>false</code> to disable the activity
+   *     execution
+   */
+  default void setActivityExecution(IProject project, boolean enabled) {
+    // NOP
+  }
+
+  /**
    * @return the shared projects associated with this session, never <code>null</code> but may be
    *     empty
    */

--- a/intellij/src/saros/intellij/context/SarosIntellijSessionContextFactory.java
+++ b/intellij/src/saros/intellij/context/SarosIntellijSessionContextFactory.java
@@ -6,6 +6,7 @@ import saros.intellij.editor.SelectedEditorStateSnapshotFactory;
 import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.eventhandler.ApplicationEventHandlersFactory;
 import saros.intellij.eventhandler.ProjectEventHandlersFactory;
+import saros.intellij.eventhandler.project.ProjectClosedHandler;
 import saros.intellij.followmode.FollowModeNotificationDispatcher;
 import saros.intellij.project.SharedResourcesManager;
 import saros.intellij.project.filesystem.ModuleInitialization;
@@ -23,6 +24,9 @@ public class SarosIntellijSessionContextFactory extends SarosCoreSessionContextF
     container.addComponent(SharedIDEContext.class);
     container.addComponent(ApplicationEventHandlersFactory.class);
     container.addComponent(ProjectEventHandlersFactory.class);
+
+    // Project interaction
+    container.addComponent(ProjectClosedHandler.class);
 
     // Editor interaction
     container.addComponent(LocalEditorHandler.class);

--- a/intellij/src/saros/intellij/eventhandler/project/ProjectClosedHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/project/ProjectClosedHandler.java
@@ -1,0 +1,107 @@
+package saros.intellij.eventhandler.project;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.project.ProjectManagerListener;
+import com.intellij.util.messages.MessageBusConnection;
+import org.jetbrains.annotations.NotNull;
+import saros.filesystem.IProject;
+import saros.intellij.context.SharedIDEContext;
+import saros.intellij.filesystem.IntelliJProjectImpl;
+import saros.repackaged.picocontainer.Disposable;
+import saros.session.ISarosSession;
+import saros.session.ISarosSessionManager;
+import saros.session.SessionEndReason;
+
+/**
+ * Ends the current session when a project containing shared modules is closed and disables the
+ * activity execution for resources of the closed project. This is done to avoid calls on disposed
+ * project objects.
+ *
+ * <p>The handler is enabled by default after instantiation.
+ */
+public class ProjectClosedHandler implements Disposable {
+
+  private final ISarosSessionManager sarosSessionManager;
+  private final ISarosSession sarosSession;
+
+  private final MessageBusConnection messageBusConnection;
+
+  @SuppressWarnings("FieldCanBeLocal")
+  private final ProjectManagerListener projectManagerListener =
+      new ProjectManagerListener() {
+        @Override
+        public void projectClosing(@NotNull Project project) {
+          Project sessionProject = sarosSession.getComponent(SharedIDEContext.class).getProject();
+
+          if (sessionProject.equals(project)) {
+            disableActivityExecutionForProjectModules(project);
+
+            Thread shutdownThread =
+                new Thread(
+                    () -> {
+                      assert !ApplicationManager.getApplication().isDispatchThread()
+                          : "The session must not be shut down from the EDT";
+
+                      sarosSessionManager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
+                    });
+
+            shutdownThread.start();
+          }
+        }
+
+        /**
+         * Disables the activity execution for the modules of the given project.
+         *
+         * <p>This method is used to report the modules of a closed project to the session in order
+         * to prevent it from trying to run any activities on disposed resources.
+         *
+         * @param project the project whose modules to disable the activity execution for
+         * @see ISarosSession#setActivityExecution(IProject,boolean)
+         */
+        private void disableActivityExecutionForProjectModules(@NotNull Project project) {
+          for (Module module : ModuleManager.getInstance(project).getModules()) {
+            IProject wrappedModule;
+
+            try {
+              wrappedModule = new IntelliJProjectImpl(module);
+
+            } catch (IllegalArgumentException | IllegalStateException exception) {
+              continue;
+            }
+
+            if (sarosSession.isShared(wrappedModule)) {
+              sarosSession.setActivityExecution(wrappedModule, false);
+            }
+          }
+        }
+      };
+
+  /**
+   * Instantiates the <code>ProjectClosedHandler</code>. Registers the held <code>
+   * ProjectManagerListener</code> with the application <code>MessageBus</code>.
+   *
+   * @param sarosSessionManager the <code>SarosSessionManager</code> instance
+   * @param sarosSession the current <code>SarosSession</code>
+   * @see MessageBusConnection
+   * @see ProjectManagerListener
+   */
+  public ProjectClosedHandler(
+      ISarosSessionManager sarosSessionManager, ISarosSession sarosSession) {
+
+    this.sarosSessionManager = sarosSessionManager;
+    this.sarosSession = sarosSession;
+
+    messageBusConnection = ApplicationManager.getApplication().getMessageBus().connect();
+    messageBusConnection.subscribe(ProjectManager.TOPIC, projectManagerListener);
+  }
+
+  /** Disconnects from the message bus when the plugin context is disposed. */
+  @Override
+  public void dispose() {
+    messageBusConnection.disconnect();
+  }
+}

--- a/intellij/src/saros/intellij/runtime/IntelliJSynchronizer.java
+++ b/intellij/src/saros/intellij/runtime/IntelliJSynchronizer.java
@@ -3,6 +3,8 @@ package saros.intellij.runtime;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.progress.ProcessCanceledException;
+import org.apache.log4j.Logger;
 import saros.synchronize.UISynchronizer;
 
 /**
@@ -10,6 +12,8 @@ import saros.synchronize.UISynchronizer;
  * {@link Application#invokeAndWait(Runnable, ModalityState)}.
  */
 public class IntelliJSynchronizer implements UISynchronizer {
+
+  private static final Logger log = Logger.getLogger(IntelliJSynchronizer.class);
 
   @Override
   public void asyncExec(Runnable runnable) {
@@ -32,7 +36,11 @@ public class IntelliJSynchronizer implements UISynchronizer {
     if (async) {
       application.invokeLater(runnable, ModalityState.defaultModalityState());
     } else {
-      application.invokeAndWait(runnable, ModalityState.defaultModalityState());
+      try {
+        application.invokeAndWait(runnable, ModalityState.defaultModalityState());
+      } catch (ProcessCanceledException e) {
+        log.error("Synchronous execution on EDT interrupted - " + runnable, e);
+      }
     }
   }
 }


### PR DESCRIPTION
#### [FEATURE][CORE] Add logic to report projects as disposed

Adds the logic to report a project as disposed to the session. This
causes all activities for such projects to be dropped.

This functionality is useful to prevent the session from trying to apply
activities to disposed (closed) projects.

As this logic is currently only used by Saros/I, it is not set up to
handle disposed partial-sharing resources. If this would be come useful
at some point, the logic should be adjusted to also hold a mapping for
disposed partially-shared resources.

#### [INTERNAL][I] Explicitly catch and log EDT interruption exceptions

Adjusts IntelliJSynchronizer to catch and log ProcessCanceledExceptions
which are thrown when a synchronous execution on the EDT is interrupted.

#### [FIX][I] #582 End session when project of shared module is closed

Adds a listener to end the session when the project containing the
shared module is closed. The listener also reports the modules of the
project as disposed to the session to prevent it from trying to apply
any already queued activities for the disposed modules.

Fixes #582.