### PR TITLE
[CORE] Instant Session Start: Await Transfer End

### DIFF
--- a/core/src/saros/negotiation/InstantIncomingProjectNegotiation.java
+++ b/core/src/saros/negotiation/InstantIncomingProjectNegotiation.java
@@ -3,6 +3,7 @@ package saros.negotiation;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.io.input.CountingInputStream;
 import org.apache.log4j.Logger;
 import org.jivesoftware.smack.XMPPException;
 import org.jivesoftware.smackx.filetransfer.IncomingFileTransfer;
@@ -78,9 +79,10 @@ public class InstantIncomingProjectNegotiation extends AbstractIncomingProjectNe
     log.debug(this + ": Host is starting to send...");
 
     IncomingFileTransfer transfer = transferListener.getRequest().accept();
-    try (IncomingStreamProtocol isp =
-        new IncomingStreamProtocol(transfer.recieveFile(), session, monitor)) {
+    try (CountingInputStream countStream = new CountingInputStream(transfer.recieveFile());
+        IncomingStreamProtocol isp = new IncomingStreamProtocol(countStream, session, monitor)) {
       isp.receiveStream();
+      log.debug("stream bytes received: " + countStream.getByteCount());
     } catch (XMPPException e) {
       throw new LocalCancellationException(e.getMessage(), CancelOption.NOTIFY_PEER);
     }

--- a/core/src/saros/negotiation/stream/OutgoingStreamProtocol.java
+++ b/core/src/saros/negotiation/stream/OutgoingStreamProtocol.java
@@ -4,7 +4,6 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import saros.activities.SPath;
 import saros.exceptions.LocalCancellationException;
@@ -14,7 +13,7 @@ import saros.negotiation.NegotiationTools.CancelOption;
 import saros.negotiation.ProjectSharingData;
 
 /** Implements Stream creation in {@link AbstractStreamProtocol} format. */
-public class OutgoingStreamProtocol extends AbstractStreamProtocol implements AutoCloseable {
+public class OutgoingStreamProtocol extends AbstractStreamProtocol {
 
   private static final Logger log = Logger.getLogger(OutgoingStreamProtocol.class);
 
@@ -75,17 +74,13 @@ public class OutgoingStreamProtocol extends AbstractStreamProtocol implements Au
   }
 
   /**
-   * Writes a end remark to notify stream endpoint about correct end of transmission and closes the
-   * stream correctly.
+   * Writes a end remark to notify stream endpoint about correct end of transmission and flushes the
+   * stream.
    *
    * @throws IOException if stream operation fails
    */
-  @Override
   public void close() throws IOException {
-    try {
-      out.writeUTF("");
-    } finally {
-      IOUtils.closeQuietly(out);
-    }
+    out.writeUTF("");
+    out.flush();
   }
 }


### PR DESCRIPTION
Instant Session Start uses a stream initiated via Smack to send files.
In some cases close() on this stream will not flush remaining data and
stop the transmission before all data has been sent.
