### PR TITLE
Remove module name reference in IntelliJProjectImpl

### DIFF
--- a/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
@@ -203,7 +203,7 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
     Module fileModule =
         ProjectFileIndexFacade.getInstance(module.getProject()).getModuleForFile(file);
 
-    if (fileModule == null || !module.getName().equals(fileModule.getName())) {
+    if (!module.equals(fileModule)) {
       return null;
     }
 

--- a/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
@@ -29,8 +29,6 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
 
   private final Project project;
 
-  private final String moduleName;
-
   private final Module module;
   private final VirtualFile moduleRoot;
 
@@ -52,8 +50,6 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
     this.module = module;
 
     this.project = module.getProject();
-
-    this.moduleName = module.getName();
 
     moduleRoot = getModuleContentRoot(module);
   }
@@ -172,7 +168,7 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
   @NotNull
   @Override
   public String getName() {
-    return moduleName;
+    return module.getName();
   }
 
   @Nullable
@@ -207,7 +203,7 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
     Module fileModule =
         ProjectFileIndexFacade.getInstance(module.getProject()).getModuleForFile(file);
 
-    if (fileModule == null || !moduleName.equals(fileModule.getName())) {
+    if (fileModule == null || !module.getName().equals(fileModule.getName())) {
       return null;
     }
 
@@ -421,6 +417,6 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + " : " + project + " - " + moduleName;
+    return getClass().getSimpleName() + " : " + project + " - " + module;
   }
 }


### PR DESCRIPTION
#### [INTERNAL][I] Remove held reference to module name

Removes the held reference to the module name and replaces it by
dynamically requesting the name from the module object. This change is
needed as module names can change during runtime, but the module is
always represented by the same object. This allows us to better handle
such name changes.

#### [INTERNAL][I] Adjust module comparison in IntelliJProjectImpl

Adjusts the module comparison in
IntelliJProjectImpl.getProjectRelativePath(VirtualFile) to use the
module objects directly. Previously, the module names were compared. As
already mentioned in the changes reworking the equals method, the name
can not be used as a unique identifier when multiple project are
allowed.