### PR TITLE
[I] Introducing IntelliJReferencePointManager

### DIFF
--- a/intellij/src/saros/core/ui/util/CollaborationUtils.java
+++ b/intellij/src/saros/core/ui/util/CollaborationUtils.java
@@ -28,6 +28,7 @@ import saros.filesystem.IReferencePointManager;
 import saros.filesystem.IResource;
 import saros.intellij.SarosComponent;
 import saros.intellij.filesystem.IntelliJProjectImpl;
+import saros.intellij.filesystem.IntelliJReferencePointManager;
 import saros.intellij.runtime.UIMonitoredJob;
 import saros.intellij.ui.Messages;
 import saros.intellij.ui.util.DialogUtils;
@@ -53,6 +54,7 @@ public class CollaborationUtils {
   private static final Logger LOG = Logger.getLogger(CollaborationUtils.class);
 
   @Inject private static ISarosSessionManager sessionManager;
+  @Inject private static IntelliJReferencePointManager intelliJReferencePointManager;
 
   static {
     SarosPluginContext.initComponent(new CollaborationUtils());
@@ -527,5 +529,10 @@ public class CollaborationUtils {
   private static void fillReferencePointManager(
       IReferencePointManager referencePointManager, Set<IProject> projects) {
     referencePointManager.putSetOfProjects(projects);
+
+    for (IProject project : projects) {
+      intelliJReferencePointManager.putIfAbsent(
+          project.getReferencePoint(), project.adaptTo(IntelliJProjectImpl.class).getModule());
+    }
   }
 }

--- a/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
+++ b/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
@@ -17,6 +17,7 @@ import saros.filesystem.IWorkspace;
 import saros.filesystem.IWorkspaceRoot;
 import saros.filesystem.NullChecksumCache;
 import saros.intellij.editor.EditorManager;
+import saros.intellij.filesystem.IntelliJReferencePointManager;
 import saros.intellij.negotiation.ModuleConfigurationProvider;
 import saros.intellij.negotiation.hooks.ModuleTypeNegotiationHook;
 import saros.intellij.preferences.IntelliJPreferences;
@@ -53,6 +54,7 @@ public class SarosIntellijContextFactory extends AbstractContextFactory {
       // Core Managers
       Component.create(IEditorManager.class, EditorManager.class),
       Component.create(ISarosSessionContextFactory.class, SarosIntellijSessionContextFactory.class),
+      Component.create(IntelliJReferencePointManager.class),
 
       // additional project negotiation data providers
       Component.create(ModuleConfigurationProvider.class),

--- a/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
@@ -54,7 +54,8 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
 
     moduleRoot = getModuleContentRoot(module);
 
-    this.referencePoint = new ReferencePointImpl(getFullPath());
+    this.referencePoint =
+        new ReferencePointImpl(IntelliJPathImpl.fromString(module.getModuleFilePath()));
   }
 
   /**

--- a/intellij/src/saros/intellij/filesystem/IntelliJReferencePointManager.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJReferencePointManager.java
@@ -1,0 +1,220 @@
+package saros.intellij.filesystem;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtil;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.jetbrains.annotations.NotNull;
+import saros.filesystem.IPath;
+import saros.filesystem.IReferencePoint;
+import saros.filesystem.IResource;
+import saros.filesystem.ReferencePointImpl;
+import saros.intellij.context.SharedIDEContext;
+import saros.intellij.project.filesystem.IntelliJPathImpl;
+import saros.session.internal.SarosSession;
+
+/**
+ * The IntelliJReferencePointManager maps an {@link IReferencePoint} reference point to {@link
+ * Module} module
+ */
+public class IntelliJReferencePointManager {
+
+  private final Map<IReferencePoint, Module> referencePointToModuleMapper;
+
+  public IntelliJReferencePointManager() {
+    referencePointToModuleMapper = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * Creates and returns the {@link IReferencePoint} reference point of given {@link Module} module.
+   * The reference point points on the module's file full path.
+   *
+   * @param module for which a reference point should be created
+   * @return the reference point of given module
+   * @exception IllegalArgumentException if the {@link Module} module is null
+   */
+  @NotNull
+  public static IReferencePoint create(@NotNull Module module) {
+    IPath path = IntelliJPathImpl.fromString(module.getModuleFilePath());
+
+    return new ReferencePointImpl(path);
+  }
+
+  /**
+   * Creates and returns the {@link IReferencePoint} reference point of given {@link VirtualFile}
+   * virtual file and {@link SarosSession} Saros session. The reference point points on the module's
+   * file full path.
+   *
+   * @param virtualFile for which a reference point should be created
+   * @param sarosSession which should be running
+   * @return the reference point of given virtual file
+   * @exception IllegalArgumentException if the {@link VirtualFile} virtual file is null
+   * @exception IllegalStateException if the {@link SarosSession} is not running
+   */
+  @NotNull
+  public static IReferencePoint create(
+      @NotNull VirtualFile virtualFile, @NotNull SarosSession sarosSession) {
+    Module module = FilesystemUtils.findModuleForVirtualFile(sarosSession, virtualFile);
+
+    return create(module);
+  }
+
+  /**
+   * Insert the {@link Module} module to the IntelliJReferencePointManager. It determinate the
+   * {@link IReferencePoint} reference point automatically.
+   *
+   * @param module which should be inserted to the IntelliJReferencePointManager.
+   * @exception IllegalArgumentException if the {@link Module} module is null
+   */
+  public void putIfAbsent(@NotNull Module module) {
+    IReferencePoint referencePoint = create(module);
+
+    putIfAbsent(referencePoint, module);
+  }
+
+  /**
+   * Insert a pair of {@link IReferencePoint} reference point and {@link Module} module
+   *
+   * @param referencePoint which should be inserted to the IntelliJReferencePointManager.
+   * @param module which should be inserted to the IntelliJReferencePointManager.
+   * @exception IllegalArgumentException if the {@link Module} module or the {@link IReferencePoint}
+   *     reference point is null
+   */
+  public void putIfAbsent(@NotNull IReferencePoint referencePoint, @NotNull Module module) {
+    referencePointToModuleMapper.putIfAbsent(referencePoint, module);
+  }
+
+  /**
+   * Returns the {@link Module} module given by the {@link IReferencePoint} reference point
+   *
+   * @param referencePoint the key for which the module should be returned
+   * @return the module given by referencePoint
+   * @exception IllegalArgumentException if the {@link IReferencePoint} reference point is null
+   * @exception IllegalArgumentException if for the {@link IReferencePoint} reference point doesn't
+   *     exist a module
+   */
+  @NotNull
+  public Module getModule(@NotNull IReferencePoint referencePoint) {
+    Module module = referencePointToModuleMapper.get(referencePoint);
+
+    if (module == null)
+      throw new IllegalArgumentException(
+          "For reference point " + referencePoint + " doesn't exist a module.");
+
+    return module;
+  }
+
+  /**
+   * Returns the {@link VirtualFile} resource in combination of the {@link IReferencePoint}
+   * reference point and the {@link IPath} relative path from the reference point to the resource.
+   *
+   * @param referencePoint The reference point, on which the resource belongs to
+   * @param referencePointRelativePath the relative path from the reference point to the resource
+   * @return the virtualFile of the reference point from referencePointRelativePath
+   * @exception IllegalArgumentException if for {@link IReferencePoint} reference point doesn't
+   *     exists a module
+   * @exception IllegalArgumentException if the {@link IReferencePoint} reference point is null
+   * @exception IllegalArgumentException if the {@link IPath} relative path is null
+   */
+  public VirtualFile getResource(
+      @NotNull IReferencePoint referencePoint, @NotNull IPath referencePointRelativePath) {
+    Module module = getModule(referencePoint);
+
+    return FilesystemUtils.findVirtualFile(module, referencePointRelativePath);
+  }
+
+  /**
+   * Returns the {@link IResource} resource in combination of the {@link IReferencePoint} reference
+   * point and the {@link IPath} relative path from the reference point to the resource.
+   *
+   * @param referencePoint The reference point, on which the resource belongs to
+   * @param referencePointRelativePath the relative path from the reference point to the resource
+   * @return the resource of the reference point from referencePointRelativePath
+   * @exception IllegalArgumentException if for {@link IReferencePoint} reference point doesn't
+   *     exists a module
+   * @exception IllegalArgumentException if the {@link IReferencePoint} reference point is null
+   * @exception IllegalArgumentException if the {@link IPath} relative path is null
+   */
+  @NotNull
+  public IResource getSarosResource(
+      @NotNull IReferencePoint referencePoint, @NotNull IPath referencePointRelativePath) {
+    Module module = getModule(referencePoint);
+    VirtualFile vFile = getResource(referencePoint, referencePointRelativePath);
+
+    return VirtualFileConverter.convertToResource(module.getProject(), vFile);
+  }
+
+  private static class FilesystemUtils {
+
+    /**
+     * * Returns the {@link Module} module of the given {@link VirtualFile virtualfile}
+     *
+     * @param virtualFile of the module
+     * @param session Saros session which should be running
+     * @return the module of the virtualFile
+     */
+    public static Module findModuleForVirtualFile(SarosSession session, VirtualFile virtualFile) {
+      Project project = session.getComponent(SharedIDEContext.class).getProject();
+      return ModuleUtil.findModuleForFile(virtualFile, project);
+    }
+
+    /**
+     * Determines and returns the {@link VirtualFile} virtual file given by the {@link Module}
+     * module and {@link IPath} relative path, or null, if the relative path is absolute or has no
+     * segments, or the virtual file is not found.
+     *
+     * @param module in which the virtual file is contained
+     * @param path to the virtual file
+     * @return the virtual file, if exists, otherwise null
+     */
+    public static VirtualFile findVirtualFile(final Module module, IPath path) {
+
+      VirtualFile moduleRoot = getModuleRoot(module);
+
+      if (path.isAbsolute()) return null;
+
+      if (path.segmentCount() == 0) return moduleRoot;
+
+      VirtualFile virtualFile = moduleRoot.findFileByRelativePath(path.toString());
+
+      if (virtualFile == null) return null;
+
+      boolean isOnContent =
+          Filesystem.runReadAction(
+              () -> ModuleRootManager.getInstance(module).getFileIndex().isInContent(virtualFile));
+
+      if (isOnContent) return virtualFile;
+
+      return null;
+    }
+
+    /**
+     * Returns the {@link VirtualFile} module root of the given {@link Module} module.
+     *
+     * <p><b>Note:</b> The Module given {@link Module} module must have exactly one module root!
+     *
+     * @param module for which the module root should be returned
+     * @return the module root of the module
+     */
+    private static VirtualFile getModuleRoot(Module module) {
+      if (module == null) return null;
+
+      ModuleRootManager moduleRootManager = ModuleRootManager.getInstance(module);
+
+      VirtualFile[] contentRoots = moduleRootManager.getContentRoots();
+
+      int numberOfContentRoots = contentRoots.length;
+
+      if (numberOfContentRoots != 1) {
+        return null;
+      }
+
+      VirtualFile moduleRoot = contentRoots[0];
+
+      return moduleRoot;
+    }
+  }
+}

--- a/intellij/src/saros/intellij/ui/wizards/AddProjectToSessionWizard.java
+++ b/intellij/src/saros/intellij/ui/wizards/AddProjectToSessionWizard.java
@@ -39,6 +39,7 @@ import saros.intellij.context.SharedIDEContext;
 import saros.intellij.editor.DocumentAPI;
 import saros.intellij.filesystem.Filesystem;
 import saros.intellij.filesystem.IntelliJProjectImpl;
+import saros.intellij.filesystem.IntelliJReferencePointManager;
 import saros.intellij.negotiation.ModuleConfiguration;
 import saros.intellij.negotiation.ModuleConfigurationInitializer;
 import saros.intellij.ui.Messages;
@@ -101,6 +102,7 @@ public class AddProjectToSessionWizard extends Wizard {
   @Inject private IChecksumCache checksumCache;
 
   @Inject private ISarosSessionManager sessionManager;
+  @Inject private IntelliJReferencePointManager intelliJReferencePointManager;
 
   private final SelectLocalModuleRepresentationPage selectLocalModuleRepresentationPage;
   private final TextAreaPage fileListPage;
@@ -802,5 +804,7 @@ public class AddProjectToSessionWizard extends Wizard {
   private void fillReferencePointManager(
       IReferencePointManager referencePointManager, IProject project) {
     referencePointManager.putIfAbsent(project.getReferencePoint(), project);
+    intelliJReferencePointManager.putIfAbsent(
+        project.getReferencePoint(), project.adaptTo(IntelliJProjectImpl.class).getModule());
   }
 }

--- a/intellij/test/junit/saros/intellij/filesystem/IntelliJReferencePointManagerTest.java
+++ b/intellij/test/junit/saros/intellij/filesystem/IntelliJReferencePointManagerTest.java
@@ -1,0 +1,110 @@
+package saros.intellij.filesystem;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.roots.ModuleFileIndex;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import saros.filesystem.IPath;
+import saros.filesystem.IReferencePoint;
+import saros.intellij.project.filesystem.IntelliJPathImpl;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(ModuleRootManager.class)
+public class IntelliJReferencePointManagerTest {
+
+  IntelliJReferencePointManager intelliJReferencePointManager;
+  IReferencePoint referencePoint;
+
+  @Before
+  public void prepare() {
+    referencePoint = EasyMock.createMock(IReferencePoint.class);
+    EasyMock.replay(referencePoint);
+
+    intelliJReferencePointManager = new IntelliJReferencePointManager();
+  }
+
+  @Test
+  public void testCreateReferencePoint() {
+    IReferencePoint referencePoint = IntelliJReferencePointManager.create(createModule("Module1"));
+    Assert.assertNotNull(referencePoint);
+  }
+
+  @Test
+  public void testModulePutIfAbsent() {
+    Module module = createModule("Module1");
+    IReferencePoint referencePoint = IntelliJReferencePointManager.create(module);
+    intelliJReferencePointManager.putIfAbsent(module);
+    Module module2 = intelliJReferencePointManager.getModule(referencePoint);
+
+    Assert.assertNotNull(module2);
+    Assert.assertEquals(module, module2);
+  }
+
+  @Test
+  public void testPairPutIfAbsent() {
+    Module module = createModule("Module1");
+    intelliJReferencePointManager.putIfAbsent(referencePoint, module);
+    Module module2 = intelliJReferencePointManager.getModule(referencePoint);
+
+    Assert.assertNotNull(module2);
+    Assert.assertEquals(module, module2);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetResourceFromEmptyIntelliJReferencePointManager() {
+    VirtualFile resource = EasyMock.createMock(VirtualFile.class);
+    EasyMock.replay(resource);
+
+    IPath relativePath = createReferencePointPath("./path/to/file");
+
+    intelliJReferencePointManager.getResource(referencePoint, relativePath);
+  }
+
+  private IPath createReferencePointPath(String path) {
+    return IntelliJPathImpl.fromString(path);
+  }
+
+  private VirtualFile createModuleRoot(String pathToFile, VirtualFile resource) {
+    VirtualFile moduleRoot = EasyMock.createMock(VirtualFile.class);
+    EasyMock.expect(moduleRoot.findFileByRelativePath(pathToFile)).andStubReturn(resource);
+
+    EasyMock.replay(moduleRoot);
+
+    return moduleRoot;
+  }
+
+  private Module createModule(String name) {
+    VirtualFile file = EasyMock.createMock(VirtualFile.class);
+    EasyMock.replay(file);
+
+    String pathToFile = "foo/bar";
+
+    return createModule(name, file, pathToFile);
+  }
+
+  private Module createModule(String name, VirtualFile resource, String pathToFile) {
+    ModuleFileIndex o = EasyMock.createMock(ModuleFileIndex.class);
+    EasyMock.replay(o);
+
+    ModuleRootManager moduleRootManager = EasyMock.createMock(ModuleRootManager.class);
+    EasyMock.expect(moduleRootManager.getContentRoots())
+        .andStubReturn(new VirtualFile[] {createModuleRoot(pathToFile, resource)});
+    EasyMock.expect(moduleRootManager.getFileIndex()).andStubReturn(o);
+    EasyMock.replay(moduleRootManager);
+
+    Module module = EasyMock.createMock(Module.class);
+    EasyMock.expect(module.getComponent(ModuleRootManager.class)).andStubReturn(moduleRootManager);
+    EasyMock.expect(module.getName()).andStubReturn(name);
+    EasyMock.expect(module.getModuleFilePath()).andStubReturn(name);
+    EasyMock.replay(module);
+
+    return module;
+  }
+}


### PR DESCRIPTION
This PR contains the introducing of the IntelliJReferencePointManager in Saros/I.
The idea is, that the IntelliJReferencePointManager stores the mapping of `IReferencePoint`s to IntelliJ `Module`s.
In additionally, it is able to create `IReferencePoint`s (like the EclipseReferencePointManager), given by a Module or VirtuaFile, and to resolve resources given by `IReferencePoints` and relative paths.
With resources is meant by `VirtualFiles` and Saros resources. 
The resolving of Saros resources with `IReferencePoints` and relatives path is needed to the resources from `SPath` (next PR).
