### PR TITLE
[INTERNAL][E] Disable Concurrent Undo Feature

### DIFF
--- a/eclipse/src/saros/SarosEclipseContextFactory.java
+++ b/eclipse/src/saros/SarosEclipseContextFactory.java
@@ -10,7 +10,6 @@ import saros.communication.SkypeManager;
 import saros.communication.chat.muc.negotiation.MUCNegotiationManager;
 import saros.communication.connection.IProxyResolver;
 import saros.communication.connection.Socks5ProxyResolver;
-import saros.concurrent.undo.UndoManager;
 import saros.context.AbstractContextFactory;
 import saros.context.IContextKeyBindings;
 import saros.editor.EditorManager;
@@ -66,7 +65,9 @@ public class SarosEclipseContextFactory extends AbstractContextFactory {
       // Core Managers
       Component.create(IEditorManager.class, EditorManager.class),
       Component.create(SessionViewOpener.class),
-      Component.create(UndoManager.class),
+      // disabled, https://github.com/saros-project/saros/issues/60
+      // do not forget to enable the option in the GeneralPreferencePage once it is fixed
+      // Component.create(UndoManager.class),
       Component.create(ISarosSessionContextFactory.class, SarosEclipseSessionContextFactory.class),
 
       // UI handlers

--- a/eclipse/src/saros/ui/preferencePages/GeneralPreferencePage.java
+++ b/eclipse/src/saros/ui/preferencePages/GeneralPreferencePage.java
@@ -93,7 +93,7 @@ public final class GeneralPreferencePage extends FieldEditorPreferencePage
     layoutParent();
     createAccountsGroup();
     createAutomaticConnectField(parent);
-    createConcurrentUndoField(parent);
+    // createConcurrentUndoField(parent);
   }
 
   /*


### PR DESCRIPTION
This feature was disable since Saros Version 14. However it seems that
the patch was not merged back after the release so this patch will
disabled it again so it is not accidently shipped.

Clarification: This feature is BROKEN as HELL, if you turn it on it is likely to freeze the IDE sooner or later.