### PR TITLE
Always close editor when file is deleted

### DIFF
--- a/eclipse/src/saros/editor/EditorManager.java
+++ b/eclipse/src/saros/editor/EditorManager.java
@@ -755,6 +755,20 @@ public class EditorManager implements IEditorManager {
 
   @Override
   public void closeEditor(final SPath path) {
+    closeEditor(path, true);
+  }
+
+  /**
+   * Closes the editor for the given resource. If <code>save=true</code> is specified, the content
+   * of the editor will be written to disk before it is closed.
+   *
+   * <p>Does nothing if the resource is not shared or there is no open editor for the resource.
+   *
+   * @param path the resource whose editor to close
+   * @param save whether to write the editor content to disk before closing it
+   * @see EditorAPI#closeEditor(IEditorPart, boolean)
+   */
+  public void closeEditor(final SPath path, boolean save) {
     if (path == null) throw new IllegalArgumentException("path must not be null");
 
     SWTUtils.runSafeSWTSync(
@@ -763,7 +777,7 @@ public class EditorManager implements IEditorManager {
           @Override
           public void run() {
             for (IEditorPart part : editorPool.getEditors(path)) {
-              EditorAPI.closeEditor(part);
+              EditorAPI.closeEditor(part, save);
             }
           }
         });

--- a/eclipse/src/saros/editor/internal/EditorAPI.java
+++ b/eclipse/src/saros/editor/internal/EditorAPI.java
@@ -184,18 +184,23 @@ public class EditorAPI {
   }
 
   /**
-   * Closes the given editor part.
+   * Closes the given editor part. If <code>save=true</code> is specified, the content of the editor
+   * will be written to disk before it is closed.
    *
    * <p>Needs to be called from an UI thread.
+   *
+   * @param part the editor part to close
+   * @param save whether to write the editor content to disk before closing it
+   * @see IWorkbenchPage#closeEditor(IEditorPart, boolean)
    */
-  public static void closeEditor(IEditorPart part) {
+  public static void closeEditor(IEditorPart part, boolean save) {
     IWorkbenchWindow window = getActiveWindow();
 
     if (window == null) return;
 
     IWorkbenchPage page = window.getActivePage();
     // Close AND let user decide if saving is necessary
-    page.closeEditor(part, true);
+    page.closeEditor(part, save);
   }
 
   /**

--- a/eclipse/src/saros/project/FileActivityConsumer.java
+++ b/eclipse/src/saros/project/FileActivityConsumer.java
@@ -141,7 +141,11 @@ public class FileActivityConsumer extends AbstractActivityConsumer implements St
   }
 
   private void handleFileDeletion(FileActivity activity) throws CoreException {
-    final IFile file = toEclipseIFile(activity.getPath().getFile());
+    SPath path = activity.getPath();
+
+    editorManager.closeEditor(path, false);
+
+    final IFile file = toEclipseIFile(path.getFile());
 
     if (file.exists()) FileUtils.delete(file);
     else LOG.warn("could not delete file " + file + " because it does not exist");

--- a/eclipse/src/saros/project/ProjectDeltaVisitor.java
+++ b/eclipse/src/saros/project/ProjectDeltaVisitor.java
@@ -220,6 +220,8 @@ final class ProjectDeltaVisitor implements IResourceDeltaVisitor {
   private void generateRemoved(IResource resource) {
 
     if (resource instanceof IFile) {
+      editorManager.closeEditor(new SPath(ResourceAdapterFactory.create(resource)), false);
+
       addActivity(
           new FileActivity(
               user,

--- a/eclipse/src/saros/ui/wizards/AddProjectToSessionWizard.java
+++ b/eclipse/src/saros/ui/wizards/AddProjectToSessionWizard.java
@@ -309,7 +309,8 @@ public class AddProjectToSessionWizard extends Wizard {
                       /*
                        * close all editors to avoid any conflicts.
                        */
-                      for (final IEditorPart editor : editorsToClose) EditorAPI.closeEditor(editor);
+                      for (final IEditorPart editor : editorsToClose)
+                        EditorAPI.closeEditor(editor, true);
                     }
                   });
 


### PR DESCRIPTION
#### [INTERNAL][E] Add logic to close editor without saving

Preparation for fixing #758.

#### [FIX][E] #758 Always close editor when file is deleted

Adjusts the logic handling file deletion actions on the sending and
receiving side. Ensures that the editor for the deleted file is always
closed properly without saving.

Skipping the save is important as the editor will only still be open for
the deleted file if it was in an unsaved state at the time of deletion.

Closing such unsaved editors for deleted files is important as they
otherwise create issues with the consistency logic. Since the watchdog
logic is based on the open editors, the remaining editor is interpreted
as the resource still being present, leading to an inconsistent state.

Fixes #758.