### PR TITLE
[INTERNAL][CORE] Moves logic from DTM to XMPPTransmitter and XMPPReceiver

### DIFF
--- a/core/src/saros/net/IConnectionManager.java
+++ b/core/src/saros/net/IConnectionManager.java
@@ -27,9 +27,9 @@ public interface IConnectionManager {
 
   /** @deprecated */
   @Deprecated
-  public void connect(JID peer) throws IOException;
+  public IByteStreamConnection connect(JID peer) throws IOException;
 
-  public void connect(String connectionID, JID peer) throws IOException;
+  public IByteStreamConnection connect(String connectionID, JID peer) throws IOException;
 
   /**
    * @deprecated Disconnects {@link IByteStreamConnection} with the specified peer

--- a/core/src/saros/net/IConnectionManager.java
+++ b/core/src/saros/net/IConnectionManager.java
@@ -21,10 +21,6 @@ public interface IConnectionManager {
    */
   public void setServices(int serviceMask);
 
-  public void addTransferListener(ITransferListener listener);
-
-  public void removeTransferListener(ITransferListener listener);
-
   /** @deprecated */
   @Deprecated
   public IByteStreamConnection connect(JID peer) throws IOException;

--- a/core/src/saros/net/IPacketInterceptor.java
+++ b/core/src/saros/net/IPacketInterceptor.java
@@ -1,17 +1,16 @@
 package saros.net;
 
 import saros.net.internal.BinaryXMPPExtension;
-import saros.net.internal.DataTransferManager;
 import saros.net.internal.TransferDescription;
 
 /**
  * An interface for intercepting packages that are about to send or dispatched via the {@link
- * DataTransferManager}
+ * ITransmitter} and {@link IReceiver}
  */
 public interface IPacketInterceptor {
 
   /**
-   * This method is called before the {@link DataTransferManager} is dispatching the packet.
+   * This method is called before the {@link IReceiver} is dispatching the packet.
    *
    * @param extension
    * @return <code>true</code> if the packet should be dispatched, <code>false</code> if the packet
@@ -20,7 +19,7 @@ public interface IPacketInterceptor {
   public boolean receivedPacket(BinaryXMPPExtension extension);
 
   /**
-   * This method is called before the {@link DataTransferManager} is sending the packet.
+   * This method is called before the {@link ITransmitter} is sending the packet.
    *
    * @param connectID
    * @param description

--- a/core/src/saros/net/IReceiver.java
+++ b/core/src/saros/net/IReceiver.java
@@ -3,7 +3,6 @@ package saros.net;
 import org.jivesoftware.smack.PacketListener;
 import org.jivesoftware.smack.filter.PacketFilter;
 import org.jivesoftware.smack.packet.Packet;
-import saros.net.internal.BinaryXMPPExtension;
 
 public interface IReceiver {
 
@@ -51,9 +50,6 @@ public interface IReceiver {
    * @see PacketCollector#cancel()
    */
   public PacketCollector createCollector(PacketFilter filter);
-
-  /** FOR INTERNAL USE */
-  public void processBinaryXMPPExtension(BinaryXMPPExtension extension);
 
   public default void addTransferListener(ITransferListener listener) {
     // NOP

--- a/core/src/saros/net/IReceiver.java
+++ b/core/src/saros/net/IReceiver.java
@@ -54,4 +54,20 @@ public interface IReceiver {
 
   /** FOR INTERNAL USE */
   public void processBinaryXMPPExtension(BinaryXMPPExtension extension);
+
+  public default void addTransferListener(ITransferListener listener) {
+    // NOP
+  }
+
+  public default void removeTransferListener(ITransferListener listener) {
+    // NOP
+  }
+
+  public default void addPacketInterceptor(IPacketInterceptor interceptor) {
+    // NOP
+  }
+
+  public default void removePacketInterceptor(IPacketInterceptor interceptor) {
+    // NOP
+  }
 }

--- a/core/src/saros/net/ITransmitter.java
+++ b/core/src/saros/net/ITransmitter.java
@@ -73,4 +73,20 @@ public interface ITransmitter {
    */
   public void send(String connectionID, JID recipient, PacketExtension extension)
       throws IOException;
+
+  public default void addTransferListener(ITransferListener listener) {
+    // NOP
+  }
+
+  public default void removeTransferListener(ITransferListener listener) {
+    // NOP
+  }
+
+  public default void addPacketInterceptor(IPacketInterceptor interceptor) {
+    // NOP
+  }
+
+  public default void removePacketInterceptor(IPacketInterceptor interceptor) {
+    // NOP
+  }
 }

--- a/core/src/saros/net/internal/BinaryChannelConnection.java
+++ b/core/src/saros/net/internal/BinaryChannelConnection.java
@@ -90,7 +90,10 @@ public class BinaryChannelConnection implements IByteStreamConnection {
 
       LOG.debug(connection + " ReceiverThread started.");
       try {
-        while (!isInterrupted()) listener.receive(readNextXMPPExtension());
+        while (!isInterrupted()) {
+          final BinaryXMPPExtension extension = readNextXMPPExtension();
+          if (receiver != null) receiver.receive(extension);
+        }
 
       } catch (SocketException e) {
         LOG.debug(connection + " connection closed locally: " + e.getMessage());
@@ -105,6 +108,8 @@ public class BinaryChannelConnection implements IByteStreamConnection {
       }
     }
   }
+
+  private IBinaryXMPPExtensionReceiver receiver;
 
   public BinaryChannelConnection(
       JID localAddress,
@@ -124,6 +129,13 @@ public class BinaryChannelConnection implements IByteStreamConnection {
 
     outputStream = new DataOutputStream(new BufferedOutputStream(stream.getOutputStream()));
     inputStream = new DataInputStream(new BufferedInputStream(stream.getInputStream()));
+  }
+
+  @Override
+  public void setBinaryXMPPExtensionReceiver(IBinaryXMPPExtensionReceiver receiver) {
+    if (this.receiver != null || receiver == null) return;
+
+    this.receiver = receiver;
   }
 
   @Override

--- a/core/src/saros/net/internal/DataTransferManager.java
+++ b/core/src/saros/net/internal/DataTransferManager.java
@@ -1,6 +1,5 @@
 package saros.net.internal;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.util.ArrayList;
@@ -12,8 +11,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.zip.DataFormatException;
-import java.util.zip.Inflater;
 import org.apache.log4j.Logger;
 import org.jivesoftware.smack.Connection;
 import saros.annotations.Component;
@@ -21,9 +18,6 @@ import saros.context.IContextKeyBindings.IBBStreamService;
 import saros.context.IContextKeyBindings.Socks5StreamService;
 import saros.net.ConnectionState;
 import saros.net.IConnectionManager;
-import saros.net.IPacketInterceptor;
-import saros.net.IReceiver;
-import saros.net.ITransferListener;
 import saros.net.stream.IStreamService;
 import saros.net.stream.StreamMode;
 import saros.net.xmpp.IConnectionListener;
@@ -44,27 +38,17 @@ public class DataTransferManager implements IConnectionListener, IConnectionMana
 
   private static final Logger LOG = Logger.getLogger(DataTransferManager.class);
 
-  private static final int CHUNKSIZE = 16 * 1024;
-
   private static final String DEFAULT_CONNECTION_ID = "default";
 
   private static final String IN = "in";
 
   private static final String OUT = "out";
 
-  private final CopyOnWriteArrayList<IPacketInterceptor> packetInterceptors =
-      new CopyOnWriteArrayList<IPacketInterceptor>();
-
-  private final List<ITransferListener> transferListeners =
-      new CopyOnWriteArrayList<ITransferListener>();
-
   private volatile JID currentLocalJID;
 
   private Connection xmppConnection;
 
   private int serviceMask = -1;
-
-  private final IReceiver receiver;
 
   private final IStreamService mainService;
 
@@ -78,57 +62,15 @@ public class DataTransferManager implements IConnectionListener, IConnectionMana
 
   private final List<IStreamService> streamServices = new CopyOnWriteArrayList<IStreamService>();
 
+  private final CopyOnWriteArrayList<IByteStreamConnectionListener> connectionListeners =
+      new CopyOnWriteArrayList<>();
+
   private final IByteStreamConnectionListener byteStreamConnectionListener =
       new IByteStreamConnectionListener() {
 
         @Override
-        public void receive(final BinaryXMPPExtension extension) {
-
-          boolean dispatchPacket = true;
-
-          for (IPacketInterceptor packetInterceptor : packetInterceptors)
-            dispatchPacket &= packetInterceptor.receivedPacket(extension);
-
-          if (!dispatchPacket) return;
-
-          if (LOG.isTraceEnabled())
-            LOG.trace(
-                "received binary XMPP extension: "
-                    + extension.getTransferDescription()
-                    + ", size: "
-                    + extension.getCompressedSize()
-                    + ", RX time: "
-                    + extension.getTransferDuration()
-                    + " ms ["
-                    + extension.getTransferMode()
-                    + "]");
-
-          if (extension.getTransferDescription().compressContent()) {
-            byte[] payload = extension.getPayload();
-            long compressedPayloadLength = payload.length;
-
-            try {
-              payload = inflate(payload);
-            } catch (IOException e) {
-              LOG.error("could not decompress extension payload", e);
-              return;
-            }
-
-            extension.setPayload(compressedPayloadLength, payload);
-          }
-
-          notifyDataReceived(
-              extension.getTransferMode(),
-              extension.getCompressedSize(),
-              extension.getUncompressedSize(),
-              extension.getTransferDuration());
-
-          receiver.processBinaryXMPPExtension(extension);
-        }
-
-        @Override
         public void connectionChanged(
-            final String connectionID,
+            final String connectionId,
             final IByteStreamConnection connection,
             final boolean incomingRequest) {
 
@@ -137,7 +79,12 @@ public class DataTransferManager implements IConnectionListener, IConnectionMana
 
           final String id =
               toConnectionIDToken(
-                  connectionID, incomingRequest ? IN : OUT, connection.getRemoteAddress());
+                  connectionId, incomingRequest ? IN : OUT, connection.getRemoteAddress());
+
+          /// TODO we currently have to announce not initialized connections otherwise the IReceiver
+          // will miss updates
+
+          notfiyconnectionChanged(id, connection, incomingRequest);
 
           LOG.debug(
               "bytestream connection changed "
@@ -180,33 +127,23 @@ public class DataTransferManager implements IConnectionListener, IConnectionMana
         }
 
         @Override
-        public void connectionClosed(String connectionID, IByteStreamConnection connection) {
-          closeConnection(connectionID, connection.getRemoteAddress());
+        public void connectionClosed(
+            final String connectionId, final IByteStreamConnection connection) {
+          closeConnection(connectionId, connection.getRemoteAddress());
+          notfiyConnectionClosed(connectionId, connection);
         }
       };
 
   public DataTransferManager(
       XMPPConnectionService connectionService,
-      IReceiver receiver,
       @Nullable @Socks5StreamService IStreamService mainService,
       @Nullable @IBBStreamService IStreamService fallbackService) {
 
-    this.receiver = receiver;
     this.fallbackService = fallbackService;
     this.mainService = mainService;
     this.setStreamServices();
 
     connectionService.addListener(this);
-  }
-
-  @Override
-  public void addTransferListener(ITransferListener listener) {
-    transferListeners.add(listener);
-  }
-
-  @Override
-  public void removeTransferListener(ITransferListener listener) {
-    transferListeners.remove(listener);
   }
 
   /** @deprecated */
@@ -287,6 +224,14 @@ public class DataTransferManager implements IConnectionListener, IConnectionMana
   public StreamMode getTransferMode(String connectionID, JID jid) {
     IByteStreamConnection connection = getCurrentConnection(connectionID, jid);
     return connection == null ? StreamMode.NONE : connection.getMode();
+  }
+
+  public void addConnectionListener(final IByteStreamConnectionListener listener) {
+    connectionListeners.addIfAbsent(listener);
+  }
+
+  public void removeConnectionListener(final IByteStreamConnectionListener listener) {
+    connectionListeners.remove(listener);
   }
 
   private IByteStreamConnection connectInternal(String connectionID, JID peer) throws IOException {
@@ -433,27 +378,6 @@ public class DataTransferManager implements IConnectionListener, IConnectionMana
     else if (this.xmppConnection != null) disposeConnection();
   }
 
-  // TODO: move to ITransmitter
-  public void addPacketInterceptor(IPacketInterceptor interceptor) {
-    packetInterceptors.addIfAbsent(interceptor);
-  }
-
-  // TODO: move to IReceiver
-  public void removePacketInterceptor(IPacketInterceptor interceptor) {
-    packetInterceptors.remove(interceptor);
-  }
-
-  /**
-   * Left over and <b>MUST</b> only used by the STF
-   *
-   * @param extension
-   * @deprecated
-   */
-  @Deprecated
-  public void addIncomingTransferObject(BinaryXMPPExtension extension) {
-    byteStreamConnectionListener.receive(extension);
-  }
-
   /**
    * Returns the current connection for the remote side. If the local side is connected to the
    * remote side as well as the remote side is connected to the local side the local to remote
@@ -482,39 +406,29 @@ public class DataTransferManager implements IConnectionListener, IConnectionMana
     return connectionIdentifier + ":" + mode + ":" + jid.toString();
   }
 
-  private void notifyDataReceived(
-      final StreamMode mode,
-      final long sizeCompressed,
-      final long sizeUncompressed,
-      final long duration) {
+  private void notfiyConnectionClosed(
+      final String connectionId, final IByteStreamConnection connection) {
 
-    for (final ITransferListener listener : transferListeners) {
+    for (final IByteStreamConnectionListener listener : connectionListeners) {
       try {
-        listener.received(mode, sizeCompressed, sizeUncompressed, duration);
+        listener.connectionClosed(connectionId, connection);
       } catch (RuntimeException e) {
-        LOG.error("invoking received() on listener: " + listener + " failed", e);
+        LOG.error("invoking connectionClosed() on listener: " + listener + " failed", e);
       }
     }
   }
 
-  private static byte[] inflate(byte[] input) throws IOException {
+  private void notfiyconnectionChanged(
+      final String connectionId,
+      final IByteStreamConnection connection,
+      final boolean incomingRequest) {
 
-    ByteArrayOutputStream bos;
-    Inflater decompressor = new Inflater();
-
-    decompressor.setInput(input, 0, input.length);
-    bos = new ByteArrayOutputStream(input.length);
-
-    byte[] buf = new byte[CHUNKSIZE];
-
-    try {
-      while (!decompressor.finished()) {
-        int count = decompressor.inflate(buf);
-        bos.write(buf, 0, count);
+    for (final IByteStreamConnectionListener listener : connectionListeners) {
+      try {
+        listener.connectionChanged(connectionId, connection, incomingRequest);
+      } catch (RuntimeException e) {
+        LOG.error("invoking connectionChanged() on listener: " + listener + " failed", e);
       }
-      return bos.toByteArray();
-    } catch (DataFormatException e) {
-      throw new IOException("failed to inflate data", e);
     }
   }
 }

--- a/core/src/saros/net/internal/IBinaryXMPPExtensionReceiver.java
+++ b/core/src/saros/net/internal/IBinaryXMPPExtensionReceiver.java
@@ -1,0 +1,11 @@
+package saros.net.internal;
+
+public interface IBinaryXMPPExtensionReceiver {
+
+  /**
+   * Gets called when a {@linkplain BinaryXMPPExtension} was received.
+   *
+   * @param extension
+   */
+  public void receive(final BinaryXMPPExtension extension);
+}

--- a/core/src/saros/net/internal/IByteStreamConnection.java
+++ b/core/src/saros/net/internal/IByteStreamConnection.java
@@ -37,4 +37,6 @@ public interface IByteStreamConnection {
   public String getConnectionID();
 
   public StreamMode getMode();
+
+  public void setBinaryXMPPExtensionReceiver(IBinaryXMPPExtensionReceiver receiver);
 }

--- a/core/src/saros/net/internal/IByteStreamConnectionListener.java
+++ b/core/src/saros/net/internal/IByteStreamConnectionListener.java
@@ -3,19 +3,12 @@ package saros.net.internal;
 /**
  * Listener interface used by IStreamService and IBytestreamConnection to notify about established
  * or changed connections and incoming XMPP extensions.
- *
- * @author jurke
  */
 public interface IByteStreamConnectionListener {
 
-  /**
-   * Gets called when a {@linkplain BinaryXMPPExtension} was received.
-   *
-   * @param extension
-   */
-  public void receive(final BinaryXMPPExtension extension);
-
-  public void connectionClosed(String connectionID, IByteStreamConnection connection);
+  public default void connectionClosed(String connectionID, IByteStreamConnection connection) {
+    // NOP;
+  }
 
   /**
    * Gets called when a connection change is detected. The {@linkplain IByteStreamConnection
@@ -27,6 +20,8 @@ public interface IByteStreamConnectionListener {
    * @param incomingRequest <code>true</code> if the connection was a result of a remote connect
    *     request, <code>false</code> if the connect request was initiated on the local side
    */
-  public void connectionChanged(
-      String connectionID, IByteStreamConnection connection, boolean incomingRequest);
+  public default void connectionChanged(
+      String connectionID, IByteStreamConnection connection, boolean incomingRequest) {
+    // NOP;
+  }
 }

--- a/core/src/saros/net/internal/XMPPReceiver.java
+++ b/core/src/saros/net/internal/XMPPReceiver.java
@@ -1,10 +1,15 @@
 package saros.net.internal;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.zip.DataFormatException;
+import java.util.zip.Inflater;
 import org.apache.log4j.Logger;
 import org.jivesoftware.smack.Connection;
 import org.jivesoftware.smack.PacketListener;
@@ -19,21 +24,32 @@ import org.xmlpull.v1.XmlPullParser;
 import saros.annotations.Component;
 import saros.net.ConnectionState;
 import saros.net.DispatchThreadContext;
+import saros.net.IPacketInterceptor;
 import saros.net.IReceiver;
+import saros.net.ITransferListener;
 import saros.net.PacketCollector;
 import saros.net.PacketCollector.CancelHook;
+import saros.net.stream.StreamMode;
 import saros.net.xmpp.IConnectionListener;
 import saros.net.xmpp.XMPPConnectionService;
 
 @Component(module = "net")
-public class XMPPReceiver implements IReceiver {
+public class XMPPReceiver implements IReceiver, IBinaryXMPPExtensionReceiver {
 
   private static final Logger LOG = Logger.getLogger(XMPPReceiver.class);
 
+  private static final int CHUNKSIZE = 16 * 1024;
+
   private final DispatchThreadContext dispatchThreadContext;
 
-  private Map<PacketListener, PacketFilter> listeners =
+  private final Map<PacketListener, PacketFilter> listeners =
       Collections.synchronizedMap(new HashMap<PacketListener, PacketFilter>());
+
+  private final CopyOnWriteArrayList<ITransferListener> transferListeners =
+      new CopyOnWriteArrayList<>();
+
+  private final CopyOnWriteArrayList<IPacketInterceptor> packetInterceptors =
+      new CopyOnWriteArrayList<>();
 
   private XmlPullParser parser;
 
@@ -65,12 +81,24 @@ public class XMPPReceiver implements IReceiver {
       };
 
   public XMPPReceiver(
-      DispatchThreadContext dispatchThreadContext, XMPPConnectionService connectionService) {
+      DispatchThreadContext dispatchThreadContext,
+      XMPPConnectionService connectionService,
+      DataTransferManager dataTransferManager) {
 
     this.dispatchThreadContext = dispatchThreadContext;
     this.parser = new MXParser();
 
     connectionService.addListener(connectionListener);
+    dataTransferManager.addConnectionListener(
+        new IByteStreamConnectionListener() {
+          @Override
+          public void connectionChanged(
+              final String connectionId,
+              final IByteStreamConnection connection,
+              final boolean incomingRequest) {
+            connection.setBinaryXMPPExtensionReceiver(XMPPReceiver.this);
+          }
+        });
   }
 
   @Override
@@ -81,6 +109,26 @@ public class XMPPReceiver implements IReceiver {
   @Override
   public void removePacketListener(PacketListener listener) {
     listeners.remove(listener);
+  }
+
+  @Override
+  public void addTransferListener(final ITransferListener listener) {
+    transferListeners.addIfAbsent(listener);
+  }
+
+  @Override
+  public void removeTransferListener(final ITransferListener listener) {
+    transferListeners.remove(listener);
+  }
+
+  @Override
+  public void addPacketInterceptor(final IPacketInterceptor interceptor) {
+    packetInterceptors.addIfAbsent(interceptor);
+  }
+
+  @Override
+  public void removePacketInterceptor(final IPacketInterceptor interceptor) {
+    packetInterceptors.remove(interceptor);
   }
 
   @Override
@@ -111,8 +159,7 @@ public class XMPPReceiver implements IReceiver {
   }
 
   @Override
-  public void processBinaryXMPPExtension(final BinaryXMPPExtension extension) {
-
+  public void receive(BinaryXMPPExtension extension) {
     dispatchThreadContext.executeAsDispatch(
         new Runnable() {
 
@@ -154,9 +201,48 @@ public class XMPPReceiver implements IReceiver {
    * <p>This method is <b>not</b> thread safe and <b>must not</b> accessed by multiple threads
    * concurrently.
    */
-  private Packet convertBinaryXMPPExtension(BinaryXMPPExtension transferObject) {
+  private Packet convertBinaryXMPPExtension(BinaryXMPPExtension extension) {
 
-    TransferDescription description = transferObject.getTransferDescription();
+    boolean dispatchPacket = true;
+
+    for (IPacketInterceptor packetInterceptor : packetInterceptors)
+      dispatchPacket &= packetInterceptor.receivedPacket(extension);
+
+    if (!dispatchPacket) return null;
+
+    if (LOG.isTraceEnabled())
+      LOG.trace(
+          "received binary XMPP extension: "
+              + extension.getTransferDescription()
+              + ", size: "
+              + extension.getCompressedSize()
+              + ", RX time: "
+              + extension.getTransferDuration()
+              + " ms ["
+              + extension.getTransferMode()
+              + "]");
+
+    if (extension.getTransferDescription().compressContent()) {
+      byte[] payload = extension.getPayload();
+      long compressedPayloadLength = payload.length;
+
+      try {
+        payload = inflate(payload);
+      } catch (IOException e) {
+        LOG.error("could not decompress extension payload", e);
+        return null;
+      }
+
+      extension.setPayload(compressedPayloadLength, payload);
+    }
+
+    notifyDataReceived(
+        extension.getTransferMode(),
+        extension.getCompressedSize(),
+        extension.getUncompressedSize(),
+        extension.getTransferDuration());
+
+    TransferDescription description = extension.getTransferDescription();
 
     String name = description.getElementName();
     String namespace = description.getNamespace();
@@ -176,16 +262,16 @@ public class XMPPReceiver implements IReceiver {
       return null;
     }
 
-    PacketExtension extension = null;
+    PacketExtension packetExtension = null;
 
     try {
-      parser.setInput(new ByteArrayInputStream(transferObject.getPayload()), "UTF-8");
+      parser.setInput(new ByteArrayInputStream(extension.getPayload()), "UTF-8");
       /*
        * We have to skip the empty start tag because Smack expects a
        * parser that already has started parsing.
        */
       parser.next();
-      extension = provider.parseExtension(parser);
+      packetExtension = provider.parseExtension(parser);
     } catch (Exception e) {
       LOG.error("could not deserialize transfer object payload: " + e.getMessage(), e);
 
@@ -198,8 +284,44 @@ public class XMPPReceiver implements IReceiver {
     packet.setPacketID(Packet.ID_NOT_AVAILABLE);
     packet.setFrom(description.getSender().toString());
     packet.setTo(description.getRecipient().toString());
-    packet.addExtension(extension);
+    packet.addExtension(packetExtension);
 
     return packet;
+  }
+
+  private void notifyDataReceived(
+      final StreamMode mode,
+      final long sizeCompressed,
+      final long sizeUncompressed,
+      final long duration) {
+
+    for (final ITransferListener listener : transferListeners) {
+      try {
+        listener.received(mode, sizeCompressed, sizeUncompressed, duration);
+      } catch (RuntimeException e) {
+        LOG.error("invoking received() on listener: " + listener + " failed", e);
+      }
+    }
+  }
+
+  private static byte[] inflate(byte[] input) throws IOException {
+
+    ByteArrayOutputStream bos;
+    Inflater decompressor = new Inflater();
+
+    decompressor.setInput(input, 0, input.length);
+    bos = new ByteArrayOutputStream(input.length);
+
+    byte[] buf = new byte[CHUNKSIZE];
+
+    try {
+      while (!decompressor.finished()) {
+        int count = decompressor.inflate(buf);
+        bos.write(buf, 0, count);
+      }
+      return bos.toByteArray();
+    } catch (DataFormatException e) {
+      throw new IOException("failed to inflate data", e);
+    }
   }
 }

--- a/core/test/junit/saros/net/internal/BinaryChannelConnectionTest.java
+++ b/core/test/junit/saros/net/internal/BinaryChannelConnectionTest.java
@@ -62,7 +62,7 @@ public class BinaryChannelConnectionTest {
     }
   }
 
-  private abstract static class StreamConnectionListener implements IByteStreamConnectionListener {
+  private static class StreamConnectionListener implements IByteStreamConnectionListener {
 
     @Override
     public void connectionClosed(String connectionIdentifier, IByteStreamConnection connection) {
@@ -75,9 +75,6 @@ public class BinaryChannelConnectionTest {
         String connectionIdentifier, IByteStreamConnection connection, boolean incomingRequest) {
       // NOP
     }
-
-    @Override
-    public abstract void receive(BinaryXMPPExtension extension);
   }
 
   private final JID aliceJID = new JID("alice@baumeister.de");
@@ -118,12 +115,7 @@ public class BinaryChannelConnectionTest {
             "junit",
             aliceStream,
             StreamMode.SOCKS5_DIRECT,
-            new StreamConnectionListener() {
-              @Override
-              public void receive(final BinaryXMPPExtension extension) {
-                // NOP
-              }
-            });
+            new StreamConnectionListener());
 
     BinaryChannelConnection bob =
         new BinaryChannelConnection(
@@ -132,13 +124,13 @@ public class BinaryChannelConnectionTest {
             "junit",
             bobStream,
             StreamMode.SOCKS5_DIRECT,
-            new StreamConnectionListener() {
-              @Override
-              public void receive(final BinaryXMPPExtension extension) {
-                extensions.add(extension);
-                received.countDown();
-              }
-            });
+            new StreamConnectionListener());
+
+    bob.setBinaryXMPPExtensionReceiver(
+        (e) -> {
+          extensions.add(e);
+          received.countDown();
+        });
 
     alice.initialize();
     bob.initialize();
@@ -199,12 +191,7 @@ public class BinaryChannelConnectionTest {
             "junit",
             aliceStream,
             StreamMode.SOCKS5_DIRECT,
-            new StreamConnectionListener() {
-              @Override
-              public void receive(final BinaryXMPPExtension extension) {
-                // NOP
-              }
-            });
+            new StreamConnectionListener());
 
     BinaryChannelConnection bob =
         new BinaryChannelConnection(
@@ -213,13 +200,13 @@ public class BinaryChannelConnectionTest {
             "junit",
             bobStream,
             StreamMode.SOCKS5_DIRECT,
-            new StreamConnectionListener() {
-              @Override
-              public void receive(final BinaryXMPPExtension extension) {
-                receivedBytes = extension.getPayload();
-                received.countDown();
-              }
-            });
+            new StreamConnectionListener());
+
+    bob.setBinaryXMPPExtensionReceiver(
+        (e) -> {
+          receivedBytes = e.getPayload();
+          received.countDown();
+        });
 
     alice.initialize();
     bob.initialize();
@@ -269,12 +256,7 @@ public class BinaryChannelConnectionTest {
             "junit",
             aliceStream,
             StreamMode.SOCKS5_DIRECT,
-            new StreamConnectionListener() {
-              @Override
-              public void receive(final BinaryXMPPExtension extension) {
-                // NOP
-              }
-            });
+            new StreamConnectionListener());
 
     BinaryChannelConnection bob =
         new BinaryChannelConnection(
@@ -283,14 +265,13 @@ public class BinaryChannelConnectionTest {
             "junit",
             bobStream,
             StreamMode.SOCKS5_DIRECT,
-            new StreamConnectionListener() {
-              @Override
-              public void receive(final BinaryXMPPExtension extension) {
-                receivedBytes = extension.getPayload();
-                received.countDown();
-              }
-            });
+            new StreamConnectionListener());
 
+    bob.setBinaryXMPPExtensionReceiver(
+        (e) -> {
+          receivedBytes = e.getPayload();
+          received.countDown();
+        });
     alice.initialize();
     bob.initialize();
 

--- a/core/test/junit/saros/net/internal/DataTransferManagerTest.java
+++ b/core/test/junit/saros/net/internal/DataTransferManagerTest.java
@@ -172,6 +172,11 @@ public class DataTransferManagerTest {
     public void initialize() {
       // NOP
     }
+
+    @Override
+    public void setBinaryXMPPExtensionReceiver(IBinaryXMPPExtensionReceiver receiver) {
+      // NOP
+    }
   }
 
   private XMPPConnectionService connectionServiceStub;
@@ -205,7 +210,7 @@ public class DataTransferManagerTest {
   @Test(expected = NullPointerException.class)
   public void testEstablishConnectionWithNullPeer() throws Exception {
 
-    IConnectionManager dtm = new DataTransferManager(connectionServiceStub, null, null, null);
+    IConnectionManager dtm = new DataTransferManager(connectionServiceStub, null, null);
 
     connectionListener.getValue().connectionStateChanged(connectionMock, ConnectionState.CONNECTED);
 
@@ -215,7 +220,7 @@ public class DataTransferManagerTest {
   @Test(expected = NullPointerException.class)
   public void testEstablishConnectionWithNullConnectionID() throws Exception {
 
-    IConnectionManager dtm = new DataTransferManager(connectionServiceStub, null, null, null);
+    IConnectionManager dtm = new DataTransferManager(connectionServiceStub, null, null);
 
     connectionListener.getValue().connectionStateChanged(connectionMock, ConnectionState.CONNECTED);
 
@@ -225,7 +230,7 @@ public class DataTransferManagerTest {
   @Test(expected = IOException.class)
   public void testEstablishConnectionWithNoTransports() throws Exception {
 
-    IConnectionManager dtm = new DataTransferManager(connectionServiceStub, null, null, null);
+    IConnectionManager dtm = new DataTransferManager(connectionServiceStub, null, null);
 
     connectionListener.getValue().connectionStateChanged(connectionMock, ConnectionState.CONNECTED);
 
@@ -239,7 +244,7 @@ public class DataTransferManagerTest {
     IStreamService fallbackTransport = new Transport(StreamMode.IBB);
 
     IConnectionManager dtm =
-        new DataTransferManager(connectionServiceStub, null, mainTransport, fallbackTransport);
+        new DataTransferManager(connectionServiceStub, mainTransport, fallbackTransport);
 
     connectionListener.getValue().connectionStateChanged(connectionMock, ConnectionState.CONNECTED);
 
@@ -267,7 +272,7 @@ public class DataTransferManagerTest {
     EasyMock.replay(mainTransport);
 
     IConnectionManager dtm =
-        new DataTransferManager(connectionServiceStub, null, mainTransport, fallbackTransport);
+        new DataTransferManager(connectionServiceStub, mainTransport, fallbackTransport);
 
     connectionListener.getValue().connectionStateChanged(connectionMock, ConnectionState.CONNECTED);
 
@@ -286,7 +291,7 @@ public class DataTransferManagerTest {
     IStreamService fallbackTransport = new Transport(StreamMode.IBB);
 
     DataTransferManager dtm =
-        new DataTransferManager(connectionServiceStub, null, mainTransport, fallbackTransport);
+        new DataTransferManager(connectionServiceStub, mainTransport, fallbackTransport);
 
     dtm.setServices(IConnectionManager.IBB_SERVICE);
 
@@ -305,8 +310,7 @@ public class DataTransferManagerTest {
 
     Transport mainTransport = new Transport(StreamMode.SOCKS5_DIRECT);
 
-    IConnectionManager dtm =
-        new DataTransferManager(connectionServiceStub, null, mainTransport, null);
+    IConnectionManager dtm = new DataTransferManager(connectionServiceStub, mainTransport, null);
 
     connectionListener.getValue().connectionStateChanged(connectionMock, ConnectionState.CONNECTED);
 
@@ -326,8 +330,7 @@ public class DataTransferManagerTest {
   public void testGetTransferMode() throws Exception {
     IStreamService mainTransport = new Transport(StreamMode.SOCKS5_DIRECT);
 
-    IConnectionManager dtm =
-        new DataTransferManager(connectionServiceStub, null, mainTransport, null);
+    IConnectionManager dtm = new DataTransferManager(connectionServiceStub, mainTransport, null);
 
     connectionListener.getValue().connectionStateChanged(connectionMock, ConnectionState.CONNECTED);
 
@@ -347,8 +350,7 @@ public class DataTransferManagerTest {
   public void testGetConnectionOnInvalidConnectionIdentifierWithNoConnection() throws Exception {
     IStreamService mainTransport = new Transport(StreamMode.SOCKS5_DIRECT);
 
-    DataTransferManager dtm =
-        new DataTransferManager(connectionServiceStub, null, mainTransport, null);
+    DataTransferManager dtm = new DataTransferManager(connectionServiceStub, mainTransport, null);
 
     connectionListener.getValue().connectionStateChanged(connectionMock, ConnectionState.CONNECTED);
 
@@ -360,8 +362,7 @@ public class DataTransferManagerTest {
   public void testGetConnectionOnInvalidConnectionIdentifier() throws Exception {
     IStreamService mainTransport = new Transport(StreamMode.SOCKS5_DIRECT);
 
-    DataTransferManager dtm =
-        new DataTransferManager(connectionServiceStub, null, mainTransport, null);
+    DataTransferManager dtm = new DataTransferManager(connectionServiceStub, mainTransport, null);
 
     connectionListener.getValue().connectionStateChanged(connectionMock, ConnectionState.CONNECTED);
 
@@ -373,8 +374,7 @@ public class DataTransferManagerTest {
   public void testGetConnectionOnValidConnectionIdentifier() throws Exception {
     Transport mainTransport = new Transport(StreamMode.SOCKS5_DIRECT);
 
-    DataTransferManager dtm =
-        new DataTransferManager(connectionServiceStub, null, mainTransport, null);
+    DataTransferManager dtm = new DataTransferManager(connectionServiceStub, mainTransport, null);
 
     connectionListener.getValue().connectionStateChanged(connectionMock, ConnectionState.CONNECTED);
 
@@ -400,7 +400,7 @@ public class DataTransferManagerTest {
     Transport fallbackTransport = new Transport(StreamMode.IBB);
 
     final IConnectionManager dtm =
-        new DataTransferManager(connectionServiceStub, null, mainTransport, fallbackTransport);
+        new DataTransferManager(connectionServiceStub, mainTransport, fallbackTransport);
 
     connectionListener.getValue().connectionStateChanged(connectionMock, ConnectionState.CONNECTED);
 
@@ -487,8 +487,7 @@ public class DataTransferManagerTest {
   public void connectWithRemoteSideConnectedFirst() throws Exception {
     Transport mainTransport = new Transport(StreamMode.SOCKS5_DIRECT);
 
-    IConnectionManager dtm =
-        new DataTransferManager(connectionServiceStub, null, mainTransport, null);
+    IConnectionManager dtm = new DataTransferManager(connectionServiceStub, mainTransport, null);
 
     connectionListener.getValue().connectionStateChanged(connectionMock, ConnectionState.CONNECTED);
 
@@ -514,7 +513,7 @@ public class DataTransferManagerTest {
     Transport fallbackTransport = new Transport(StreamMode.IBB);
 
     final DataTransferManager dtm =
-        new DataTransferManager(connectionServiceStub, null, mainTransport, fallbackTransport);
+        new DataTransferManager(connectionServiceStub, mainTransport, fallbackTransport);
 
     connectionListener.getValue().connectionStateChanged(connectionMock, ConnectionState.CONNECTED);
 
@@ -561,8 +560,7 @@ public class DataTransferManagerTest {
   public void testConnectionClosureOnManualClose() throws Exception {
     Transport mainTransport = new Transport(StreamMode.SOCKS5_DIRECT);
 
-    IConnectionManager dtm =
-        new DataTransferManager(connectionServiceStub, null, mainTransport, null);
+    IConnectionManager dtm = new DataTransferManager(connectionServiceStub, mainTransport, null);
 
     connectionListener.getValue().connectionStateChanged(connectionMock, ConnectionState.CONNECTED);
 
@@ -586,8 +584,7 @@ public class DataTransferManagerTest {
   public void testConnectionClosureOnDisconnect() throws Exception {
     Transport mainTransport = new Transport(StreamMode.SOCKS5_DIRECT);
 
-    IConnectionManager dtm =
-        new DataTransferManager(connectionServiceStub, null, mainTransport, null);
+    IConnectionManager dtm = new DataTransferManager(connectionServiceStub, mainTransport, null);
 
     connectionListener.getValue().connectionStateChanged(connectionMock, ConnectionState.CONNECTED);
 

--- a/core/test/junit/saros/net/internal/DataTransferManagerTest.java
+++ b/core/test/junit/saros/net/internal/DataTransferManagerTest.java
@@ -2,7 +2,9 @@ package saros.net.internal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -342,8 +344,7 @@ public class DataTransferManagerTest {
         dtm.getTransferMode(new JID("nothing@all")));
   }
 
-  @Test(expected = IOException.class)
-  public void testSendOnInvalidConnectionIdentifierWithNoConnection() throws Exception {
+  public void testGetConnectionOnInvalidConnectionIdentifierWithNoConnection() throws Exception {
     IStreamService mainTransport = new Transport(StreamMode.SOCKS5_DIRECT);
 
     DataTransferManager dtm =
@@ -353,13 +354,10 @@ public class DataTransferManagerTest {
 
     TransferDescription description = TransferDescription.newDescription();
 
-    description.setRecipient(new JID("foo@bar.com"));
-
-    dtm.sendData("foo", description, new byte[0]);
+    assertNull(dtm.getConnection("foo", new JID("foo@bar.com")));
   }
 
-  @Test(expected = IOException.class)
-  public void testSendOnInvalidConnectionIdentifier() throws Exception {
+  public void testGetConnectionOnInvalidConnectionIdentifier() throws Exception {
     IStreamService mainTransport = new Transport(StreamMode.SOCKS5_DIRECT);
 
     DataTransferManager dtm =
@@ -367,17 +365,12 @@ public class DataTransferManagerTest {
 
     connectionListener.getValue().connectionStateChanged(connectionMock, ConnectionState.CONNECTED);
 
-    TransferDescription description = TransferDescription.newDescription();
-
     dtm.connect("bar", new JID("foo@bar.com"));
-
-    description.setRecipient(new JID("foo@bar.com"));
-
-    dtm.sendData("foo", description, new byte[0]);
+    assertNull(dtm.getConnection("foo", new JID("foo@bar.com")));
   }
 
   @Test
-  public void testSendOnValidConnectionIdentifier() throws Exception {
+  public void testGetConnectionOnValidConnectionIdentifier() throws Exception {
     Transport mainTransport = new Transport(StreamMode.SOCKS5_DIRECT);
 
     DataTransferManager dtm =
@@ -385,13 +378,9 @@ public class DataTransferManagerTest {
 
     connectionListener.getValue().connectionStateChanged(connectionMock, ConnectionState.CONNECTED);
 
-    TransferDescription description = TransferDescription.newDescription();
-
     dtm.connect("foo", new JID("foo@bar.com"));
 
-    description.setRecipient(new JID("foo@bar.com"));
-
-    dtm.sendData("foo", description, new byte[0]);
+    assertNotNull(dtm.getConnection("foo", new JID("foo@bar.com")));
   }
 
   @Test(timeout = 30000)
@@ -555,7 +544,7 @@ public class DataTransferManagerTest {
 
     description.setRecipient(new JID("foo@bar.com"));
 
-    dtm.sendData(description, new byte[0]);
+    dtm.getConnection(null, new JID("foo@bar.com")).send(description, new byte[0]);
 
     assertEquals(
         "wrong connection was chosen",

--- a/core/test/junit/saros/test/fakes/net/NonThreadedReceiver.java
+++ b/core/test/junit/saros/test/fakes/net/NonThreadedReceiver.java
@@ -9,7 +9,6 @@ import org.jivesoftware.smack.packet.Packet;
 import saros.net.IReceiver;
 import saros.net.PacketCollector;
 import saros.net.PacketCollector.CancelHook;
-import saros.net.internal.BinaryXMPPExtension;
 
 class NonThreadedReceiver implements IReceiver {
 
@@ -52,10 +51,5 @@ class NonThreadedReceiver implements IReceiver {
     addPacketListener(collector, filter);
 
     return collector;
-  }
-
-  @Override
-  public void processBinaryXMPPExtension(final BinaryXMPPExtension extension) {
-    throw new UnsupportedOperationException();
   }
 }

--- a/core/test/junit/saros/test/fakes/net/ThreadedReceiver.java
+++ b/core/test/junit/saros/test/fakes/net/ThreadedReceiver.java
@@ -11,7 +11,6 @@ import org.jivesoftware.smack.packet.Packet;
 import saros.net.IReceiver;
 import saros.net.PacketCollector;
 import saros.net.PacketCollector.CancelHook;
-import saros.net.internal.BinaryXMPPExtension;
 import saros.util.NamedThreadFactory;
 
 public class ThreadedReceiver implements IReceiver {
@@ -74,10 +73,5 @@ public class ThreadedReceiver implements IReceiver {
     addPacketListener(collector, filter);
 
     return collector;
-  }
-
-  @Override
-  public void processBinaryXMPPExtension(final BinaryXMPPExtension extension) {
-    throw new UnsupportedOperationException();
   }
 }

--- a/eclipse/src/saros/feedback/DataTransferCollector.java
+++ b/eclipse/src/saros/feedback/DataTransferCollector.java
@@ -4,8 +4,9 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import saros.annotations.Component;
-import saros.net.IConnectionManager;
+import saros.net.IReceiver;
 import saros.net.ITransferListener;
+import saros.net.ITransmitter;
 import saros.net.stream.StreamMode;
 import saros.session.ISarosSession;
 
@@ -40,7 +41,8 @@ public class DataTransferCollector extends AbstractStatisticCollector {
   private final Map<StreamMode, TransferStatisticHolder> statistic =
       new EnumMap<StreamMode, TransferStatisticHolder>(StreamMode.class);
 
-  private final IConnectionManager connectionManager;
+  private final IReceiver receiver;
+  private final ITransmitter transmitter;
 
   private final ITransferListener dataTransferlistener =
       new ITransferListener() {
@@ -82,9 +84,11 @@ public class DataTransferCollector extends AbstractStatisticCollector {
   public DataTransferCollector(
       StatisticManager statisticManager,
       ISarosSession session,
-      IConnectionManager connectionManager) {
+      IReceiver receiver,
+      ITransmitter transmitter) {
     super(statisticManager, session);
-    this.connectionManager = connectionManager;
+    this.receiver = receiver;
+    this.transmitter = transmitter;
   }
 
   @Override
@@ -102,12 +106,14 @@ public class DataTransferCollector extends AbstractStatisticCollector {
 
   @Override
   protected void doOnSessionStart(ISarosSession sarosSession) {
-    connectionManager.addTransferListener(dataTransferlistener);
+    receiver.addTransferListener(dataTransferlistener);
+    transmitter.addTransferListener(dataTransferlistener);
   }
 
   @Override
   protected void doOnSessionEnd(ISarosSession sarosSession) {
-    connectionManager.removeTransferListener(dataTransferlistener);
+    receiver.removeTransferListener(dataTransferlistener);
+    transmitter.removeTransferListener(dataTransferlistener);
   }
 
   private void storeTransferStatisticForMode(

--- a/eclipse/test/junit/saros/feedback/StatisticCollectorTest.java
+++ b/eclipse/test/junit/saros/feedback/StatisticCollectorTest.java
@@ -15,8 +15,8 @@ import org.osgi.service.prefs.Preferences;
 import saros.context.IContextKeyBindings;
 import saros.editor.EditorManager;
 import saros.editor.FollowModeManager;
-import saros.net.IConnectionManager;
-import saros.net.internal.DataTransferManager;
+import saros.net.IReceiver;
+import saros.net.ITransmitter;
 import saros.net.xmpp.JID;
 import saros.preferences.EclipsePreferenceConstants;
 import saros.repackaged.picocontainer.BindKey;
@@ -115,7 +115,8 @@ public class StatisticCollectorTest {
 
     FeedbackPreferences.setPreferences(preferences);
 
-    addMockedComponent(IConnectionManager.class, DataTransferManager.class);
+    addMockedComponent(IReceiver.class, IReceiver.class);
+    addMockedComponent(ITransmitter.class, ITransmitter.class);
 
     // Components we want to create
     container.addComponent(StatisticManager.class);

--- a/eclipse/test/junit/saros/session/internal/SarosSessionTest.java
+++ b/eclipse/test/junit/saros/session/internal/SarosSessionTest.java
@@ -48,7 +48,6 @@ import saros.net.IConnectionManager;
 import saros.net.IReceiver;
 import saros.net.ITransmitter;
 import saros.net.PacketCollector;
-import saros.net.internal.BinaryXMPPExtension;
 import saros.net.xmpp.JID;
 import saros.net.xmpp.XMPPConnectionService;
 import saros.preferences.EclipsePreferenceConstants;
@@ -98,11 +97,6 @@ public class SarosSessionTest {
 
     @Override
     public PacketCollector createCollector(PacketFilter filter) {
-      throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void processBinaryXMPPExtension(final BinaryXMPPExtension extension) {
       throw new UnsupportedOperationException();
     }
 
@@ -305,6 +299,9 @@ public class SarosSessionTest {
 
     container.removeComponent(ITransmitter.class);
     addMockedComponent(ITransmitter.class);
+
+    container.removeComponent(IReceiver.class);
+    addMockedComponent(IReceiver.class);
 
     /*
      * Additional components

--- a/stf/src/saros/stf/server/StfRemoteObject.java
+++ b/stf/src/saros/stf/server/StfRemoteObject.java
@@ -8,6 +8,8 @@ import saros.context.IContainerContext;
 import saros.editor.EditorManager;
 import saros.editor.FollowModeManager;
 import saros.net.IConnectionManager;
+import saros.net.IReceiver;
+import saros.net.ITransmitter;
 import saros.net.internal.DataTransferManager;
 import saros.net.xmpp.XMPPConnectionService;
 import saros.session.ISarosSession;
@@ -37,6 +39,14 @@ public abstract class StfRemoteObject implements Constants {
 
   protected DataTransferManager getDataTransferManager() {
     return (DataTransferManager) context.getComponent(IConnectionManager.class);
+  }
+
+  protected IReceiver getReceiver() {
+    return context.getComponent(IReceiver.class);
+  }
+
+  protected ITransmitter getTransmitter() {
+    return context.getComponent(ITransmitter.class);
   }
 
   /** @return is <code>null</code> if there is no running session */

--- a/stf/src/saros/stf/server/rmi/controlbot/manipulation/impl/NetworkManipulatorImpl.java
+++ b/stf/src/saros/stf/server/rmi/controlbot/manipulation/impl/NetworkManipulatorImpl.java
@@ -16,6 +16,7 @@ import saros.activities.NOPActivity;
 import saros.monitoring.IProgressMonitor;
 import saros.net.IPacketInterceptor;
 import saros.net.internal.BinaryXMPPExtension;
+import saros.net.internal.IByteStreamConnection;
 import saros.net.internal.TransferDescription;
 import saros.net.xmpp.JID;
 import saros.session.IActivityConsumer;
@@ -316,6 +317,9 @@ public final class NetworkManipulatorImpl extends StfRemoteObject
       return;
     }
 
+    IByteStreamConnection connection =
+        getDataTransferManager().getConnection(ISarosSession.SESSION_CONNECTION_ID, jid);
+
     while (!pendingOutgoingPackets.isEmpty()) {
       try {
         OutgoingPacketHolder holder = pendingOutgoingPackets.remove();
@@ -326,8 +330,7 @@ public final class NetworkManipulatorImpl extends StfRemoteObject
                 + ", payload length: "
                 + holder.payload.length);
 
-        getDataTransferManager()
-            .sendData(ISarosSession.SESSION_CONNECTION_ID, holder.description, holder.payload);
+        connection.send(holder.description, holder.payload);
       } catch (Exception e) {
         LOG.error(e.getMessage(), e);
       }

--- a/stf/src/saros/stf/server/rmi/controlbot/manipulation/impl/NetworkManipulatorImpl.java
+++ b/stf/src/saros/stf/server/rmi/controlbot/manipulation/impl/NetworkManipulatorImpl.java
@@ -18,6 +18,7 @@ import saros.net.IPacketInterceptor;
 import saros.net.internal.BinaryXMPPExtension;
 import saros.net.internal.IByteStreamConnection;
 import saros.net.internal.TransferDescription;
+import saros.net.internal.XMPPReceiver;
 import saros.net.xmpp.JID;
 import saros.session.IActivityConsumer;
 import saros.session.IActivityListener;
@@ -169,7 +170,8 @@ public final class NetworkManipulatorImpl extends StfRemoteObject
 
   private NetworkManipulatorImpl() {
     this.getSessionManager().addSessionLifecycleListener(this);
-    getDataTransferManager().addPacketInterceptor(sessionPacketInterceptor);
+    this.getReceiver().addPacketInterceptor(sessionPacketInterceptor);
+    this.getTransmitter().addPacketInterceptor(sessionPacketInterceptor);
   }
 
   @Override
@@ -274,7 +276,7 @@ public final class NetworkManipulatorImpl extends StfRemoteObject
 
         LOG.trace("dispatching blocked packet: " + object);
 
-        getDataTransferManager().addIncomingTransferObject(object);
+        ((XMPPReceiver) getReceiver()).receive(object);
       } catch (Exception e) {
         LOG.error(e.getMessage(), e);
       }


### PR DESCRIPTION
This is just a cleanup, removing transfer logic out of the DTM which already implements the IConnectionManager, indicating that this class is no longer responsible for data transfer.
