### PR TITLE
Wrap calls to FileIndex methods in a read action

### DIFF
--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -7,7 +7,7 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.event.SelectionEvent;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.FileIndex;
+import com.intellij.openapi.roots.ModuleFileIndex;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vfs.LocalFileSystem;
@@ -402,13 +402,13 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
    */
   private void addProjectResources(IProject project) {
     Module module = project.adaptTo(IntelliJProjectImpl.class).getModule();
-    FileIndex moduleFileIndex = ModuleRootManager.getInstance(module).getFileIndex();
+    ModuleFileIndex moduleFileIndex = ModuleRootManager.getInstance(module).getFileIndex();
     Project intellijProject = module.getProject();
 
     Set<VirtualFile> openFiles = new HashSet<>();
 
     for (VirtualFile openFile : ProjectAPI.getOpenFiles(intellijProject)) {
-      if (moduleFileIndex.isInContent(openFile)) {
+      if (Filesystem.runReadAction(() -> moduleFileIndex.isInContent(openFile))) {
         openFiles.add(openFile);
       }
     }

--- a/intellij/src/saros/intellij/editor/ProjectAPI.java
+++ b/intellij/src/saros/intellij/editor/ProjectAPI.java
@@ -117,6 +117,7 @@ public class ProjectAPI {
    * @see ProjectFileIndex#isExcluded(VirtualFile)
    */
   public static boolean isExcluded(@NotNull Project project, @NotNull VirtualFile virtualFile) {
-    return ProjectFileIndex.getInstance(project).isExcluded(virtualFile);
+    ProjectFileIndex projectFileIndex = ProjectFileIndex.getInstance(project);
+    return Filesystem.runReadAction(() -> projectFileIndex.isExcluded(virtualFile));
   }
 }

--- a/intellij/src/saros/intellij/filesystem/Filesystem.java
+++ b/intellij/src/saros/intellij/filesystem/Filesystem.java
@@ -31,7 +31,6 @@ public class Filesystem {
    *
    * @see Application#runWriteAction(Runnable)
    */
-  @Nullable
   @SuppressWarnings("unchecked")
   public static <T, E extends Throwable> T runWriteAction(
       @NotNull final ThrowableComputable<T, E> computation,
@@ -97,7 +96,6 @@ public class Filesystem {
   }
 
   /** @see Application#runReadAction(Computable computation) */
-  @Nullable
   public static <T> T runReadAction(@NotNull final Computable<T> computation) {
     return application.runReadAction(computation);
   }

--- a/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
@@ -57,7 +57,7 @@ public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IF
 
     for (final VirtualFile child : children) {
 
-      if (!moduleFileIndex.isInContent(child)) {
+      if (!Filesystem.runReadAction(() -> moduleFileIndex.isInContent(child))) {
 
         continue;
       }

--- a/intellij/src/saros/intellij/filesystem/VirtualFileConverter.java
+++ b/intellij/src/saros/intellij/filesystem/VirtualFileConverter.java
@@ -57,7 +57,8 @@ public class VirtualFileConverter {
   public static IResource convertToResource(
       @NotNull Project project, @NotNull VirtualFile virtualFile) {
 
-    Module module = ModuleUtil.findModuleForFile(virtualFile, project);
+    Module module =
+        Filesystem.runReadAction(() -> ModuleUtil.findModuleForFile(virtualFile, project));
 
     if (module == null) {
       log.debug(

--- a/intellij/src/saros/intellij/ui/menu/ShareWithUserAction.java
+++ b/intellij/src/saros/intellij/ui/menu/ShareWithUserAction.java
@@ -14,6 +14,7 @@ import org.apache.log4j.Logger;
 import saros.core.ui.util.CollaborationUtils;
 import saros.filesystem.IResource;
 import saros.intellij.context.SharedIDEContext;
+import saros.intellij.filesystem.Filesystem;
 import saros.intellij.filesystem.IntelliJProjectImpl;
 import saros.intellij.ui.Messages;
 import saros.intellij.ui.util.IconManager;
@@ -27,7 +28,8 @@ import saros.net.xmpp.JID;
  *
  * <p>This class assumes that the project is allowed to be shared (at the moment only completely
  * shared projects are implemented) and that the call to {@link
- * ShareWithUserAction#getModuleFromVirtFile(VirtualFile, Project)} is supported for this IDE type.
+ * ShareWithUserAction#getModuleForVirtualFile(VirtualFile, Project)} is supported for this IDE
+ * type.
  */
 public class ShareWithUserAction extends AnAction {
 
@@ -61,7 +63,7 @@ public class ShareWithUserAction extends AnAction {
 
     // We allow only completely shared projects, so no need to check
     // for partially shared ones.
-    List<IResource> resources = Arrays.asList(getModuleFromVirtFile(virtualFile, e.getProject()));
+    List<IResource> resources = Arrays.asList(getModuleForVirtualFile(virtualFile, e.getProject()));
 
     List<JID> contacts = Arrays.asList(userJID);
 
@@ -69,13 +71,13 @@ public class ShareWithUserAction extends AnAction {
     CollaborationUtils.startSession(resources, contacts);
   }
 
-  private IResource getModuleFromVirtFile(VirtualFile virtFile, Project project) {
+  private IResource getModuleForVirtualFile(VirtualFile virtualFile, Project project) {
+    ProjectFileIndex projectFileIndex = ProjectFileIndex.getInstance(project);
 
-    Module module = ProjectFileIndex.SERVICE.getInstance(project).getModuleForFile(virtFile);
+    Module module = Filesystem.runReadAction(() -> projectFileIndex.getModuleForFile(virtualFile));
 
     if (module == null) {
-      // FIXME: Find way to select moduleName for non-module based IDEAs
-      // (Webstorm)
+      // FIXME: Find way to select moduleName for non-module based IDEAs (Webstorm)
       throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
#### [INTERNAL][I] Remove Nullable annotation from Filesystem

Removes Nullable annotation from FileSystem.runReadAction and
runWriteAction as we can't make any statement about the return value of
the computation. Whether the returned value can be null or not depends
solely on the contents of the computation itself. This makes the
annotation not very helpful.

#### [INTERNAL][I] Wrap calls to FileIndex methods in a read action

Wraps any calls to methods of FileIndex or its implementations in a read
action to comply with the IntelliJ access guidelines and avoid illegal
access assertion errors.