### PR TITLE
[FIX][E] #19 Add Contact to session is enabled for offline contacts

### DIFF
--- a/eclipse/plugin.xml
+++ b/eclipse/plugin.xml
@@ -1040,10 +1040,13 @@
                         definitionId="saros.ui.definitions.isSarosSessionRunning">
                   </reference>
                   <reference
+                        definitionId="saros.ui.definitions.isSarosSessionHost">
+                  </reference>
+                  <reference
                         definitionId="saros.ui.definitions.contactsSelected">
                   </reference>
                   <reference
-                        definitionId="saros.ui.definitions.isSarosSessionHost">
+                        definitionId="saros.ui.definitions.contactsOnline">
                   </reference>
                </and>
             </visibleWhen>
@@ -1188,6 +1191,28 @@
                type="saros.net.xmpp.JID">
          </adapt>
       </definition>
+      <definition
+      		id="saros.ui.definitions.isContactOnline">
+         <adapt
+               type="saros.net.xmpp.JID">
+            <test
+                  property="saros.isOnline">
+            </test>
+         </adapt>
+      </definition>
+            <definition
+            id="saros.ui.definitions.contactsOnline">
+         <with
+               variable="selection">
+            <iterate
+                  ifEmpty="false"
+                  operator="and">
+               <reference
+                     definitionId="saros.ui.definitions.isContactOnline">
+               </reference>
+            </iterate>
+         </with>
+      </definition>      
       <definition
             id="saros.ui.definitions.contactsSelected">
          <with
@@ -1380,7 +1405,7 @@
             class="saros.ui.expressions.ContactPropertyTester"
             id="saros.ui.expressions.ContactPropertyTester"
             namespace="saros"
-            properties="isInSarosSession"
+            properties="isInSarosSession,isOnline"
             type="saros.net.xmpp.JID">
       </propertyTester>
       <propertyTester

--- a/eclipse/src/saros/ui/expressions/ContactPropertyTester.java
+++ b/eclipse/src/saros/ui/expressions/ContactPropertyTester.java
@@ -1,17 +1,19 @@
 package saros.ui.expressions;
 
 import org.eclipse.core.expressions.PropertyTester;
+import org.jivesoftware.smack.Roster;
 import saros.SarosPluginContext;
 import saros.net.xmpp.JID;
+import saros.net.xmpp.XMPPConnectionService;
 import saros.repackaged.picocontainer.annotations.Inject;
 import saros.session.ISarosSession;
 import saros.session.ISarosSessionManager;
-import saros.session.User;
 
 /** Adds tests to a contact represented by a {@link JID}. */
 public class ContactPropertyTester extends PropertyTester {
 
   @Inject private ISarosSessionManager sessionManager;
+  @Inject private XMPPConnectionService connectionService;
 
   public ContactPropertyTester() {
     SarosPluginContext.initComponent(this);
@@ -22,16 +24,18 @@ public class ContactPropertyTester extends PropertyTester {
 
     if (!(receiver instanceof JID)) return false;
 
-    final ISarosSession session = sessionManager.getSession();
-
-    if (session == null) return false;
-
     final JID jid = (JID) receiver;
 
     if ("isInSarosSession".equals(property)) {
-      for (final User user : session.getUsers()) {
-        if (user.getJID().equals(jid)) return true;
-      }
+
+      final ISarosSession session = sessionManager.getSession();
+
+      return session != null && session.getUsers().stream().anyMatch(u -> u.getJID().equals(jid));
+    } else if ("isOnline".equals(property)) {
+
+      final Roster roster = connectionService.getRoster();
+
+      return roster != null && roster.getPresence(jid.getBareJID().toString()).isAvailable();
     }
 
     return false;

--- a/eclipse/src/saros/ui/views/SarosView.java
+++ b/eclipse/src/saros/ui/views/SarosView.java
@@ -76,6 +76,7 @@ import saros.ui.actions.RenameContactAction;
 import saros.ui.actions.RequestSessionInviteAction;
 import saros.ui.actions.SendFileAction;
 import saros.ui.actions.SkypeAction;
+import saros.ui.expressions.ContactPropertyTester;
 import saros.ui.menuContributions.StartSessionWithProjects;
 import saros.ui.model.roster.RosterEntryElement;
 import saros.ui.sounds.SoundPlayer;
@@ -456,7 +457,13 @@ public class SarosView extends ViewPart {
                 SelectionRetrieverFactory.getSelectionRetriever(JID.class).getSelection();
             if (contacts.size() == 0) return;
 
-            if (sarosSessionManager.getSession() == null) {
+            final JID jid = contacts.get(0);
+
+            // FIXME dirty hack
+            final ContactPropertyTester tester = new ContactPropertyTester();
+            final boolean isOnline = tester.test(jid, "isOnline", null, null);
+
+            if (sarosSessionManager.getSession() == null && isOnline) {
               MenuManager shareProjectSubMenu =
                   new MenuManager(
                       "Share Project(s)...",
@@ -466,19 +473,19 @@ public class SarosView extends ViewPart {
               shareProjectSubMenu.add(new StartSessionWithProjects());
               // TODO it seems it not that trivial to add tooltips to these entries
               manager.add(shareProjectSubMenu);
+              manager.add(new Separator());
             }
-
-            manager.add(getAction(SkypeAction.ACTION_ID));
 
             // TODO: Currently only Saros/S is known to have a working JoinSessionRequestHandler,
             //       remove this once the situation changes / change this to it's own feature.
             Boolean isServer =
-                discoveryManager.isFeatureSupported(
-                    contacts.get(0), SarosConstants.NAMESPACE_SERVER);
+                discoveryManager.isFeatureSupported(jid, SarosConstants.NAMESPACE_SERVER);
             if (contacts.size() == 1 && isServer != null && isServer) {
               manager.add(getAction(RequestSessionInviteAction.ACTION_ID));
+              manager.add(new Separator());
             }
-            manager.add(new Separator());
+
+            manager.add(getAction(SkypeAction.ACTION_ID));
             manager.add(getAction(OpenChatAction.ACTION_ID));
             manager.add(getAction(SendFileAction.ACTION_ID));
             manager.add(getAction(RenameContactAction.ACTION_ID));


### PR DESCRIPTION
This patch fixes #19. The option(s) to invite an offline contact is no
longer possible.