### PR TITLE
Adjusting SPath references in Saros/I with IntelliJReferencePointManager

### DIFF
--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -936,8 +936,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
           }
 
           for (SPath editorPath : editorPaths) {
-            if (referencePoint == null
-                || referencePoint.equals(editorPath.getProject().getReferencePoint())) {
+            if (referencePoint == null || referencePoint.equals(editorPath.getReferencePoint())) {
 
               saveDocument(editorPath);
             }
@@ -975,7 +974,8 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
     Set<String> visibleFilePaths = new HashSet<>();
 
-    Project project = path.getProject().adaptTo(IntelliJProjectImpl.class).getModule().getProject();
+    Project project =
+        intelliJReferencePointManager.getModule(path.getReferencePoint()).getProject();
 
     for (VirtualFile virtualFile : ProjectAPI.getSelectedFiles(project)) {
       visibleFilePaths.add(virtualFile.getPath());

--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -619,7 +619,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
   public String getContent(final SPath path) {
     return Filesystem.runReadAction(
         () -> {
-          VirtualFile virtualFile = VirtualFileConverter.convertToVirtualFile(path);
+          VirtualFile virtualFile = intelliJReferencePointManager.getResource(path);
 
           if (virtualFile == null || !virtualFile.exists() || virtualFile.isDirectory()) {
 
@@ -973,7 +973,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
       visibleFilePaths.add(virtualFile.getPath());
     }
 
-    VirtualFile passedFile = VirtualFileConverter.convertToVirtualFile(path);
+    VirtualFile passedFile = intelliJReferencePointManager.getResource(path);
 
     if (passedFile == null) {
       LOG.warn(

--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -447,7 +447,9 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
           throw new IllegalStateException(
               "Could not create SPath for resource that is known to be shared: " + openFile);
 
-        } else if (path.getResource().isDerived()) {
+        } else if (intelliJReferencePointManager
+            .getSarosResource(path.getReferencePoint(), path.getProjectRelativePath())
+            .isDerived()) {
           LOG.debug("Skipping editor for derived open file " + path);
 
           continue;
@@ -700,7 +702,10 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
    *     <code>null</code> if the local user has no editor open.
    */
   void generateEditorActivated(SPath path) {
-    if (path == null || session.isShared(path.getResource())) {
+    if (path == null
+        || session.isShared(
+            intelliJReferencePointManager.getSarosResource(
+                path.getReferencePoint(), path.getProjectRelativePath()))) {
       editorListenerDispatch.editorActivated(session.getLocalUser(), path);
 
       fireActivity(new EditorActivity(session.getLocalUser(), EditorActivity.Type.ACTIVATED, path));
@@ -715,7 +720,10 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
    * EditorListenerDispatcher.
    */
   void generateEditorClosed(@NotNull SPath path) {
-    if (session.isShared(path.getResource())) {
+    IResource resource =
+        intelliJReferencePointManager.getSarosResource(
+            path.getReferencePoint(), path.getProjectRelativePath());
+    if (session.isShared(resource)) {
       editorListenerDispatch.editorClosed(session.getLocalUser(), path);
 
       fireActivity(new EditorActivity(session.getLocalUser(), EditorActivity.Type.CLOSED, path));

--- a/intellij/src/saros/intellij/editor/LocalEditorHandler.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorHandler.java
@@ -10,7 +10,6 @@ import org.jetbrains.annotations.Nullable;
 import saros.activities.SPath;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
-import saros.intellij.filesystem.IntelliJProjectImpl;
 import saros.intellij.filesystem.IntelliJReferencePointManager;
 import saros.intellij.filesystem.VirtualFileConverter;
 import saros.session.ISarosSession;
@@ -142,7 +141,8 @@ public class LocalEditorHandler {
       return null;
     }
 
-    Project project = path.getProject().adaptTo(IntelliJProjectImpl.class).getModule().getProject();
+    Project project =
+        intelliJReferencePointManager.getModule(path.getReferencePoint()).getProject();
 
     Editor editor = ProjectAPI.openEditor(project, virtualFile, activate);
 
@@ -262,7 +262,8 @@ public class LocalEditorHandler {
       return false;
     }
 
-    Project project = path.getProject().adaptTo(IntelliJProjectImpl.class).getModule().getProject();
+    Project project =
+        intelliJReferencePointManager.getModule(path.getReferencePoint()).getProject();
 
     return ProjectAPI.isOpen(project, doc);
   }

--- a/intellij/src/saros/intellij/editor/LocalEditorHandler.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorHandler.java
@@ -62,7 +62,10 @@ public class LocalEditorHandler {
 
     SPath path = VirtualFileConverter.convertToSPath(project, virtualFile);
 
-    if (path == null || !sarosSession.isShared(path.getResource())) {
+    if (path == null
+        || !sarosSession.isShared(
+            intelliJReferencePointManager.getSarosResource(
+                path.getReferencePoint(), path.getProjectRelativePath()))) {
       LOG.debug(
           "Ignored open editor request for file "
               + virtualFile
@@ -124,12 +127,16 @@ public class LocalEditorHandler {
   private Editor openEditor(
       @NotNull VirtualFile virtualFile, @NotNull SPath path, boolean activate) {
 
+    IResource resource =
+        intelliJReferencePointManager.getSarosResource(
+            path.getReferencePoint(), path.getProjectRelativePath());
+
     if (!virtualFile.exists()) {
       LOG.debug("Could not open Editor for file " + virtualFile + " as it does not exist");
 
       return null;
 
-    } else if (!sarosSession.isShared(path.getResource())) {
+    } else if (!sarosSession.isShared(resource)) {
       LOG.debug("Ignored open editor request for file " + virtualFile + " as it is not shared");
 
       return null;
@@ -156,7 +163,10 @@ public class LocalEditorHandler {
   public void closeEditor(@NotNull Project project, @NotNull VirtualFile virtualFile) {
     SPath path = VirtualFileConverter.convertToSPath(project, virtualFile);
 
-    if (path != null && sarosSession.isShared(path.getResource())) {
+    if (path != null
+        && sarosSession.isShared(
+            intelliJReferencePointManager.getSarosResource(
+                path.getReferencePoint(), path.getProjectRelativePath()))) {
       editorPool.removeEditor(path);
       manager.generateEditorClosed(path);
     }
@@ -224,7 +234,10 @@ public class LocalEditorHandler {
 
     SPath path = VirtualFileConverter.convertToSPath(project, file);
 
-    if (path != null && sarosSession.isShared(path.getResource())) {
+    if (path != null
+        && sarosSession.isShared(
+            intelliJReferencePointManager.getSarosResource(
+                path.getReferencePoint(), path.getProjectRelativePath()))) {
       manager.generateEditorActivated(path);
     }
   }

--- a/intellij/src/saros/intellij/editor/LocalEditorHandler.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorHandler.java
@@ -11,6 +11,7 @@ import saros.activities.SPath;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
 import saros.intellij.filesystem.IntelliJProjectImpl;
+import saros.intellij.filesystem.IntelliJReferencePointManager;
 import saros.intellij.filesystem.VirtualFileConverter;
 import saros.session.ISarosSession;
 
@@ -24,14 +25,18 @@ public class LocalEditorHandler {
 
   private final EditorManager manager;
   private final ISarosSession sarosSession;
+  private final IntelliJReferencePointManager intelliJReferencePointManager;
 
   /** This is just a reference to {@link EditorManager}'s editorPool and not a separate pool. */
   private final EditorPool editorPool;
 
-  public LocalEditorHandler(EditorManager editorManager, ISarosSession sarosSession) {
+  public LocalEditorHandler(
+      EditorManager editorManager,
+      ISarosSession sarosSession,
+      IntelliJReferencePointManager intelliJReferencePointManager) {
     this.manager = editorManager;
     this.sarosSession = sarosSession;
-
+    this.intelliJReferencePointManager = intelliJReferencePointManager;
     this.editorPool = manager.getEditorPool();
   }
 
@@ -177,7 +182,7 @@ public class LocalEditorHandler {
     Document document = editorPool.getDocument(path);
 
     if (document == null) {
-      VirtualFile file = VirtualFileConverter.convertToVirtualFile(path);
+      VirtualFile file = intelliJReferencePointManager.getResource(path);
 
       if (file == null || !file.exists()) {
         LOG.warn("Failed to save document for " + path + " - could not get a valid VirtualFile");

--- a/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
@@ -16,8 +16,11 @@ import saros.editor.IEditorManager;
 import saros.editor.text.LineRange;
 import saros.editor.text.TextSelection;
 import saros.filesystem.IFile;
+import saros.filesystem.IResource;
 import saros.intellij.editor.annotations.AnnotationManager;
+import saros.intellij.filesystem.IntelliJFileImpl;
 import saros.intellij.filesystem.IntelliJProjectImpl;
+import saros.intellij.filesystem.IntelliJReferencePointManager;
 import saros.intellij.filesystem.VirtualFileConverter;
 import saros.intellij.ui.Messages;
 import saros.intellij.ui.util.NotificationPanel;
@@ -31,6 +34,7 @@ public class LocalEditorManipulator {
 
   private final AnnotationManager annotationManager;
   private final ISarosSession sarosSession;
+  private final IntelliJReferencePointManager intelliJReferencePointManager;
 
   /** This is just a reference to {@link EditorManager}'s editorPool and not a separate pool. */
   private EditorPool editorPool;
@@ -40,11 +44,13 @@ public class LocalEditorManipulator {
   public LocalEditorManipulator(
       AnnotationManager annotationManager,
       EditorManager editorManager,
-      ISarosSession sarosSession) {
+      ISarosSession sarosSession,
+      IntelliJReferencePointManager intelliJReferencePointManager) {
 
     this.annotationManager = annotationManager;
     this.manager = editorManager;
     this.sarosSession = sarosSession;
+    this.intelliJReferencePointManager = intelliJReferencePointManager;
 
     this.editorPool = manager.getEditorPool();
   }
@@ -319,7 +325,12 @@ public class LocalEditorManipulator {
 
     int documentLength = document.getTextLength();
 
-    IFile file = path.getFile();
+    IResource resource =
+        intelliJReferencePointManager.getSarosResource(
+            path.getReferencePoint(), path.getProjectRelativePath());
+
+    IFile file = resource.adaptTo(IntelliJFileImpl.class);
+
     annotationManager.removeAnnotations(file);
 
     String text;

--- a/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
@@ -21,7 +21,6 @@ import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.filesystem.IntelliJFileImpl;
 import saros.intellij.filesystem.IntelliJProjectImpl;
 import saros.intellij.filesystem.IntelliJReferencePointManager;
-import saros.intellij.filesystem.VirtualFileConverter;
 import saros.intellij.ui.Messages;
 import saros.intellij.ui.util.NotificationPanel;
 import saros.session.ISarosSession;
@@ -73,7 +72,7 @@ public class LocalEditorManipulator {
       return null;
     }
 
-    VirtualFile virtualFile = VirtualFileConverter.convertToVirtualFile(path);
+    VirtualFile virtualFile = intelliJReferencePointManager.getResource(path);
 
     if (virtualFile == null || !virtualFile.exists()) {
       LOG.warn(
@@ -107,7 +106,7 @@ public class LocalEditorManipulator {
 
     LOG.debug("Removed editor for path " + path + " from EditorPool");
 
-    VirtualFile virtualFile = VirtualFileConverter.convertToVirtualFile(path);
+    VirtualFile virtualFile = intelliJReferencePointManager.getResource(path);
 
     if (virtualFile == null || !virtualFile.exists()) {
       LOG.warn(
@@ -145,7 +144,7 @@ public class LocalEditorManipulator {
      * editorPool so we have to create it temporarily here.
      */
     if (doc == null) {
-      VirtualFile virtualFile = VirtualFileConverter.convertToVirtualFile(path);
+      VirtualFile virtualFile = intelliJReferencePointManager.getResource(path);
 
       if (virtualFile == null || !virtualFile.exists()) {
         LOG.warn(
@@ -301,7 +300,7 @@ public class LocalEditorManipulator {
    * @see Document
    */
   public void handleContentRecovery(SPath path, byte[] content, String encoding, User source) {
-    VirtualFile virtualFile = VirtualFileConverter.convertToVirtualFile(path);
+    VirtualFile virtualFile = intelliJReferencePointManager.getResource(path);
     if (virtualFile == null) {
       LOG.warn(
           "Could not recover file content of "

--- a/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
@@ -19,7 +19,6 @@ import saros.filesystem.IFile;
 import saros.filesystem.IResource;
 import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.filesystem.IntelliJFileImpl;
-import saros.intellij.filesystem.IntelliJProjectImpl;
 import saros.intellij.filesystem.IntelliJReferencePointManager;
 import saros.intellij.ui.Messages;
 import saros.intellij.ui.util.NotificationPanel;
@@ -87,7 +86,8 @@ public class LocalEditorManipulator {
       return null;
     }
 
-    Project project = path.getProject().adaptTo(IntelliJProjectImpl.class).getModule().getProject();
+    Project project =
+        intelliJReferencePointManager.getModule(path.getReferencePoint()).getProject();
 
     Editor editor = ProjectAPI.openEditor(project, virtualFile, activate);
 
@@ -121,7 +121,8 @@ public class LocalEditorManipulator {
       return;
     }
 
-    Project project = path.getProject().adaptTo(IntelliJProjectImpl.class).getModule().getProject();
+    Project project =
+        intelliJReferencePointManager.getModule(path.getReferencePoint()).getProject();
 
     if (ProjectAPI.isOpen(project, virtualFile)) {
       ProjectAPI.closeEditor(project, virtualFile);
@@ -138,7 +139,8 @@ public class LocalEditorManipulator {
    * @param operations the operations to apply to the document
    */
   void applyTextOperations(SPath path, Operation operations) {
-    Project project = path.getProject().adaptTo(IntelliJProjectImpl.class).getModule().getProject();
+    Project project =
+        intelliJReferencePointManager.getModule(path.getReferencePoint()).getProject();
 
     Document doc = editorPool.getDocument(path);
 
@@ -313,7 +315,8 @@ public class LocalEditorManipulator {
       return;
     }
 
-    Project project = path.getProject().adaptTo(IntelliJProjectImpl.class).getModule().getProject();
+    Project project =
+        intelliJReferencePointManager.getModule(path.getReferencePoint()).getProject();
 
     Document document = DocumentAPI.getDocument(virtualFile);
     if (document == null) {

--- a/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
@@ -66,7 +66,10 @@ public class LocalEditorManipulator {
    *     not shared
    */
   public Editor openEditor(@NotNull SPath path, boolean activate) {
-    if (!sarosSession.isShared(path.getResource())) {
+    IResource resource =
+        intelliJReferencePointManager.getSarosResource(
+            path.getReferencePoint(), path.getProjectRelativePath());
+    if (!sarosSession.isShared(resource)) {
       LOG.warn("Ignored open editor request for path " + path + " as it is not shared");
 
       return null;

--- a/intellij/src/saros/intellij/eventhandler/ApplicationEventHandlersFactory.java
+++ b/intellij/src/saros/intellij/eventhandler/ApplicationEventHandlersFactory.java
@@ -8,6 +8,7 @@ import saros.intellij.editor.EditorManager;
 import saros.intellij.editor.LocalEditorHandler;
 import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.eventhandler.filesystem.LocalFilesystemModificationHandler;
+import saros.intellij.filesystem.IntelliJReferencePointManager;
 import saros.observables.FileReplacementInProgressObservable;
 import saros.session.ISarosSession;
 
@@ -19,19 +20,22 @@ public class ApplicationEventHandlersFactory {
   private final FileReplacementInProgressObservable fileReplacementInProgressObservable;
   private final AnnotationManager annotationManager;
   private final LocalEditorHandler localEditorHandler;
+  private final IntelliJReferencePointManager intelliJReferencePointManager;
 
   public ApplicationEventHandlersFactory(
       EditorManager editorManager,
       ISarosSession sarosSession,
       FileReplacementInProgressObservable fileReplacementInProgressObservable,
       AnnotationManager annotationManager,
-      LocalEditorHandler localEditorHandler) {
+      LocalEditorHandler localEditorHandler,
+      IntelliJReferencePointManager intelliJReferencePointManager) {
 
     this.editorManager = editorManager;
     this.sarosSession = sarosSession;
     this.fileReplacementInProgressObservable = fileReplacementInProgressObservable;
     this.annotationManager = annotationManager;
     this.localEditorHandler = localEditorHandler;
+    this.intelliJReferencePointManager = intelliJReferencePointManager;
   }
 
   /**
@@ -68,7 +72,8 @@ public class ApplicationEventHandlersFactory {
             sarosSession,
             fileReplacementInProgressObservable,
             annotationManager,
-            localEditorHandler));
+            localEditorHandler,
+            intelliJReferencePointManager));
 
     return new ApplicationEventHandlers(applicationEventHandlers);
   }

--- a/intellij/src/saros/intellij/eventhandler/ProjectEventHandlersFactory.java
+++ b/intellij/src/saros/intellij/eventhandler/ProjectEventHandlersFactory.java
@@ -17,6 +17,7 @@ import saros.intellij.eventhandler.editor.editorstate.PreexistingSelectionDispat
 import saros.intellij.eventhandler.editor.editorstate.ViewportAdjustmentExecutor;
 import saros.intellij.eventhandler.editor.selection.LocalTextSelectionChangeHandler;
 import saros.intellij.eventhandler.editor.viewport.LocalViewPortChangeHandler;
+import saros.intellij.filesystem.IntelliJReferencePointManager;
 import saros.session.ISarosSession;
 
 /** Factory to instantiate {@link ProjectEventHandlers} objects. */
@@ -27,19 +28,22 @@ public class ProjectEventHandlersFactory {
   private final AnnotationManager annotationManager;
   private final LocalEditorHandler localEditorHandler;
   private final LocalEditorManipulator localEditorManipulator;
+  private final IntelliJReferencePointManager intelliJReferencePointManager;
 
   public ProjectEventHandlersFactory(
       EditorManager editorManager,
       ISarosSession sarosSession,
       AnnotationManager annotationManager,
       LocalEditorHandler localEditorHandler,
-      LocalEditorManipulator localEditorManipulator) {
+      LocalEditorManipulator localEditorManipulator,
+      IntelliJReferencePointManager intelliJReferencePointManager) {
 
     this.editorManager = editorManager;
     this.sarosSession = sarosSession;
     this.annotationManager = annotationManager;
     this.localEditorHandler = localEditorHandler;
     this.localEditorManipulator = localEditorManipulator;
+    this.intelliJReferencePointManager = intelliJReferencePointManager;
   }
 
   /**
@@ -62,7 +66,11 @@ public class ProjectEventHandlersFactory {
      */
     projectEventHandlers.add(
         new LocalClosedEditorModificationHandler(
-            project, editorManager, sarosSession, annotationManager));
+            project,
+            editorManager,
+            sarosSession,
+            annotationManager,
+            intelliJReferencePointManager));
 
     projectEventHandlers.add(
         new LocalDocumentModificationHandler(project, editorManager, sarosSession));
@@ -71,7 +79,12 @@ public class ProjectEventHandlersFactory {
      * editor state change handlers
      */
     projectEventHandlers.add(
-        new AnnotationUpdater(project, annotationManager, localEditorHandler, sarosSession));
+        new AnnotationUpdater(
+            project,
+            annotationManager,
+            localEditorHandler,
+            sarosSession,
+            intelliJReferencePointManager));
 
     projectEventHandlers.add(new EditorStatusChangeActivityDispatcher(project, localEditorHandler));
 

--- a/intellij/src/saros/intellij/eventhandler/ProjectEventHandlersFactory.java
+++ b/intellij/src/saros/intellij/eventhandler/ProjectEventHandlersFactory.java
@@ -73,7 +73,8 @@ public class ProjectEventHandlersFactory {
             intelliJReferencePointManager));
 
     projectEventHandlers.add(
-        new LocalDocumentModificationHandler(project, editorManager, sarosSession));
+        new LocalDocumentModificationHandler(
+            project, editorManager, sarosSession, intelliJReferencePointManager));
 
     /*
      * editor state change handlers
@@ -90,7 +91,11 @@ public class ProjectEventHandlersFactory {
 
     projectEventHandlers.add(
         new PreexistingSelectionDispatcher(
-            project, editorManager, localEditorHandler, sarosSession));
+            project,
+            editorManager,
+            localEditorHandler,
+            sarosSession,
+            intelliJReferencePointManager));
 
     projectEventHandlers.add(new ViewportAdjustmentExecutor(project, localEditorManipulator));
 

--- a/intellij/src/saros/intellij/eventhandler/editor/document/AbstractLocalDocumentModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/document/AbstractLocalDocumentModificationHandler.java
@@ -8,9 +8,11 @@ import com.intellij.openapi.vfs.VirtualFile;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import saros.activities.SPath;
+import saros.filesystem.IResource;
 import saros.intellij.editor.DocumentAPI;
 import saros.intellij.editor.EditorManager;
 import saros.intellij.eventhandler.IProjectEventHandler;
+import saros.intellij.filesystem.IntelliJReferencePointManager;
 import saros.intellij.filesystem.VirtualFileConverter;
 import saros.session.ISarosSession;
 
@@ -22,7 +24,7 @@ public abstract class AbstractLocalDocumentModificationHandler implements IProje
 
   protected final Project project;
   protected final EditorManager editorManager;
-
+  private final IntelliJReferencePointManager intelliJReferencePointManager;
   private final ISarosSession sarosSession;
 
   private boolean enabled;
@@ -36,14 +38,19 @@ public abstract class AbstractLocalDocumentModificationHandler implements IProje
    * @param project the shared project the handler is registered to
    * @param editorManager the EditorManager instance
    * @param sarosSession the current session instance
+   * @param intelliJReferencePointManager the IntelliJReferencePointManager instance
    */
   AbstractLocalDocumentModificationHandler(
-      Project project, EditorManager editorManager, ISarosSession sarosSession) {
+      Project project,
+      EditorManager editorManager,
+      ISarosSession sarosSession,
+      IntelliJReferencePointManager intelliJReferencePointManager) {
 
     this.project = project;
     this.editorManager = editorManager;
 
     this.sarosSession = sarosSession;
+    this.intelliJReferencePointManager = intelliJReferencePointManager;
 
     this.enabled = false;
     this.disposed = false;
@@ -130,7 +137,11 @@ public abstract class AbstractLocalDocumentModificationHandler implements IProje
 
     path = VirtualFileConverter.convertToSPath(project, virtualFile);
 
-    if (path == null || !sarosSession.isShared(path.getResource())) {
+    IResource resource =
+        intelliJReferencePointManager.getSarosResource(
+            path.getReferencePoint(), path.getProjectRelativePath());
+
+    if (path == null || !sarosSession.isShared(resource)) {
       if (LOG.isTraceEnabled()) {
         LOG.trace("Ignoring Event for document " + document + " - document is not shared");
       }

--- a/intellij/src/saros/intellij/eventhandler/editor/document/LocalClosedEditorModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/document/LocalClosedEditorModificationHandler.java
@@ -40,7 +40,7 @@ public class LocalClosedEditorModificationHandler extends AbstractLocalDocumentM
       AnnotationManager annotationManager,
       IntelliJReferencePointManager intelliJReferencePointManager) {
 
-    super(project, editorManager, sarosSession);
+    super(project, editorManager, sarosSession, intelliJReferencePointManager);
 
     this.annotationManager = annotationManager;
     this.intelliJReferencePointManager = intelliJReferencePointManager;

--- a/intellij/src/saros/intellij/eventhandler/editor/document/LocalClosedEditorModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/document/LocalClosedEditorModificationHandler.java
@@ -7,9 +7,12 @@ import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 import saros.activities.SPath;
 import saros.filesystem.IFile;
+import saros.filesystem.IResource;
 import saros.intellij.editor.EditorManager;
 import saros.intellij.editor.ProjectAPI;
 import saros.intellij.editor.annotations.AnnotationManager;
+import saros.intellij.filesystem.IntelliJFileImpl;
+import saros.intellij.filesystem.IntelliJReferencePointManager;
 import saros.session.ISarosSession;
 
 /**
@@ -20,6 +23,7 @@ import saros.session.ISarosSession;
  */
 public class LocalClosedEditorModificationHandler extends AbstractLocalDocumentModificationHandler {
   private final AnnotationManager annotationManager;
+  private final IntelliJReferencePointManager intelliJReferencePointManager;
 
   private final DocumentListener documentListener =
       new DocumentListener() {
@@ -33,11 +37,13 @@ public class LocalClosedEditorModificationHandler extends AbstractLocalDocumentM
       Project project,
       EditorManager editorManager,
       ISarosSession sarosSession,
-      AnnotationManager annotationManager) {
+      AnnotationManager annotationManager,
+      IntelliJReferencePointManager intelliJReferencePointManager) {
 
     super(project, editorManager, sarosSession);
 
     this.annotationManager = annotationManager;
+    this.intelliJReferencePointManager = intelliJReferencePointManager;
   }
 
   /**
@@ -62,7 +68,11 @@ public class LocalClosedEditorModificationHandler extends AbstractLocalDocumentM
     String replacedText = event.getOldFragment().toString();
 
     if (!ProjectAPI.isOpen(project, document)) {
-      IFile file = path.getFile();
+      IResource resource =
+          intelliJReferencePointManager.getSarosResource(
+              path.getReferencePoint(), path.getProjectRelativePath());
+
+      IFile file = resource.adaptTo(IntelliJFileImpl.class);
 
       int replacedTextLength = replacedText.length();
       if (replacedTextLength > 0) {

--- a/intellij/src/saros/intellij/eventhandler/editor/document/LocalDocumentModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/document/LocalDocumentModificationHandler.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 import saros.activities.SPath;
 import saros.intellij.editor.EditorManager;
+import saros.intellij.filesystem.IntelliJReferencePointManager;
 import saros.session.ISarosSession;
 
 /**
@@ -26,9 +27,12 @@ public class LocalDocumentModificationHandler extends AbstractLocalDocumentModif
       };
 
   public LocalDocumentModificationHandler(
-      Project project, EditorManager editorManager, ISarosSession sarosSession) {
+      Project project,
+      EditorManager editorManager,
+      ISarosSession sarosSession,
+      IntelliJReferencePointManager intelliJReferencePointManager) {
 
-    super(project, editorManager, sarosSession);
+    super(project, editorManager, sarosSession, intelliJReferencePointManager);
   }
 
   /**

--- a/intellij/src/saros/intellij/eventhandler/editor/editorstate/AnnotationUpdater.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/editorstate/AnnotationUpdater.java
@@ -9,8 +9,11 @@ import com.intellij.util.messages.MessageBusConnection;
 import org.jetbrains.annotations.NotNull;
 import saros.activities.SPath;
 import saros.filesystem.IFile;
+import saros.filesystem.IResource;
 import saros.intellij.editor.LocalEditorHandler;
 import saros.intellij.editor.annotations.AnnotationManager;
+import saros.intellij.filesystem.IntelliJFileImpl;
+import saros.intellij.filesystem.IntelliJReferencePointManager;
 import saros.intellij.filesystem.VirtualFileConverter;
 import saros.session.ISarosSession;
 
@@ -23,6 +26,7 @@ public class AnnotationUpdater extends AbstractLocalEditorStatusChangeHandler {
   private final AnnotationManager annotationManager;
   private final LocalEditorHandler localEditorHandler;
   private final ISarosSession sarosSession;
+  private final IntelliJReferencePointManager intelliJReferencePointManager;
 
   private final FileEditorManagerListener fileEditorManagerListener =
       new FileEditorManagerListener() {
@@ -49,13 +53,15 @@ public class AnnotationUpdater extends AbstractLocalEditorStatusChangeHandler {
       Project project,
       AnnotationManager annotationManager,
       LocalEditorHandler localEditorHandler,
-      ISarosSession sarosSession) {
+      ISarosSession sarosSession,
+      IntelliJReferencePointManager intelliJReferencePointManager) {
 
     super(project);
 
     this.annotationManager = annotationManager;
     this.localEditorHandler = localEditorHandler;
     this.sarosSession = sarosSession;
+    this.intelliJReferencePointManager = intelliJReferencePointManager;
   }
 
   /**
@@ -74,7 +80,11 @@ public class AnnotationUpdater extends AbstractLocalEditorStatusChangeHandler {
       return;
     }
 
-    IFile file = sPath.getFile();
+    IResource resource =
+        intelliJReferencePointManager.getSarosResource(
+            sPath.getReferencePoint(), sPath.getProjectRelativePath());
+
+    IFile file = resource.adaptTo(IntelliJFileImpl.class);
 
     if (sarosSession.isShared(file)) {
       annotationManager.applyStoredAnnotations(file, editor);
@@ -94,7 +104,11 @@ public class AnnotationUpdater extends AbstractLocalEditorStatusChangeHandler {
       return;
     }
 
-    IFile file = sPath.getFile();
+    IResource resource =
+        intelliJReferencePointManager.getSarosResource(
+            sPath.getReferencePoint(), sPath.getProjectRelativePath());
+
+    IFile file = resource.adaptTo(IntelliJFileImpl.class);
 
     if (sarosSession.isShared(file)) {
       annotationManager.updateAnnotationStore(file);

--- a/intellij/src/saros/intellij/eventhandler/editor/editorstate/PreexistingSelectionDispatcher.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/editorstate/PreexistingSelectionDispatcher.java
@@ -8,8 +8,10 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.messages.MessageBusConnection;
 import org.jetbrains.annotations.NotNull;
 import saros.activities.SPath;
+import saros.filesystem.IResource;
 import saros.intellij.editor.EditorManager;
 import saros.intellij.editor.LocalEditorHandler;
+import saros.intellij.filesystem.IntelliJReferencePointManager;
 import saros.intellij.filesystem.VirtualFileConverter;
 import saros.session.ISarosSession;
 
@@ -27,6 +29,7 @@ public class PreexistingSelectionDispatcher extends AbstractLocalEditorStatusCha
   private final EditorManager editorManager;
   private final LocalEditorHandler localEditorHandler;
   private final ISarosSession sarosSession;
+  private final IntelliJReferencePointManager intelliJReferencePointManager;
 
   private final FileEditorManagerListener fileEditorManagerListener =
       new FileEditorManagerListener() {
@@ -42,13 +45,15 @@ public class PreexistingSelectionDispatcher extends AbstractLocalEditorStatusCha
       Project project,
       EditorManager editorManager,
       LocalEditorHandler localEditorHandler,
-      ISarosSession sarosSession) {
+      ISarosSession sarosSession,
+      IntelliJReferencePointManager intelliJReferencePointManager) {
 
     super(project);
 
     this.editorManager = editorManager;
     this.localEditorHandler = localEditorHandler;
     this.sarosSession = sarosSession;
+    this.intelliJReferencePointManager = intelliJReferencePointManager;
   }
 
   /**
@@ -63,7 +68,11 @@ public class PreexistingSelectionDispatcher extends AbstractLocalEditorStatusCha
 
     SPath sPath = VirtualFileConverter.convertToSPath(project, virtualFile);
 
-    if (sPath != null && sarosSession.isShared(sPath.getResource()) && editor != null) {
+    IResource resource =
+        intelliJReferencePointManager.getSarosResource(
+            sPath.getReferencePoint(), sPath.getProjectRelativePath());
+
+    if (sPath != null && sarosSession.isShared(resource) && editor != null) {
       editorManager.sendExistingSelection(sPath, editor);
     }
   }

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -32,7 +32,9 @@ import saros.activities.FolderCreatedActivity;
 import saros.activities.FolderDeletedActivity;
 import saros.activities.IActivity;
 import saros.activities.SPath;
+import saros.filesystem.IFile;
 import saros.filesystem.IPath;
+import saros.filesystem.IResource;
 import saros.intellij.editor.DocumentAPI;
 import saros.intellij.editor.EditorManager;
 import saros.intellij.editor.LocalEditorHandler;
@@ -40,6 +42,8 @@ import saros.intellij.editor.ProjectAPI;
 import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.eventhandler.IApplicationEventHandler;
 import saros.intellij.eventhandler.editor.document.LocalDocumentModificationHandler;
+import saros.intellij.filesystem.IntelliJFileImpl;
+import saros.intellij.filesystem.IntelliJReferencePointManager;
 import saros.intellij.filesystem.VirtualFileConverter;
 import saros.intellij.project.filesystem.IntelliJPathImpl;
 import saros.observables.FileReplacementInProgressObservable;
@@ -67,6 +71,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
   private final FileReplacementInProgressObservable fileReplacementInProgressObservable;
   private final AnnotationManager annotationManager;
   private final LocalEditorHandler localEditorHandler;
+  private final IntelliJReferencePointManager intelliJReferencePointManager;
 
   private boolean enabled;
   private boolean disposed;
@@ -176,7 +181,8 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
       ISarosSession session,
       FileReplacementInProgressObservable fileReplacementInProgressObservable,
       AnnotationManager annotationManager,
-      LocalEditorHandler localEditorHandler) {
+      LocalEditorHandler localEditorHandler,
+      IntelliJReferencePointManager intelliJReferencePointManager) {
 
     this.project = project;
 
@@ -190,6 +196,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
     this.disposed = false;
 
     this.localFileSystem = LocalFileSystem.getInstance();
+    this.intelliJReferencePointManager = intelliJReferencePointManager;
   }
 
   /**
@@ -369,6 +376,12 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
     SPath path = VirtualFileConverter.convertToSPath(project, deletedVirtualFile);
 
+    IResource resource =
+        intelliJReferencePointManager.getSarosResource(
+            path.getReferencePoint(), path.getProjectRelativePath());
+
+    IFile file = resource.adaptTo(IntelliJFileImpl.class);
+
     if (path == null || !session.isShared(path.getResource())) {
       if (LOG.isTraceEnabled()) {
         LOG.trace("Ignoring non-shared resource deletion: " + deletedVirtualFile);
@@ -393,7 +406,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
       editorManager.removeAllEditorsForPath(path);
 
-      annotationManager.removeAnnotations(path.getFile());
+      annotationManager.removeAnnotations(file);
     }
 
     dispatchActivity(activity);
@@ -617,11 +630,18 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
     SPath oldFilePath = VirtualFileConverter.convertToSPath(project, oldFile);
     SPath newParentPath = VirtualFileConverter.convertToSPath(project, newBaseParent);
 
+    IResource oldResource =
+        intelliJReferencePointManager.getSarosResource(
+            oldFilePath.getReferencePoint(), oldFilePath.getProjectRelativePath());
+
+    IResource newParentResource =
+        intelliJReferencePointManager.getSarosResource(
+            newParentPath.getReferencePoint(), newParentPath.getProjectRelativePath());
+
     User user = session.getLocalUser();
 
-    boolean oldPathIsShared = oldFilePath != null && session.isShared(oldFilePath.getResource());
-    boolean newPathIsShared =
-        newParentPath != null && session.isShared(newParentPath.getResource());
+    boolean oldPathIsShared = oldFilePath != null && session.isShared(oldResource);
+    boolean newPathIsShared = newParentPath != null && session.isShared(newParentResource);
 
     boolean fileIsOpen = ProjectAPI.isOpen(project, oldFile);
 
@@ -662,7 +682,13 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
       editorManager.replaceAllEditorsForPath(oldFilePath, newFilePath);
 
-      annotationManager.updateAnnotationPath(oldFilePath.getFile(), newFilePath.getFile());
+      IResource newFileResource =
+          intelliJReferencePointManager.getSarosResource(
+              newFilePath.getReferencePoint(), newFilePath.getProjectRelativePath());
+
+      annotationManager.updateAnnotationPath(
+          oldResource.adaptTo(IntelliJFileImpl.class),
+          newFileResource.adaptTo(IntelliJFileImpl.class));
 
     } else if (newPathIsShared) {
       // moved file into shared module
@@ -697,7 +723,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
       editorManager.removeAllEditorsForPath(oldFilePath);
 
-      annotationManager.removeAnnotations(oldFilePath.getFile());
+      annotationManager.removeAnnotations(oldResource.adaptTo(IntelliJFileImpl.class));
 
     } else {
       // neither source nor destination are shared

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -218,7 +218,11 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
     SPath path = VirtualFileConverter.convertToSPath(project, file);
 
-    if (path == null || !session.isShared(path.getResource())) {
+    IResource resource =
+        intelliJReferencePointManager.getSarosResource(
+            path.getReferencePoint(), path.getProjectRelativePath());
+
+    if (path == null || !session.isShared(resource)) {
       if (LOG.isTraceEnabled()) {
         LOG.trace("Ignoring non-shared resource's contents change: " + file);
       }
@@ -276,7 +280,11 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
     SPath path = VirtualFileConverter.convertToSPath(project, createdVirtualFile);
 
-    if (path == null || !session.isShared(path.getResource())) {
+    IResource resource =
+        intelliJReferencePointManager.getSarosResource(
+            path.getReferencePoint(), path.getProjectRelativePath());
+
+    if (path == null || !session.isShared(resource)) {
       if (LOG.isTraceEnabled()) {
         LOG.trace("Ignoring non-shared resource creation: " + createdVirtualFile);
       }
@@ -336,7 +344,11 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
     SPath copyPath = VirtualFileConverter.convertToSPath(project, copy);
 
-    if (copyPath == null || !session.isShared(copyPath.getResource())) {
+    IResource resource =
+        intelliJReferencePointManager.getSarosResource(
+            copyPath.getReferencePoint(), copyPath.getProjectRelativePath());
+
+    if (copyPath == null || !session.isShared(resource)) {
       if (LOG.isTraceEnabled()) {
         LOG.trace("Ignoring non-shared resource copy: " + copy);
       }
@@ -380,9 +392,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
         intelliJReferencePointManager.getSarosResource(
             path.getReferencePoint(), path.getProjectRelativePath());
 
-    IFile file = resource.adaptTo(IntelliJFileImpl.class);
-
-    if (path == null || !session.isShared(path.getResource())) {
+    if (path == null || !session.isShared(resource)) {
       if (LOG.isTraceEnabled()) {
         LOG.trace("Ignoring non-shared resource deletion: " + deletedVirtualFile);
       }
@@ -405,6 +415,8 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
               user, Type.REMOVED, FileActivity.Purpose.ACTIVITY, path, null, null, null);
 
       editorManager.removeAllEditorsForPath(path);
+
+      IFile file = resource.adaptTo(IntelliJFileImpl.class);
 
       annotationManager.removeAnnotations(file);
     }
@@ -489,11 +501,17 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
     SPath oldPath = VirtualFileConverter.convertToSPath(project, oldFile);
     SPath newParentPath = VirtualFileConverter.convertToSPath(project, newParent);
 
+    IResource oldResource =
+        intelliJReferencePointManager.getSarosResource(
+            oldPath.getReferencePoint(), oldPath.getProjectRelativePath());
+    IResource newParentResource =
+        intelliJReferencePointManager.getSarosResource(
+            newParentPath.getReferencePoint(), newParentPath.getProjectRelativePath());
+
     User user = session.getLocalUser();
 
-    boolean oldPathIsShared = oldPath != null && session.isShared(oldPath.getResource());
-    boolean newPathIsShared =
-        newParentPath != null && session.isShared(newParentPath.getResource());
+    boolean oldPathIsShared = oldPath != null && session.isShared(oldResource);
+    boolean newPathIsShared = newParentPath != null && session.isShared(newParentResource);
 
     if (!oldPathIsShared && !newPathIsShared) {
       if (LOG.isTraceEnabled()) {
@@ -809,7 +827,11 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
           SPath path = VirtualFileConverter.convertToSPath(project, file);
 
-          if (path != null && session.isShared(path.getResource())) {
+          IResource resource =
+              intelliJReferencePointManager.getSarosResource(
+                  path.getReferencePoint(), path.getProjectRelativePath());
+
+          if (path != null && session.isShared(resource)) {
             LOG.error(
                 "Renamed resource is a root directory. "
                     + "Such an activity can not be shared through Saros.");

--- a/intellij/src/saros/intellij/filesystem/IntelliJReferencePointManager.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJReferencePointManager.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.NotNull;
+import saros.activities.SPath;
 import saros.filesystem.IPath;
 import saros.filesystem.IReferencePoint;
 import saros.filesystem.IResource;
@@ -124,6 +125,18 @@ public class IntelliJReferencePointManager {
     Module module = getModule(referencePoint);
 
     return FilesystemUtils.findVirtualFile(module, referencePointRelativePath);
+  }
+
+  /**
+   * Returns the {@link VirtualFile} resource represented by given {@link SPath} Saros Path.
+   *
+   * @param sPath to th virtualFile outgoing from the reference point in sPath
+   * @return the virtualFile represented by sPath
+   * @exception IllegalArgumentException if for {@link IReferencePoint} reference point doesn't
+   *     exists a module, which is contained in sPath
+   */
+  public VirtualFile getResource(@NotNull SPath sPath) {
+    return getResource(sPath.getReferencePoint(), sPath.getProjectRelativePath());
   }
 
   /**

--- a/intellij/src/saros/intellij/filesystem/IntelliJReferencePointManager.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJReferencePointManager.java
@@ -133,7 +133,7 @@ public class IntelliJReferencePointManager {
    * @param sPath to th virtualFile outgoing from the reference point in sPath
    * @return the virtualFile represented by sPath
    * @exception IllegalArgumentException if for {@link IReferencePoint} reference point doesn't
-   *     exists a module, which is contained in sPath
+   *     exists a module which is contained in sPath
    */
   public VirtualFile getResource(@NotNull SPath sPath) {
     return getResource(sPath.getReferencePoint(), sPath.getProjectRelativePath());

--- a/intellij/src/saros/intellij/project/SharedResourcesManager.java
+++ b/intellij/src/saros/intellij/project/SharedResourcesManager.java
@@ -23,6 +23,7 @@ import saros.intellij.editor.SelectedEditorStateSnapshot;
 import saros.intellij.editor.SelectedEditorStateSnapshotFactory;
 import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.eventhandler.IApplicationEventHandler.ApplicationEventHandlerType;
+import saros.intellij.filesystem.IntelliJFileImpl;
 import saros.intellij.filesystem.IntelliJFolderImpl;
 import saros.intellij.filesystem.IntelliJReferencePointManager;
 import saros.repackaged.picocontainer.Startable;
@@ -161,10 +162,12 @@ public class SharedResourcesManager implements Startable {
 
     try {
       if (type == FileActivity.Type.CREATED) {
-        IFile file =
-            (IFile)
-                intelliJReferencePointManager.getSarosResource(
-                    path.getReferencePoint(), path.getProjectRelativePath());
+        IResource resource =
+            intelliJReferencePointManager.getSarosResource(
+                path.getReferencePoint(), path.getProjectRelativePath());
+
+        IFile file = resource.adaptTo(IntelliJFileImpl.class);
+
         if (file.exists()) {
           localEditorManipulator.handleContentRecovery(
               path, activity.getContent(), activity.getEncoding(), activity.getSource());
@@ -200,14 +203,17 @@ public class SharedResourcesManager implements Startable {
     SPath oldPath = activity.getOldPath();
     SPath newPath = activity.getPath();
 
-    IFile oldFile =
-        (IFile)
-            intelliJReferencePointManager.getSarosResource(
-                oldPath.getReferencePoint(), oldPath.getProjectRelativePath());
-    IFile newFile =
-        (IFile)
-            intelliJReferencePointManager.getSarosResource(
-                newPath.getReferencePoint(), newPath.getProjectRelativePath());
+    IResource oldResource =
+        intelliJReferencePointManager.getSarosResource(
+            oldPath.getReferencePoint(), oldPath.getProjectRelativePath());
+
+    IFile oldFile = oldResource.adaptTo(IntelliJFileImpl.class);
+
+    IResource newResource =
+        intelliJReferencePointManager.getSarosResource(
+            newPath.getReferencePoint(), newPath.getProjectRelativePath());
+
+    IFile newFile = newResource.adaptTo(IntelliJFileImpl.class);
 
     if (!oldFile.exists()) {
       LOG.warn(
@@ -265,10 +271,11 @@ public class SharedResourcesManager implements Startable {
   private void handleFileDeletion(@NotNull FileActivity activity) throws IOException {
 
     SPath path = activity.getPath();
-    IFile file =
-        (IFile)
-            intelliJReferencePointManager.getSarosResource(
-                path.getReferencePoint(), path.getProjectRelativePath());
+    IResource resource =
+        intelliJReferencePointManager.getSarosResource(
+            path.getReferencePoint(), path.getProjectRelativePath());
+
+    IFile file = resource.adaptTo(IntelliJFileImpl.class);
 
     if (!file.exists()) {
       LOG.warn("Could not delete file " + file + " as it does not exist.");
@@ -299,10 +306,12 @@ public class SharedResourcesManager implements Startable {
   private void handleFileCreation(@NotNull FileActivity activity) throws IOException {
 
     SPath sPath = activity.getPath();
-    IFile file =
-        (IFile)
-            intelliJReferencePointManager.getSarosResource(
-                sPath.getReferencePoint(), sPath.getProjectRelativePath());
+
+    IResource resource =
+        intelliJReferencePointManager.getSarosResource(
+            sPath.getReferencePoint(), sPath.getProjectRelativePath());
+
+    IFile file = resource.adaptTo(IntelliJFileImpl.class);
 
     if (file.exists()) {
       LOG.warn("Could not create file " + file + " as it already exists.");

--- a/intellij/src/saros/intellij/project/SharedResourcesManager.java
+++ b/intellij/src/saros/intellij/project/SharedResourcesManager.java
@@ -15,6 +15,7 @@ import saros.activities.IFileSystemModificationActivity;
 import saros.activities.SPath;
 import saros.filesystem.IFile;
 import saros.filesystem.IFolder;
+import saros.filesystem.IResource;
 import saros.intellij.context.SharedIDEContext;
 import saros.intellij.editor.LocalEditorHandler;
 import saros.intellij.editor.LocalEditorManipulator;
@@ -22,6 +23,8 @@ import saros.intellij.editor.SelectedEditorStateSnapshot;
 import saros.intellij.editor.SelectedEditorStateSnapshotFactory;
 import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.eventhandler.IApplicationEventHandler.ApplicationEventHandlerType;
+import saros.intellij.filesystem.IntelliJFolderImpl;
+import saros.intellij.filesystem.IntelliJReferencePointManager;
 import saros.repackaged.picocontainer.Startable;
 import saros.session.AbstractActivityConsumer;
 import saros.session.IActivityConsumer;
@@ -43,6 +46,7 @@ public class SharedResourcesManager implements Startable {
   private final LocalEditorManipulator localEditorManipulator;
   private final AnnotationManager annotationManager;
   private final SelectedEditorStateSnapshotFactory selectedEditorStateSnapshotFactory;
+  private final IntelliJReferencePointManager intelliJReferencePointManager;
 
   @Override
   public void start() {
@@ -66,7 +70,8 @@ public class SharedResourcesManager implements Startable {
       LocalEditorManipulator localEditorManipulator,
       AnnotationManager annotationManager,
       SharedIDEContext sharedIDEContext,
-      SelectedEditorStateSnapshotFactory selectedEditorStateSnapshotFactory) {
+      SelectedEditorStateSnapshotFactory selectedEditorStateSnapshotFactory,
+      IntelliJReferencePointManager intelliJReferencePointManager) {
 
     this.sarosSession = sarosSession;
     this.localEditorHandler = localEditorHandler;
@@ -74,6 +79,7 @@ public class SharedResourcesManager implements Startable {
     this.annotationManager = annotationManager;
     this.sharedIDEContext = sharedIDEContext;
     this.selectedEditorStateSnapshotFactory = selectedEditorStateSnapshotFactory;
+    this.intelliJReferencePointManager = intelliJReferencePointManager;
   }
 
   private final IActivityConsumer consumer =
@@ -155,7 +161,11 @@ public class SharedResourcesManager implements Startable {
 
     try {
       if (type == FileActivity.Type.CREATED) {
-        if (path.getFile().exists()) {
+        IFile file =
+            (IFile)
+                intelliJReferencePointManager.getSarosResource(
+                    path.getReferencePoint(), path.getProjectRelativePath());
+        if (file.exists()) {
           localEditorManipulator.handleContentRecovery(
               path, activity.getContent(), activity.getEncoding(), activity.getSource());
 
@@ -190,8 +200,14 @@ public class SharedResourcesManager implements Startable {
     SPath oldPath = activity.getOldPath();
     SPath newPath = activity.getPath();
 
-    IFile oldFile = oldPath.getFile();
-    IFile newFile = newPath.getFile();
+    IFile oldFile =
+        (IFile)
+            intelliJReferencePointManager.getSarosResource(
+                oldPath.getReferencePoint(), oldPath.getProjectRelativePath());
+    IFile newFile =
+        (IFile)
+            intelliJReferencePointManager.getSarosResource(
+                newPath.getReferencePoint(), newPath.getProjectRelativePath());
 
     if (!oldFile.exists()) {
       LOG.warn(
@@ -249,7 +265,10 @@ public class SharedResourcesManager implements Startable {
   private void handleFileDeletion(@NotNull FileActivity activity) throws IOException {
 
     SPath path = activity.getPath();
-    IFile file = path.getFile();
+    IFile file =
+        (IFile)
+            intelliJReferencePointManager.getSarosResource(
+                path.getReferencePoint(), path.getProjectRelativePath());
 
     if (!file.exists()) {
       LOG.warn("Could not delete file " + file + " as it does not exist.");
@@ -279,8 +298,11 @@ public class SharedResourcesManager implements Startable {
 
   private void handleFileCreation(@NotNull FileActivity activity) throws IOException {
 
-    SPath path = activity.getPath();
-    IFile file = path.getFile();
+    SPath sPath = activity.getPath();
+    IFile file =
+        (IFile)
+            intelliJReferencePointManager.getSarosResource(
+                sPath.getReferencePoint(), sPath.getProjectRelativePath());
 
     if (file.exists()) {
       LOG.warn("Could not create file " + file + " as it already exists.");
@@ -302,7 +324,11 @@ public class SharedResourcesManager implements Startable {
 
   private void handleFolderCreation(@NotNull FolderCreatedActivity activity) throws IOException {
 
-    IFolder folder = activity.getPath().getFolder();
+    SPath sPath = activity.getPath();
+    IResource resource =
+        intelliJReferencePointManager.getSarosResource(
+            sPath.getReferencePoint(), sPath.getProjectRelativePath());
+    IFolder folder = resource.adaptTo(IntelliJFolderImpl.class);
 
     if (folder.exists()) {
       LOG.warn("Could not create folder " + folder + " as it already exist.");
@@ -332,8 +358,11 @@ public class SharedResourcesManager implements Startable {
    */
   // TODO deal with children that are not part of the current session (submodules)
   private void handleFolderDeletion(@NotNull FolderDeletedActivity activity) throws IOException {
-
-    IFolder folder = activity.getPath().getFolder();
+    SPath sPath = activity.getPath();
+    IResource resource =
+        intelliJReferencePointManager.getSarosResource(
+            sPath.getReferencePoint(), sPath.getProjectRelativePath());
+    IFolder folder = resource.adaptTo(IntelliJFolderImpl.class);
 
     if (!folder.exists()) {
       LOG.warn("Could not delete folder " + folder + " as it does not exist.");

--- a/intellij/src/saros/intellij/ui/views/buttons/ConsistencyButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/ConsistencyButton.java
@@ -246,7 +246,9 @@ public class ConsistencyButton extends AbstractSessionToolbarButton {
     StringBuilder sb = new StringBuilder();
 
     for (SPath path : paths) {
-      IResource resource = path.getResource();
+      IResource resource =
+          intelliJReferencePointManager.getSarosResource(
+              path.getReferencePoint(), path.getProjectRelativePath());
 
       if (resource == null) {
         LOG.warn("Inconsistent resource " + path + " could not be " + "found.");

--- a/intellij/src/saros/intellij/ui/views/buttons/ConsistencyButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/ConsistencyButton.java
@@ -13,6 +13,7 @@ import saros.activities.SPath;
 import saros.concurrent.watchdog.ConsistencyWatchdogClient;
 import saros.concurrent.watchdog.IsInconsistentObservable;
 import saros.filesystem.IResource;
+import saros.intellij.filesystem.IntelliJReferencePointManager;
 import saros.intellij.ui.Messages;
 import saros.intellij.ui.actions.ConsistencyAction;
 import saros.intellij.ui.util.DialogUtils;
@@ -71,6 +72,8 @@ public class ConsistencyButton extends AbstractSessionToolbarButton {
   private final ValueChangeListener<Boolean> isConsistencyListener = this::handleConsistencyChange;
 
   @Inject private IsInconsistentObservable inconsistentObservable;
+
+  @Inject private IntelliJReferencePointManager intelliJReferencePointManager;
 
   private volatile SessionInconsistencyState sessionInconsistencyState;
 
@@ -228,7 +231,9 @@ public class ConsistencyButton extends AbstractSessionToolbarButton {
 
     for (SPath path : paths) {
       sbInconsistentFiles.append(Messages.ConsistencyButton_inconsistent_list_module).append(": ");
-      sbInconsistentFiles.append(path.getProject().getName()).append(", ");
+      sbInconsistentFiles
+          .append(intelliJReferencePointManager.getModule(path.getReferencePoint()).getName())
+          .append(", ");
       sbInconsistentFiles.append(Messages.ConsistencyButton_inconsistent_list_file).append(": ");
       sbInconsistentFiles.append(path.getProjectRelativePath().toOSString());
       sbInconsistentFiles.append("\n");

--- a/intellij/test/junit/saros/intellij/eventhandler/editor/document/LocalDocumentModificationHandlerTest.java
+++ b/intellij/test/junit/saros/intellij/eventhandler/editor/document/LocalDocumentModificationHandlerTest.java
@@ -29,7 +29,7 @@ public class LocalDocumentModificationHandlerTest {
   public void before() {
     mockEditorFactory();
     localDocumentModificationHandler =
-        new LocalDocumentModificationHandler(null, dummyEditorManager(), null);
+        new LocalDocumentModificationHandler(null, dummyEditorManager(), null, null);
     listening = false;
   }
 


### PR DESCRIPTION
This PR contains adjustings of SPath references in Saros/I, because the SPath class can't only return the IReferencePoint and the relative path to the saros resource, but also the saros resources itself (like IFolder, IFile, ...).
The idea is, that the IntelliJReferencePointManager gets the SPath object and determinates IntelliJ and Saros resources 