### PR TITLE
Update google java format info

### DIFF
--- a/docs/contribute/development-environment.md
+++ b/docs/contribute/development-environment.md
@@ -3,21 +3,21 @@ title: Saros Development Environment
 ---
 
 The following page describes how a development environment can be set up in order to develop all Saros products (Eclipse-Plugin, IntelliJ-Plugin and Server).
-If you want to execute the STF tests it is recommended to use eclipse. Otherwise it is also possible to develop with IntelliJ IDEA and execute the stf tests in a docker container.
+If you want to execute the STF tests it is recommended to use Eclipse. Otherwise it is also possible to develop with IntelliJ IDEA and execute the stf tests in a docker container.
 
 ## Common
 * You have to [clone](https://help.github.com/articles/cloning-a-repository/) the Saros repository with [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
 * You need a **Java 8 JDK**.
-* You need an **Eclipse 4.6** installation which is used for dependency resolution. You can either install a [minimal Eclipse](http://www.eclipse.org/downloads/packages/release/neon/3/eclipse-ide-java-developers) or [Eclipse for Eclipse Committers](http://www.eclipse.org/downloads/packages/release/neon/3/eclipse-ide-eclipse-committers) if you also want to develop with eclipse.
+* You need an **Eclipse 4.6** installation which is used for dependency resolution. You can either install a [minimal Eclipse](http://www.eclipse.org/downloads/packages/release/neon/3/eclipse-ide-java-developers) or [Eclipse for Eclipse Committers](http://www.eclipse.org/downloads/packages/release/neon/3/eclipse-ide-eclipse-committers) if you also want to develop with Eclipse.
 * Install **GEF Legacy** into Eclipse using the 'GEF-Legacy Releases' update site given [here](https://projects.eclipse.org/projects/tools.gef/downloads)
-* You need an **Intellij IDEA** installation which is used for dependency resolution. Install a current version of [**IntelliJ IDEA**](https://www.jetbrains.com/idea/download/#section=linux) (we have only tested Saros/I for IntelliJ releases 2017.X and later)
+* You need an **IntelliJ IDEA** installation which is used for dependency resolution. Install a current version of [**IntelliJ IDEA**](https://www.jetbrains.com/idea/download/#section=linux) (we have only tested Saros/I for IntelliJ releases 2017.X and later)
 
-Set the **system-wide environment variable `ECLIPSE_HOME`** to the eclipse installation dir that contains the directory `plugins`.<br/>
-Set the **system-wide environment variable `INTELLIJ_HOME`** to the intellij installation dir that contains the directory `lib`.
+Set the **system-wide environment variable `ECLIPSE_HOME`** to the Eclipse installation dir that contains the directory `plugins`.<br/>
+Set the **system-wide environment variable `INTELLIJ_HOME`** to the IntelliJ installation dir that contains the directory `lib`.
 
-If the `ECLIPSE_HOME` variable is not set or not global the correponding eclipse specific dependencies cannot be found during build.<br/>
-If the `INTELLIJ_HOME` variable is not set or not global the intellij-gradle plugin will download a version of IntelliJ which is
-defined in the gradle build description.
+If the `ECLIPSE_HOME` variable is not set or not global the corresponding Eclipse specific dependencies cannot be found during build.<br/>
+If the `INTELLIJ_HOME` variable is not set or not global the intellij-gradle-plugin will download a version of IntelliJ which is
+defined in the Gradle build description.
 
 ### Google Java Format
 We are using [google java format](https://github.com/google/google-java-format) to ensure that our source code adheres to unified formatting rules.
@@ -47,13 +47,13 @@ If you develop on Eclipse you should have already installed the Eclipse version 
 ### Import the Saros Project
 * Open a bash terminal, navigate to the repository directory and execute `./gradlew prepareEclipse` (use `./gradlew.bat` for windows)
 * Import the project as Git project
-* If you add dependencies you have to execute the `prepareEclipse` task again in order to regenerate the dependency information for eclipse.
+* If you add dependencies you have to execute the `prepareEclipse` task again in order to regenerate the dependency information for Eclipse.
 
-## Develop with Intellij
-It is necessary to import the saros project and change the project setting so that all build/test/debug actions are processed
+## Develop with IntelliJ
+It is necessary to import the Saros project and change the project setting so that all build/test/debug actions are processed
 by Gradle.
 
-See [the saros testing framework documentation](saros-testing-framework.md) for more information about interactive testing in the Intellij environment.
+See [the Saros testing framework documentation](saros-testing-framework.md) for more information about interactive testing in the IntelliJ environment.
 
 ### Configure
 
@@ -69,18 +69,18 @@ To avoid the issue, you can have a look at the discussion on the [PR #395](https
 This is necessary in order to allow IntelliJ to execute all build and test action via Gradle.
 * Navigate to `Settings > Build, Exection, Deployment > Build Tools > Gradle > Runner`
 * Check the box `Delegate IDE build/run actions to gradle`
-* Select `Gradle Test Runner` in the dropdown box with the caption `Run tests using`
+* Select `Gradle Test Runner` in the drop-down box with the caption `Run tests using`
 
 ### Open Project
 **Don't import the project.** Otherwise all existing IntelliJ configurations (e.g. formatting rules) will be removed.
 
 * Click on `Open`
 * Select the repository root as project root and click `OK`
-* Open the gradle task view and execute the task `prepareIntellij`
+* Open the Gradle task view and execute the task `prepareIntellij`
 
 ## Develop without an IDE
 If you prefer to develop with a text editor (like Vim or Emacs) you can build and test
-the code via gradle. In order to call a task you have to execute `./gradlew <task>...` in
+the code via Gradle. In order to call a task you have to execute `./gradlew <task>...` in
 your local Saros repository root directory.
 
 The following tasks are used to build and test the different Saros components:
@@ -95,7 +95,7 @@ The following tasks are used to build and test the different Saros components:
 In order to build the whole project without using existing build artifacts simply call `./gradlew cleanAll sarosEclipse sarosIntellij sarosServer`.
 
 Gradle checks whether the component specific sources are changed. Therefore a task become a NOP if nothing changed and the build results still exist.
-If you want to force gradle to reexecute the tasks you have to call `./gradlew --rerun-tasks <task>...` or call the `cleanAll` task before other tasks.
+If you want to force Gradle to re-execute the tasks, you have to call `./gradlew --rerun-tasks <task>...` or call the `cleanAll` task before other tasks.
 The final build results are copied into the directory `<repository root>/build/distribute/(eclipse|intellij)`.
 
 ### Formatting via standalone Google Java Formatter

--- a/docs/contribute/development-environment.md
+++ b/docs/contribute/development-environment.md
@@ -19,6 +19,15 @@ If the `ECLIPSE_HOME` variable is not set or not global the correponding eclipse
 If the `INTELLIJ_HOME` variable is not set or not global the intellij-gradle plugin will download a version of IntelliJ which is
 defined in the gradle build description.
 
+### Google Java Format
+We are using [google java format](https://github.com/google/google-java-format) to ensure that our source code adheres to unified formatting rules.
+This is checked on our build server, so please make sure to format your code with the tool before pushing.
+For ease of use, the formatter can also be integrated into the default formatting logic of Eclipse and IntelliJ through a plugin.
+Installation instructions are given in the IDE specific sections on the topic ([Eclipse](#install-and-enable-google-java-formatter), [IntelliJ](#install-and-enable-google-java-formatter-1)).
+
+**Important:** We still use [**google java format 1.6**](https://github.com/google/google-java-format/releases/tag/google-java-format-1.6) as the maintainers of the tool have not provided an official build of the corresponding Eclipse plugin for later versions.
+
+
 ## Develop with Eclipse
 If you develop on Eclipse you should have already installed the Eclipse version for "Eclipse Committers".
 
@@ -32,7 +41,7 @@ If you develop on Eclipse you should have already installed the Eclipse version 
 * Select the profile [`saros/clean-up-profile.xml`](https://github.com/saros-project/saros/blob/master/saros/clean-up-profile.xml)
 
 #### Install and Enable Google Java Formatter
-* Install the [eclipse Google Java Formatter](https://github.com/google/google-java-format#eclipse) which is available as Drop-In in [GitHub Releases](https://github.com/google/google-java-format/releases).
+* Install the [Eclipse Google Java Formatter](https://github.com/google/google-java-format#eclipse) **version 1.6**, which is available as a Drop-In in the [GitHub Releases](https://github.com/google/google-java-format/releases/tag/google-java-format-1.6).
 * Enable the formatter by choosing `google-java-format` in `Window > Preferences > Java > Code Style > Formatter > Formatter Implementation`
 
 ### Import the Saros Project
@@ -49,8 +58,12 @@ See [the saros testing framework documentation](saros-testing-framework.md) for 
 ### Configure
 
 #### Install and Enable Google Java Formatter
-* Install the [intellij Google Java Formatter](https://plugins.jetbrains.com/plugin/8527-google-java-format) which is available in the IntelliJ plugin repository. Search for `google-java-format`.
-* Open `Settings > google-java-format Settings` and check the checkbox `Enable google-java-format`
+* Install the [Intellij Google Java Formatter](https://plugins.jetbrains.com/plugin/8527-google-java-format) **version 1.6** which is available in the IntelliJ plugin repository (search for `google-java-format`) or in the [GitHub Releases](https://github.com/google/google-java-format/releases/tag/google-java-format-1.6).
+
+**Important:** If you are using an IntelliJ version newer than 2018.2, the official 1.6 release will not work for you as it's configured to be incompatible with newer IntelliJ releases.
+These compatibility settings were adjusted for later versions of the plugin, but such changes are not available for the 1.6 release.
+
+To avoid the issue, you can have a look at the discussion on the [PR #395](https://github.com/saros-project/saros/pull/395), where we provide a modified plugin zip and reference the adjusted version of the source code if you prefer to build the plugin yourself instead.
 
 #### Delegate IDE Action
 This is necessary in order to allow IntelliJ to execute all build and test action via Gradle.
@@ -86,7 +99,7 @@ If you want to force gradle to reexecute the tasks you have to call `./gradlew -
 The final build results are copied into the directory `<repository root>/build/distribute/(eclipse|intellij)`.
 
 ### Formatting via standalone Google Java Formatter
-* Download the latest release of the [Google Java Formatter](https://github.com/google/google-java-format/releases) `google-java-format-<version>-all-deps.jar`
+* Download the **release 1.6** of the [Google Java Formatter](https://github.com/google/google-java-format/releases/tag/google-java-format-1.6) `google-java-format-<version>-all-deps.jar`
 * Call `java -jar google-java-format-<version>-all-deps.jar --dry-run --set-exit-if-changed **/*.jar` in a shell with enabled globstar (`shopt -s globstar`) to **check the formatting**
   and add the option `--replace` and remove the option `--dry-run` if you want to **trigger automated formatting**.
 ## Format checking in a githook


### PR DESCRIPTION
#### [DOC] Update information on google java format

Updates the information on our use of the google java format tool to
specify that we are using version 1.6. Changes the links to the release
page to point to the specific release.

Updates the IntelliJ installation section to point to the workaround
used to run the google java format IntelliJ plugin for releases later
than 2018.2.

Remove reference to enabling google-java-format plugin for IntelliJ as
this is done by default.

#### [DOC] Fix minor issues in development setup guide

Fixed typos.

Fixed name capitalization.