### PR TITLE
Fix version mismatch notification and notification utils bug

### DIFF
--- a/intellij/src/saros/core/ui/eventhandler/NegotiationHandler.java
+++ b/intellij/src/saros/core/ui/eventhandler/NegotiationHandler.java
@@ -122,7 +122,7 @@ public class NegotiationHandler implements INegotiationHandler {
     OutgoingInvitationJob(OutgoingSessionNegotiation negotiation) {
       super(
           MessageFormat.format(
-              Messages.NegotiationHandler_inviting_user, getNickname(negotiation.getPeer())));
+              Messages.NegotiationHandler_session_processing, getNickname(negotiation.getPeer())));
       this.negotiation = negotiation;
       peer = negotiation.getPeer().getBase();
     }
@@ -132,40 +132,46 @@ public class NegotiationHandler implements INegotiationHandler {
       try {
         SessionNegotiation.Status status = negotiation.start(monitor);
 
+        String message;
+
         switch (status) {
           case CANCEL:
             return Status.CANCEL_STATUS;
           case ERROR:
-            return new Status(
-                IStatus.ERROR, SarosComponent.PLUGIN_ID, negotiation.getErrorMessage());
+            message =
+                MessageFormat.format(
+                    Messages.NegotiationHandler_session_local_error_message,
+                    negotiation.getErrorMessage());
+
+            NotificationPanel.showError(
+                message, Messages.NegotiationHandler_session_local_error_title);
+
+            return new Status(IStatus.ERROR, SarosComponent.PLUGIN_ID, message);
           case OK:
             break;
           case REMOTE_CANCEL:
-            NotificationPanel.showInformation(
-                MessageFormat.format(Messages.NegotiationHandler_canceled_invitation_text, peer),
-                Messages.NegotiationHandler_canceled_invitation);
+            message =
+                MessageFormat.format(
+                    Messages.NegotiationHandler_session_remote_cancel_message, peer);
 
-            return new Status(
-                IStatus.CANCEL,
-                SarosComponent.PLUGIN_ID,
-                MessageFormat.format(Messages.NegotiationHandler_canceled_invitation_text, peer));
+            NotificationPanel.showInformation(
+                message, Messages.NegotiationHandler_session_remote_cancel_title);
+
+            return new Status(IStatus.CANCEL, SarosComponent.PLUGIN_ID, message);
 
           case REMOTE_ERROR:
-            NotificationPanel.showError(
+            message =
                 MessageFormat.format(
-                    Messages.NegotiationHandler_error_during_invitation_text,
+                    Messages.NegotiationHandler_session_remote_error_message,
                     peer,
-                    negotiation.getErrorMessage()),
-                Messages.NegotiationHandler_error_during_invitation);
+                    negotiation.getErrorMessage());
 
-            return new Status(
-                IStatus.ERROR,
-                SarosComponent.PLUGIN_ID,
-                MessageFormat.format(
-                    Messages.NegotiationHandler_error_during_invitation_text,
-                    peer,
-                    negotiation.getErrorMessage()));
+            NotificationPanel.showError(
+                message, Messages.NegotiationHandler_session_remote_error_title);
+
+            return new Status(IStatus.ERROR, SarosComponent.PLUGIN_ID, message);
         }
+
       } catch (Exception e) {
         LOG.error("This exception is not expected here: ", e);
         return new Status(IStatus.ERROR, SarosComponent.PLUGIN_ID, e.getMessage(), e);
@@ -207,7 +213,7 @@ public class NegotiationHandler implements INegotiationHandler {
           case REMOTE_CANCEL:
             message =
                 MessageFormat.format(
-                    Messages.NegotiationHandler_project_sharing_canceled_text, peerName);
+                    Messages.NegotiationHandler_project_sharing_canceled_message, peerName);
 
             ApplicationManager.getApplication()
                 .invokeLater(
@@ -220,11 +226,11 @@ public class NegotiationHandler implements INegotiationHandler {
           case REMOTE_ERROR:
             message =
                 MessageFormat.format(
-                    Messages.NegotiationHandler_sharing_project_canceled_remotely,
+                    Messages.NegotiationHandler_sharing_project_canceled_remotely_title,
                     peerName,
                     negotiation.getErrorMessage());
             NotificationPanel.showError(
-                message, Messages.NegotiationHandler_sharing_project_canceled_remotely_text);
+                message, Messages.NegotiationHandler_sharing_project_canceled_remotely_message);
 
             return new Status(IStatus.ERROR, SarosComponent.PLUGIN_ID, message);
         }

--- a/intellij/src/saros/intellij/context/SharedIDEContext.java
+++ b/intellij/src/saros/intellij/context/SharedIDEContext.java
@@ -157,6 +157,7 @@ public class SharedIDEContext implements Disposable {
    * @return the project object for the current session
    * @throws IllegalStateException if this is called before the context was completely initialized
    */
+  // TODO improve behavior before initialization
   @NotNull
   public Project getProject() {
     if (project == null) {
@@ -164,6 +165,15 @@ public class SharedIDEContext implements Disposable {
     }
 
     return project;
+  }
+
+  /**
+   * Returns whether the context is completely initialized.
+   *
+   * @return whether the context is completely initialized
+   */
+  public boolean isInitialized() {
+    return project != null;
   }
 
   /**

--- a/intellij/src/saros/intellij/ui/Messages.java
+++ b/intellij/src/saros/intellij/ui/Messages.java
@@ -85,15 +85,17 @@ public class Messages {
   public static String ConnectButton_connect_to_new_account_title;
   public static String ConnectButton_connect_to_new_account_message;
 
-  public static String NegotiationHandler_canceled_invitation;
-  public static String NegotiationHandler_canceled_invitation_text;
-  public static String NegotiationHandler_error_during_invitation;
-  public static String NegotiationHandler_error_during_invitation_text;
-  public static String NegotiationHandler_inviting_user;
-  public static String NegotiationHandler_project_sharing_canceled_text;
+  public static String NegotiationHandler_session_local_error_title;
+  public static String NegotiationHandler_session_local_error_message;
+  public static String NegotiationHandler_session_remote_cancel_title;
+  public static String NegotiationHandler_session_remote_cancel_message;
+  public static String NegotiationHandler_session_remote_error_title;
+  public static String NegotiationHandler_session_remote_error_message;
+  public static String NegotiationHandler_session_processing;
+  public static String NegotiationHandler_project_sharing_canceled_message;
   public static String NegotiationHandler_sharing_project;
-  public static String NegotiationHandler_sharing_project_canceled_remotely;
-  public static String NegotiationHandler_sharing_project_canceled_remotely_text;
+  public static String NegotiationHandler_sharing_project_canceled_remotely_title;
+  public static String NegotiationHandler_sharing_project_canceled_remotely_message;
 
   public static String ShowDescriptionPage_description;
   public static String ShowDescriptionPage_title2;

--- a/intellij/src/saros/intellij/ui/messages.properties
+++ b/intellij/src/saros/intellij/ui/messages.properties
@@ -72,16 +72,17 @@ ConnectButton_account_creation_xmpp_server_invalid_port_message=No valid server 
 ConnectButton_connect_to_new_account_title=Connect to new Account?
 ConnectButton_connect_to_new_account_message=Connect to the created Account?\nNOTE: This will remove you from any sessions that are currently running without correctly informing the other participants.
 
-
-NegotiationHandler_canceled_invitation=Canceled Invitation
-NegotiationHandler_canceled_invitation_text={0} has canceled your Invitation.
-NegotiationHandler_error_during_invitation=Error during Invitation
-NegotiationHandler_error_during_invitation_text=Your invitation to {0} has been canceled remotely because of an error:\n\n{1}
-NegotiationHandler_inviting_user=Inviting {0}...
-NegotiationHandler_project_sharing_canceled_text={0} has canceled the project sharing.
+NegotiationHandler_session_local_error_title=Negotiation Canceled
+NegotiationHandler_session_local_error_message=The session negotiation was canceled as a local error occurred: {0}
+NegotiationHandler_session_remote_cancel_title=Remote User Canceled Negotiation
+NegotiationHandler_session_remote_cancel_message={0} has canceled the session negotiation.
+NegotiationHandler_session_remote_error_title=Remote Error during Negotiation
+NegotiationHandler_session_remote_error_message=The session negotiation with {0} has been canceled remotely because of an error:\n{1}
+NegotiationHandler_session_processing=Starting session negotiation with {0}...
+NegotiationHandler_project_sharing_canceled_message={0} has canceled the project sharing.
 NegotiationHandler_sharing_project=Synchronizing modules
-NegotiationHandler_sharing_project_canceled_remotely=The project sharing with {0} has been canceled remotely because of an error:\n\n{1}
-NegotiationHandler_sharing_project_canceled_remotely_text=Error during project sharing
+NegotiationHandler_sharing_project_canceled_remotely_title=The project sharing with {0} has been canceled remotely because of an error:\n{1}
+NegotiationHandler_sharing_project_canceled_remotely_message=Error during project sharing
 
 ShowDescriptionPage_description=You have been invited to join a Saros session. If you accept the invitation by pressing 'next', a new wizard for the project negotiation will open.
 ShowDescriptionPage_title2=Session Invitation

--- a/intellij/src/saros/intellij/ui/util/NotificationPanel.java
+++ b/intellij/src/saros/intellij/ui/util/NotificationPanel.java
@@ -7,7 +7,6 @@ import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.project.Project;
 import org.apache.log4j.Logger;
 import saros.SarosPluginContext;
 import saros.repackaged.picocontainer.annotations.Inject;
@@ -48,15 +47,16 @@ public class NotificationPanel {
   private static void showNotification(
       NotificationType notificationType, String message, String title) {
 
-    Project project = projectUtils.getSharedProject();
+    projectUtils.runWithProject(
+        (project) -> {
+          LOG.info("Showing notification - " + notificationType + ": " + title + " - " + message);
 
-    LOG.info("Showing notification - " + notificationType + ": " + title + " - " + message);
-
-    final Notification notification =
-        GROUP_DISPLAY_ID_INFO.createNotification(
-            title, message, notificationType, URL_OPENING_LISTENER);
-    ApplicationManager.getApplication()
-        .invokeLater(() -> Notifications.Bus.notify(notification, project));
+          final Notification notification =
+              GROUP_DISPLAY_ID_INFO.createNotification(
+                  title, message, notificationType, URL_OPENING_LISTENER);
+          ApplicationManager.getApplication()
+              .invokeLater(() -> Notifications.Bus.notify(notification, project));
+        });
   }
 
   /**

--- a/intellij/src/saros/intellij/ui/util/UIProjectUtils.java
+++ b/intellij/src/saros/intellij/ui/util/UIProjectUtils.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.concurrency.Promise;
+import saros.intellij.context.SharedIDEContext;
 import saros.session.ISarosSession;
 import saros.session.ISarosSessionManager;
 import saros.session.ISessionLifecycleListener;
@@ -42,18 +43,6 @@ public class UIProjectUtils {
    * Returns the <code>Project</code> object contained in the session context or <code>null</code>
    * if there currently is no session.
    *
-   * @return the <code>Project</code> object contained in the session context or <code>null</code>
-   *     if there currently is no session.
-   */
-  @Nullable
-  Project getSharedProject() {
-    return getProjectFromSession();
-  }
-
-  /**
-   * Returns the <code>Project</code> object contained in the session context or <code>null</code>
-   * if there currently is no session.
-   *
    * <p><b>NOTE:</b> This method should only be used to for UI purposes. To interact with the
    * project whose module is shared as part of a Saros session, please use the Project object
    * contained in the session context.
@@ -69,7 +58,13 @@ public class UIProjectUtils {
       return null;
     }
 
-    return currentSession.getComponent(Project.class);
+    SharedIDEContext sharedIDEContext = currentSession.getComponent(SharedIDEContext.class);
+
+    if (sharedIDEContext == null || !sharedIDEContext.isInitialized()) {
+      return null;
+    }
+
+    return sharedIDEContext.getProject();
   }
 
   /**


### PR DESCRIPTION
#### [FIX][I] Fix project selection logic for notifications

Adjusts the notification panel logic to use the session project or, if
no such project is available, use the last focused project. This
guarantees that a project is always specified to guarantee that the
notification is always displayed as a pop-up.

Indirectly fixes a bug where the old logic requesting the Project object
directly from the plugin context was still used in
UIProjectUtils.getProjectFromSession(). This lead to the method always
returning null, even if a shared project was available.

Adds a method to check whether the shared IDE context is completely
initialized. This is needed as it is not guaranteed that the
notification logic is only called after the initialization. This is only
a workaround. The logic should be improved to better handle calls in the
uninitialized state.

Subsequently removes the method UIProjectUtils.getSharedProject() as it
is no longer used.

#### [FIX][I] #674 Show notification if outgoing session negotiation errors

Adjusts the logic in NegotiationHandler to display a user notification
when the outgoing session negotiation exist with an error status. This
is only a temporary fix. In the long-term, the usage of UIMonitoredJob
should be replaced by a generic implementation based on
ProgressMonitorAdater that handles all of these cases for all calls.

Fixes #674.