### PR TITLE
[INTERNAL][CORE] Removes deprecated method from ISharedEditorListener

### DIFF
--- a/core/src/saros/editor/ISharedEditorListener.java
+++ b/core/src/saros/editor/ISharedEditorListener.java
@@ -35,20 +35,6 @@ public interface ISharedEditorListener {
   }
 
   /**
-   * Fired when the local user starts or stops following a remote user.
-   *
-   * @param target the user who will be or was being followed
-   * @param isFollowed <code>true</code> if following has started, <code>false</code> if it has
-   *     ended
-   * @deprecated Implement {@link IFollowModeListener} instead and register to the {@link
-   *     FollowModeManager}.
-   */
-  @Deprecated
-  public default void followModeChanged(User target, boolean isFollowed) {
-    // NOP
-  }
-
-  /**
    * Fired when a user changes an editor's text content. This should only be treated as an event
    * notification; it should not be assumed that the change has already been applied locally when
    * this method is called.

--- a/core/src/saros/editor/SharedEditorListenerDispatch.java
+++ b/core/src/saros/editor/SharedEditorListenerDispatch.java
@@ -42,12 +42,6 @@ public class SharedEditorListenerDispatch implements ISharedEditorListener {
   }
 
   @Override
-  public void followModeChanged(User target, boolean isFollowed) {
-    for (ISharedEditorListener listener : editorListeners)
-      listener.followModeChanged(target, isFollowed);
-  }
-
-  @Override
   public void textEdited(TextEditActivity textEdit) {
     for (ISharedEditorListener listener : editorListeners) listener.textEdited(textEdit);
   }


### PR DESCRIPTION
Was not used anywhere, nor was the method actually triggered by any
logic.
