### PR TITLE
Prepare for update to Java 11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,10 +91,10 @@ configure(projectsToConfigure) { projectToConf ->
   dependencies {
     addLog4JDependency(configurations.testConfig)
     testConfig junitVersion
-    testConfig 'org.easymock:easymock:3.5.1'
-    testConfig 'org.powermock:powermock-core:2.0.0'
-    testConfig 'org.powermock:powermock-module-junit4:2.0.0'
-    testConfig 'org.powermock:powermock-api-easymock:2.0.0'
+    testConfig 'org.easymock:easymock:4.0.1'
+    testConfig 'org.powermock:powermock-core:2.0.5'
+    testConfig 'org.powermock:powermock-module-junit4:2.0.5'
+    testConfig 'org.powermock:powermock-api-easymock:2.0.5'
   }
 
   // generate lib directory that contains all release dependencies

--- a/core/test/junit/saros/session/SarosSessionManagerTest.java
+++ b/core/test/junit/saros/session/SarosSessionManagerTest.java
@@ -28,7 +28,7 @@ import saros.session.internal.SarosSession;
 @PowerMockIgnore({"javax.xml.*"})
 public class SarosSessionManagerTest {
 
-  private class DummyError extends Error {
+  class DummyError extends Error {
     private static final long serialVersionUID = 1L;
   }
 

--- a/core/test/junit/saros/session/SarosSessionManagerTest.java
+++ b/core/test/junit/saros/session/SarosSessionManagerTest.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import saros.communication.connection.ConnectionHandler;
@@ -24,6 +25,7 @@ import saros.session.internal.SarosSession;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({SarosSession.class, SarosSessionManager.class})
+@PowerMockIgnore({"javax.xml.*"})
 public class SarosSessionManagerTest {
 
   private class DummyError extends Error {

--- a/eclipse/test/junit/saros/SarosEclipseContextFactoryTest.java
+++ b/eclipse/test/junit/saros/SarosEclipseContextFactoryTest.java
@@ -5,6 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.MockPolicy;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import saros.context.CoreContextFactory;
@@ -19,6 +20,7 @@ import saros.test.mocks.PrepareEclipseComponents;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Saros.class})
 @MockPolicy({PrepareCoreComponents.class, PrepareEclipseComponents.class})
+@PowerMockIgnore({"javax.xml.*"})
 public class SarosEclipseContextFactoryTest {
 
   private MutablePicoContainer container;

--- a/eclipse/test/junit/saros/SarosEclipseContextTest.java
+++ b/eclipse/test/junit/saros/SarosEclipseContextTest.java
@@ -7,6 +7,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.MockPolicy;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import saros.context.CoreContextFactory;
@@ -21,6 +22,7 @@ import saros.test.mocks.PrepareEclipseComponents;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Saros.class})
 @MockPolicy({PrepareEclipseComponents.class})
+@PowerMockIgnore({"javax.xml.*"})
 public class SarosEclipseContextTest {
 
   private MutablePicoContainer container;

--- a/eclipse/test/junit/saros/session/internal/SarosSessionTest.java
+++ b/eclipse/test/junit/saros/session/internal/SarosSessionTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.osgi.service.prefs.Preferences;
 import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import saros.awareness.AwarenessInformationCollector;
@@ -72,6 +73,7 @@ import saros.test.mocks.EditorManagerMock;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({StatisticManager.class, ResourcesPlugin.class})
+@PowerMockIgnore({"javax.xml.*"})
 public class SarosSessionTest {
 
   private static final String SAROS_SESSION_ID = "SAROS_SESSION_TEST";

--- a/intellij/test/junit/saros/intellij/context/SarosIntellijContextTest.java
+++ b/intellij/test/junit/saros/intellij/context/SarosIntellijContextTest.java
@@ -5,12 +5,14 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import saros.context.CoreContextFactory;
 import saros.context.IContainerContext;
 import saros.context.IContextFactory;
 import saros.test.mocks.ContextMocker;
 
 /** Checks the Saros/I context for integrity. */
+@PowerMockIgnore({"javax.xml.*"})
 public class SarosIntellijContextTest extends AbstractContextTest {
 
   @Override


### PR DESCRIPTION
#### [BUILD][CORE] Update testing libraries

Updates EasyMock and PowerMock to the newest compatible versions. This
was done to keep the number of issues related to java 11 to a minimum.

#### [FIX] Add PowerMockIgnore annotations for javax.xml.*

These annotations are necessary to avoid an internal issue with
powermock. This workaround will most likely become unnecessary at some
point in the future.

#### [FIX] Make SarosSessionManagerTest$DummyError package-protected

This was done to avoid an issue with the CTOR accessibility occurring
when using Java 11.