### PR TITLE
[FIX][I] Honor IntelliJ resource exclusion

### DIFF
--- a/intellij/src/saros/intellij/editor/ProjectAPI.java
+++ b/intellij/src/saros/intellij/editor/ProjectAPI.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 import saros.intellij.filesystem.Filesystem;
@@ -105,5 +106,17 @@ public class ProjectAPI {
   @NotNull
   private static FileEditorManager getFileEditorManager(@NotNull Project project) {
     return FileEditorManager.getInstance(project);
+  }
+
+  /**
+   * Returns whether the given virtual file is seen as excluded for the given project.
+   *
+   * @param project the project to check for
+   * @param virtualFile the virtual file to check
+   * @return whether the given virtual file is seen as excluded for the given project
+   * @see ProjectFileIndex#isExcluded(VirtualFile)
+   */
+  public static boolean isExcluded(@NotNull Project project, @NotNull VirtualFile virtualFile) {
+    return ProjectFileIndex.getInstance(project).isExcluded(virtualFile);
   }
 }

--- a/intellij/src/saros/intellij/filesystem/IntelliJFileImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFileImpl.java
@@ -17,6 +17,7 @@ import saros.filesystem.IFile;
 import saros.filesystem.IPath;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
+import saros.intellij.editor.ProjectAPI;
 
 public final class IntelliJFileImpl extends IntelliJResourceImpl implements IFile {
 
@@ -100,13 +101,17 @@ public final class IntelliJFileImpl extends IntelliJResourceImpl implements IFil
 
   @Override
   public boolean isDerived() {
-    VirtualFile file = project.findVirtualFile(path);
+    VirtualFile virtualFile = project.findVirtualFile(path);
 
-    if (file != null && file.equals(project.getModule().getModuleFile())) {
+    if (virtualFile == null) {
       return true;
     }
 
-    return !exists();
+    boolean isExcluded = ProjectAPI.isExcluded(project.getModule().getProject(), virtualFile);
+
+    boolean isModuleFile = virtualFile.equals(project.getModule().getModuleFile());
+
+    return !exists() || isExcluded || isModuleFile;
   }
 
   @Override

--- a/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
@@ -17,6 +17,7 @@ import saros.filesystem.IFolder;
 import saros.filesystem.IPath;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
+import saros.intellij.editor.ProjectAPI;
 import saros.intellij.project.filesystem.IntelliJPathImpl;
 
 public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IFolder {
@@ -154,7 +155,15 @@ public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IF
 
   @Override
   public boolean isDerived() {
-    return !exists();
+    VirtualFile virtualFile = project.findVirtualFile(path);
+
+    if (virtualFile == null) {
+      return true;
+    }
+
+    boolean isExcluded = ProjectAPI.isExcluded(project.getModule().getProject(), virtualFile);
+
+    return !exists() || isExcluded;
   }
 
   @Override


### PR DESCRIPTION
Adjusts the isDerived() implementation for the IntelliJ file and folder
implementation to also consider whether the resource is seen as excluded
for the corresponding project.

Even though this is a general improvement, it brings new possibilities
for issues during a session. When the excluded resource mapping does not
match for all clients, creating a local resource that already exists for
another client as an excluded resource leads to an unsolvable session
desync.