### PR TITLE
Use transferred file type for created file if necessary

### DIFF
--- a/core/src/saros/activities/FileActivity.java
+++ b/core/src/saros/activities/FileActivity.java
@@ -34,7 +34,7 @@ public class FileActivity extends AbstractResourceActivity
 
   @XStreamAsAttribute protected final Purpose purpose;
 
-  @XStreamAsAttribute protected String encoding;
+  @XStreamAsAttribute protected final String encoding;
 
   protected final byte[] content;
 

--- a/core/src/saros/activities/FileActivity.java
+++ b/core/src/saros/activities/FileActivity.java
@@ -36,6 +36,8 @@ public class FileActivity extends AbstractResourceActivity
 
   @XStreamAsAttribute protected final String encoding;
 
+  @XStreamAsAttribute protected final String fileType;
+
   protected final byte[] content;
 
   /**
@@ -49,6 +51,8 @@ public class FileActivity extends AbstractResourceActivity
    * @param content content of the file denoted by the path (only valid for {@link Type#CREATED} and
    *     {@link Type#MOVED})
    * @param encoding the encoding the content is encoded with or <code>null</code>
+   * @param fileType the file type of the new file (only used for {@link Type#CREATED} and {@link
+   *     Type#MOVED})
    */
   public FileActivity(
       User source,
@@ -57,7 +61,8 @@ public class FileActivity extends AbstractResourceActivity
       SPath newPath,
       SPath oldPath,
       byte[] content,
-      String encoding) {
+      String encoding,
+      String fileType) {
 
     super(source, newPath);
 
@@ -82,6 +87,7 @@ public class FileActivity extends AbstractResourceActivity
     this.content = content;
     this.encoding = encoding;
     this.purpose = purpose;
+    this.fileType = fileType;
   }
 
   @Override
@@ -116,6 +122,15 @@ public class FileActivity extends AbstractResourceActivity
     return encoding;
   }
 
+  /**
+   * Returns the file type for the file.
+   *
+   * @return the file type for the file
+   */
+  public String getFileType() {
+    return fileType;
+  }
+
   @Override
   public String toString() {
     return "FileActivity [dst:path="
@@ -126,6 +141,8 @@ public class FileActivity extends AbstractResourceActivity
         + type
         + ", encoding="
         + (encoding == null ? "N/A" : encoding)
+        + ", file type="
+        + fileType
         + ", content="
         + (content == null ? "0" : content.length)
         + " byte(s)]";

--- a/core/src/saros/activities/TargetedFileActivity.java
+++ b/core/src/saros/activities/TargetedFileActivity.java
@@ -34,9 +34,10 @@ public class TargetedFileActivity extends FileActivity implements ITargetedActiv
       SPath oldPath,
       byte[] content,
       String encoding,
+      String fileType,
       Purpose purpose) {
 
-    super(source, type, purpose, newPath, oldPath, content, encoding);
+    super(source, type, purpose, newPath, oldPath, content, encoding, fileType);
 
     if (target == null) throw new IllegalArgumentException("target must not be null");
 
@@ -67,6 +68,8 @@ public class TargetedFileActivity extends FileActivity implements ITargetedActiv
         + type
         + ", encoding="
         + (encoding == null ? "N/A" : encoding)
+        + ", file type="
+        + fileType
         + ", content="
         + (content == null ? "0" : content.length)
         + " byte(s)]";

--- a/core/src/saros/concurrent/watchdog/ConsistencyWatchdogHandler.java
+++ b/core/src/saros/concurrent/watchdog/ConsistencyWatchdogHandler.java
@@ -176,7 +176,7 @@ public final class ConsistencyWatchdogHandler extends AbstractActivityProducer
       // Tell the client to delete the file
       fireActivity(
           new TargetedFileActivity(
-              user, from, Type.REMOVED, path, null, null, null, Purpose.RECOVERY));
+              user, from, Type.REMOVED, path, null, null, null, null, Purpose.RECOVERY));
       fireActivity(
           new ChecksumActivity(
               user,
@@ -215,7 +215,7 @@ public final class ConsistencyWatchdogHandler extends AbstractActivityProducer
 
     fireActivity(
         new TargetedFileActivity(
-            user, from, Type.CREATED, path, null, content, charset, Purpose.RECOVERY));
+            user, from, Type.CREATED, path, null, content, charset, null, Purpose.RECOVERY));
 
     /*
      * Immediately follow up with a new checksum activity so that the remote

--- a/eclipse/src/saros/project/ProjectDeltaVisitor.java
+++ b/eclipse/src/saros/project/ProjectDeltaVisitor.java
@@ -182,7 +182,7 @@ final class ProjectDeltaVisitor implements IResourceDeltaVisitor {
 
       // TODO add encoding
       addActivity(
-          new FileActivity(user, Type.CREATED, Purpose.ACTIVITY, spath, null, content, null));
+          new FileActivity(user, Type.CREATED, Purpose.ACTIVITY, spath, null, content, null, null));
 
     } else if (isFolder(resource)) {
       addActivity(new FolderCreatedActivity(user, spath));
@@ -214,7 +214,8 @@ final class ProjectDeltaVisitor implements IResourceDeltaVisitor {
             ResourceAdapterFactory.create(oldFullPath.removeFirstSegments(1)));
     // TODO add encoding
     addActivity(
-        new FileActivity(user, Type.MOVED, Purpose.ACTIVITY, newPath, oldPath, content, null));
+        new FileActivity(
+            user, Type.MOVED, Purpose.ACTIVITY, newPath, oldPath, content, null, null));
   }
 
   private void generateRemoved(IResource resource) {
@@ -226,6 +227,7 @@ final class ProjectDeltaVisitor implements IResourceDeltaVisitor {
               Type.REMOVED,
               Purpose.ACTIVITY,
               new SPath(ResourceAdapterFactory.create(resource)),
+              null,
               null,
               null,
               null));
@@ -261,7 +263,7 @@ final class ProjectDeltaVisitor implements IResourceDeltaVisitor {
     // TODO add encoding
     else
       addActivity(
-          new FileActivity(user, Type.CREATED, Purpose.ACTIVITY, spath, null, content, null));
+          new FileActivity(user, Type.CREATED, Purpose.ACTIVITY, spath, null, content, null, null));
   }
 
   private void addActivity(IResourceActivity activity) {

--- a/eclipse/test/junit/saros/project/FileActivityConsumerTest.java
+++ b/eclipse/test/junit/saros/project/FileActivityConsumerTest.java
@@ -119,6 +119,7 @@ public class FileActivityConsumerTest {
         createPathMockForFile(file),
         null,
         content,
+        null,
         null);
   }
 }

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -294,9 +294,18 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
       byte[] content = getContent(createdVirtualFile);
 
+      String fileType = createdVirtualFile.getFileType().getName();
+
       activity =
           new FileActivity(
-              user, Type.CREATED, FileActivity.Purpose.ACTIVITY, path, null, content, charset);
+              user,
+              Type.CREATED,
+              FileActivity.Purpose.ACTIVITY,
+              path,
+              null,
+              content,
+              charset,
+              fileType);
     }
 
     dispatchActivity(activity);
@@ -348,9 +357,18 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
     byte[] content = getContent(copy);
 
+    String fileType = copy.getFileType().getName();
+
     IActivity activity =
         new FileActivity(
-            user, Type.CREATED, FileActivity.Purpose.ACTIVITY, copyPath, null, content, charset);
+            user,
+            Type.CREATED,
+            FileActivity.Purpose.ACTIVITY,
+            copyPath,
+            null,
+            content,
+            charset,
+            fileType);
 
     dispatchActivity(activity);
   }
@@ -470,7 +488,8 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
     User user = session.getLocalUser();
 
     IActivity activity =
-        new FileActivity(user, Type.REMOVED, FileActivity.Purpose.ACTIVITY, path, null, null, null);
+        new FileActivity(
+            user, Type.REMOVED, FileActivity.Purpose.ACTIVITY, path, null, null, null, null);
 
     cleanUpDeletedFileState(path);
 
@@ -775,6 +794,8 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
               newParentPath.getProject(),
               newParentPath.getProjectRelativePath().append(relativePath));
 
+      String fileType = oldFile.getFileType().getName();
+
       activity =
           new FileActivity(
               user,
@@ -783,7 +804,8 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
               newFilePath,
               oldFilePath,
               null,
-              encoding);
+              encoding,
+              fileType);
 
       updateMovedFileState(oldFilePath, newFilePath);
 
@@ -796,6 +818,8 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
               newParentPath.getProject(),
               newParentPath.getProjectRelativePath().append(relativePath));
 
+      String fileType = oldFile.getFileType().getName();
+
       activity =
           new FileActivity(
               user,
@@ -804,7 +828,8 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
               newFilePath,
               null,
               fileContent,
-              encoding);
+              encoding,
+              fileType);
 
       if (fileIsOpen) {
         setUpMovedEditorState(oldFile, newFilePath);
@@ -814,7 +839,14 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
       // moved file out of shared module
       activity =
           new FileActivity(
-              user, Type.REMOVED, FileActivity.Purpose.ACTIVITY, oldFilePath, null, null, null);
+              user,
+              Type.REMOVED,
+              FileActivity.Purpose.ACTIVITY,
+              oldFilePath,
+              null,
+              null,
+              null,
+              null);
 
       cleanUpDeletedFileState(oldFilePath);
 


### PR DESCRIPTION
#### [INTERNAL][CORE] Make variable for encoding final in FileActivity

#### [FIX][I] #683 Introduce file type field for FileActivity

Adds the field fileType to FileActivity. This field can be used to
transfer the file type associated with the file, which is necessary in
cases where there is no file type automatically associated with the
created file on the receiving side.

This field is currently only used/needed by Saros/I, but I did not see
another sensible way of fixing #683. Look at the discussion of PR #748
for more information.

Preparation for fixing #683.

#### [FIX][I] #683 Use transferred file type for created file if needed

Adjusts the logic creating new files as a reaction to a received
activity by using the transferred file type for the newly created file
if there is no default file type association.

This was done to avoid situations where we could not obtain a document
representation of a newly created file as it had no file type associated
with it, leading to a desync as no content could be read from or written
to the file.

Fixes #683.