### PR TITLE
Allow different module names

### DIFF
--- a/intellij/src/saros/intellij/ui/messages.properties
+++ b/intellij/src/saros/intellij/ui/messages.properties
@@ -156,9 +156,9 @@ ModuleTab_module_base_path_file_chooser_title=Choose Module Base Path
 ModuleTab_module_base_path_file_chooser_description=Choose the base bath used for the new module.
 ModuleTab_use_existing_module=Use existing module
 ModuleTab_use_existing_module_local_module=Local module
-ModuleTab_create_new_module_name_invalid_tooltip=The module name must match the module name shared by the host.
+ModuleTab_create_new_module_name_invalid_tooltip=The module name must not contain separator characters and must not match any existing module name for the chosen project.
 ModuleTab_create_new_module_base_path_invalid_tooltip=The given module base path does not exist or does not point to a directory.
-ModuleTab_use_existing_module_local_module_invalid_tooltip=The local module name must match the module name shared by the host.
+ModuleTab_use_existing_module_local_module_invalid_tooltip=An existing module must be chosen.
 
 ColorPreferences_display_name=Saros
 ColorPreferences_text_selection_attribute_display_name=User Color {0}//Text Selection

--- a/intellij/src/saros/intellij/ui/wizards/pages/moduleselection/ModuleTab.java
+++ b/intellij/src/saros/intellij/ui/wizards/pages/moduleselection/ModuleTab.java
@@ -60,15 +60,15 @@ class ModuleTab {
   private final JRadioButton useExistingModuleRadioButton;
   private final JComboBox<Module> existingModuleComboBox;
 
-  private boolean moduleNameTextFieldValid;
+  private boolean moduleNameTextFieldShownAsValid;
   private final Border moduleNameTextFieldDefaultBorder;
   private final Border moduleNameTextFieldErrorBorder;
 
-  private boolean moduleBasePathTextFieldValid;
+  private boolean moduleBasePathTextFieldShownAsValid;
   private final Border moduleBasePathTextFieldDefaultBorder;
   private final Border moduleBasePathTextFieldErrorBorder;
 
-  private boolean existingModuleComboBoxValid;
+  private boolean existingModuleComboBoxShownAsValid;
   private final Border existingModuleComboBoxDefaultBorder;
   private final Border existingModuleComboBoxErrorBorder;
 
@@ -92,20 +92,20 @@ class ModuleTab {
     this.newModuleBasePathTextField = new TextFieldWithBrowseButton();
     this.existingModuleComboBox = new ComboBox<>();
 
-    this.moduleNameTextFieldValid = true;
+    this.moduleNameTextFieldShownAsValid = true;
     this.moduleNameTextFieldDefaultBorder = newModuleNameTextField.getBorder();
     this.moduleNameTextFieldErrorBorder =
         BorderFactory.createCompoundBorder(
             moduleNameTextFieldDefaultBorder, BorderFactory.createLineBorder(JBColor.RED));
 
-    this.moduleBasePathTextFieldValid = true;
+    this.moduleBasePathTextFieldShownAsValid = true;
     this.moduleBasePathTextFieldDefaultBorder =
         newModuleBasePathTextField.getTextField().getBorder();
     this.moduleBasePathTextFieldErrorBorder =
         BorderFactory.createCompoundBorder(
             moduleBasePathTextFieldDefaultBorder, BorderFactory.createLineBorder(JBColor.RED));
 
-    this.existingModuleComboBoxValid = true;
+    this.existingModuleComboBoxShownAsValid = true;
     this.existingModuleComboBoxDefaultBorder = existingModuleComboBox.getBorder();
     this.existingModuleComboBoxErrorBorder =
         BorderFactory.createCompoundBorder(
@@ -175,6 +175,10 @@ class ModuleTab {
             default:
               throw new IllegalStateException("Encountered unknown radio button selection.");
           }
+
+          updateNewModuleNameValidityIndicator();
+          updateNewBasePathValidityIndicator();
+          updateExistingModuleValidityIndicator();
 
           updateInputValidity();
         };
@@ -519,18 +523,18 @@ class ModuleTab {
    * on the returned value of {@link #hasValidNewModuleName()}.
    */
   private void updateNewModuleNameValidityIndicator() {
-    boolean hasValidNewModuleName = hasValidNewModuleName();
+    boolean showFieldAsValid = hasValidNewModuleName() || !createNewModuleRadioButton.isSelected();
 
-    if (hasValidNewModuleName == moduleNameTextFieldValid) {
+    if (showFieldAsValid == moduleNameTextFieldShownAsValid) {
       return;
     }
 
-    moduleNameTextFieldValid = hasValidNewModuleName;
+    moduleNameTextFieldShownAsValid = showFieldAsValid;
 
     Border border;
     String toolTip;
 
-    if (hasValidNewModuleName) {
+    if (showFieldAsValid) {
       border = moduleNameTextFieldDefaultBorder;
       toolTip = "";
 
@@ -548,18 +552,18 @@ class ModuleTab {
    * based on the returned value of {@link #hasValidNewBasePath()}.
    */
   private void updateNewBasePathValidityIndicator() {
-    boolean hasValidNewBasePath = hasValidNewBasePath();
+    boolean showFieldAsValid = hasValidNewBasePath() || !createNewModuleRadioButton.isSelected();
 
-    if (hasValidNewBasePath == moduleBasePathTextFieldValid) {
+    if (showFieldAsValid == moduleBasePathTextFieldShownAsValid) {
       return;
     }
 
-    moduleBasePathTextFieldValid = hasValidNewBasePath;
+    moduleBasePathTextFieldShownAsValid = showFieldAsValid;
 
     Border border;
     String toolTip;
 
-    if (hasValidNewBasePath) {
+    if (showFieldAsValid) {
       border = moduleBasePathTextFieldDefaultBorder;
       toolTip = "";
 
@@ -577,18 +581,19 @@ class ModuleTab {
    * based on the returned value of {@link #hasValidExistingModule()}.
    */
   private void updateExistingModuleValidityIndicator() {
-    boolean hasValidExistingModule = hasValidExistingModule();
+    boolean showFieldAsValid =
+        hasValidExistingModule() || !useExistingModuleRadioButton.isSelected();
 
-    if (hasValidExistingModule == existingModuleComboBoxValid) {
+    if (showFieldAsValid == existingModuleComboBoxShownAsValid) {
       return;
     }
 
-    existingModuleComboBoxValid = hasValidExistingModule;
+    existingModuleComboBoxShownAsValid = showFieldAsValid;
 
     Border border;
     String toolTip;
 
-    if (hasValidExistingModule) {
+    if (showFieldAsValid) {
       border = existingModuleComboBoxDefaultBorder;
       toolTip = "";
 


### PR DESCRIPTION
#### [INTERNAL][I] Allow different module names

Adjusts the project negotiation dialog to allow the accepting side
choose a module name different from the name on the host side. This is
not possible as we no longer share the module file.

Subsequently adds a check to the option to create a new module to
disallow to continue the dialog when a module with the chosen name
already exists in the chosen project. Previously, such a situation would
lead to the negotiation aborting with an error message.

#### [FIX][I] Only show fields as invalid if they are currently evaluated

Adjusts the dialog to accept a project negotiation to only show fields
as invalid if they are currently being evaluated. Otherwise, fields are
marked as invalid that are not used for the currently chosen mode, which
could lead to confusion.