### PR TITLE
Explicitly handle child resources when deleting folders

### DIFF
--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -378,6 +378,12 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
   /**
    * Generates and dispatches a folder deletion activity for the deleted folder.
    *
+   * <p>Also explicitly creates deletion activities for all contained resources belonging to the
+   * same module. Contained files are processed first (in ascending depth order), followed by the
+   * contained folders in descending depth order. This ensures that deletion activities for folders
+   * are only send once the activities for all contained resources were sent, allowing the receiver
+   * to also explicitly handle all resource deletions.
+   *
    * @param deletedFolder the folder that was deleted
    */
   private void generateFolderDeletionActivity(@NotNull VirtualFile deletedFolder) {
@@ -507,7 +513,16 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
   /**
    * Generates and dispatches matching creation and deletion activities replicating moving the given
-   * directory. Also dispatches activities for all contained resources belonging to the same module.
+   * directory.
+   *
+   * <p>Also explicitly creates activities to move all contained resources belonging to the same
+   * module. When creating the new resources, the creation/move activities are created in ascending
+   * depth order. This ensures that creation/move activities are only send once the creation
+   * activities for all parent resources were sent. When creating the deletion activities, the
+   * contained files are processed first (in ascending depth order), followed by the contained
+   * folders in descending depth order. This ensures that move activities for folders are only send
+   * once the activities for all contained resources were sent, allowing the receiver to also
+   * explicitly handle all resource deletions.
    *
    * <p>How the resources (including the given directory) are handled depends on whether the source
    * and target directory is shared.

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -355,8 +355,8 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
    *
    * @param virtualFileEvent the event to react to
    * @see VirtualFileListener#beforeFileDeletion(VirtualFileEvent)
-   * @see #generateFileDeletion(VirtualFile)
-   * @see #generateFolderDeletion(VirtualFile)
+   * @see #generateFileDeletionActivity(VirtualFile)
+   * @see #generateFolderDeletionActivity(VirtualFile)
    */
   private void generateResourceDeletionActivity(@NotNull VirtualFileEvent virtualFileEvent) {
 
@@ -369,9 +369,9 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
     }
 
     if (deletedVirtualFile.isDirectory()) {
-      generateFolderDeletion(deletedVirtualFile);
+      generateFolderDeletionActivity(deletedVirtualFile);
     } else {
-      generateFileDeletion(deletedVirtualFile);
+      generateFileDeletionActivity(deletedVirtualFile);
     }
   }
 
@@ -380,7 +380,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
    *
    * @param deletedFolder the folder that was deleted
    */
-  private void generateFolderDeletion(@NotNull VirtualFile deletedFolder) {
+  private void generateFolderDeletionActivity(@NotNull VirtualFile deletedFolder) {
     SPath path = VirtualFileConverter.convertToSPath(project, deletedFolder);
 
     if (path == null || !session.isShared(path.getResource())) {
@@ -406,7 +406,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
     ContentIterator contentIterator =
         fileOrDir -> {
           if (!fileOrDir.isDirectory()) {
-            generateFileDeletion(fileOrDir);
+            generateFileDeletionActivity(fileOrDir);
 
             return true;
           }
@@ -445,7 +445,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
    *
    * @param deletedFile the file that was deleted
    */
-  private void generateFileDeletion(VirtualFile deletedFile) {
+  private void generateFileDeletionActivity(VirtualFile deletedFile) {
     SPath path = VirtualFileConverter.convertToSPath(project, deletedFile);
 
     if (path == null || !session.isShared(path.getResource())) {
@@ -474,8 +474,8 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
    * Generates and dispatches activities handling resources moves.
    *
    * @param virtualFileMoveEvent the event to react to
-   * @see #generateFileMove(VirtualFile, VirtualFile, VirtualFile, String, String)
-   * @see #generateFolderMove(VirtualFile, VirtualFile, VirtualFile, String)
+   * @see #generateFileMoveActivity(VirtualFile, VirtualFile, VirtualFile, String, String)
+   * @see #generateFolderMoveActivity(VirtualFile, VirtualFile, VirtualFile, String)
    * @see #generateResourceCreationActivity(VirtualFileEvent) (VirtualFileEvent)
    * @see #generateResourceDeletionActivity(VirtualFileEvent) (VirtualFileEvent)
    */
@@ -498,10 +498,10 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
     }
 
     if (oldFile.isDirectory()) {
-      generateFolderMove(oldFile, oldParent, newParent, null);
+      generateFolderMoveActivity(oldFile, oldParent, newParent, null);
 
     } else {
-      generateFileMove(oldFile, oldParent, newParent, null, null);
+      generateFileMoveActivity(oldFile, oldParent, newParent, null, null);
     }
   }
 
@@ -532,9 +532,9 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
    * @param oldParent the old parent of the moved file
    * @param newParent the new parent of the moved file
    * @param newFolderName the new name for the folder or null if the folder was not renamed
-   * @see #generateFileMove(VirtualFile, VirtualFile, VirtualFile, String, String)
+   * @see #generateFileMoveActivity(VirtualFile, VirtualFile, VirtualFile, String, String)
    */
-  private void generateFolderMove(
+  private void generateFolderMoveActivity(
       @NotNull VirtualFile oldFile,
       @NotNull VirtualFile oldParent,
       @NotNull VirtualFile newParent,
@@ -584,7 +584,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
           }
 
           if (!fileOrDir.isDirectory()) {
-            generateFileMove(fileOrDir, oldParent, newParent, newFolderName, null);
+            generateFileMoveActivity(fileOrDir, oldParent, newParent, newFolderName, null);
 
             return true;
           }
@@ -659,9 +659,9 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
    * @param newBaseParent the new base parent of the file
    * @param newBaseName the new name for the base parent or null if it was not renamed
    * @param newFileName the new name for the file or null if it was not renamed
-   * @see #generateFolderMove(VirtualFile, VirtualFile, VirtualFile, String)
+   * @see #generateFolderMoveActivity(VirtualFile, VirtualFile, VirtualFile, String)
    */
-  private void generateFileMove(
+  private void generateFileMoveActivity(
       @NotNull VirtualFile oldFile,
       @NotNull VirtualFile oldBaseParent,
       @NotNull VirtualFile newBaseParent,
@@ -804,8 +804,8 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
    * <p>Other property changes are ignored.
    *
    * @param filePropertyEvent the event to react to
-   * @see #generateFolderMove(VirtualFile, VirtualFile, VirtualFile, String)
-   * @see #generateFileMove(VirtualFile, VirtualFile, VirtualFile, String, String)
+   * @see #generateFolderMoveActivity(VirtualFile, VirtualFile, VirtualFile, String)
+   * @see #generateFileMoveActivity(VirtualFile, VirtualFile, VirtualFile, String, String)
    */
   private void generateRenamingResourceMoveActivity(
       @NotNull VirtualFilePropertyEvent filePropertyEvent) {
@@ -849,9 +849,9 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
         }
 
         if (file.isDirectory()) {
-          generateFolderMove(file, parent, parent, newName);
+          generateFolderMoveActivity(file, parent, parent, newName);
         } else {
-          generateFileMove(file, parent, parent, null, newName);
+          generateFileMoveActivity(file, parent, parent, null, newName);
         }
 
         break;

--- a/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
@@ -4,7 +4,7 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ModuleFileIndex;
 import com.intellij.openapi.roots.ModuleRootManager;
-import com.intellij.openapi.roots.impl.ProjectFileIndexFacade;
+import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.vfs.VirtualFile;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -198,8 +198,8 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
    */
   @Nullable
   private IPath getProjectRelativePath(@NotNull VirtualFile file) {
-    Module fileModule =
-        ProjectFileIndexFacade.getInstance(module.getProject()).getModuleForFile(file);
+    ProjectFileIndex projectFileIndex = ProjectFileIndex.getInstance(project);
+    Module fileModule = Filesystem.runReadAction(() -> projectFileIndex.getModuleForFile(file));
 
     if (!module.equals(fileModule)) {
       return null;


### PR DESCRIPTION
#### [FIX][I] Wrap file index usage in read action in IntelliJProjectImpl

#### [REFACTOR][I] Split resource deletion handling

Split resource deletion handling into separate methods for file and
folder deletions. This was done in preparation for the adjustment of the
folder deletion logic to explicitly handle child resources as this new
logic requires additional calls to the file deletion logic.

Moves the creation of a VirtualFileFilter to separate method. This is
done as it will also be used by the logic iterating the contents of the
deleted folder.

#### [FIX][I] Explicitly send deletion activities for child resources

Adjusts LocalFilesystemModification.generateFolderDeletion(...) to
explicitly create deletion activities for the contained resources. This
ensures that the resource deletion of the child resources is handled
correctly for all other participants. Furthermore, it ensures that the
local state of all deleted child resources is also correctly torn down.

This is done as a fix for an issue related to and discussed in #714.

#### [REFACTOR][I] Adjust method names in LocalFilesystemModificationHandler

#### [DOC][I] Add javadoc on the order of child resource activity creation

Amends the javadoc of generateFolderDeletionActivity(...) and
generateFolderMoveActivity(...) to explain the ordering in which the
activities for contained child resources are created/dispatched.

#### [REFACTOR][I] Move file state handling to separate methods

Tries to partly encapsulate the handling of the internal Saros state for
a file in LocalFilesystemModificationHandler by moving it to separate
methods. This makes it easier to uniformly adjust the logic in the
future and offers a base for a possible extraction of the logic in the
future.