### PR TITLE
[FIX][I] #703 Adjust URI parsing to work with Windows paths

### DIFF
--- a/docs/releases/saros-i_0.2.1.md
+++ b/docs/releases/saros-i_0.2.1.md
@@ -28,11 +28,12 @@ The current release `0.2.1` is not compatible with the previous Saros/I releases
 
 ## Changes
 
-- Fixed [#696](https://github.com/saros-project/saros/issues/696) - Color settings page not loading for Windows users
 - Allow project module to be shared
   - The project module (i.e. the module that contains the project configuration and is used to load the project) can not be shared through Saros. The project configuration files will be ignored by the session.
 - Honor excluded resources
   - The Saros session now ignores resources marked as 'excluded' in the IDE. As a result, such resources and activities modifying them won't be shared with other participants.
+- Fixed [#696](https://github.com/saros-project/saros/issues/696) - Color settings page not loading on the Windows platform
+- Fixed [#703](https://github.com/saros-project/saros/issues/703) - Fix "Use existing module" option failing on the Windows platform
 
 ## Features
 

--- a/intellij/resources/META-INF/plugin.xml
+++ b/intellij/resources/META-INF/plugin.xml
@@ -11,9 +11,10 @@
     <change-notes>
         <![CDATA[
         <ul>
-            <li>Fixed <a href="https://github.com/saros-project/saros/issues/696">#696</a> - Color settings page not loading for Windows users</li>
             <li>Allow project module to be shared</li>
             <li>Honor excluded resources</li>
+            <li>Fixed <a href="https://github.com/saros-project/saros/issues/696">#696</a> - Color settings page not loading on the Windows platform</li>
+            <li>Fixed <a href="https://github.com/saros-project/saros/issues/703">#703</a> - Fix "Use existing module" option failing on the Windows platform</li>
         </ul>
         <br>
         This list only refers to changes included in the latest release.

--- a/intellij/src/saros/intellij/negotiation/ModuleConfigurationProvider.java
+++ b/intellij/src/saros/intellij/negotiation/ModuleConfigurationProvider.java
@@ -104,7 +104,6 @@ public class ModuleConfigurationProvider implements ProjectDataProvider {
     VirtualFile contentRoot = contentEntry.getFile();
 
     if (contentRoot == null) {
-
       log.error(
           "Encountered content root without a valid local representation for shared module \""
               + module
@@ -113,7 +112,7 @@ public class ModuleConfigurationProvider implements ProjectDataProvider {
       return optionsMap;
     }
 
-    String contentRootPath = contentRoot.getPath();
+    Path contentRootPath = Paths.get(contentRoot.getPath());
 
     String sourceRoots =
         flatten(contentRootPath, contentEntry.getSourceFolders(JavaSourceRootType.SOURCE));
@@ -135,7 +134,7 @@ public class ModuleConfigurationProvider implements ProjectDataProvider {
   }
 
   /**
-   * Flattens the list of source folders into a single string containing their relive paths.
+   * Flattens the list of source folders into a single string containing their relative paths.
    *
    * <p>This is done by first making the paths relative to the passed base path, escaping any
    * existing usages of {@link #DELIMITER}, and then joining them into a single string separated by
@@ -147,39 +146,18 @@ public class ModuleConfigurationProvider implements ProjectDataProvider {
    *     of the passed list of source folders is empty
    */
   @Nullable
-  private String flatten(@NotNull String basePath, @NotNull List<SourceFolder> sourceFolders) {
+  private String flatten(@NotNull Path basePath, @NotNull List<SourceFolder> sourceFolders) {
     if (sourceFolders.isEmpty()) {
       return null;
     }
 
     return sourceFolders
         .stream()
-        .map(SourceFolder::getFile)
+        .map(sourceFolder -> ModuleUtils.getRelativeRootPath(basePath, sourceFolder))
         .filter(Objects::nonNull)
-        .map(VirtualFile::getPath)
-        .map(sourcePath -> relativize(basePath, sourcePath))
+        .map(Path::toString)
         .map(ModuleConfigurationProvider::escape)
         .collect(Collectors.joining(DELIMITER));
-  }
-
-  /**
-   * Relativizes the given source path against the given base path.
-   *
-   * @param base the base path
-   * @param path the path to the source location
-   * @return the relative path from the base path to the given source location
-   */
-  @NotNull
-  private String relativize(@NotNull String base, @NotNull String path) {
-    assert path.startsWith(base)
-        : "Encountered path that is not located below the given base directory";
-
-    Path basePath = Paths.get(base);
-    Path childPath = Paths.get(path);
-
-    Path relativePath = basePath.relativize(childPath);
-
-    return relativePath.toString();
   }
 
   /**

--- a/intellij/src/saros/intellij/negotiation/ModuleConfigurationProvider.java
+++ b/intellij/src/saros/intellij/negotiation/ModuleConfigurationProvider.java
@@ -32,12 +32,12 @@ import saros.negotiation.ProjectNegotiationData;
 public class ModuleConfigurationProvider implements ProjectDataProvider {
   private static Logger log = Logger.getLogger(ModuleConfigurationProvider.class);
 
-  public static final String MODULE_TYPE_KEY = "MODULE_TYPE";
-  public static final String SDK_KEY = "SKD";
-  public static final String SOURCE_ROOTS_KEY = "SOURCE_ROOTS";
-  public static final String TEST_SOURCE_ROOTS_KEY = "TEST_SOURCE_ROOTS";
-  public static final String RESOURCE_ROOTS_KEY = "RESOURCE_ROOTS";
-  public static final String TEST_RESOURCE_ROOTS_KEY = "TEST_RESOURCE_ROOTS";
+  static final String MODULE_TYPE_KEY = "MODULE_TYPE";
+  static final String SDK_KEY = "SKD";
+  static final String SOURCE_ROOTS_KEY = "SOURCE_ROOTS";
+  static final String TEST_SOURCE_ROOTS_KEY = "TEST_SOURCE_ROOTS";
+  static final String RESOURCE_ROOTS_KEY = "RESOURCE_ROOTS";
+  static final String TEST_RESOURCE_ROOTS_KEY = "TEST_RESOURCE_ROOTS";
 
   private static final CharSequence DELIMITER = ":";
 
@@ -173,7 +173,7 @@ public class ModuleConfigurationProvider implements ProjectDataProvider {
    * @see ProjectNegotiationData#getAdditionalProjectData()
    */
   @Nullable
-  public static String[] split(@Nullable String options) {
+  static String[] split(@Nullable String options) {
     if (options == null) {
       return null;
     }

--- a/intellij/src/saros/intellij/negotiation/ModuleUtils.java
+++ b/intellij/src/saros/intellij/negotiation/ModuleUtils.java
@@ -1,0 +1,56 @@
+package saros.intellij.negotiation;
+
+import com.intellij.openapi.roots.SourceFolder;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.apache.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/** Provides utility methods to interact with modules. */
+class ModuleUtils {
+  private static final Logger log = Logger.getLogger(ModuleUtils.class);
+
+  /**
+   * Returns the relative path from the given base path to the relative source folder.
+   *
+   * @param basePath the base path to construct the relative path from
+   * @param sourceFolder the source folder to construct the relative path for
+   * @return the relative path from the given base path to the relative source folder or <code>null
+   *     </code> if the relative path could not be constructed
+   * @throws AssertionError when the path of the source folder does not start with the given base
+   *     path
+   */
+  @Nullable
+  static Path getRelativeRootPath(@NotNull Path basePath, @NotNull SourceFolder sourceFolder) {
+    String sourcePath = sourceFolder.getUrl();
+    try {
+      // Workaround to convert the URI to the canonical path needed for Windows paths
+      File childFile = new File(new URI(sourcePath).getPath());
+      Path childPath = Paths.get(childFile.getCanonicalPath());
+
+      assert childPath.startsWith(basePath)
+          : "Encountered path that is not located below the given base directory "
+              + basePath
+              + " - "
+              + childPath;
+
+      return basePath.relativize(childPath);
+
+    } catch (URISyntaxException e) {
+      log.warn("Could not parse source folder url", e);
+
+    } catch (IOException e) {
+      log.warn("Could not make source folder path canonical", e);
+
+    } catch (IllegalArgumentException e) {
+      log.warn("Could not construct relative path for the given source folder", e);
+    }
+
+    return null;
+  }
+}


### PR DESCRIPTION
#### [FIX][I] #703 Adjust URI parsing to work with Windows paths

Adjusts the URI parsing used when reading the source root configuration
of the shared module to also work with Windows paths.

Subsequently adjusted ModuleConfigurationProvider to also use the URI
approach instead of relying on the VirtualFiles of the roots. This was
done to unify the shared root state. When using the VirtualFiles, roots
that are registered with the module but don't have a valid
representation in the file system (and therefore don't have a valid
VirtualFile representation) would be ignored. Such roots are now also
transmitted by the host.

Subsequently moved the logic to parse and relativize root paths to
ModuleUtils so that it can be used by ModuleConfigurationProvider and
ModuleConfigurationInitializer.

Fixes #703.

#### [REFACTORING][I] Reduce method visibility in ModuleConfigurationProvider