### PR TITLE
[FIX][E] #676 Fix check whether account exists in configuration wizard

### DIFF
--- a/eclipse/src/saros/ui/wizards/ConfigurationWizard.java
+++ b/eclipse/src/saros/ui/wizards/ConfigurationWizard.java
@@ -198,9 +198,8 @@ public class ConfigurationWizard extends Wizard {
     boolean useTLS = enterXMPPAccountWizardPage.isUsingTLS();
     boolean useSASL = enterXMPPAccountWizardPage.isUsingSASL();
 
-    if (isExistingAccount)
-      return accountStore.createAccount(username, password, domain, server, port, useTLS, useSASL);
+    if (isExistingAccount) return accountStore.getAccount(username, domain, server, port);
 
-    return accountStore.getAccount(username, domain, server, port);
+    return accountStore.createAccount(username, password, domain, server, port, useTLS, useSASL);
   }
 }


### PR DESCRIPTION
Flips the check to now correctly request the existing account if it is
detected.