### PR TITLE
[FIX][E] #392 EditorManager may fire duplicate partActivated events

### DIFF
--- a/eclipse/src/saros/editor/EditorManager.java
+++ b/eclipse/src/saros/editor/EditorManager.java
@@ -839,6 +839,15 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
     }
 
     SPath editorPath = EditorAPI.getEditorPath(editorPart);
+
+    if (editorPath.equals(locallyActiveEditor)) {
+      LOG.debug(
+          "ignoring partActivated event for editor path "
+              + editorPath
+              + " because it is already active");
+      return;
+    }
+
     TextSelection selection = EditorAPI.getSelection(editorPart);
 
     // Set (and thus send) in this order:


### PR DESCRIPTION
This patch fixes issue #392.

As it turns out we hook into partBroughtOnTop events. What is going on
is something like:

EditorManager#jumpToUser

For what reason ever when opening / switching to the new editor a
partBroughtOnTop event may be fired containing the current focused
editor. The logic transforms this into an editorActivated event which
gets passed back to the FollowModeManager before the
FollowModeManager#follow method is even finished. The result is that the
FollowModeManager state is changed to not following and after that it
will report that it has start following.

This patch will drop editorActivated events for editors that are
currently the active editor.