### PR TITLE
[BUILD][I] Fix Saros/I build script to allow import into Eclipse

### DIFF
--- a/intellij/build.gradle
+++ b/intellij/build.gradle
@@ -106,12 +106,6 @@ task unlockIntellijSandbox {
 runIde.dependsOn(lockIntellijSandbox)
 runIde.finalizedBy(unlockIntellijSandbox)
 
-afterEvaluate {
-  dependencies {
-    compile intellij {}
-  }
-}
-
 artifacts {
   archives buildPlugin
 }


### PR DESCRIPTION
Adjusts the Saros/I build script. This is necessary to allow the project
to be imported cleanly into Eclipse.