### PR TITLE
[BUILD] Remove ui package from gradle/compiler.xml

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -27,8 +27,6 @@
       <module name="saros.stf.test_test" target="1.8" />
       <module name="saros.stf_main" target="1.8" />
       <module name="saros.stf_test" target="1.8" />
-      <module name="saros.ui_main" target="1.8" />
-      <module name="saros.ui_test" target="1.8" />
       <module name="saros.whiteboard_main" target="1.8" />
       <module name="saros.whiteboard_test" target="1.8" />
     </bytecodeTargetLevel>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -17,7 +17,6 @@
             <option value="$PROJECT_DIR$/server" />
             <option value="$PROJECT_DIR$/stf" />
             <option value="$PROJECT_DIR$/stf.test" />
-            <option value="$PROJECT_DIR$/ui" />
             <option value="$PROJECT_DIR$/whiteboard" />
           </set>
         </option>


### PR DESCRIPTION
Opening the Saros project without the ui packages in IntelliJ changes the gradle.xml file and compiler.xml.