### PR TITLE
[UI][I] Use IntelliJ UI wrapper classes

### DIFF
--- a/intellij/src/saros/intellij/ui/wizards/Wizard.java
+++ b/intellij/src/saros/intellij/ui/wizards/Wizard.java
@@ -4,10 +4,10 @@ import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
+import com.intellij.util.ui.JBInsets;
 import java.awt.BorderLayout;
 import java.awt.CardLayout;
 import java.awt.Dimension;
-import java.awt.Insets;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -115,7 +115,7 @@ public abstract class Wizard extends JDialog {
 
     getContentPane().add(headerPanel, BorderLayout.NORTH);
 
-    cardPanel.setBorder(new EmptyBorder(new Insets(5, 10, 5, 10)));
+    cardPanel.setBorder(new EmptyBorder(new JBInsets(5, 10, 5, 10)));
     cardPanel.setVisible(true);
 
     getContentPane().add(cardPanel, BorderLayout.CENTER);

--- a/intellij/src/saros/intellij/ui/wizards/pages/NavigationPanel.java
+++ b/intellij/src/saros/intellij/ui/wizards/pages/NavigationPanel.java
@@ -1,7 +1,7 @@
 package saros.intellij.ui.wizards.pages;
 
+import com.intellij.util.ui.JBInsets;
 import java.awt.BorderLayout;
-import java.awt.Insets;
 import java.awt.event.ActionListener;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -46,7 +46,7 @@ public class NavigationPanel extends JPanel {
 
     add(new JSeparator(), BorderLayout.NORTH);
 
-    box.setBorder(new EmptyBorder(new Insets(5, 10, 5, 10)));
+    box.setBorder(new EmptyBorder(new JBInsets(5, 10, 5, 10)));
 
     backButton.setActionCommand(BACK_ACTION);
     box.add(backButton);

--- a/intellij/src/saros/intellij/ui/wizards/pages/TextAreaPage.java
+++ b/intellij/src/saros/intellij/ui/wizards/pages/TextAreaPage.java
@@ -1,5 +1,6 @@
 package saros.intellij.ui.wizards.pages;
 
+import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBScrollPane;
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -17,7 +18,7 @@ import javax.swing.text.DefaultEditorKit;
 public class TextAreaPage extends AbstractWizardPage {
   private JTextArea display;
   private String title = "";
-  private Color fontColor = Color.BLACK;
+  private Color fontColor = JBColor.BLACK;
 
   /**
    * Constructor with custom ID


### PR DESCRIPTION
Replaces the direct usage of UI classes with the matching wrappers
provided by IntelliJ.

This was solely done by following the IntelliJ suggestions.

This solves an open issue where the text color of the dialog showing
which files of the existing module have to be adjusted to use it for an
incoming project negotiation was not adjusted correctly when using
different IDE themes. This logic is automatically provided by the
IntelliJ color class wrapper.