### PR TITLE
[CORE] Network: Reduce Number of TCP Packets

### DIFF
--- a/core/src/saros/net/internal/BinaryChannelConnection.java
+++ b/core/src/saros/net/internal/BinaryChannelConnection.java
@@ -220,8 +220,6 @@ public class BinaryChannelConnection implements IByteStreamConnection {
       Integer elementNameId;
 
       synchronized (this) {
-        boolean sendUpdate = false;
-
         final String namespace = data.getNamespace();
         namespaceId = outNamespaceCache.get(namespace);
 
@@ -241,7 +239,6 @@ public class BinaryChannelConnection implements IByteStreamConnection {
           outputStream.write(Opcode.NAMESPACE_UPDATE);
           outputStream.write(namespaceId);
           outputStream.writeUTF(namespace);
-          sendUpdate = true;
         }
 
         final String elementName = data.getElementName();
@@ -263,10 +260,7 @@ public class BinaryChannelConnection implements IByteStreamConnection {
           outputStream.write(Opcode.ELEMENT_NAME_UPDATE);
           outputStream.writeShort(elementNameId);
           outputStream.writeUTF(elementName);
-          sendUpdate = true;
         }
-
-        if (sendUpdate) outputStream.flush();
       }
 
       assert content.length > 0;
@@ -464,7 +458,6 @@ public class BinaryChannelConnection implements IByteStreamConnection {
     outputStream.write(namespaceId);
     outputStream.writeShort(elementNameId);
     outputStream.write(compress ? 1 : 0);
-    outputStream.flush();
   }
 
   /** Splits the given data into chunks of CHUNKSIZE to send the BinaryPackets. */


### PR DESCRIPTION
To reduce user input latency, the network socket is configured to send
a new TCP packet each time flush() is called on its provided stream.
The downside is more packets are generated, thus increasing overhead for
additional headers, processing time and thelikelihood of packet loss.

The saros network protocol uses four message types, three of which
describe the payload and one the DATA type carrying the payload. Since
the describing messages are only useful for handling the payload, they
do not need to be sent separately.
