### PR TITLE
Add XStream Security Framework Setup

### DIFF
--- a/core/src/saros/account/XMPPAccountStore.java
+++ b/core/src/saros/account/XMPPAccountStore.java
@@ -31,6 +31,7 @@ import javax.crypto.spec.SecretKeySpec;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import saros.annotations.Component;
+import saros.misc.xstream.XStreamFactory;
 import saros.net.xmpp.JID;
 
 /**
@@ -231,7 +232,8 @@ public final class XMPPAccountStore {
   }
 
   private XStream createXStream() {
-    XStream xStream = new XStream();
+    XStream xStream = XStreamFactory.getSecureXStream();
+
     xStream.alias("accounts", AccountStoreInformation.class);
     xStream.alias("xmppAccount", XMPPAccount.class);
     return xStream;

--- a/core/src/saros/editor/colorstorage/ColorIDSetStorage.java
+++ b/core/src/saros/editor/colorstorage/ColorIDSetStorage.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Set;
 import org.apache.log4j.Logger;
 import saros.annotations.Component;
+import saros.misc.xstream.XStreamFactory;
 import saros.preferences.IPreferenceStore;
 
 /**
@@ -181,7 +182,8 @@ public final class ColorIDSetStorage {
   }
 
   private XStream createXStream() {
-    XStream xStream = new XStream();
+    XStream xStream = XStreamFactory.getSecureXStream();
+
     xStream.alias("colorIDSet", ColorIDSet.class);
     return xStream;
   }

--- a/core/src/saros/misc/xstream/XStreamExtensionProvider.java
+++ b/core/src/saros/misc/xstream/XStreamExtensionProvider.java
@@ -92,7 +92,7 @@ public class XStreamExtensionProvider<T> implements PacketExtensionProvider, IQP
     this.elementName = elementName;
     this.namespace = namespace;
 
-    xstream = new XStream();
+    xstream = XStreamFactory.getSecureXStream();
 
     if (classLoader != null) xstream.setClassLoader(classLoader);
     else xstream.setClassLoader(getClass().getClassLoader());

--- a/core/src/saros/misc/xstream/XStreamFactory.java
+++ b/core/src/saros/misc/xstream/XStreamFactory.java
@@ -1,0 +1,62 @@
+package saros.misc.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.io.HierarchicalStreamDriver;
+import com.thoughtworks.xstream.security.NoTypePermission;
+import com.thoughtworks.xstream.security.NullPermission;
+import com.thoughtworks.xstream.security.PrimitiveTypePermission;
+import java.util.Collection;
+import java.util.Map;
+
+/** Factory class providing XStream objects with the correctly set-up security framework. */
+public class XStreamFactory {
+
+  /**
+   * Returns an <code>XStream</code> object with an set-up security framework.
+   *
+   * @return an <code>XStream</code> object with an set-up security framework
+   */
+  public static XStream getSecureXStream() {
+    XStream xStream = new XStream();
+
+    setUpSecurityFramework(xStream);
+
+    return xStream;
+  }
+
+  /**
+   * Returns an <code>XStream</code> object with an set-up security framework. The passed <code>
+   * HierarchicalStreamDriver</code> will be used when instantiating the <code>XStream</code> object
+   *
+   * @return an <code>XStream</code> object with an set-up security framework
+   */
+  public static XStream getSecureXStream(HierarchicalStreamDriver hierarchicalStreamDriver) {
+    XStream xStream = new XStream(hierarchicalStreamDriver);
+
+    setUpSecurityFramework(xStream);
+
+    return xStream;
+  }
+
+  /**
+   * Sets up the security framework for the passed <code>XStream</code> object.
+   *
+   * @param xStream the <code>XStream</code> object to set the security framework up for
+   * @see <a
+   *     href="https://x-stream.github.io/security.html">https://x-stream.github.io/security.html</a>
+   */
+  private static void setUpSecurityFramework(XStream xStream) {
+    // forbid all classes by default
+    xStream.addPermission(NoTypePermission.NONE);
+
+    // allow default java stuff
+    xStream.addPermission(NullPermission.NULL);
+    xStream.addPermission(PrimitiveTypePermission.PRIMITIVES);
+    xStream.allowTypeHierarchy(Collection.class);
+    xStream.allowTypeHierarchy(Map.class);
+    xStream.allowTypes(new Class[] {String.class});
+
+    // allow all saros classes
+    xStream.allowTypesByWildcard(new String[] {"saros.**"});
+  }
+}

--- a/core/test/junit/saros/misc/xstream/ReplaceableConverterTest.java
+++ b/core/test/junit/saros/misc/xstream/ReplaceableConverterTest.java
@@ -33,7 +33,7 @@ public class ReplaceableConverterTest {
     EasyMock.replay(c1);
 
     /* XStream config */
-    XStream xstream = new XStream(new DomDriver());
+    XStream xstream = XStreamFactory.getSecureXStream(new DomDriver());
     ReplaceableConverter resetable = new ReplaceableConverter(c1);
     xstream.registerConverter(resetable);
 
@@ -73,7 +73,7 @@ public class ReplaceableConverterTest {
     EasyMock.replay(c1, c2);
 
     /* XStream config */
-    XStream xstream = new XStream(new DomDriver());
+    XStream xstream = XStreamFactory.getSecureXStream(new DomDriver());
     ReplaceableConverter resetable = new ReplaceableConverter(c1);
     xstream.registerConverter(resetable);
 

--- a/core/test/junit/saros/misc/xstream/ReplaceableSingleValueConverterTest.java
+++ b/core/test/junit/saros/misc/xstream/ReplaceableSingleValueConverterTest.java
@@ -32,7 +32,7 @@ public class ReplaceableSingleValueConverterTest {
     EasyMock.replay(c1);
 
     /* XStream config */
-    XStream xstream = new XStream(new DomDriver());
+    XStream xstream = XStreamFactory.getSecureXStream(new DomDriver());
     ReplaceableSingleValueConverter resetable = new ReplaceableSingleValueConverter(c1);
     xstream.registerConverter(resetable);
 
@@ -72,7 +72,7 @@ public class ReplaceableSingleValueConverterTest {
     EasyMock.replay(c1, c2);
 
     /* XStream config */
-    XStream xstream = new XStream(new DomDriver());
+    XStream xstream = XStreamFactory.getSecureXStream(new DomDriver());
     ReplaceableConverter resetable = new ReplaceableConverter(c1);
     xstream.registerConverter(resetable);
 

--- a/core/test/junit/saros/misc/xstream/SPathConverterTest.java
+++ b/core/test/junit/saros/misc/xstream/SPathConverterTest.java
@@ -62,10 +62,10 @@ public class SPathConverterTest {
     EasyMock.replay(session);
 
     /* XStream */
-    XStream sender = new XStream(new DomDriver());
+    XStream sender = XStreamFactory.getSecureXStream(new DomDriver());
     sender.registerConverter(new SPathConverter(session, pathFactory));
 
-    XStream receiver = new XStream(new DomDriver());
+    XStream receiver = XStreamFactory.getSecureXStream(new DomDriver());
     receiver.registerConverter(new SPathConverter(session, pathFactory));
 
     /* Test */
@@ -93,10 +93,10 @@ public class SPathConverterTest {
     EasyMock.replay(senderSession, receiverSession);
 
     /* XStream */
-    XStream sender = new XStream(new DomDriver());
+    XStream sender = XStreamFactory.getSecureXStream(new DomDriver());
     sender.registerConverter(new SPathConverter(senderSession, pathFactory));
 
-    XStream receiver = new XStream(new DomDriver());
+    XStream receiver = XStreamFactory.getSecureXStream(new DomDriver());
     receiver.registerConverter(new SPathConverter(receiverSession, pathFactory));
 
     /* Test */
@@ -127,10 +127,10 @@ public class SPathConverterTest {
     EasyMock.replay(senderSession, receiverSession);
 
     /* XStream */
-    XStream sender = new XStream(new DomDriver());
+    XStream sender = XStreamFactory.getSecureXStream(new DomDriver());
     sender.registerConverter(new SPathConverter(senderSession, pathFactory));
 
-    XStream receiver = new XStream(new DomDriver());
+    XStream receiver = XStreamFactory.getSecureXStream(new DomDriver());
     receiver.registerConverter(new SPathConverter(receiverSession, pathFactory));
 
     /* Test */

--- a/core/test/junit/saros/misc/xstream/UserConverterTest.java
+++ b/core/test/junit/saros/misc/xstream/UserConverterTest.java
@@ -32,7 +32,7 @@ public class UserConverterTest {
     EasyMock.replay(session);
 
     /* XStream */
-    xstream = new XStream(new DomDriver());
+    xstream = XStreamFactory.getSecureXStream(new DomDriver());
     xstream.registerConverter(new UserConverter(session));
   }
 

--- a/core/test/junit/saros/negotiation/FileListTest.java
+++ b/core/test/junit/saros/negotiation/FileListTest.java
@@ -27,6 +27,7 @@ import saros.filesystem.IFolder;
 import saros.filesystem.IPath;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
+import saros.misc.xstream.XStreamFactory;
 
 /*
  *Project Layout for test
@@ -41,7 +42,7 @@ import saros.filesystem.IResource;
  */
 public class FileListTest {
 
-  private static final XStream xstream = new XStream();
+  private static final XStream xstream = XStreamFactory.getSecureXStream();
 
   static {
     xstream.registerConverter(BooleanConverter.BINARY);


### PR DESCRIPTION
#### [FIX][CORE] #209 Add XStreamFactory to set up security framework

Adds XStreamFactory as a factory class providing XStream objects whose
security framework was already setup to our needs. The security
framework is set up to allow the following objects:
 - null
 - Java primitives and their wrappers
 - Class extending 'Collection'
 - Classes extending 'Map'
 - String
 - Classes in any package starting with 'saros.**'

This should currently allow any existing logic to function as before.

The security framework was introduces to prevent misuse of the
functionality. See https://x-stream.github.io/security.html

Base for fixing #209.

#### [FIX][CORE] #209 Use XStreamFactory to obtain XStream objects

Adjusts the core logic to always use the XStreamFactory to obtain
XStream objects.

This change was also applied to internal usages of XStream that do not
handle any network messages. It is not strictly necessary here but does
not hurt and is still good practice. Furthermore, it prevents the logs
from becoming polluted by warning messages about missing security
framework setups for XStream objects.

This change was also applied to test usages of XStream to ensure that
faulty configurations of the security framework will be reported by the
tests.

Fixes #209.