### PR TITLE
Fix module creation failure handling

### DIFF
--- a/intellij/src/saros/intellij/eventhandler/project/ProjectClosedHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/project/ProjectClosedHandler.java
@@ -69,7 +69,7 @@ public class ProjectClosedHandler implements Disposable {
             try {
               wrappedModule = new IntelliJProjectImpl(module);
 
-            } catch (IllegalStateException exception) {
+            } catch (IllegalArgumentException exception) {
               continue;
             }
 

--- a/intellij/src/saros/intellij/ui/Messages.java
+++ b/intellij/src/saros/intellij/ui/Messages.java
@@ -137,6 +137,8 @@ public class Messages {
   public static String ContactPopMenu_module_not_found_message_condition;
 
   public static String ShareWithUserAction_description;
+  public static String ShareWithUserAction_illegal_module_title;
+  public static String ShareWithUserAction_illegal_module_message;
 
   public static String SessionStatusChangeHandler_session_started_title;
   public static String SessionStatusChangeHandler_session_started_host_message;

--- a/intellij/src/saros/intellij/ui/Messages.java
+++ b/intellij/src/saros/intellij/ui/Messages.java
@@ -126,7 +126,6 @@ public class Messages {
 
   public static String ContactPopMenu_root_popup_text;
   public static String ContactPopMenu_menu_tooltip_share_module;
-  public static String ContactPopMenu_menu_tooltip_project_module;
   public static String ContactPopMenu_menu_tooltip_invalid_module;
   public static String ContactPopMenu_menu_entry_error_processing_project;
   public static String ContactPopMenu_menu_entry_no_modules_found;

--- a/intellij/src/saros/intellij/ui/messages.properties
+++ b/intellij/src/saros/intellij/ui/messages.properties
@@ -124,6 +124,8 @@ ContactPopMenu_module_not_found_title=Module not found - Project sharing aborted
 ContactPopMenu_module_not_found_message_condition=Saros could not find the chosen module {0}. Please make sure that the module is correctly configured in the current project and exists on disk.\nIf there seems to be no problem with the module
 
 ShareWithUserAction_description=Share this module with {0}
+ShareWithUserAction_illegal_module_title=Failed to share module
+ShareWithUserAction_illegal_module_message=The chosen module could not be shared as it does not adhere to the current module restrictions.\n\n{0}
 
 SessionStatusChangeHandler_session_started_title=Saros Session Started
 SessionStatusChangeHandler_session_started_host_message=You successfully started a session with {0}.

--- a/intellij/src/saros/intellij/ui/messages.properties
+++ b/intellij/src/saros/intellij/ui/messages.properties
@@ -113,7 +113,6 @@ Contact_saros_message_conditional={0}, please contact the Saros development team
 
 ContactPopMenu_root_popup_text=Work together on...
 ContactPopMenu_menu_tooltip_share_module=Share this module through Saros.
-ContactPopMenu_menu_tooltip_project_module=Project modules currently can not be shared through Saros/I.
 ContactPopMenu_menu_tooltip_invalid_module=Module can not be shared as it does not match the current module restrictions.
 ContactPopMenu_menu_entry_error_processing_project=Saros encountered an error while trying to process the project.
 ContactPopMenu_menu_entry_no_modules_found=No modules found!


### PR DESCRIPTION
#### [FIX][I] Catch correct exception in ProjectClosedHandler

#### [FIX][I] Handle illegal module exception in ShareWithUserAction

Adjusts the logic creating the IntelliJProjectReference in
ShareWithUserAction to catch and correctly handle the
IllegalArgumentException thrown in case an illegal module is selected to
be shared.

#### [NOP][I] Remove unused message entry