### PR TITLE
[DOC] Correct CSS selector for gap between tab and content

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -229,7 +229,7 @@ $mobile-width: 690px;
 /* Multiversion tabs */
 
 // Avoid gap between border of tab and content
-.tab-content :first-child {
+.tab-content > .tab-pane {
   margin-top: 0px;
   padding-top: 10px;
 }


### PR DESCRIPTION
The old selector `.tab-content :first-child` matched *all* elements that are the first child of their respective parent, such as the first list items in all lists. Furthermore, the intended padding was only added for the Eclipse tab (which was such a `:first-child`) but not the IntelliJ tab (which is always the second child, after the Eclipse tab).
