### PR TITLE
[BUILD] Remove unnecessary config enabling build assertions

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -48,11 +48,6 @@ jar {
   }
 }
 
-
-tasks.withType(Test) {
-  enableAssertions = true
-}
-
 task testJar(type: Jar) {
   classifier = 'tests'
   from sourceSets.test.output

--- a/eclipse/build.gradle
+++ b/eclipse/build.gradle
@@ -66,10 +66,6 @@ dependencies {
   testImplementation configurations.testConfig
 }
 
-tasks.withType(Test) {
-  enableAssertions = true
-}
-
 compileJava.dependsOn rootProject.mavenizeP2Repository
 
 jar {


### PR DESCRIPTION
Removes the gradle config enabling assertions for testing from the core
and eclipse config. These settings are not needed as enabled assertions
is the default behavior.