### PR TITLE
[CORE] Use try-with-resources in ISS

### DIFF
--- a/core/src/saros/negotiation/InstantIncomingProjectNegotiation.java
+++ b/core/src/saros/negotiation/InstantIncomingProjectNegotiation.java
@@ -1,10 +1,8 @@
 package saros.negotiation;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.jivesoftware.smack.XMPPException;
 import org.jivesoftware.smackx.filetransfer.IncomingFileTransfer;
@@ -70,7 +68,6 @@ public class InstantIncomingProjectNegotiation extends AbstractIncomingProjectNe
 
   private void receiveStream(IProgressMonitor monitor, int fileCount)
       throws SarosCancellationException, IOException {
-
     String message = "Receiving files from " + getPeer().getName() + "...";
     monitor.beginTask(message, fileCount);
     monitor.subTask("Waiting for Host to start...");
@@ -81,17 +78,11 @@ public class InstantIncomingProjectNegotiation extends AbstractIncomingProjectNe
     log.debug(this + ": Host is starting to send...");
 
     IncomingFileTransfer transfer = transferListener.getRequest().accept();
-    InputStream in = null;
-    try {
-      in = transfer.recieveFile();
-
-      IncomingStreamProtocol isp;
-      isp = new IncomingStreamProtocol(in, session, monitor);
+    try (IncomingStreamProtocol isp =
+        new IncomingStreamProtocol(transfer.recieveFile(), session, monitor)) {
       isp.receiveStream();
     } catch (XMPPException e) {
       throw new LocalCancellationException(e.getMessage(), CancelOption.NOTIFY_PEER);
-    } finally {
-      IOUtils.closeQuietly(in);
     }
 
     log.debug(this + ": stream transmission done");

--- a/core/src/saros/negotiation/stream/IncomingStreamProtocol.java
+++ b/core/src/saros/negotiation/stream/IncomingStreamProtocol.java
@@ -14,7 +14,7 @@ import saros.negotiation.NegotiationTools.CancelOption;
 import saros.session.ISarosSession;
 
 /** Implements Stream processing in {@link AbstractStreamProtocol} format. */
-public class IncomingStreamProtocol extends AbstractStreamProtocol {
+public class IncomingStreamProtocol extends AbstractStreamProtocol implements AutoCloseable {
 
   private static final Logger log = Logger.getLogger(IncomingStreamProtocol.class);
 
@@ -35,44 +35,44 @@ public class IncomingStreamProtocol extends AbstractStreamProtocol {
    * @throws LocalCancellationException on local user cancellation
    */
   public void receiveStream() throws IOException, LocalCancellationException {
-    BoundedInputStream fileIn = null;
-    try {
-      while (true) {
-        String projectID = in.readUTF();
+    while (true) {
+      String projectID = in.readUTF();
 
-        /* check stream end */
-        if (projectID.isEmpty()) break;
+      /* check stream end */
+      if (projectID.isEmpty()) break;
 
-        String fileName = in.readUTF();
-        IFile file = session.getProject(projectID).getFile(fileName);
+      String fileName = in.readUTF();
+      IFile file = session.getProject(projectID).getFile(fileName);
 
-        String message = "receiving " + displayName(file);
-        log.debug(message);
-        monitor.subTask(message);
+      String message = "receiving " + displayName(file);
+      log.debug(message);
+      monitor.subTask(message);
 
-        /*
-         * folder creation is already done after file exchange, but in
-         * case of future changes
-         */
-        FileSystem.createFolder(file);
+      /*
+       * folder creation is already done after file exchange, but in
+       * case of future changes
+       */
+      FileSystem.createFolder(file);
 
-        long fileSize = in.readLong();
-        fileIn = new BoundedInputStream(in, fileSize);
+      long fileSize = in.readLong();
+      try (BoundedInputStream fileIn = new BoundedInputStream(in, fileSize)) {
         fileIn.setPropagateClose(false);
 
         if (file.exists()) file.setContents(fileIn, false, true);
         else file.create(fileIn, false);
-
-        if (monitor.isCanceled()) {
-          throw new LocalCancellationException(
-              "User canceled transmission", CancelOption.NOTIFY_PEER);
-        }
-
-        monitor.worked(1);
       }
-    } finally {
-      IOUtils.closeQuietly(fileIn);
-      IOUtils.closeQuietly(in);
+
+      if (monitor.isCanceled()) {
+        throw new LocalCancellationException(
+            "User canceled transmission", CancelOption.NOTIFY_PEER);
+      }
+
+      monitor.worked(1);
     }
+  }
+
+  @Override
+  public void close() {
+    IOUtils.closeQuietly(in);
   }
 }


### PR DESCRIPTION
To simplify code and avoid potential resource leaks use
try-with-resources Statement in Instant Session Start code.
