### PR TITLE
[LOG][CORE] Drop log level of PortUnreachableException

### DIFF
--- a/core/src/saros/net/stun/internal/StunServiceImpl.java
+++ b/core/src/saros/net/stun/internal/StunServiceImpl.java
@@ -10,6 +10,7 @@ import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.PortUnreachableException;
 import java.net.SocketAddress;
 import java.net.SocketTimeoutException;
 import java.util.ArrayList;
@@ -140,6 +141,9 @@ public final class StunServiceImpl implements IStunService {
                 new InetSocketAddress(stunAddress, stunPort),
                 new InetSocketAddress(localAddress, 0),
                 timeout);
+      } catch (PortUnreachableException e) {
+        log.warn("aborted STUN discovery: " + e.getMessage());
+        return;
       } catch (IOException e) {
         log.error("an error occurred while performing a STUN discovery: " + e.getMessage(), e);
         return;

--- a/core/src/saros/preferences/PreferenceInitializer.java
+++ b/core/src/saros/preferences/PreferenceInitializer.java
@@ -29,7 +29,7 @@ public class PreferenceInitializer {
     store.setDefault(PreferenceConstants.LOCAL_SOCKS5_PROXY_CANDIDATES, "");
     store.setDefault(PreferenceConstants.FORCE_IBB_CONNECTIONS, false);
 
-    store.setDefault(PreferenceConstants.STUN, "stunserver.org");
+    store.setDefault(PreferenceConstants.STUN, "");
     store.setDefault(PreferenceConstants.STUN_PORT, 0);
     store.setDefault(PreferenceConstants.CONCURRENT_UNDO, false);
 


### PR DESCRIPTION
The stun discovery often throws a PortUnreachableException that the ICMP
port is unreachable. This does not seem to hinder the functionality, but
is still logged as a warning.

This warning leads to confusion for the users when reporting bugs as
they assume that the log entry (including the stacktrace) is the cause
of whatever issue they are having with Saros.

To avoid this wrong assumption (and users only sending this part of the
stacktrace), the log level is reduced to info and the stacktrace is
dropped.