### PR TITLE
Fix #223 - Drop vector time when resource is removed

### DIFF
--- a/core/src/saros/activities/DeletionAcknowledgmentActivity.java
+++ b/core/src/saros/activities/DeletionAcknowledgmentActivity.java
@@ -1,0 +1,28 @@
+package saros.activities;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import saros.session.User;
+import saros.session.internal.DeletionAcknowledgmentDispatcher;
+
+/**
+ * Activity for notifying other participants that a file was successfully deleted locally.
+ *
+ * @see DeletionAcknowledgmentDispatcher
+ */
+@XStreamAlias("deletionAcknowledgementActivity")
+public class DeletionAcknowledgmentActivity extends AbstractResourceActivity {
+
+  public DeletionAcknowledgmentActivity(User user, SPath resource) {
+    super(user, resource);
+  }
+
+  @Override
+  public void dispatch(IActivityReceiver receiver) {
+    receiver.receive(this);
+  }
+
+  @Override
+  public String toString() {
+    return this.getClass().getSimpleName() + " : " + getSource() + " - " + getPath();
+  }
+}

--- a/core/src/saros/activities/FolderDeletedActivity.java
+++ b/core/src/saros/activities/FolderDeletedActivity.java
@@ -1,9 +1,19 @@
 package saros.activities;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import saros.concurrent.management.ConcurrentDocumentClient;
+import saros.concurrent.management.ConcurrentDocumentServer;
 import saros.session.User;
 
-/** An activity that represents the deletion of a folder made by a user during a session. */
+/**
+ * An activity that represents the deletion of a folder made by a user during a session.
+ *
+ * <p><b>NOTE:</b> Any resource that is contained in the deleted folder should have been processed
+ * separately before dispatching the folder deletion activity. This is important to allow the other
+ * session participants to clean up the state of all deleted child resources. Furthermore, the
+ * explicit handling of deleted child resources is required by the {@link ConcurrentDocumentServer}
+ * and {@link ConcurrentDocumentClient}.
+ */
 @XStreamAlias("folderDeleted")
 public class FolderDeletedActivity extends AbstractResourceActivity
     implements IFileSystemModificationActivity {

--- a/core/src/saros/activities/IActivityReceiver.java
+++ b/core/src/saros/activities/IActivityReceiver.java
@@ -31,6 +31,10 @@ public interface IActivityReceiver {
     /*NOP*/
   }
 
+  default void receive(DeletionAcknowledgmentActivity deletionAcknowledgmentActivity) {
+    /*NOP*/
+  }
+
   default void receive(EditorActivity editorActivity) {
     /*NOP*/
   }

--- a/core/src/saros/communication/extensions/ActivitiesExtension.java
+++ b/core/src/saros/communication/extensions/ActivitiesExtension.java
@@ -27,6 +27,7 @@ import org.jivesoftware.smack.packet.PacketExtension;
 import saros.activities.ChangeColorActivity;
 import saros.activities.ChecksumActivity;
 import saros.activities.ChecksumErrorActivity;
+import saros.activities.DeletionAcknowledgmentActivity;
 import saros.activities.EditorActivity;
 import saros.activities.FileActivity;
 import saros.activities.FolderCreatedActivity;
@@ -143,6 +144,7 @@ public class ActivitiesExtension extends SarosSessionPacketExtension {
           ChangeColorActivity.class,
           ChecksumActivity.class,
           ChecksumErrorActivity.class,
+          DeletionAcknowledgmentActivity.class,
           EditorActivity.class,
           FileActivity.class,
           FolderCreatedActivity.class,

--- a/core/src/saros/concurrent/jupiter/internal/Jupiter.java
+++ b/core/src/saros/concurrent/jupiter/internal/Jupiter.java
@@ -260,16 +260,20 @@ public class Jupiter implements Algorithm {
     if (!this.ackJupiterActivityList.isEmpty()
         && (time.getRemoteOperationCount()
             < this.ackJupiterActivityList.get(0).getLocalOperationCount())) {
+      // TODO improve exception message; what is precondition 1?
       throw new TransformationException("Precondition #1 violated.");
     } else if (time.getRemoteOperationCount() > this.vectorTime.getLocalOperationCount()) {
       throw new TransformationException(
-          "precondition #2 violated (Remote vector time is greater than local vector time).");
+          "precondition #2 violated (Remote vector time is greater than local vector time) - remote time: "
+              + time
+              + " ,local time: "
+              + vectorTime);
     } else if (time.getLocalOperationCount() != this.vectorTime.getRemoteOperationCount()) {
       throw new TransformationException(
-          "Precondition #3 violated (Vector time does not match): "
+          "Precondition #3 violated (Vector time does not match) - remote time :"
               + time
-              + " , "
-              + this.vectorTime);
+              + " ,local time: "
+              + vectorTime);
     }
   }
 

--- a/core/src/saros/concurrent/management/ConcurrentDocumentClient.java
+++ b/core/src/saros/concurrent/management/ConcurrentDocumentClient.java
@@ -93,6 +93,9 @@ public class ConcurrentDocumentClient implements Startable {
    * <p>This method will transform them back from Jupiter-specific activities to locally executable
    * activities. @GUI Must be called on the GUI Thread to ensure proper synchronization
    *
+   * <p>Drops activities that are reported as filtered out by {@link
+   * ResourceActivityFilter#isFiltered(IActivity)}.
+   *
    * @host and @client This is called whenever activities are received from REMOTELY both on the
    *     client and on the host
    * @param activity The activity to be transformed

--- a/core/src/saros/concurrent/management/ConcurrentDocumentServer.java
+++ b/core/src/saros/concurrent/management/ConcurrentDocumentServer.java
@@ -91,6 +91,9 @@ public class ConcurrentDocumentServer implements Startable {
    * Transforms the given activities on the server side and returns a list of QueueItems containing
    * the transformed activities and there receivers.
    *
+   * <p>Drops activities that are reported as filtered out by {@link
+   * ResourceActivityFilter#isFiltered(IActivity)}.
+   *
    * @host
    * @sarosThread Must be executed in the Saros dispatch thread.
    * @notGUI This method may not be called from SWT, otherwise a deadlock might occur!!

--- a/core/src/saros/concurrent/management/DeletedResourceFilter.java
+++ b/core/src/saros/concurrent/management/DeletedResourceFilter.java
@@ -1,0 +1,139 @@
+package saros.concurrent.management;
+
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.function.Consumer;
+import saros.activities.ChecksumActivity;
+import saros.activities.FileActivity;
+import saros.activities.FileActivity.Type;
+import saros.activities.IActivity;
+import saros.activities.IResourceActivity;
+import saros.activities.SPath;
+
+/** Class to handle resource deletions and filter out activities for already deleted resources. */
+class DeletedResourceFilter {
+  /** Method passed by the CTOR caller that can be used to react to resource deletions. */
+  private final Consumer<SPath> resourceDeletionHandler;
+
+  /**
+   * A set of shared resources that were deleted during the session. It is used to filter out
+   * activities for such resources that were created before the other participants ran the
+   * corresponding resource deletion activity locally.
+   *
+   * <p>The set is updated once the resource is recreated as we then want to handle activities for
+   * it again.
+   *
+   * <p>This way of filtering can lead to issues when the order of activities is not preserved, e.g.
+   * when we receive the content change for a new file is received before the file creation. Such
+   * activities will be dropped, leading to inconsistencies.
+   */
+  // FIXME this set is never pruned for resources whose deletion was already processed by all
+  //  participants
+  private final Set<SPath> deletedResources;
+
+  /**
+   * Creates a new deleted resource filter. The passed method is called every time a resource
+   * deletion is detected <b>after</b> the resource is added to the set of deleted resources.
+   *
+   * @param resourceDeletionHandler method that is called every time a resource deletion is detected
+   */
+  DeletedResourceFilter(Consumer<SPath> resourceDeletionHandler) {
+    this.resourceDeletionHandler = resourceDeletionHandler;
+
+    this.deletedResources = new CopyOnWriteArraySet<>();
+  }
+
+  /**
+   * Adds the deleted resource to the held set of deleted shared resources. This causes activities
+   * for such resources to be detected as filtered out by {@link #isFiltered(IActivity)} until it is
+   * created again. Subsequently calls {@link #resourceDeletionHandler} with the deleted resource.
+   *
+   * <p>Does nothing if the passed activity is not a {@link FileActivity} or does not have the type
+   * {@link Type#REMOVED} or {@link Type#MOVED}.
+   *
+   * @param activity the activity to handle
+   * @see #deletedResources
+   * @see #handleResourceCreation(IActivity)
+   */
+  void handleResourceDeletion(IActivity activity) {
+    if (!(activity instanceof FileActivity)) {
+      return;
+    }
+
+    FileActivity fileActivity = (FileActivity) activity;
+
+    SPath removedFile;
+    if (fileActivity.getType() == Type.REMOVED) {
+      removedFile = fileActivity.getPath();
+
+    } else if (fileActivity.getType() == Type.MOVED
+        && !fileActivity.getPath().equals(fileActivity.getOldPath())) {
+
+      removedFile = fileActivity.getOldPath();
+
+    } else {
+      return;
+    }
+
+    deletedResources.add(removedFile);
+    resourceDeletionHandler.accept(removedFile);
+  }
+
+  /**
+   * Removes the created resource from the held set of deleted shared resources. This causes
+   * activities for the resources to no longer be detected as filtered out by {@link
+   * #isFiltered(IActivity)}.
+   *
+   * <p>Does nothing if the passed activity is not a {@link FileActivity} or does not have the type
+   * {@link Type#CREATED} or {@link Type#MOVED}.
+   *
+   * @param activity the activity to handle
+   * @see #deletedResources
+   * @see #handleResourceDeletion(IActivity)
+   */
+  void handleResourceCreation(IActivity activity) {
+    if (!(activity instanceof FileActivity)) {
+      return;
+    }
+
+    FileActivity fileActivity = (FileActivity) activity;
+
+    if (fileActivity.getType() == Type.MOVED || fileActivity.getType() == Type.CREATED) {
+      SPath addedFile = fileActivity.getPath();
+
+      deletedResources.remove(addedFile);
+    }
+  }
+
+  /**
+   * Returns whether the passed activity is filtered out. This is determined by the held set of
+   * deleted resources.
+   *
+   * <p>Non-resource activities are never detected as being filtered. Furthermore, resource
+   * activities of the type {@link ChecksumActivity} that confirm the file deletion are never
+   * detected as being filtered.
+   *
+   * @param activity the activity to check
+   * @return whether the passed activity is filtered out
+   * @see #handleResourceDeletion(IActivity)
+   * @see #handleResourceCreation(IActivity)
+   */
+  boolean isFiltered(IActivity activity) {
+    if (!(activity instanceof IResourceActivity)) {
+      return false;
+    }
+
+    IResourceActivity resourceActivity = (IResourceActivity) activity;
+
+    boolean pathIsFiltered = deletedResources.contains(resourceActivity.getPath());
+
+    if (pathIsFiltered && activity instanceof ChecksumActivity) {
+      ChecksumActivity checksumActivity = (ChecksumActivity) activity;
+
+      return checksumActivity.getHash() != ChecksumActivity.NON_EXISTING_DOC
+          && checksumActivity.getLength() != ChecksumActivity.NON_EXISTING_DOC;
+    }
+
+    return pathIsFiltered;
+  }
+}

--- a/core/src/saros/concurrent/management/DeletedResourceFilter.java
+++ b/core/src/saros/concurrent/management/DeletedResourceFilter.java
@@ -1,52 +1,158 @@
 package saros.concurrent.management;
 
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
+import org.apache.log4j.Logger;
 import saros.activities.ChecksumActivity;
+import saros.activities.DeletionAcknowledgmentActivity;
 import saros.activities.FileActivity;
 import saros.activities.FileActivity.Type;
 import saros.activities.IActivity;
 import saros.activities.IResourceActivity;
 import saros.activities.SPath;
+import saros.filesystem.IProject;
+import saros.session.AbstractActivityConsumer;
+import saros.session.IActivityConsumer;
+import saros.session.IActivityConsumer.Priority;
+import saros.session.ISarosSession;
+import saros.session.ISessionListener;
+import saros.session.User;
 
 /** Class to handle resource deletions and filter out activities for already deleted resources. */
 class DeletedResourceFilter {
-  /** Method passed by the CTOR caller that can be used to react to resource deletions. */
+  private static final Logger log = Logger.getLogger(DeletedResourceFilter.class);
+
+  private final ISarosSession sarosSession;
+
+  /** Method passed by the constructor caller that can be used to react to resource deletions. */
   private final Consumer<SPath> resourceDeletionHandler;
 
   /**
-   * A set of shared resources that were deleted during the session. It is used to filter out
-   * activities for such resources that were created before the other participants ran the
-   * corresponding resource deletion activity locally.
+   * A map of shared resources that were deleted during the session onto the pending acknowledgments
+   * from other participants. It is used to filter out activities for such resources that were
+   * created before the other participants ran the corresponding resource deletion activity locally.
    *
    * <p>The set is updated once the resource is recreated as we then want to handle activities for
-   * it again.
+   * it again. Furthermore, it is updated once all acknowledgments for a resource deletion were
+   * received as the filter is then no longer necessary.
    *
    * <p>This way of filtering can lead to issues when the order of activities is not preserved, e.g.
    * when we receive the content change for a new file is received before the file creation. Such
    * activities will be dropped, leading to inconsistencies.
    */
-  // FIXME this set is never pruned for resources whose deletion was already processed by all
-  //  participants
-  private final Set<SPath> deletedResources;
+  private final Map<SPath, List<User>> deletedResources;
+
+  /** Activity consumer processing received deletion acknowledgments. */
+  private final IActivityConsumer activityConsumer =
+      new AbstractActivityConsumer() {
+        @Override
+        public void receive(DeletionAcknowledgmentActivity deletionAcknowledgmentActivity) {
+          User source = deletionAcknowledgmentActivity.getSource();
+          SPath resource = deletionAcknowledgmentActivity.getPath();
+
+          List<User> remainingUsers = deletedResources.get(resource);
+
+          if (remainingUsers == null) {
+            log.warn(
+                "Received unexpected deletion acknowledgment for file that is not filtered: "
+                    + source
+                    + " - "
+                    + resource);
+
+            return;
+
+          } else if (!remainingUsers.contains(source)) {
+            log.warn(
+                "Received acknowledgment for file deletion from unexpected user: "
+                    + source
+                    + " - "
+                    + resource);
+
+            return;
+          }
+
+          log.debug("Received deletion acknowledgment from " + source + " for " + resource);
+
+          remainingUsers.remove(source);
+
+          if (remainingUsers.isEmpty()) {
+            log.debug(
+                "Dropping activity filter for "
+                    + resource
+                    + " as all acknowledgments were received");
+
+            deletedResources.remove(resource);
+          }
+        }
+      };
+
+  /**
+   * Session listener updating the held map of filtered resources when participants leave the
+   * session or resources are removed from the session.
+   */
+  private final ISessionListener sessionListener =
+      new ISessionListener() {
+        @Override
+        public void userLeft(User user) {
+          Iterator<Entry<SPath, List<User>>> iterator = deletedResources.entrySet().iterator();
+          while (iterator.hasNext()) {
+            Entry<SPath, List<User>> entry = iterator.next();
+
+            List<User> remainingUsers = entry.getValue();
+            remainingUsers.remove(user);
+
+            if (remainingUsers.isEmpty()) {
+              log.debug(
+                  "Dropping activity filter for "
+                      + entry.getKey()
+                      + " as there are no more pending acknowledgments");
+
+              iterator.remove();
+            }
+          }
+        }
+
+        @Override
+        public void projectRemoved(IProject project) {
+          Iterator<Entry<SPath, List<User>>> iterator = deletedResources.entrySet().iterator();
+          while (iterator.hasNext()) {
+            SPath resource = iterator.next().getKey();
+
+            if (resource.getProject().equals(project)) {
+              log.debug(
+                  "Dropping activity filter for "
+                      + resource
+                      + " as it is no longer part of the session");
+
+              iterator.remove();
+            }
+          }
+        }
+      };
 
   /**
    * Creates a new deleted resource filter. The passed method is called every time a resource
-   * deletion is detected <b>after</b> the resource is added to the set of deleted resources.
+   * deletion is detected <b>after</b> the resource is added to the map of deleted resources.
    *
+   * @param sarosSession the current saros session
    * @param resourceDeletionHandler method that is called every time a resource deletion is detected
    */
-  DeletedResourceFilter(Consumer<SPath> resourceDeletionHandler) {
+  DeletedResourceFilter(ISarosSession sarosSession, Consumer<SPath> resourceDeletionHandler) {
+    this.sarosSession = sarosSession;
     this.resourceDeletionHandler = resourceDeletionHandler;
 
-    this.deletedResources = new CopyOnWriteArraySet<>();
+    this.deletedResources = new ConcurrentHashMap<>();
   }
 
   /**
-   * Adds the deleted resource to the held set of deleted shared resources. This causes activities
+   * Adds the deleted resource to the held map of deleted shared resources. This causes activities
    * for such resources to be detected as filtered out by {@link #isFiltered(IActivity)} until it is
-   * created again. Subsequently calls {@link #resourceDeletionHandler} with the deleted resource.
+   * created again (or all deletion acknowledgments were received). Subsequently calls {@link
+   * #resourceDeletionHandler} with the deleted resource.
    *
    * <p>Does nothing if the passed activity is not a {@link FileActivity} or does not have the type
    * {@link Type#REMOVED} or {@link Type#MOVED}.
@@ -75,12 +181,25 @@ class DeletedResourceFilter {
       return;
     }
 
-    deletedResources.add(removedFile);
+    List<User> remoteUsers = sarosSession.getRemoteUsers();
+
+    remoteUsers.remove(activity.getSource());
+
+    if (!remoteUsers.isEmpty()) {
+      log.debug(
+          "Adding activity filter for deleted file "
+              + removedFile
+              + ", waiting for acknowledgment from user(s) "
+              + remoteUsers);
+
+      deletedResources.put(removedFile, remoteUsers);
+    }
+
     resourceDeletionHandler.accept(removedFile);
   }
 
   /**
-   * Removes the created resource from the held set of deleted shared resources. This causes
+   * Removes the created resource from the held map of deleted shared resources. This causes
    * activities for the resources to no longer be detected as filtered out by {@link
    * #isFiltered(IActivity)}.
    *
@@ -101,7 +220,11 @@ class DeletedResourceFilter {
     if (fileActivity.getType() == Type.MOVED || fileActivity.getType() == Type.CREATED) {
       SPath addedFile = fileActivity.getPath();
 
-      deletedResources.remove(addedFile);
+      if (deletedResources.containsKey(addedFile)) {
+        log.debug("Removing activity filter for re-created file " + addedFile);
+
+        deletedResources.remove(addedFile);
+      }
     }
   }
 
@@ -110,8 +233,8 @@ class DeletedResourceFilter {
    * deleted resources.
    *
    * <p>Non-resource activities are never detected as being filtered. Furthermore, resource
-   * activities of the type {@link ChecksumActivity} that confirm the file deletion are never
-   * detected as being filtered.
+   * activities of the type {@link ChecksumActivity} that confirm the file deletion or activities of
+   * the type {@link DeletionAcknowledgmentActivity} are never detected as being filtered.
    *
    * @param activity the activity to check
    * @return whether the passed activity is filtered out
@@ -119,13 +242,20 @@ class DeletedResourceFilter {
    * @see #handleResourceCreation(IActivity)
    */
   boolean isFiltered(IActivity activity) {
-    if (!(activity instanceof IResourceActivity)) {
+
+    if (!(activity instanceof IResourceActivity)
+        || activity instanceof DeletionAcknowledgmentActivity) {
+
       return false;
     }
 
-    IResourceActivity resourceActivity = (IResourceActivity) activity;
+    SPath path = ((IResourceActivity) activity).getPath();
 
-    boolean pathIsFiltered = deletedResources.contains(resourceActivity.getPath());
+    if (path == null) {
+      return false;
+    }
+
+    boolean pathIsFiltered = deletedResources.containsKey(path);
 
     if (pathIsFiltered && activity instanceof ChecksumActivity) {
       ChecksumActivity checksumActivity = (ChecksumActivity) activity;
@@ -135,5 +265,17 @@ class DeletedResourceFilter {
     }
 
     return pathIsFiltered;
+  }
+
+  /** Initializes all contained components. */
+  public void initialize() {
+    sarosSession.addActivityConsumer(activityConsumer, Priority.PASSIVE);
+    sarosSession.addListener(sessionListener);
+  }
+
+  /** Disposes all contained components to prepare them for garbage collection. */
+  public void dispose() {
+    sarosSession.removeActivityConsumer(activityConsumer);
+    sarosSession.removeListener(sessionListener);
   }
 }

--- a/core/src/saros/session/SarosCoreSessionContextFactory.java
+++ b/core/src/saros/session/SarosCoreSessionContextFactory.java
@@ -15,6 +15,7 @@ import saros.repackaged.picocontainer.MutablePicoContainer;
 import saros.session.internal.ActivityHandler;
 import saros.session.internal.ActivitySequencer;
 import saros.session.internal.ChangeColorManager;
+import saros.session.internal.DeletionAcknowledgmentDispatcher;
 import saros.session.internal.LeaveAndKickHandler;
 import saros.session.internal.PermissionManager;
 import saros.session.internal.UserInformationHandler;
@@ -58,6 +59,7 @@ public class SarosCoreSessionContextFactory implements ISarosSessionContextFacto
     container.addComponent(ActivityHandler.class);
     container.addComponent(ActivitySequencer.class);
     container.addComponent(ChangeColorManager.class);
+    container.addComponent(DeletionAcknowledgmentDispatcher.class);
     container.addComponent(FollowModeManager.class);
     container.addComponent(FollowModeBroadcaster.class);
     container.addComponent(LeaveAndKickHandler.class);

--- a/core/src/saros/session/internal/ActivityHandler.java
+++ b/core/src/saros/session/internal/ActivityHandler.java
@@ -401,7 +401,7 @@ public final class ActivityHandler implements Startable {
     final List<User> allUsers = session.getUsers();
 
     for (IActivity activity : activities) {
-      documentServer.checkFileDeleted(activity);
+      documentServer.handleResourceChange(activity);
 
       if (activity instanceof JupiterActivity || activity instanceof ChecksumActivity) {
 

--- a/core/src/saros/session/internal/DeletionAcknowledgmentDispatcher.java
+++ b/core/src/saros/session/internal/DeletionAcknowledgmentDispatcher.java
@@ -1,0 +1,84 @@
+package saros.session.internal;
+
+import org.apache.log4j.Logger;
+import saros.activities.DeletionAcknowledgmentActivity;
+import saros.activities.FileActivity;
+import saros.activities.FileActivity.Type;
+import saros.activities.IActivity;
+import saros.activities.SPath;
+import saros.repackaged.picocontainer.Startable;
+import saros.session.AbstractActivityConsumer;
+import saros.session.AbstractActivityProducer;
+import saros.session.IActivityConsumer;
+import saros.session.IActivityConsumer.Priority;
+import saros.session.ISarosSession;
+import saros.session.User;
+
+/**
+ * Class reacting to the reception of activities containing the deletion of a file by sending an
+ * acknowledgement.
+ *
+ * @see DeletionAcknowledgmentActivity
+ */
+public class DeletionAcknowledgmentDispatcher extends AbstractActivityProducer
+    implements Startable {
+
+  private static final Logger log = Logger.getLogger(DeletionAcknowledgmentDispatcher.class);
+
+  private final ISarosSession sarosSession;
+
+  private final IActivityConsumer activityConsumer =
+      new AbstractActivityConsumer() {
+        @Override
+        public void receive(FileActivity fileActivity) {
+          acknowledgeDeletionActivity(fileActivity);
+        }
+      };
+
+  public DeletionAcknowledgmentDispatcher(ISarosSession sarosSession) {
+    this.sarosSession = sarosSession;
+  }
+
+  @Override
+  public void start() {
+    sarosSession.addActivityProducer(this);
+    sarosSession.addActivityConsumer(activityConsumer, Priority.PASSIVE);
+  }
+
+  @Override
+  public void stop() {
+    sarosSession.removeActivityProducer(this);
+    sarosSession.removeActivityConsumer(activityConsumer);
+  }
+
+  /**
+   * Checks whether the passed file activity contains the deletion of a file and sends an
+   * acknowledgment to all other participants.
+   *
+   * <p>Activities that contain file deletions are {@link FileActivity file activities} of the type
+   * {@link Type#REMOVED} or {@link Type#MOVED}.
+   *
+   * @param fileActivity the file activity to check and acknowledge if applicable
+   */
+  private void acknowledgeDeletionActivity(FileActivity fileActivity) {
+    SPath deletedResource;
+
+    if (fileActivity.getType() == Type.MOVED) {
+      deletedResource = fileActivity.getOldPath();
+
+    } else if (fileActivity.getType() == Type.REMOVED) {
+      deletedResource = fileActivity.getPath();
+
+    } else {
+      return;
+    }
+
+    User localUser = sarosSession.getLocalUser();
+
+    IActivity deletionAcknowledgementActivity =
+        new DeletionAcknowledgmentActivity(localUser, deletedResource);
+
+    log.debug("Sending deletion acknowledgment for " + deletedResource);
+    fireActivity(deletionAcknowledgementActivity);
+  }
+}

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -475,8 +475,6 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
     cleanUpDeletedFileState(path);
 
     dispatchActivity(activity);
-
-    // TODO reset the vector time for the deleted file or contained files if folder
   }
 
   /**
@@ -835,15 +833,11 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
     dispatchActivity(activity);
 
-    if (oldPathIsShared) {
-      if (fileIsOpen) {
-        EditorActivity closeOldEditorActivity =
-            new EditorActivity(user, EditorActivity.Type.CLOSED, oldFilePath);
+    if (oldPathIsShared && fileIsOpen) {
+      EditorActivity closeOldEditorActivity =
+          new EditorActivity(user, EditorActivity.Type.CLOSED, oldFilePath);
 
-        dispatchActivity(closeOldEditorActivity);
-      }
-
-      // TODO reset the vector time for the old file
+      dispatchActivity(closeOldEditorActivity);
     }
 
     if (newPathIsShared && fileIsOpen) {


### PR DESCRIPTION
#### [CORE] Improve exception messages for jupiter preconditions

#### [FIX][CORE] #223 Drop vector time when resource is removed

Adjusts ConcurrentDocumentClient and ConcurrentDocumentServer to drop
the vector time for a resource when it is deleted (or moved, thereby
"deleting" the resource with the previous path).

Adds DeletedResourceFilter to encapsulate the logic of detecting and
correctly handling resource deletions.
Furthermore, it provides a way of filtering out subsequent activities
for deleted resource.  This is needed as there can be straggling
activities for deleted resources that were created by remote
participants before they executed the deletion activity for the
resource.  Such activities are now filter out until the corresponding
resource is recreated.  This ensures that activities for the new
resource will still be processed correctly.
Checksum activities confirming the file deletion are explicitly excluded
from this filer (i.e. they will not be dropped for deleted resources) as
they are needed to check the consistency of all clients.

Fixes #223. Also fixes #710.

#### [NOP][I] Remove comments to reset vector time

#### [INTERNAL][CORE] Add deletion acknowledgments

Adds DeletionAcknowledgmentActivity, which can be used to acknowledge
that a file was successfully deleted locally as a reaction to a received
activity. This acknowledgment allows us to drop the activity filter for
the deleted resource once all other session participants have
acknowledged that they received the deletion.

Adds the DeletionAcknowledgmentDispatcher to automatically dispatch an
acknowledgment when an activity is received that contains a file
deletion.

#### [INTERNAL][CORE] Use deletion acknowledgments to drop activity filters

Uses received deletion acknowledgment activities to determine when all
other participants have received the deletion, allowing the local
instance to drop the activity filter for the deleted resource.

#### [REFACTOR][CORE] Adjust wording in activity filter

Adjusts the wording in the activity filter to reflect that it is
specifically dealing with files and not resources in general.

#### [FIX][CORE] Exclude editor closed activities from filter

Adjusts ResourceActivityFilter.isFiltered(IActivity) to also never
filter out editor activities of the type "CLOSED". This is necessary as
such activities are used to clean up the user editor state.

Adjusts the wording of the javadoc for isFiltered(IActivity).

Adjusts code in ResourceActivityFilter to always uses the full qualifier
when using a variable of the type 'FileActivity.Type'. This was done to
make them easier to differentiate from the newly introduced usage of
variables of the type 'EditorActivity.Type'.

#### [DOC][CORE] Add documentation on how to handle deleted child resources

Adds information on how to handle deleted child resources to
FolderDeletedActivity.

Adds notes that activities might be filtered out to the corresponding
methods in ConcurrentDocumentServer and ConcurrentDocumentClient.