### PR TITLE
[INTERNAL][E] Throttle generation of editor related activities

### DIFF
--- a/eclipse/src/saros/concurrent/undo/UndoManager.java
+++ b/eclipse/src/saros/concurrent/undo/UndoManager.java
@@ -377,7 +377,7 @@ public class UndoManager extends AbstractActivityConsumer implements Disposable 
     sessionManager.addSessionLifecycleListener(sessionLifecycleListener);
     this.sessionManager = sessionManager;
 
-    editorManager.addActivityListener(this.activityListener);
+    editorManager.getActivityProducer().addActivityListener(this.activityListener);
     this.editorManager = editorManager;
 
     editorManager.addSharedEditorListener(sharedEditorListener);
@@ -473,7 +473,7 @@ public class UndoManager extends AbstractActivityConsumer implements Disposable 
   public void dispose() {
     OperationHistoryFactory.getOperationHistory().removeOperationHistoryListener(historyListener);
     sessionManager.removeSessionLifecycleListener(sessionLifecycleListener);
-    editorManager.removeActivityListener(activityListener);
+    editorManager.getActivityProducer().removeActivityListener(activityListener);
     enabled = false;
     eclipseHistory.removeOperationApprover(operationBlocker);
     editorManager.removeSharedEditorListener(sharedEditorListener);

--- a/eclipse/src/saros/editor/EditorActivityDelayer.java
+++ b/eclipse/src/saros/editor/EditorActivityDelayer.java
@@ -1,0 +1,97 @@
+package saros.editor;
+
+import org.apache.log4j.Logger;
+import org.eclipse.swt.widgets.Display;
+import saros.activities.EditorActivity;
+import saros.activities.IActivity;
+import saros.activities.TextEditActivity;
+import saros.activities.TextSelectionActivity;
+import saros.activities.ViewportActivity;
+import saros.session.AbstractActivityProducer;
+import saros.session.ISarosSession;
+import saros.ui.util.SWTUtils;
+import saros.util.StackTrace;
+
+/**
+ * This class is responsible for delaying and discarding certain activities that are normally
+ * generated frequently.
+ */
+// TODO Viewport activities are also fire to frequently, worst case is selecting text with mouse
+// while scrolling up or down
+
+final class EditorActivityDelayer extends AbstractActivityProducer {
+
+  private static final int DELAY = 100; // ms
+
+  private static final Logger log = Logger.getLogger(EditorActivityDelayer.class);
+
+  private final Display display;
+
+  private TextSelectionActivity currentSelectionActivity = null;
+
+  EditorActivityDelayer() {
+    display = SWTUtils.getDisplay();
+  }
+
+  void start(final ISarosSession session) {
+    session.addActivityProducer(this);
+  }
+
+  void stop(final ISarosSession session) {
+    session.removeActivityProducer(this);
+  }
+
+  void fireActivity(final ViewportActivity activity) {
+    if (!checkThreadAccess(activity)) return;
+
+    flushCurrentSelectionActivity();
+    super.fireActivity(activity);
+  }
+
+  void fireActivity(final TextSelectionActivity activity) {
+    if (!checkThreadAccess(activity)) return;
+
+    if (currentSelectionActivity == null) {
+      currentSelectionActivity = activity;
+      display.timerExec(DELAY, this::flushCurrentSelectionActivity);
+    } else if (currentSelectionActivity.getPath().equals(activity.getPath())) {
+      currentSelectionActivity = activity;
+    } else {
+      flushCurrentSelectionActivity();
+      currentSelectionActivity = activity;
+      display.timerExec(DELAY, this::flushCurrentSelectionActivity);
+    }
+  }
+
+  void fireActivity(final TextEditActivity activity) {
+    if (!checkThreadAccess(activity)) return;
+
+    flushCurrentSelectionActivity();
+    super.fireActivity(activity);
+  }
+
+  void fireActivity(final EditorActivity activity) {
+    if (!checkThreadAccess(activity)) return;
+
+    flushCurrentSelectionActivity();
+    super.fireActivity(activity);
+  }
+
+  private void flushCurrentSelectionActivity() {
+    if (currentSelectionActivity == null) return;
+
+    super.fireActivity(currentSelectionActivity);
+    currentSelectionActivity = null;
+  }
+
+  private boolean checkThreadAccess(final IActivity activity) {
+    if (Display.getCurrent() != null) return true;
+
+    if (log.isDebugEnabled())
+      log.error(
+          "dropping activity " + activity + " due to invalid thread access", new StackTrace());
+    else log.warn("dropping activity " + activity + " due to invalid thread access");
+
+    return false;
+  }
+}

--- a/eclipse/src/saros/editor/EditorManager.java
+++ b/eclipse/src/saros/editor/EditorManager.java
@@ -59,9 +59,9 @@ import saros.filesystem.ResourceAdapterFactory;
 import saros.observables.FileReplacementInProgressObservable;
 import saros.repackaged.picocontainer.annotations.Inject;
 import saros.session.AbstractActivityConsumer;
-import saros.session.AbstractActivityProducer;
 import saros.session.IActivityConsumer;
 import saros.session.IActivityConsumer.Priority;
+import saros.session.IActivityProducer;
 import saros.session.ISarosSession;
 import saros.session.ISarosSessionManager;
 import saros.session.ISessionLifecycleListener;
@@ -86,7 +86,7 @@ import saros.util.StackTrace;
  *     annotations...
  */
 @Component(module = "core")
-public class EditorManager extends AbstractActivityProducer implements IEditorManager {
+public class EditorManager implements IEditorManager {
 
   /**
    * @JTourBusStop 6, Some Basics:
@@ -108,6 +108,8 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
   private ISarosSession session;
 
   private SharedEditorListenerDispatch editorListenerDispatch = new SharedEditorListenerDispatch();
+
+  private final EditorActivityDelayer activityDelayer = new EditorActivityDelayer();
 
   private final IPreferenceStore preferenceStore;
 
@@ -273,15 +275,16 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
           // TODO The user should be able to ask for this
           User localUser = session.getLocalUser();
           for (SPath path : getOpenEditors()) {
-            fireActivity(new EditorActivity(localUser, Type.ACTIVATED, path));
+            activityDelayer.fireActivity(new EditorActivity(localUser, Type.ACTIVATED, path));
           }
 
-          fireActivity(new EditorActivity(localUser, Type.ACTIVATED, locallyActiveEditor));
+          activityDelayer.fireActivity(
+              new EditorActivity(localUser, Type.ACTIVATED, locallyActiveEditor));
 
           if (locallyActiveEditor == null) return;
 
           if (localViewport != null) {
-            fireActivity(
+            activityDelayer.fireActivity(
                 new ViewportActivity(
                     localUser,
                     localViewport.getStartLine(),
@@ -295,7 +298,8 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
             int offset = localSelection.getOffset();
             int length = localSelection.getLength();
 
-            fireActivity(new TextSelectionActivity(localUser, offset, length, locallyActiveEditor));
+            activityDelayer.fireActivity(
+                new TextSelectionActivity(localUser, offset, length, locallyActiveEditor));
           } else {
             LOG.warn("No selection for locallyActivateEditor: " + locallyActiveEditor);
           }
@@ -487,7 +491,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
     editorListenerDispatch.editorActivated(session.getLocalUser(), path);
 
-    fireActivity(new EditorActivity(session.getLocalUser(), Type.ACTIVATED, path));
+    activityDelayer.fireActivity(new EditorActivity(session.getLocalUser(), Type.ACTIVATED, path));
   }
 
   /**
@@ -521,7 +525,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
         new ViewportActivity(
             session.getLocalUser(), viewport.getStartLine(), viewport.getNumberOfLines(), path);
 
-    fireActivity(activity);
+    activityDelayer.fireActivity(activity);
   }
 
   /**
@@ -545,7 +549,8 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
     int offset = newSelection.getOffset();
     int length = newSelection.getLength();
 
-    fireActivity(new TextSelectionActivity(session.getLocalUser(), offset, length, path));
+    activityDelayer.fireActivity(
+        new TextSelectionActivity(session.getLocalUser(), offset, length, path));
   }
 
   /**
@@ -624,7 +629,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
       return;
     }
 
-    fireActivity(textEdit);
+    activityDelayer.fireActivity(textEdit);
 
     // inform all registered ISharedEditorListeners about this text edit
     editorListenerDispatch.textEdited(textEdit);
@@ -931,7 +936,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
     editorListenerDispatch.editorClosed(session.getLocalUser(), path);
 
-    fireActivity(new EditorActivity(session.getLocalUser(), Type.CLOSED, path));
+    activityDelayer.fireActivity(new EditorActivity(session.getLocalUser(), Type.CLOSED, path));
 
     /**
      * TODO We need a reliable way to communicate editors which are outside the shared project scope
@@ -1201,7 +1206,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
    *     Permission#WRITE_ACCESS} was editing.
    */
   void sendEditorActivitySaved(SPath path) {
-    fireActivity(new EditorActivity(session.getLocalUser(), Type.SAVED, path));
+    activityDelayer.fireActivity(new EditorActivity(session.getLocalUser(), Type.SAVED, path));
   }
 
   /**
@@ -1651,7 +1656,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
     hasWriteAccess = session.hasWriteAccess();
     session.addListener(sessionListener);
-    session.addActivityProducer(this);
+    activityDelayer.start(session);
     session.addActivityConsumer(consumer, Priority.ACTIVE);
 
     annotationModelHelper = new AnnotationModelHelper();
@@ -1706,7 +1711,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
     assert session != null;
     session.getStopManager().removeBlockable(stopManagerListener);
     session.removeListener(sessionListener);
-    session.removeActivityProducer(this);
+    activityDelayer.stop(session);
     session.removeActivityConsumer(consumer);
     session = null;
 
@@ -1724,5 +1729,14 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
   private void checkThreadAccess() {
     if (!SWTUtils.isSWT()) throw new IllegalStateException("method must be invoked from EDT");
+  }
+
+  /**
+   * Returns the activity producer for this editor.
+   *
+   * @return the activity producer
+   */
+  public IActivityProducer getActivityProducer() {
+    return activityDelayer;
   }
 }

--- a/eclipse/test/junit/saros/SarosEclipseContextFactoryTest.java
+++ b/eclipse/test/junit/saros/SarosEclipseContextFactoryTest.java
@@ -37,6 +37,7 @@ public class SarosEclipseContextFactoryTest {
     // mock Eclipse dependencies
     EclipseMocker.mockResourcesPlugin();
     EclipseMocker.mockPlatform();
+    EclipseMocker.mockSWTDisplay();
   }
 
   @Test

--- a/eclipse/test/junit/saros/SarosEclipseContextTest.java
+++ b/eclipse/test/junit/saros/SarosEclipseContextTest.java
@@ -34,7 +34,7 @@ public class SarosEclipseContextTest {
     // mock Eclipse dependencies
     EclipseMocker.mockResourcesPlugin();
     EclipseMocker.mockPlatform();
-
+    EclipseMocker.mockSWTDisplay();
     // mock Saros environment
     saros = EclipseMocker.mockSaros();
 

--- a/eclipse/test/junit/saros/test/mocks/EclipseMocker.java
+++ b/eclipse/test/junit/saros/test/mocks/EclipseMocker.java
@@ -21,6 +21,7 @@ import saros.preferences.EclipsePreferenceStoreAdapter;
 import saros.repackaged.picocontainer.MutablePicoContainer;
 import saros.test.util.EclipseMemoryPreferenceStore;
 import saros.test.util.MemoryPreferences;
+import saros.ui.util.SWTUtils;
 
 public class EclipseMocker {
   /** Mock the static call {@link ResourcesPlugin#getWorkspace()}. */
@@ -48,6 +49,12 @@ public class EclipseMocker {
     Platform.getBundle("org.eclipse.core.runtime");
     EasyMock.expectLastCall().andStubReturn(bundle);
     PowerMock.replay(Platform.class);
+  }
+
+  public static void mockSWTDisplay() {
+    PowerMock.mockStaticPartial(SWTUtils.class, "getDisplay");
+    EasyMock.expect(SWTUtils.getDisplay()).andStubReturn(null);
+    PowerMock.replay(SWTUtils.class);
   }
 
   /** Mock a somewhat clever Saros, with a version number and a preference store. */

--- a/eclipse/test/junit/saros/test/mocks/PrepareEclipseComponents.java
+++ b/eclipse/test/junit/saros/test/mocks/PrepareEclipseComponents.java
@@ -2,9 +2,11 @@ package saros.test.mocks;
 
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.swt.widgets.Display;
 import org.powermock.core.spi.PowerMockPolicy;
 import org.powermock.mockpolicies.MockPolicyClassLoadingSettings;
 import org.powermock.mockpolicies.MockPolicyInterceptionSettings;
+import saros.ui.util.SWTUtils;
 
 /**
  * This policy can be used to avoid reiterating Eclipse components that need to be prepared by
@@ -24,13 +26,18 @@ public class PrepareEclipseComponents implements PowerMockPolicy {
   @Override
   public void applyClassLoadingPolicy(MockPolicyClassLoadingSettings settings) {
     // Add more final classes here, if need be
-    String[] classes = {ResourcesPlugin.class.getName(), Platform.class.getName()};
+    String[] classes = {
+      Display.class.getName(),
+      SWTUtils.class.getName(),
+      ResourcesPlugin.class.getName(),
+      Platform.class.getName()
+    };
 
     settings.addFullyQualifiedNamesOfClassesToLoadByMockClassloader(classes);
   }
 
   @Override
   public void applyInterceptionPolicy(MockPolicyInterceptionSettings settings) {
-    //
+    // NOP
   }
 }


### PR DESCRIPTION
They are already "optimized" during sending an execution. However if you
have a fast network and a fast computer selecting text will equal
running a computer game, consuming the resources of a CPU die and
depending on the garbage collection additional dies.

This patch introduced a delayer which currently starts to reduce the
number of Selection Activities.