### PR TITLE
Drop re-parsing events

### DIFF
--- a/intellij/resources/META-INF/plugin.xml
+++ b/intellij/resources/META-INF/plugin.xml
@@ -35,6 +35,7 @@
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html on how to target different products -->
     <!-- uncomment to enable plugin in all products
+    <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.lang</depends>
     -->
 

--- a/intellij/resources/META-INF/plugin.xml
+++ b/intellij/resources/META-INF/plugin.xml
@@ -30,10 +30,10 @@
         Saros Project
     </vendor>
 
-    <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
+    <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
     <idea-version since-build="182.5107.16"/>
 
-    <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html on how to target different products -->
+    <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html on how to target different products -->
     <!-- uncomment to enable plugin in all products
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.lang</depends>

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -886,6 +886,16 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
         String oldName = (String) oldValue;
         String newName = (String) newValue;
 
+        // TODO consider using FilePropertyEvent#isRename() once compatibility is dropped to 2019.2
+        if (oldName.equals(newName)) {
+          LOG.debug(
+              "Dropping file property event for "
+                  + file
+                  + " as it is detected to be a re-parsing of the file.");
+
+          return;
+        }
+
         if (LOG.isTraceEnabled()) {
           LOG.trace(
               "Reacting before resource name change - resource: "


### PR DESCRIPTION
#### [FIX][I] #740 Drop events triggered by file re-parsing

Adjusts the handling of local file property change events to correctly
filter out events triggered by a re-parsing of the file. This explicit
check is needed as such events are reported as re-namings onto the same
name, leading to issues in our logic (as this creates move activities
onto the same resource, resulting in a resource clash on the receiving
side).

This check is currently done by comparing the new and old name. Once
backwards compatibility is dropped below 2019.2, we should consider
using the dedicated method FilePropertyEvent.isRename() for this purpose
instead.

Fixes #740.

#### [INTERNAL][I] Amend JetBrains plugin dependencies

Amends the commented out list of plugin dependencies to adhere to the
plugin SDK guidelines.

The support for other JetBrains IDEs still remains disabled for now.

Even though the plugin now passes a smoke test in many JetBrains IDEs
(CLion, Pycharm, WebStorm), I still don't feel comfortable marking the
plugin as compatible as there still might be implementation differences
(see issue #740, which does not seem to occur in IntelliJ).
Furthermore, the plugin is still in a somewhat unstable state, meaning
we still might make major architectural changes in the future. Enabling
support for other IDEs and therefore guaranteeing compatibility with
these other IDEs increases the testing effort by a lot.

#### [NOP][I] Update links to IntelliJ documentation in plugin.xml HTTPS