### PR TITLE
Offer module configuration adjustment for existing modules

### DIFF
--- a/intellij/src/saros/intellij/negotiation/ModuleConfiguration.java
+++ b/intellij/src/saros/intellij/negotiation/ModuleConfiguration.java
@@ -1,0 +1,91 @@
+package saros.intellij.negotiation;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.jps.model.JpsElement;
+import org.jetbrains.jps.model.java.JavaResourceRootType;
+import org.jetbrains.jps.model.java.JavaSourceRootType;
+import org.jetbrains.jps.model.module.JpsModuleSourceRootType;
+
+/** Data holder class for module configuration options used as part of the project negotiation. */
+public class ModuleConfiguration {
+  private final String sdkName;
+  private final String moduleType;
+  private final Map<JpsModuleSourceRootType<? extends JpsElement>, String[]> rootPaths;
+
+  private final boolean existingModule;
+
+  public ModuleConfiguration(@NotNull Map<String, String> options, boolean existingModule) {
+    this.sdkName = options.get(ModuleConfigurationProvider.SDK_KEY);
+
+    this.moduleType = options.get(ModuleConfigurationProvider.MODULE_TYPE_KEY);
+
+    this.rootPaths = new HashMap<>();
+
+    rootPaths.put(
+        JavaSourceRootType.SOURCE,
+        ModuleConfigurationProvider.split(
+            options.get(ModuleConfigurationProvider.SOURCE_ROOTS_KEY)));
+
+    rootPaths.put(
+        JavaSourceRootType.TEST_SOURCE,
+        ModuleConfigurationProvider.split(
+            options.get(ModuleConfigurationProvider.TEST_SOURCE_ROOTS_KEY)));
+
+    rootPaths.put(
+        JavaResourceRootType.RESOURCE,
+        ModuleConfigurationProvider.split(
+            options.get(ModuleConfigurationProvider.RESOURCE_ROOTS_KEY)));
+
+    rootPaths.put(
+        JavaResourceRootType.TEST_RESOURCE,
+        ModuleConfigurationProvider.split(
+            options.get(ModuleConfigurationProvider.TEST_RESOURCE_ROOTS_KEY)));
+
+    this.existingModule = existingModule;
+  }
+
+  /**
+   * Returns the module type.
+   *
+   * @return the module type or <code>null</code> if no module type was received
+   */
+  @Nullable
+  public String getModuleType() {
+    return moduleType;
+  }
+
+  /**
+   * Returns the module sdk name.
+   *
+   * @return the module sdk name or <code>null</code> if no module type was received
+   */
+  @Nullable
+  public String getSdkName() {
+    return sdkName;
+  }
+
+  /**
+   * Returns the source root paths.
+   *
+   * @return the source root paths, values might be mapped to <code>null</code> if no paths were
+   *     received for the root type
+   */
+  @NotNull
+  public Map<JpsModuleSourceRootType<? extends JpsElement>, String[]> getRootPaths() {
+    return Collections.unmodifiableMap(rootPaths);
+  }
+
+  /**
+   * Returns whether the module was pre-existing.
+   *
+   * @return <code>true</code> if the module was pre-existing, <code>false</code> if it was created
+   *     as part of the project negotiation
+   */
+  public boolean isExistingModule() {
+    return existingModule;
+  }
+}

--- a/intellij/src/saros/intellij/negotiation/ModuleConfigurationProvider.java
+++ b/intellij/src/saros/intellij/negotiation/ModuleConfigurationProvider.java
@@ -190,11 +190,16 @@ public class ModuleConfigurationProvider implements ProjectDataProvider {
    * the key values defined in this class.
    *
    * @param options string containing a number of options
-   * @return a list of all options contained in the passed string
+   * @return a list of all options contained in the passed string or <code>null</code> if the passed
+   *     option string is <code>null</code>
    * @see ProjectNegotiationData#getAdditionalProjectData()
    */
-  @NotNull
-  public static String[] split(@NotNull String options) {
+  @Nullable
+  public static String[] split(@Nullable String options) {
+    if (options == null) {
+      return null;
+    }
+
     String[] splitOptions = SPLIT_PATTERN.split(options);
 
     for (int i = 0; i < splitOptions.length; i++) {

--- a/intellij/src/saros/intellij/ui/Messages.java
+++ b/intellij/src/saros/intellij/ui/Messages.java
@@ -183,5 +183,8 @@ public class Messages {
   public static String ColorPreferences_user_example_text_contribution;
   public static String ColorPreferences_user_example_text_selection;
 
+  public static String ModuleConfigurationInitializer_override_module_config_title;
+  public static String ModuleConfigurationInitializer_override_module_config_message;
+
   private Messages() {}
 }

--- a/intellij/src/saros/intellij/ui/messages.properties
+++ b/intellij/src/saros/intellij/ui/messages.properties
@@ -169,3 +169,6 @@ ColorPreferences_default_user_description=the default user
 ColorPreferences_user_description=user {0}
 ColorPreferences_user_example_text_contribution=This is what <contrib{0}>a contribution annotation</contrib{0}> for {1} would look like.
 ColorPreferences_user_example_text_selection=This is what <sel{0}>a selection annotation</sel{0}> for {1} would look like.
+
+ModuleConfigurationInitializer_override_module_config_title=Override local module configuration?
+ModuleConfigurationInitializer_override_module_config_message=The received module configuration does not match the one of the chosen local module.\nShould the local configuration be replaced with the received one?

--- a/intellij/src/saros/intellij/ui/util/SafeDialogUtils.java
+++ b/intellij/src/saros/intellij/ui/util/SafeDialogUtils.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.TextRange;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import saros.SarosPluginContext;
 import saros.exceptions.IllegalAWTContextException;
 
@@ -192,5 +193,35 @@ public class SafeDialogUtils {
         ModalityState.defaultModalityState());
 
     return response.get();
+  }
+
+  /**
+   * Shows a non-blocking yes/no dialog. The passed <code>runnable</code> can be used to run code
+   * after the dialog is finished. However, it is <b>only</b> run if the user finishes the dialog
+   * with the option {@link Messages#YES}.
+   *
+   * @param project the project used as a reference to generate and position the dialog
+   * @param message the text displayed as the message of the dialog
+   * @param title the text displayed as the title of the dialog
+   * @param runAfter the runnable to execute if the user chooses {@link Messages#YES}
+   */
+  public static void showYesNoDialog(
+      @NotNull Project project,
+      @NotNull String message,
+      @NotNull String title,
+      @NotNull Runnable runAfter) {
+
+    LOG.info("Showing non-blocking yes/no dialog: " + title + " - " + message);
+
+    application.invokeLater(
+        () -> {
+          int option =
+              Messages.showYesNoDialog(project, message, title, Messages.getQuestionIcon());
+
+          if (option == Messages.YES) {
+            runAfter.run();
+          }
+        },
+        ModalityState.defaultModalityState());
   }
 }


### PR DESCRIPTION
#### [INTERNAL][I] Add non-blocking yes/no dialog

Adds the option for a non-blocking yes/no dialog that accepts a runnable
that is run if the 'Yes' option is chosen.

#### [INTERNAL][I] Add data holder class for module configurations

Adds the data holder class ModuleConfiguration. The class encapsulates
the parsing of the module configuration option contained in the
additional project options transferred as part of the project
negotiation data.

#### [INTERNAL][I] Update module config of existing modules

Adjusts the ModuleConfigurationInitializer to also offer the user to
load the module config of the host in case an existing module is used
but the config differs from the received one.
This functionality is now useful as we no longer transfer the module
file.

Subsequently adjusts the logic applying the config to newly created
modules to also use the ModuleConfiguration data holder class.

Also adjusts ModuleConfigurationProvider.split(String) to accept (and
subsequently return) null values.