### PR TITLE
[FIX][I] Correctly reset icon of consistency button on session end

### DIFF
--- a/intellij/src/saros/intellij/ui/views/buttons/ConsistencyButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/ConsistencyButton.java
@@ -115,6 +115,7 @@ public class ConsistencyButton extends AbstractSessionToolbarButton {
 
     setEnabledFromUIThread(false);
     setToolTipText(Messages.ConsistencyButton_tooltip_functionality);
+    setButtonIcon(IconManager.IN_SYNC_ICON);
   }
 
   private class SessionInconsistencyState {


### PR DESCRIPTION
Correctly resets the icon of the consistency button to the "consistent
state" version on session end. This is done to ensure that the button is
correctly reset when the session is ended while the client was in an
inconsistent state.