### PR TITLE
[DOC] Set title in head

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -1,4 +1,5 @@
 <head>
+  <title>{{ page.title | default: site.title }}</title>
   <meta charset='utf-8'>
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width,maximum-scale=2">


### PR DESCRIPTION
Sets the page or site title as the title in the HEAD section of the
generated HTML site. This allows the title to be displayed correctly in
the browser tab name.