### PR TITLE
[DOC] Change README logo position

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="docs/assets/images/logo/saros-logo-100x100.png" alt="drawing" height="42pt"/> Saros - Distributed Party Programming
+# <img src="docs/assets/images/logo/saros-logo.svg" alt="drawing" align="right" width="100"/> Saros - Distributed Party Programming
 [![Travis](https://travis-ci.com/saros-project/saros.svg?branch=master)](https://travis-ci.com/saros-project/saros/branches)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/297b67607a5f4b5b8d00d0446615849b)](https://www.codacy.com/manual/Saros/saros)
 [![Gitter](https://badges.gitter.im/saros-project/saros.svg)](https://gitter.im/saros-project/saros)

--- a/docs/assets/images/logo/saros-logo.svg
+++ b/docs/assets/images/logo/saros-logo.svg
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   width="452.17035"
+   height="499.52087"
+   id="svg2">
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3802">
+      <stop
+         id="stop3804"
+         style="stop-color:#9d9d9f;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3806"
+         style="stop-color:#2a2a2a;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3794">
+      <stop
+         id="stop3796"
+         style="stop-color:#ffe700;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3798"
+         style="stop-color:#ffb500;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3780">
+      <stop
+         id="stop3782"
+         style="stop-color:#0197fd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3784"
+         style="stop-color:#014afd;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3772">
+      <stop
+         id="stop3774"
+         style="stop-color:#7996c0;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3776"
+         style="stop-color:#7996c0;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="175.71426"
+       y1="186.6479"
+       x2="347.14285"
+       y2="186.6479"
+       id="linearGradient3788"
+       xlink:href="#linearGradient3780"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="175.71426"
+       y1="186.6479"
+       x2="347.14285"
+       y2="186.6479"
+       id="linearGradient3800"
+       xlink:href="#linearGradient3794"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="175.71426"
+       y1="186.6479"
+       x2="347.14285"
+       y2="186.6479"
+       id="linearGradient3808"
+       xlink:href="#linearGradient3802"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     transform="translate(-83.036464,-26.947689)"
+     id="layer1">
+    <path
+       d="m 347.14285,186.6479 c 0,47.3387 -38.3756,85.71429 -85.71429,85.71429 -47.3387,0 -85.71429,-38.37559 -85.71429,-85.71429 0,-47.33869 38.37559,-85.71428 85.71429,-85.71428 47.33869,0 85.71429,38.37559 85.71429,85.71428 z"
+       transform="matrix(-0.23357111,-1.2029748,1.2029748,-0.23357111,140.458,490.09257)"
+       id="path2996"
+       style="fill:url(#linearGradient3788);fill-opacity:1;stroke:none" />
+    <path
+       d="m 347.14285,186.6479 c 0,47.3387 -38.3756,85.71429 -85.71429,85.71429 -47.3387,0 -85.71429,-38.37559 -85.71429,-85.71429 0,-47.33869 38.37559,-85.71428 85.71429,-85.71428 47.33869,0 85.71429,38.37559 85.71429,85.71428 z"
+       transform="matrix(0.75173697,0.46821563,-0.46821563,0.75173697,350.15165,67.504261)"
+       id="path3000"
+       style="fill:url(#linearGradient3808);fill-opacity:1;stroke:none" />
+    <path
+       d="m 347.14285,186.6479 c 0,47.3387 -38.3756,85.71429 -85.71429,85.71429 -47.3387,0 -85.71429,-38.37559 -85.71429,-85.71429 0,-47.33869 38.37559,-85.71428 85.71429,-85.71428 47.33869,0 85.71429,38.37559 85.71429,85.71428 z"
+       transform="matrix(1.6175986,0.20912541,-0.20912541,1.6175986,-160.99653,30.055162)"
+       id="path3002"
+       style="fill:url(#linearGradient3800);fill-opacity:1;stroke:none" />
+  </g>
+</svg>


### PR DESCRIPTION
Moves logo to the right.

Also uses an SVG version of the logo to allow the image to scale better.

This change is mostly a matter of taste. You can have a look at the result [here](https://github.com/saros-project/saros/blob/pr/doc/adjust_readme_logo_position/README.md).

I also considered a slightly different scaling that allows the first paragraph to fit into a single line. But that made the README look to cramped in my opinion. You can have a look at the other version [here](https://github.com/saros-project/saros/blob/test/README.md).

What are your thoughts? Do you prefer one version to the other?