### PR TITLE
[BUILD][I] Update developer build version to 2019.2.3

### DIFF
--- a/intellij/build.gradle
+++ b/intellij/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.4.9"
+    classpath "gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.4.10"
   }
 }
 
@@ -69,7 +69,7 @@ intellij {
   if (intellijHome) {
     localPath = intellijHome
   } else {
-    version = 'IC-2019.2.1'
+    version = 'IC-2019.2.3'
   }
 
   // don't overwrite the version compatibility defined in the plugin.xml


### PR DESCRIPTION
Updates the IntelliJ version used locally to build Saros/I when no
installation is linked to 2019.2.3.

This was done after looking at the incompatibility notes, trying it out
locally, and doing some smoke testing to determine whether the update to
2019.2.3 introduces any issues. There did not appear to be any issues.

Subsequently updates the gradle intellij plugin to version 0.4.10.