### PR TITLE
[INTERNAL][I] Avoid usage of IResource methods using project paths

### DIFF
--- a/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
@@ -330,10 +330,13 @@ public class LocalEditorManipulator {
 
       text = new String(content);
 
+      String qualifiedResource =
+          file.getProject().getName() + " - " + file.getProjectRelativePath();
+
       NotificationPanel.showWarning(
           String.format(
               Messages.LocalEditorManipulator_incompatible_encoding_message,
-              file.getLocation(),
+              qualifiedResource,
               encoding,
               Charset.defaultCharset()),
           Messages.LocalEditorManipulator_incompatible_encoding_title);

--- a/intellij/src/saros/intellij/ui/views/buttons/ConsistencyButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/ConsistencyButton.java
@@ -253,7 +253,9 @@ public class ConsistencyButton extends AbstractSessionToolbarButton {
         sb.append(", ");
       }
 
-      sb.append(resource.getFullPath());
+      sb.append(resource.getProject().getName())
+          .append(" - ")
+          .append(resource.getProjectRelativePath());
     }
 
     return sb.toString();


### PR DESCRIPTION
Avoid the usage of IResource.getFullPath() and getLocation() as they
don't accurately represent the actual module structure. By just
appending the relative path to the module name, this suggest a certain
module structure that must not necessarily be present.

This inaccurate path could create confusion with the user. To avoid
this, I would suggest the usage of the format "MODULE_NAME -
RELATIVE_PATH". This should still give the user ample information to
identify the correct resource in the filesystem.