### PR TITLE
Handle resource move corner cases

### DIFF
--- a/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
@@ -30,7 +30,6 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
   private final Project project;
 
   private final Module module;
-  private final VirtualFile moduleRoot;
 
   /**
    * Creates a core compatible {@link IProject project} using the given IntelliJ module.
@@ -51,7 +50,8 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
 
     this.project = module.getProject();
 
-    moduleRoot = getModuleContentRoot(module);
+    // Still used to ensure that the module has exactly one content root
+    getModuleContentRoot(module);
   }
 
   /**
@@ -118,7 +118,7 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
   public IResource[] members() throws IOException {
     final List<IResource> result = new ArrayList<>();
 
-    final VirtualFile[] children = moduleRoot.getChildren();
+    final VirtualFile[] children = getModuleContentRoot(module).getChildren();
 
     ModuleFileIndex moduleFileIndex = ModuleRootManager.getInstance(module).getFileIndex();
 
@@ -205,6 +205,8 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
       return null;
     }
 
+    VirtualFile moduleRoot = getModuleContentRoot(module);
+
     try {
       Path relativePath = Paths.get(moduleRoot.getPath()).relativize(Paths.get(file.getPath()));
 
@@ -245,7 +247,7 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
   @NotNull
   @Override
   public IPath getLocation() {
-    return IntelliJPathImpl.fromString(moduleRoot.getPath());
+    return IntelliJPathImpl.fromString(getModuleContentRoot(module).getPath());
   }
 
   @Nullable
@@ -359,6 +361,8 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
   public VirtualFile findVirtualFile(final IPath path) {
 
     if (path.isAbsolute()) return null;
+
+    VirtualFile moduleRoot = getModuleContentRoot(module);
 
     if (path.segmentCount() == 0) return moduleRoot;
 

--- a/intellij/src/saros/intellij/filesystem/IntelliJResourceImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJResourceImpl.java
@@ -49,6 +49,8 @@ public abstract class IntelliJResourceImpl implements IResource {
    * @param virtualFile the virtual file to check
    * @return whether the given virtual file is the module file for the shared module
    */
+  // TODO consider whether to check all module files for the project to ensure that it is always
+  //  ignored, independently of where it is currently located
   private boolean isModuleFile(@NotNull Module module, @NotNull VirtualFile virtualFile) {
     if (virtualFile.isDirectory()) {
       return false;


### PR DESCRIPTION
#### [INTERNAL][I] Remove static reference to module content root

Replaces the static references to the content root in
IntelliJProjectImpl with dynamic requests. This ensures that the correct
content root is used after it was moved.

#### [REFACTOR][I] Move shared check to dedicated method

#### [FIX][I] #684 Filter move activities for the content root

Adjusts LocalFilesystemModificationHandler to filter out folder move
activities for the content root of the shared module. This allows the
participants to freely move/rename the shared module without causing
desyncs.

Fixes #684.

#### [FIX][I] Filter move activities for module files

Adjusts the logic to not send activities when the module file is moved
back into the shared module.

This logic is currently enough to handle the special case that the
module file of a shared module is moved outside of the shared module.
This is no longer true once multiple modules can be shared at the same
time, as we then also have to handle the case where the module file is
moved into a different shared module. Furthermore, it gets more
complicated when the module file is moved between (different) shared
modules, neither of which are actually associated with the module file,
as this would be seen as a normal file move. Also, modifications made to
the file while it is located in a different shared module would be
shared.