### PR TITLE
[BUILD] Adjust gradle config to correctly configure modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,17 @@ mavenize {
   }
 }
 
+// Adjust Intellij module configuration for all sub-projects
+configure(subprojects) {projectToConf->
+  apply plugin: 'idea'
+
+  idea{
+    module{
+      excludeDirs += [file("bin"), file("lib"), file("libs")]
+    }
+  }
+}
+
 
 ext.projectsToConfigure = subprojects - project(':saros.picocontainer')
 // Configurations that are specific to all subprojects


### PR DESCRIPTION
Adjusts the base build.gradle configuration in order to correctly
configure the modules creates from the configurations. Adds the folders
'bin', 'lib', and 'libs' as excluded resources. This is needed as they
contain compiled resources (libraries or class files), which otherwise
would be found by the IntelliJ search, polluting the search results.

Fixes #490.