### PR TITLE
Fix title/heading capitalization

### DIFF
--- a/docs/contribute/best-practices.md
+++ b/docs/contribute/best-practices.md
@@ -16,7 +16,7 @@ title: Best Practices
     that the behavior is well defined, for instance using an
     observable collection)
 
-### Class member visibility
+### Class Member Visibility
 
 By default all fields and methods should be **`private`**. For any field
 or method with a visibility higher than **`private `**(visible from the
@@ -28,7 +28,7 @@ accessible. This is fine up to **package-private** (no modifier). But it
 is not acceptable to make a member part of a package's API
 (`protected `or `public`) solely for testing purposes.
 
-### Final members and variables
+### Final Members and Variables
 
 *   For class variables: By default, make them final, unless you find a
     good reason not to. It makes the code easier to understand when you
@@ -90,7 +90,7 @@ public class A implements D {
   ...
 ```
 
-### Control flow
+### Control Flow
 
 Test whether you can return from a method instead of testing whether
 you should execute a block of code.
@@ -124,7 +124,7 @@ Furthermore, there is no need to put the code after the return
 statement into an explicit "else"-branch. You can easily save one
 level of block-nesting.
 
-### Checking parameters
+### Checking Parameters
 
 *   Methods may assume that they are called with correct non-null input
     unless the method specifies that it allows incorrect or null input.
@@ -164,7 +164,7 @@ level of block-nesting.
 Saros/E is an Eclipse IDE Plugin. Therefore it needs to meet
 the [Eclipse User Interface Guidelines](http://wiki.eclipse.org/User_Interface_Guidelines#Checklist_For_Developers).
 
-### Standard heuristics for system design
+### Standard Heuristics for System Design
 
 When improving Saros either technically or visually you should check
 if you followed the [10 basic heuristics for good user interfaces](https://www.nngroup.com/articles/ten-usability-heuristics).
@@ -172,7 +172,7 @@ if you followed the [10 basic heuristics for good user interfaces](https://www.n
 You do not need many users for this, usually 3 users are enough to quickly find out the most
 important. You can kindly ask them record their test with a tool like [Screencast-O-Matic](http://www.screencast-o-matic.com).
 
-### Progress and Cancelation 101
+### Progress and Cancellation 101
 
 Whenever a method is long-running, i.e. there is a chance that it will
 take longer than 100ms or involves any external factors such as the user
@@ -185,7 +185,7 @@ experience might be reduced. For instance in Saros, there used to be no
 possibility to cancel a file transfer from one user to the other but
 just to cancel in between the files. This behavior seems okay, but once
 we started to see archive files of 10 MB and more, which could only be
-canceled by disconnecting from the Jabber-Server, the undesireability of
+canceled by disconnecting from the Jabber-Server, the undesirability of
 the behavior becomes pretty clear.
 
 Fortunately enough there is a straight-forward and simple solution,
@@ -231,7 +231,7 @@ sufficient to achieve the basic uses of progress monitoring.
 
 #### Nesting Progress
 
-In many cases the situtation is a little bit more complicated, as the
+In many cases the situation is a little bit more complicated, as the
 operation that is long-running is making calls to other long-running
 operations as well. To solve this problem, we need to create **child
 progress monitors**, which consume a given number of work steps from
@@ -266,7 +266,7 @@ public void computeFirstStep(SubMonitor progress){
 }
 ```
 
-#### Reporting information to the user
+#### Reporting Information to the User
 
 A progress monitor provides 3 ways to report information from a long
 running operation to the user
@@ -279,7 +279,7 @@ running operation to the user
 This information is typically presented to the user as a Dialog with a
 message being equal to the taskname of the top level progress monitor, a
 progress bar showing the growing amount of work already done and a label
-for the current sub-task which switches everytime the sub-task is being
+for the current sub-task which switches every time the sub-task is being
 set.
 
 Since the taskName is fixed (by default), only the top level task name
@@ -303,7 +303,7 @@ public void computeInTwoSteps(SubMonitor progress){
 }
 ```
 
-#### Dealing with operation of unspecified length
+#### Dealing With Operations of Unspecified Length
 
 To have a progress dialog on operations for which the amount of steps
 are unknown, the following solution is recommended:
@@ -362,7 +362,7 @@ public BigInteger factorial(int n, SubMonitor progress){
 }
 ```
 
-Btw: It is an convention that we try to avoid `InterruptedException` for
+BTW: It is a convention that we try to avoid `InterruptedException` for
 this, because it is a checked exception and thus cumbersome for the
 caller. To maintain this convention, a method MUST specify whether it is
 cancelable, by providing the demonstrated JavaDoc tag.
@@ -471,7 +471,7 @@ How to do it right:
 
 -   When calling a blocking method, Java uses InterruptedException to
     signal that the waiting thread was told to stop waiting.
--   As a a caller to a blocking method it is your responsibility to deal
+-   As a caller to a blocking method it is your responsibility to deal
     with the possibility of being interrupted. This is why exception is
     checked in Java.
 -   The contract of InterruptedException is the following:
@@ -480,7 +480,7 @@ How to do it right:
 -   Since the InterruptException-contract is assumed to be honored by
     all methods in Java, there are three ways of dealing with the
     InterruptedException:
-    1.  Rethrowing the InterruptedException to tell callers that this
+    1.  Re-throwing the InterruptedException to tell callers that this
         method might be interrupted: As we do not like checked exception
         this is an inferior solution to the problem.
     2.  Resetting the interrupt flag
@@ -589,7 +589,7 @@ public class BroadcastListener implements Listener {
 }
 ```
 
-The code for an Observable becomes therfore much simpler. It only needs
+The code for an Observable therefore becomes much simpler. It only needs
 to know the `BroadcastListener` and can easily notify all registered
 listeners at once.
 ```java
@@ -623,7 +623,7 @@ class Observable {
         users of the class can rely on the objects to be immutable and
         all methods to be side effect free. This helps A LOT when using
         a class.
--   Avoid implementing many interfaces in the same class whereever
+-   Avoid implementing many interfaces in the same class wherever
     possible (more than one is necessary only in rare cases). Use nested
     or anonymous classes instead. It makes it much easier to understand
     and modify your code.
@@ -642,7 +642,7 @@ class Observable {
     so that your threads are named) or even better an `Executor`.
   * Spend some time learning about the [Java Concurrency library java.util.concurrent](http://java.sun.com/javase/6/docs/api/java/util/concurrent/package-summary.md).
 
-## Kinds of comments
+## Kinds of Comments
 
 This section is based on Steve McConnell's Code Complete, Chapter 32.
 

--- a/docs/contribute/best-practices.md
+++ b/docs/contribute/best-practices.md
@@ -539,8 +539,7 @@ How to do it right:
 ```
 -   BTW: There is no obligation in the contract for you to exit as
     quickly as possible.
--   For more read:
-    <http://www-128.ibm.com/developerworks/java/library/j-jtp05236.md>
+-   For more read: <https://www.ibm.com/developerworks/library/j-jtp05236/index.html>
 
 ## Broadcast Listener
 
@@ -640,7 +639,7 @@ class Observable {
   * Try to avoid instantiating the class `Thread` directly but
     rather use a `ThreadFactory` (in particular the `NamedThreadFactory`
     so that your threads are named) or even better an `Executor`.
-  * Spend some time learning about the [Java Concurrency library java.util.concurrent](http://java.sun.com/javase/6/docs/api/java/util/concurrent/package-summary.md).
+  * Spend some time learning about the [Java Concurrency library java.util.concurrent](https://docs.oracle.com/javase/6/docs/api/java/util/concurrent/package-summary.html).
 
 ## Kinds of Comments
 

--- a/docs/contribute/development-environment.md
+++ b/docs/contribute/development-environment.md
@@ -3,9 +3,10 @@ title: Saros Development Environment
 ---
 
 The following page describes how a development environment can be set up in order to develop all Saros products (Eclipse-Plugin, IntelliJ-Plugin and Server).
-If you want to execute the STF tests it is recommended to use Eclipse. Otherwise it is also possible to develop with IntelliJ IDEA and execute the stf tests in a docker container.
+If you want to execute the STF tests it is recommended to use Eclipse. Otherwise it is also possible to develop with IntelliJ IDEA and execute the STF tests in a docker container.
 
 ## Common
+
 * You have to [clone](https://help.github.com/articles/cloning-a-repository/) the Saros repository with [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
 * You need a **Java 8 JDK**.
 * You need an **Eclipse 4.6** installation which is used for dependency resolution. You can either install a [minimal Eclipse](http://www.eclipse.org/downloads/packages/release/neon/3/eclipse-ide-java-developers) or [Eclipse for Eclipse Committers](http://www.eclipse.org/downloads/packages/release/neon/3/eclipse-ide-eclipse-committers) if you also want to develop with Eclipse.
@@ -20,6 +21,7 @@ If the `INTELLIJ_HOME` variable is not set or not global the intellij-gradle-plu
 defined in the Gradle build description.
 
 ### Google Java Format
+
 We are using [google java format](https://github.com/google/google-java-format) to ensure that our source code adheres to unified formatting rules.
 This is checked on our build server, so please make sure to format your code with the tool before pushing.
 For ease of use, the formatter can also be integrated into the default formatting logic of Eclipse and IntelliJ through a plugin.
@@ -29,13 +31,14 @@ Installation instructions are given in the IDE specific sections on the topic ([
 
 
 
-### Gradle setup on Widows
+### Gradle Setup on Widows
 
 If you are developing on a Windows system using multiple drives, please make sure that the Gradle cache (contained in the `.gradle` directory) is located on the same drive as the Saros repository.
 
 This can be done by either ensuring that the git repository is located on the same drive as the [default Gradle user home directory](https://docs.gradle.org/current/userguide/directory_layout.html#dir:gradle_user_home) or by setting a different base directory for the Gradle user home using the environment variable `GRADLE_USER_HOME`.
 
 ## Develop with Eclipse
+
 If you develop on Eclipse you should have already installed the Eclipse version for "Eclipse Committers".
 
 ### Configure
@@ -48,15 +51,18 @@ If you develop on Eclipse you should have already installed the Eclipse version 
 * Select the profile [`saros/clean-up-profile.xml`](https://github.com/saros-project/saros/blob/master/saros/clean-up-profile.xml)
 
 #### Install and Enable Google Java Formatter
+
 * Install the [Eclipse Google Java Formatter](https://github.com/google/google-java-format#eclipse) **version 1.6**, which is available as a Drop-In in the [GitHub Releases](https://github.com/google/google-java-format/releases/tag/google-java-format-1.6).
 * Enable the formatter by choosing `google-java-format` in `Window > Preferences > Java > Code Style > Formatter > Formatter Implementation`
 
 ### Import the Saros Project
+
 * Open a bash terminal, navigate to the repository directory and execute `./gradlew prepareEclipse` (use `./gradlew.bat` for windows)
 * Import the project as Git project
 * If you add dependencies you have to execute the `prepareEclipse` task again in order to regenerate the dependency information for Eclipse.
 
 ## Develop with IntelliJ
+
 It is necessary to import the Saros project and change the project setting so that all build/test/debug actions are processed
 by Gradle.
 
@@ -65,7 +71,8 @@ See [the Saros testing framework documentation](saros-testing-framework.md) for 
 ### Configure
 
 #### Install and Enable Google Java Formatter
-* Install the [Intellij Google Java Formatter](https://plugins.jetbrains.com/plugin/8527-google-java-format) **version 1.6** which is available in the IntelliJ plugin repository (search for `google-java-format`) or in the [GitHub Releases](https://github.com/google/google-java-format/releases/tag/google-java-format-1.6).
+
+* Install the [IntelliJ Google Java Formatter](https://plugins.jetbrains.com/plugin/8527-google-java-format) **version 1.6** which is available in the IntelliJ plugin repository (search for `google-java-format`) or in the [GitHub Releases](https://github.com/google/google-java-format/releases/tag/google-java-format-1.6).
 
 **Important:** If you are using an IntelliJ version newer than 2018.2, the official 1.6 release will not work for you as it's configured to be incompatible with newer IntelliJ releases.
 These compatibility settings were adjusted for later versions of the plugin, but such changes are not available for the 1.6 release.
@@ -73,19 +80,22 @@ These compatibility settings were adjusted for later versions of the plugin, but
 To avoid the issue, you can have a look at the discussion on the [PR #395](https://github.com/saros-project/saros/pull/395), where we provide a modified plugin zip and reference the adjusted version of the source code if you prefer to build the plugin yourself instead.
 
 #### Delegate IDE Action
+
 This is necessary in order to allow IntelliJ to execute all build and test action via Gradle.
 * Navigate to `Settings > Build, Exection, Deployment > Build Tools > Gradle > Runner`
 * Check the box `Delegate IDE build/run actions to gradle`
 * Select `Gradle Test Runner` in the drop-down box with the caption `Run tests using`
 
 ### Open Project
+
 **Don't import the project.** Otherwise all existing IntelliJ configurations (e.g. formatting rules) will be removed.
 
 * Click on `Open`
 * Select the repository root as project root and click `OK`
 * Open the Gradle task view and execute the task `prepareIntellij`
 
-## Develop without an IDE
+## Develop Without an IDE
+
 If you prefer to develop with a text editor (like Vim or Emacs) you can build and test
 the code via Gradle. In order to call a task you have to execute `./gradlew <task>...` in
 your local Saros repository root directory.
@@ -105,14 +115,19 @@ Gradle checks whether the component specific sources are changed. Therefore a ta
 If you want to force Gradle to re-execute the tasks, you have to call `./gradlew --rerun-tasks <task>...` or call the `cleanAll` task before other tasks.
 The final build results are copied into the directory `<repository root>/build/distribute/(eclipse|intellij)`.
 
-### Formatting via standalone Google Java Formatter
+### Formatting via Standalone Google Java Formatter
+
 * Download the **release 1.6** of the [Google Java Formatter](https://github.com/google/google-java-format/releases/tag/google-java-format-1.6) `google-java-format-<version>-all-deps.jar`
 * Call `java -jar google-java-format-<version>-all-deps.jar --dry-run --set-exit-if-changed **/*.jar` in a shell with enabled globstar (`shopt -s globstar`) to **check the formatting**
   and add the option `--replace` and remove the option `--dry-run` if you want to **trigger automated formatting**.
-## Format checking in a githook
+
+## Format Checking in a Git Hook
+
 If you want to check that your commit does not contain wrong formatted code use a git pre-commit hook.
 * Create an executable file in your repository `.git/hooks/pre-commit` which executes the standalone formatter as described in the previous section.
-### Example git hook
+
+### Example Git Hook
+
 Example hook that checks only java files that are staged.
 ```bash
   #!/bin/bash

--- a/docs/contribute/development-environment.md
+++ b/docs/contribute/development-environment.md
@@ -11,7 +11,7 @@ If you want to execute the STF tests it is recommended to use Eclipse. Otherwise
 * You need a **Java 8 JDK**.
 * You need an **Eclipse 4.6** installation which is used for dependency resolution. You can either install a [minimal Eclipse](http://www.eclipse.org/downloads/packages/release/neon/3/eclipse-ide-java-developers) or [Eclipse for Eclipse Committers](http://www.eclipse.org/downloads/packages/release/neon/3/eclipse-ide-eclipse-committers) if you also want to develop with Eclipse.
 * Install **GEF Legacy** into Eclipse using the 'GEF-Legacy Releases' update site given [here](https://projects.eclipse.org/projects/tools.gef/downloads)
-* You need an **IntelliJ IDEA** installation which is used for dependency resolution. Install a current version of [**IntelliJ IDEA**](https://www.jetbrains.com/idea/download/#section=linux) (we have only tested Saros/I for IntelliJ releases 2017.X and later)
+* You need an **IntelliJ IDEA** installation which is used for dependency resolution. Install a current version of [**IntelliJ IDEA**](https://www.jetbrains.com/idea/download/) (we have only tested Saros/I for IntelliJ releases 2017.X and later)
 
 Set the **system-wide environment variable `ECLIPSE_HOME`** to the Eclipse installation dir that contains the directory `plugins`.<br/>
 Set the **system-wide environment variable `INTELLIJ_HOME`** to the IntelliJ installation dir that contains the directory `lib`.
@@ -48,7 +48,7 @@ If you develop on Eclipse you should have already installed the Eclipse version 
 * Right-click the "Saros" project in the project explorer and navigate to<br/>
   `Properties > Java Code Style > Clean up`
 * Under the box `Active profile:`, click `Import...`
-* Select the profile [`saros/clean-up-profile.xml`](https://github.com/saros-project/saros/blob/master/saros/clean-up-profile.xml)
+* Select the profile [`saros/clean-up-profile.xml`](https://github.com/saros-project/saros/blob/master/eclipse/clean-up-profile.xml)
 
 #### Install and Enable Google Java Formatter
 

--- a/docs/contribute/documentation.md
+++ b/docs/contribute/documentation.md
@@ -1,5 +1,5 @@
 ---
-title: Documentation writing
+title: Documentation Writing
 ---
 
 The whole documentation is hosted by [GitHub Pages](https://pages.github.com/) and the corresponding markdown sources are
@@ -7,14 +7,14 @@ located in the `docs` directory of the [Saros main repository](https://github.co
 process of the documentation modification is the same as the common [development process](processes/development.md).
 
 ## Guidelines
-We prefer a small documentation that contains only important information which are related to Saros. In order to achive this
+We prefer a small documentation that contains only important information which are related to Saros. In order to achieve this
 please follow these guidelines:
 * **Remove obsoleted documentation**
 * Rather **reference information** than copy them
 * Keep the documentation **short and clear** (e.g. by using lists)
 * Avoid new nested link structures and link lists
 
-## Write IDE specific documentation
+## Write IDE Specific Documentation
 Use the following tags if you want to embed an IDE specific part into a documentation or want to provide IDE specific versions of a page.
 
 **Markdown:**
@@ -31,11 +31,11 @@ Intellij content here
 ```
 **Rendered Markdown:**
 {% capture eclipse %}
-## Eclipse content here
+## Eclipse Content Here
 Eclipse content here
 {% endcapture %}
 {% capture intellij %}
-## Intellij content here
+## IntelliJ Content Here
 Intellij content here
 {% endcapture %}
 {% include ide-tabs.html eclipse=eclipse intellij=intellij %}
@@ -45,25 +45,25 @@ Intellij content here
 Therefore the content of the documentation could break the documentation build! This happens if you have typo in your tags or forgot something etc.
 If you want to make sure that the documentation works, compile the documentation (see below for more information).
 
-## Reference IDE specific documentation
+## Reference IDE Specific Documentation
 
-You can reference the IDE specific version of a page via an url parameter `tab=<ide>` (e.g. `<url>?tab=intellij` or `<url>?tab=eclipse`).
+You can reference the IDE specific version of a page via a URL parameter `tab=<ide>` (e.g. `<url>?tab=intellij` or `<url>?tab=eclipse`).
 Example:
-* [Intellij content of this page](?tab=intellij)
+* [IntelliJ content of this page](?tab=intellij)
 * [Eclipse content of this page](?tab=eclipse)
 
 ## Compile GitHub Pages
-### Compile and show via docker
+### Compile and Show via Docker
 The whole environment described below is already available in the docker image `starefossen/github-pages`. Use the following
-steps in order to compile and show the github pages:
+steps in order to compile and show the GitHub pages:
 * Open a bash terminal
 * Change the working directory to the `docs` directory in your local Saros git repository
 * execute `docker run -t --name jekyll -v "$PWD":/usr/src/app -p "4000:4000" starefossen/github-pages`
 
 In order to remove the corresponding container simply execute `docker stop jekyll`
 
-### Compile locally
-#### Install required tools and dependencies:
+### Compile Locally
+#### Install Required Tools and Dependencies
 
 * [Install ruby 2.x or higher](https://www.ruby-lang.org/en/documentation/installation/)
 * Install bundler:
@@ -74,7 +74,7 @@ In order to remove the corresponding container simply execute `docker stop jekyl
 
 See [here](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll) for more information.
 
-#### Compile and show documentation
+#### Compile and Show Documentation
 
 * Move into this directory (`<repository_dir>/docs`)
 * Execute `bundle exec jekyll serve`

--- a/docs/contribute/guidelines.md
+++ b/docs/contribute/guidelines.md
@@ -21,7 +21,7 @@ title: Coding and Commit Guidelines
 ### Commit Message
 
 1.  Follow the general rule of how Git commit messages are formatted.
-    Refer to the [Git manual](https://git-scm.com/book/ch5-2.md#Commit-Guidelines) for
+    Refer to the [Git manual](https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines) for
     more information. In particular, every patch must have an
     informative short summary or "subject line" (also see next point in
     the list) and it should have a more detailed explanation below.

--- a/docs/contribute/guidelines.md
+++ b/docs/contribute/guidelines.md
@@ -18,7 +18,7 @@ title: Coding and Commit Guidelines
     manual](https://git-scm.com/book/tr/v2/Customizing-Git-Git-Configuration#Formatting-and-Whitespace)
     for more information.
 
-### Commit message
+### Commit Message
 
 1.  Follow the general rule of how Git commit messages are formatted.
     Refer to the [Git manual](https://git-scm.com/book/ch5-2.md#Commit-Guidelines) for
@@ -60,7 +60,7 @@ implementation in IntelliJ.
 If you can't decide on a single type tag, you probably mixed up
 different concerns and should consider splitting your patch.
 
-## Coding rules
+## Coding Rules
 
 ### Formatting
 
@@ -99,7 +99,7 @@ The only differences and additional conventions are:
     that the behavior is well defined, for instance using an
     observable collection)
 
-#### Class member visibility
+#### Class Member Visibility
 
 By default all fields and methods should be **`private`**. For any field
 or method with a visibility higher than **`private `**(visible from the
@@ -111,7 +111,7 @@ accessible. This is fine up to **package-private** (no modifier). But it
 is not acceptable to make a member part of a package's API
 (`protected `or `public`) solely for testing purposes.
 
-#### Final members and variables
+#### Final Members and Variables
 
 *   For class variables: By default, make them final, unless you find a
     good reason not to. It makes the code easier to understand when you
@@ -174,7 +174,7 @@ public class A implements D {
   ...
 ```
 
-#### Control flow
+#### Control Flow
 
 Test whether you can return from a method instead of testing whether
 you should execute a block of code.
@@ -208,7 +208,7 @@ Furthermore, there is no need to put the code after the return
 statement into an explicit "else"-branch. You can easily save one
 level of block-nesting.
 
-#### Checking parameters
+#### Checking Parameters
 
 *   Methods may assume that they are called with correct non-null input
     unless the method specifies that it allows incorrect or null input.

--- a/docs/contribute/html-gui.md
+++ b/docs/contribute/html-gui.md
@@ -1,5 +1,5 @@
 ---
-title: HTML-GUI (deprecated)
+title: HTML-GUI (Deprecated)
 ---
 
 
@@ -12,15 +12,15 @@ In the following you find a list of pro and cons for each approach and why we we
 ## SWT-Browser
 The solution based on the SWT browser used the SWTBrowser which was delivered with the swt toolkit that is released with eclipse.
 
-### Eclipse integration
+### Eclipse Integration
 In order to build and test Saros it was necessary to download an OS specific SWT version (this was handeled by the build tool). It was easy to
 release the solution for eclipse, because eclipse already provides a swt version, because the whole IDE is written in swt.
 
-### IntelliJ integration
+### IntelliJ Integration
 The IntelliJ version of the integration required to load a swt version manually which was loaded during runtime of Saros with a self-written
 SWT loader. This is not a solution that is safe to be released. The whole IntelliJ specific code was located in the package `saros.intellij.ui.swt_browser`.
 
-### Issues with the integration
+### Issues With the Integration
 Even if the SWT library was available and loaded, the browser integration was brittle.
 This was rooted in the way the SWT browser was implemented. Instead of releasing an browser with swt, the OS default browser is used.
 This integration of the default browser was brittle on all platforms, but the most unstable was Linux. The newer versions of swt (e.g. swt released with eclipse 4.8) are more stable, but the `BrowserFunction` (allows to call java from javascript) was still not stable in all versions (unavailable in 4.8-4.12 due to [#538335](https://bugs.eclipse.org/bugs/show_bug.cgi?id=538335)).
@@ -30,15 +30,15 @@ The second approach was to embed a view of the GUI toolkit JavaFX scene into the
 Furthermore, JavaFX provides a bridge to swt as well as to swing. Therefore it is possible to embed a JavaFX component into an eclipse plugin (that uses swt) as well
 as into an IntelliJ plugin (that uses swing). 
 
-### Eclipse integration
+### Eclipse Integration
 We integrated JavaFX in eclipse with the help of the efxclipse tooling and integrated the feature `org.eclipse.fx.target.rcp.feature`.
 This feature provides the osgi bundle `org.eclipse.fx.ui.workbench3`. This bundle provides the class `org.eclipse.fx.ui.workbench3.FXPartView` that allows to write an e3 (old eclipse ui model) view with JavaFX components.
 This class simply wraps the `javafx.embed.swt.FXCanvas`. In order to load the JavaFX library during runtime the osgi bundle `org.eclipse.fx.osgi` is also provided. This bundle is a fragment of the bundle `org.eclipse.osgi` and adds a hook that enhances the classpath of eclipse in order to load the additional javafx/swt jar that allows to integrate javafx components into swt. If this bundle is missing, the class `javafx.embed.swt.FXCanvas` is missing.
 
-### IntelliJ integration
+### IntelliJ Integration
 The integration into IntelliJ was straightforward: create and use a `javafx.embed.swing.JFXPanel`. The following [post](https://stackoverflow.com/a/35611230/6948317) gives an implementation example.
 
-### Eclipse tests
+### Eclipse Tests
 The first tests on Windows and Linux were successful (tested with Eclipse Neon, Oxygen, 2019-06 and JDK8-9). The only issue
 was that it was necessary with JDK8 to force eclipse to use GTK 2, because the JavaFX library (shipped with JDK8) was linked to GTK 2.
 
@@ -57,17 +57,17 @@ One approach that might work for eclipse, but not Intellij (therefore we never t
 * Provide all bundles via an update-site an hope that the eclipse plugin installer decides which platform is required and installes only the required version.
 * The `org.eclipse.fx.osgi` bundle should detect the JavaFX bundle and add it to the class or module path during runtime.
 
-### IntelliJ tests
+### IntelliJ Tests
 We tested the IntelliJ version only with 2019-01 and the corresponding JDKs after we noticed that the approach does not work in all cases.
 
 
-## Usage of the removed HTML-GUI
+## Usage of the Removed HTML-GUI
 **This documentation is only relevant if you want to try the old HTML-GUI approach**<br/>
 Below you can find how you can build and test the HTML-GUI. One prerequisite is to checkout the [last commit](https://github.com/saros-project/saros/commit/18d77e9f18d50accd1267f4d801c8f74ef301715) including the HTML-GUI.
 
 The usage of the HTML version of Saros is guarded by a feature toggle.
 
-### Eclipse setup
+### Eclipse Setup
 
 In Eclipse you have to uncomment the `SarosViewBrowserVersion` view in `eclipse/plugin.xml`.
 and provide the Java property
@@ -79,7 +79,7 @@ by changing the corresponding line in `eclipse/saros.properties`.
 To be able to see the HTML GUI in eclipse when running Saros, you have
 to open the Saros view in eclipse via Window > Show View > Other > Saros > Saros View.
 
-### IntelliJ setup
+### IntelliJ Setup
 
 In IntelliJ you just have to provide
 ```properties
@@ -106,7 +106,7 @@ are defined in `ui.frontend/html/package.json`
 see [here](https://docs.npmjs.com/files/package.json) for a detailed
 documentation.
 
-### Building the JavaScript application
+### Building the JavaScript Application
 
 Currently, the building of the JavaScript application is NOT integrated
 in the general Saros build process and must therefore be executed

--- a/docs/contribute/open-topics.md
+++ b/docs/contribute/open-topics.md
@@ -12,7 +12,7 @@ Please, let us know (e.g. via our [Gitter](https://gitter.im/saros-project/saros
 ## HTML-GUI
 You can find all information about the idea of the HTML-GUI [here](html-gui.md).
 
-## GIT support
+## GIT Support
 Corresponding Pull Requests:
 * [Add JGit facade](https://github.com/saros-project/saros/pull/428)
 * [Add Activties to Share Commit](https://github.com/saros-project/saros/pull/444)
@@ -21,7 +21,7 @@ A former contributor started in implementation of a basic git support.
 The main idea was to send differences between the git history of two developers as [git bundle](https://git-scm.com/docs/git-bundle). The determination of the differences was 
 implemented via Saros activities. See page 18 of the [the corresponding thesis](https://www.inf.fu-berlin.de/inst/ag-se/theses/Jeschke2019-saros-git-support.pdf) for a corresponding interaction diagram.
 
-## Improving the runtime of the STF Tests
+## Improving the Runtime of the STF Tests
 
 A former contributor already thought about ways to reduce the runtime of the STF tests (which is is very high).
 She proposed the following approaches (see [the corresponding thesis for more information](https://www.inf.fu-berlin.de/inst/ag-se/theses/Puscasu18-saros-improving-quality-STF-tests.pdf)):
@@ -38,7 +38,7 @@ We did not integrate the pull request, because:
 * We want to avoid additional complexity which hampers the induction of new contributors.
 
 
-### Minimize the Setup/Teardown effort of similar tests
+### Minimize the Setup/Teardown Effort of Similar Tests
 See here for the corresponding [Pull Request](https://github.com/saros-project/saros/pull/528)<br/>
 The main idea is to identify tests with similar setups. Instead of recreating the setup for each test, the old setup is just cleaned up.
 
@@ -54,7 +54,7 @@ The pull request contains a basic implementation with mostly stubbed methods.
 
 ## Java-JavaScript Bridge
 Corresponding Pull Requests:
-Reimplementation of the `ui` classes in kotlin:
+Reimplementation of the `ui` classes in Kotlin:
 * [Part 1](https://github.com/saros-project/saros/pull/437)
 * [Part 2](https://github.com/saros-project/saros/pull/438)
 * [Part 3](https://github.com/saros-project/saros/pull/436)
@@ -66,21 +66,21 @@ Reimplementation of the `ui` classes in kotlin:
 * [Part 9](https://github.com/saros-project/saros/pull/430)
 * [Part 10](https://github.com/saros-project/saros/pull/429)
 
-The main idea is to reduce redundancy and complexity during the interaction of Java and JavaScript. Therefore this work compared different approaches (Scala with Scala.js, Kotlin and Fantom) which allow to generate the JavaScript code based on a JVM language. See this [thesis](https://www.inf.fu-berlin.de/inst/ag-se/theses/Paul-Gattringer2018-saros-UI-bridge.pdf) (german only) for more information.
+The main idea is to reduce redundancy and complexity during the interaction of Java and JavaScript. Therefore this work compared different approaches (Scala with Scala.js, Kotlin and Fantom) which allow to generate the JavaScript code based on a JVM language. See this [thesis](https://www.inf.fu-berlin.de/inst/ag-se/theses/Paul-Gattringer2018-saros-UI-bridge.pdf) (German only) for more information.
 
 We did not integrate the pull requests, because:
 * The approach introduces a new language and therefore increases the complexity of our project and build process.
 * The savings of redundancy are smaller than expected. Only the redundancy of the model classes can the avoided.
-* The most interesting part (The injection of java functions into javascript and vice versa) is not simplified by the approach.
+* The most interesting part (The injection of java functions into JavaScript and vice versa) is not simplified by the approach.
 
 ## Instant Session Start
 
 Goal of this topic is to speed up the initial file sharing process at session starts.
 Instead of waiting for full synchronization, this feature prioritizes files and allows direct access after receiving.
-This main goal has already been achieved, but users are still bound to the read-only mode during project sharing and optimizations are open / onhold for merging.
-More Infos can be found in this [thesis](https://www.inf.fu-berlin.de/inst/ag-se/theses/Moll18-saros-session-start.pdf) (german only).
+This main goal has already been achieved, but users are still bound to the read-only mode during project sharing and optimizations are open / on hold for merging.
+More Infos can be found in this [thesis](https://www.inf.fu-berlin.de/inst/ag-se/theses/Moll18-saros-session-start.pdf) (German only).
 
 Currently the author ([@stefaus](https://github.com/stefaus)) of this thesis wants to finish the rest of this work and some patches are already available.
-Nevertheless the topic is on hold mainly because it is mandatory to change the way resources are shared first (from project based to per ressource tracking).
+Nevertheless the topic is on hold mainly because it is mandatory to change the way resources are shared first (from project based to per resource tracking).
 
-An Overview of the current work state is documented here: [Projectboard: Instant Session Start Feature](https://github.com/saros-project/saros/projects/15) and a broader view at [Projectboard: Session Start Topics](https://github.com/saros-project/saros/projects/18).
+An Overview of the current work state is documented here: [Project Board: Instant Session Start Feature](https://github.com/saros-project/saros/projects/15) and a broader view at [Project Board: Session Start Topics](https://github.com/saros-project/saros/projects/18).

--- a/docs/contribute/processes/continuous-integration.md
+++ b/docs/contribute/processes/continuous-integration.md
@@ -2,7 +2,7 @@
 title: Continuous Integration Process
 ---
 
-## Push-triggered jobs
+## Push-Triggered Jobs
 
 Whenever commits are pushed to a branch of the main repository, Travis CI triggers a new job that builds and tests the state of the updated branch.
 During the test phase, only the JUnit tests (excluding STF tests) are executed.
@@ -11,13 +11,13 @@ Furthermore, the static code analysis tool Codacy is run to scan the code and bi
 This scan only looks at the changes made by the pushed commits, meaning it will not analyze existing/unchanged code.
 The results of the analysis are available through the GitHub interface or can be viewed using the [Codacy web interface](https://app.codacy.com/project/Saros/saros/dashboard).
 
-## Pull-request-triggered jobs
+## Pull-Request-Triggered Jobs
 
 Travis CI also runs when a new pull request is created or an existing pull request is updated.
 See the [Travis documentation](https://docs.travis-ci.com/user/pull-requests/#%E2%80%98Double-builds%E2%80%99-on-pull-requests) for more information.
 These jobs are identical to the jobs triggered by a push. The only difference is that issues of the static code analysis are also reported in the pull request.
 
-## Daily jobs
+## Daily Jobs
 
 Travis CI executes a daily cron job that triggers the following builds:
 * Builds and tests the current master branch

--- a/docs/contribute/processes/development.md
+++ b/docs/contribute/processes/development.md
@@ -2,13 +2,13 @@
 title: Development Process
 ---
 
-## Development workflow
+## Development Workflow
 
 Our development workflow bases on the standard [GitHub fork workflow](https://guides.github.com/activities/forking/).
 
 Before a pull request is merged, it will have to pass out [review process](review.md).
 
-## Pull request structure
+## Pull Request Structure
 
 In the Saros project, we use two different strategies to merge pull requests: [squash and merge](#squash-and-merge) and [rebase and merge](#rebase-and-merge).
 
@@ -17,14 +17,14 @@ Which strategy is used to merge a particular pull request depends on the size, c
 
 Independently of the merge strategy, please make sure that all commits have an [appropriate commit message](../guidelines.html#commit-message).
 
-### [Squash and merge](https://help.github.com/articles/about-pull-request-merges/#squash-and-merge-your-pull-request-commits)
+### [Squash and Merge](https://help.github.com/articles/about-pull-request-merges/#squash-and-merge-your-pull-request-commits)
 
 *This is the preferred merging strategy for small and coherent changes.*
 
 If your change only touches a specific file, functionality, or API and is not "to large" (this is somewhat subjective and will be up to you and the reviewers; as a general rule of thumb, it should not change more than 200 lines of code).
 This allows the changes to be bundled into one concise commit.
 
-### [Rebase and merge](https://help.github.com/en/articles/about-pull-request-merges#rebase-and-merge-your-pull-request-commits)
+### [Rebase and Merge](https://help.github.com/en/articles/about-pull-request-merges#rebase-and-merge-your-pull-request-commits)
 
 *This is the preferred merging strategy for larger changes.*
 

--- a/docs/contribute/processes/release.md
+++ b/docs/contribute/processes/release.md
@@ -44,16 +44,16 @@ Please make sure before creating the artifacts that **all unit and stf tests are
 **Artifacts:**
 * Plug-in zip
 
-#### Plug-in zip
+#### Plug-In zip
 
 * Open bash
-* Navigate to the saros repository dir
+* Navigate to the Saros repository dir
 * Execute the command `./gradlew sarosIntellij`
 * You find the zip here: `./build/distribution/intellij/saros.inteliij.zip`
 
 ## How do I test the artifacts?
 
-As mentioned before you should already executed all unit and stf tests (which has to be successful).
+As mentioned before you should already executed all unit and STF tests (which has to be successful).
 
 The release artifacts are manually tested with at least one other person:
 * You have to install the artifact and start a session.
@@ -99,7 +99,7 @@ in the marketplace.
 
 **Login process**
 
-* Login with the saro-outreach user
+* Login with the saros-outreach user
 
 **Release/Metadata change process**
 
@@ -128,7 +128,7 @@ We release the IntelliJ IDEA plug-in zip via this repository.
 * Login as user `saros-infrastructure` in [GitHub](https://github.com)
 * Open the [JetBrains Plugin Repository](https://plugins.jetbrains.com/)
 * Click on `Sign In`
-* Instead of entering user credentials, choose the login via Github (click on the GitHub icon)
+* Instead of entering user credentials, choose the login via GitHub (click on the GitHub icon)
 
 **Release process**
 
@@ -157,7 +157,7 @@ We release the Saros for Eclipse drop-in and the Saros for IntelliJ zip via this
 * Click on `draft a new release`
 * Fill the form:
   * Tag: `saros-<ide>-<version>` (e.g. `saros-intellij-0.1.1`)
-  * Tag taget: a commit id
+  * Tag target: a commit id
   * Release title: Short title as `Saros for <ide> <version>`
   * Description: Short description of artifacts and link the release notes
   * Upload binaries as artifacts (e.g. drop-in, plug-in zip)

--- a/docs/contribute/processes/review.md
+++ b/docs/contribute/processes/review.md
@@ -136,6 +136,7 @@ Information on when to use which merge strategy is given in our [development pro
 ##### Squash and Merge
 This method squashes all changes of your pull request. If you choose this option, GitHub proposes a possible commit name
 and message which you can change before you merge.
+
 ![GitHub choose commit message](../images/processes/GitHub_choose_commit_message.png)
 
 Use this method if you don't want to preserve the commit history. This is always useful if the history contains multiple commits which

--- a/docs/contribute/processes/review.md
+++ b/docs/contribute/processes/review.md
@@ -128,7 +128,7 @@ In case you don't know yet:
 
 ![GitHub merge options](../images/processes/GitHub_choose_merge_method.png)
 
-We allow the two options [merge and squash](https://help.github.com/articles/about-pull-request-merges/#squash-and-merge-your-pull-request-commits) and [rebase and merge](https://help.github.com/articles/about-pull-request-merges/#rebase-and-merge-your-pull-request-commits).
+We allow the two options [squash and merge](https://help.github.com/articles/about-pull-request-merges/#squash-and-merge-your-pull-request-commits) and [rebase and merge](https://help.github.com/articles/about-pull-request-merges/#rebase-and-merge-your-pull-request-commits).
 Both options avoid merge commits which lead to a strict chronological commit history.
 
 Information on when to use which merge strategy is given in our [development process documentation](development.md#pull-request-structure).

--- a/docs/contribute/processes/review.md
+++ b/docs/contribute/processes/review.md
@@ -2,7 +2,7 @@
 title: Review Process
 ---
 
-## Review rules at a glance
+## Review Rules at a Glance
 
 Make sure that your change:
 
@@ -42,11 +42,11 @@ code. This rigid process serves a dual purpose:
     and may provide valuable feedback, helping the author to write
     better code -- now and in the future.
 
-## How to receive a review
+## How to Receive a Review
 
-### Step 1: Creating your pull request
+### Step 1: Creating Your Pull Request
 
-#### a) Scope of your pull request
+#### a) Scope of Your Pull Request
 
 *   **Smaller pull requests** are always better. If it takes more than 15
     minutes to review your pull request, it is very unlikely that anyone is
@@ -59,7 +59,7 @@ code. This rigid process serves a dual purpose:
     up (automatic) refactorings and functional changes in one pull request, but
     provide two separate ones -- both of them will be easier to review.
 
-#### b) Format of your pull request
+#### b) Format of Your Pull Request
 
 *   Write a **concise commit message** following our
     [guidelines](../guidelines.md). If you have
@@ -67,14 +67,14 @@ code. This rigid process serves a dual purpose:
     probably mixed up different concerns and should address them in
     separate pull requests instead.
 
-### Step 2/3/6: Pushing and pushing again
+### Step 2/3/6: Pushing and Pushing Again
 
 In case you don't know yet:
 
 *   [Learn how to push your first change.](https://help.github.com/articles/pushing-to-a-remote/)
 *   [Learn how to amend an existing patch.](https://medium.com/@igor_marques/git-basics-adding-more-changes-to-your-last-commit-1629344cb9a8)
 
-### Step 4: Invite reviewers
+### Step 4: Invite Reviewers
 
 *   You can invite individual reviewers by their names.
     *   Take a look into the [commit history](https://github.com/saros-project/saros/commits/master)
@@ -99,7 +99,7 @@ In case you don't know yet:
     time getting others to review your pull request? Be a role model and do a
     few reviews yourself.
 
-### Step 5: While integrating the reviewers' suggestions: Avoid perfectionism
+### Step 5: While Integrating the Reviewers' Suggestions: Avoid Perfectionism
 
 *   Ever heard of the "Good Enough Principle"? Resist the temptation to
     correct even the last typo in every class your pull request touched. Finish
@@ -111,12 +111,12 @@ In case you don't know yet:
     ground and focus the discussion on the actual pull request, not some
     imaginary perfect pull request-to-be.
 
-### Step 6 - External pull requests: Request the merge of the pull request
+### Step 6 - External Pull Requests: Request the Merge of the Pull Request
 
 *   Ensure that the pull request is up-to-date with the target branch and meets the [merge requirements](#review-rules-at-a-glance).
 *   Request that a developer with the necessary rights merges your pull request.
 
-### Step 6 - Internal: Merge the pull request
+### Step 6 - Internal: Merge the Pull Request
 
 *   Normally, submitting an approved pull request is the duty of the author, i.e. you.
     *   Vice versa, don't just simply submit foreign pull requests even if
@@ -133,7 +133,7 @@ Both options avoid merge commits which lead to a strict chronological commit his
 
 Information on when to use which merge strategy is given in our [development process documentation](development.md#pull-request-structure).
 
-##### Merge and squash
+##### Squash and Merge
 This method squashes all changes of your pull request. If you choose this option, GitHub proposes a possible commit name
 and message which you can change before you merge.
 ![GitHub choose commit message](../images/processes/GitHub_choose_commit_message.png)
@@ -141,14 +141,14 @@ and message which you can change before you merge.
 Use this method if you don't want to preserve the commit history. This is always useful if the history contains multiple commits which
 are nice to have during the reviewing process, but not necessary in the whole history of the project.
 
-##### Rebase and merge
+##### Rebase and Merge
 This method rebases the branch which should be merged into the master branch and subsequently merges the change
 into the master branch. This has the effect that the history of the branches is linearized before merging and a merge commit
 becomes superfluous.
 
 Use this method if you want to preserve the commit history. But make sure that **all of your commits in the pull requests comply with our guidelines for commit messages!**.
 
-## How to perform a review
+## How to Perform a Review
 
 To get an equal distribution of work load in the Saros community,
 everyone who submits pull requests needs to do *twice* as many reviews of
@@ -156,12 +156,12 @@ foreign pull requests. Every time you submit a new pull request or pull request 
 review, you owe the team two reviews of your own. This section describes
 the most important things about doing a review.
 
-### How to look for issues
+### How to Look for Issues
 
 A review process becomes more effective if the reviewers take different
 perspectives on the code. Here are just two of them:
 
-#### Close up
+#### Close Up
 
 * Look at each change and make sure that
    * it is well documented
@@ -176,7 +176,7 @@ perspectives on the code. Here are just two of them:
 * Comment on the [corresponding line of the pull request](https://help.github.com/articles/commenting-on-a-pull-request/#adding-line-comments-to-a-pull-request).
 
 
-#### 10,000 feet view
+#### 10,000 Feet View
 
 * Does the change make sense on a conceptual level?
 * Is the goal stated in the commit message actually archived?
@@ -192,7 +192,7 @@ look at the bigger picture: Are there already other methods, interfaces,
 classes for this or a similar job? Can the same goal be achieved using
 existing components of Saros?
 
-### How to report the issues found
+### How to Report the Found Issues
 
 *   **Explain the problem**: Don't just point to a problem and expect
     the author to understand what you are talking about. If it really
@@ -210,7 +210,7 @@ existing components of Saros?
     analytical part (explaining why something is a problem) or for the
     constructive part (explaining how to solve such problems).
 
-### How to handle recurring problems
+### How to Handle Recurring Problems
 
 *   **Explain the schema, not all instances:** Some types of errors
     occur in multiple places and it's certainly not the reviewer's job
@@ -218,13 +218,13 @@ existing components of Saros?
     pattern clear to the author. One reported instance might be enough;
     just make sure to tell the author to look out for more of that kind.
 
-### How to cope with a lack of understanding
+### How to Cope With a Lack of Understanding
 
 *   **Don't be afraid to ask** if you don't understand some parts of
     the code. Nobody requires the reviewer to be smarter than the author
     just *different*.
 
-### How to hook into the ongoing review process
+### How to Hook Into the Ongoing Review Process
 
 *   If you are not the first reviewer, there are probably already some
     comments of others. There are different kinds:

--- a/docs/contribute/saros-server.md
+++ b/docs/contribute/saros-server.md
@@ -2,9 +2,9 @@
 title: Saros Server Development
 ---
 
-## What is the Saros Server
+## What is the Saros Server?
 
-Please refer to the [User Documentation](../documentation/saros-server.md) for an explaination and the use-case of the saros server.
+Please refer to the [User Documentation](../documentation/saros-server.md) for an explanation and the use-case of the Saros server.
 
 Technically it is a headless session-host.
 
@@ -18,7 +18,7 @@ Notable exceptions are the [filesystem](https://github.com/saros-project/saros/t
 
 ### Permission System
 
-Traditionally the Session-Host is responsible for moderating an active Saros-Session. The Host-Role allows adding new users and accepting new projects into the session. A headless implementation like the server cannot do this, which is why the server currectly accepts every request for invitations and new projects. Therefor it can only be executed in a trusted environment.
+Traditionally the Session-Host is responsible for moderating an active Saros-Session. The Host-Role allows adding new users and accepting new projects into the session. A headless implementation like the server cannot do this, which is why the server currently accepts every request for invitations and new projects. Therefor it can only be executed in a trusted environment.
 
 The server will need some kind of permission system to allow a remote user to manage these tasks. The simplest (and likely sufficient) variant would move this role to some kind of "Admin"-User, that may be configured for a given server.
 
@@ -37,6 +37,6 @@ This concept could prove to be very memory inefficient, as a new process and JVM
 
 - It is not clear, how this can be represented in the XMPP-Protocol. The Super-Server would be logged with an XMPP-ID to setup the initial communication, but each session-server would need to be dynamically assigned a new JID or the same JID. New JIDs would need some kind of configuration and cooperation with the XMPP-Server. Re-using the same JID is currently not tested with Saros and might cause other unpredictable issues.
 
-### Cleanup old files
+### Cleanup of Old Files
 
 Currently the Server creates it's workspace as a temporary folder, it would be better, if the folder could be cleaned up on shutdown, although caching might be appropriate for larger frequently shared projects.

--- a/docs/contribute/saros-testing-framework.md
+++ b/docs/contribute/saros-testing-framework.md
@@ -13,7 +13,7 @@ You need a [development environment](development-environment.md) with **Eclipse 
 
 ### Configuration
 
-* Before you can run the stf tests you need four XMPP accounts. If you want to use our XMPP server you can create accounts as described in the [user documentation](../documentation/getting-started.html?tab=eclipse).
+* Before you can run the STF tests you need four XMPP accounts. If you want to use our XMPP server you can create accounts as described in the [user documentation](../documentation/getting-started.html?tab=eclipse).
 * Then you have to create the file `configuration.properties` in directory `saros/test/framework/stf/src/saros/stf/client`.
 * Add the following lines to the config and **replace the placeholders with your credentials** (make sure **every tester has an unique JID**)
 
@@ -39,12 +39,12 @@ DAVE_HOST = localhost
 DAVE_PORT = 12348
 ```
 
-### Prepare dependencies
+### Prepare Dependencies
 
 Eclipse uses the `META-INF/MANIFEST.MF` in order to resolve dependencies inside the launch config.
-Therefore the current workaround is to execute the gradle task `generateLibAll` in order to generate a directory `lib` that contains the required dependencies.
+Therefore the current workaround is to execute the Gradle task `generateLibAll` in order to generate a directory `lib` that contains the required dependencies.
 
-### Run tests
+### Run Tests
 
 1.  Start the **requiered launch configurations** which are located
     in the directory `test/resources/launch` by **right clicking the
@@ -57,26 +57,29 @@ Therefore the current workaround is to execute the gradle task `generateLibAll` 
     *ALICE*. In this case you only need to start *Saros\_STF\_Alice*.
 2.  **Right click** on the test you want to run and select **Run As > JUnit test**
 
-## Intellij
-We are currently working on an version of STF that work with the HTML-GUI and therefore with both IDEs, but for now it is not possible to run the Eclipse STF tests from within IntelliJ or execute STF tests for IntelliJ.
-However Intellij/Gradle supports to run multiple intellij instances from within intellij in order to test Saros by hand.
+## IntelliJ
 
-### Run multiple Intellij instances for testing
+We are currently working on an version of STF that work with the HTML-GUI and therefore with both IDEs, but for now it is not possible to run the Eclipse STF tests from within IntelliJ or execute STF tests for IntelliJ.
+However IntelliJ/Gradle supports to run multiple IntelliJ instances from within IntelliJ in order to test Saros by hand.
+
+### Run Multiple IntelliJ Instances for Testing
+
 * Open the `Gradle` tool window
 * Open the task directory `saros.intellij > Tasks > intellij`
 * Execute task `runIde` for each IntelliJ IDEA instance you need.
 
-Each simultaneously execution of `runIde` creates a sandbox directory in the `build` directory of the intellij project.
+Each simultaneously execution of `runIde` creates a sandbox directory in the `build` directory of the IntelliJ project.
 If you want to configure the parent directory of the sandbox directories you have to set the environment variable `SAROS_INTELLIJ_SANDBOX`
 to the corresponding directory.
 
 ## Without an IDE
 
-### Test IntelliJ by hand
-If you want to test IntelliJ by hand simply call the gradle task `./gradlew runIde` as within IntelliJ. If you close the IntelliJ instance
-by killing the gradle process per terminal the intellij workspaces cannot be reused. Therefore you should close the instances by closing the IDE window.
+### Test IntelliJ by Hand
 
-### Start Eclipse STF tests
+If you want to test IntelliJ by hand simply call the Gradle task `./gradlew runIde` as within IntelliJ. If you close the IntelliJ instance
+by killing the Gradle process per terminal the IntelliJ workspaces cannot be reused. Therefore you should close the instances by closing the IDE window.
+
+### Start Eclipse STF Tests
 
 If you want to execute the Eclipse STF tests without an IDE you can use the docker setup which is used in the CI server.
 In order to use the corresponding script you need a current **docker installation**.
@@ -87,10 +90,11 @@ In order to use the corresponding script you need a current **docker installatio
 * Execute `export CONFIG_DIR=travis/config SCRIPT_DIR=travis/script/stf`
 * Create the required docker contains by executing  
   `./travis/script/stf/setup_stf_container.sh $PWD`
-* Start the stf tests by executing
+* Start the STF tests by executing
   `docker exec -t stf_master /home/ci/saros_src/travis/script/stf/master/start_stf_tests.sh`
 
-### Clean test environment
+### Clean Test Environment
+
 In order to clean the environment you have to stop and remove all created containers and
 remove the network.
 
@@ -98,6 +102,7 @@ remove the network.
 * Remove network `docker network rm stf_test_network`
 * Remove the `stf_ws` directory
 
-### View eclipse test instances
+### View Eclipse Test Instances
+
 If you want to see how the tests are performed you have install a vncviewer.
 Start the vncviewer and connect to the vncservers running on the test container. You have to connect to host `localhost` and the ports `5901`, `5902`, `5903` and `5904`.

--- a/docs/contribute/whiteboard.md
+++ b/docs/contribute/whiteboard.md
@@ -2,14 +2,12 @@
 title: Saros HTML Whiteboard
 ---
 
-# {{ page.title }}
-
 The Saros Whiteboard was designed to enable Saros users to communicate ideas graphically.
 
 ## Developing the Whiteboard
 
 ### Setup
-First of all, The view has to be un-commented from `saros.whiteboard/plugin.xml`, the view has the following id: `saros.whiteboard.ui.HTMLWhiteboardView`.
+First of all, the view has to be un-commented from `saros.whiteboard/plugin.xml`, the view has the following id: `saros.whiteboard.ui.HTMLWhiteboardView`.
 
 Then install the dependencies using the command `npm run setup`, note that `npm install` does not suffice.
 
@@ -24,7 +22,7 @@ The Saros HTML Whiteboard uses a graphics library called [Fabric.js](http://fabr
 
 As for the bundling, it uses [Webpack](https://webpack.js.org/) to bundle the resources using [Babel](https://babeljs.io/) loader to transpile the code to a more browser-friendly version.
 
-## How it works internally
+## How it Works Internally
 
 The Saros HTML Whiteboard builds upon the internal infrastructure of the [GEF](https://www.eclipse.org/gef/) based Whiteboard and uses most of its components such as [SXE](https://xmpp.org/extensions/xep-0284.html).
 

--- a/docs/documentation/faq.md
+++ b/docs/documentation/faq.md
@@ -1,9 +1,9 @@
 ---
-title: Frequently asked questions
+title: Frequently Asked Questions
 ---
 
 This page lists common questions about Saros. If your question is not
-answered here you should look aroud the
+answered here you should look around the
 [Support](../support/) area. There you will
 find more information that may help you.
 
@@ -29,14 +29,14 @@ In the following we are using these definitions:
 * **Freeware** - You can use the software for free, but the code is not published.
 * **Self-hosted** - The possibility to host a corresponding server that manages the connection or also the shared workspaces.
 
-#### Web-based IDEs
+#### Web-Based IDEs
 
 |Name         |Category    |Self-hosted |
 |-------------|------------|------------|
 |CodeEnvy     |Commercial  |No          |
 |Cloud9       |Commercial  |No          |
 
-#### Plug-ins
+#### Plug-Ins
 
 |Name         |IDE                                              |Category    |Self-hosted |
 |-------------|-------------------------------------------------|------------|------------|
@@ -45,7 +45,7 @@ In the following we are using these definitions:
 |Live Share   |Visual Studio (Code)                             |Freeware    |No          |
 |Teletype     |Atom                                             |Open-Source |Yes         |
 
-#### Stand-alone Editors
+#### Stand-Alone Editors
 
 |Name         |OS                  |Category    |Self-hosted |
 |-------------|--------------------|------------|------------|
@@ -151,7 +151,7 @@ Saros session?
 -   Saros uses an [XMPP](http://en.wikipedia.org/wiki/XMPP) server to
     get in contact with the other participant(s). Companies can [run their own XMPP server](setup-xmpp.md)
     for maximum privacy; home users can use almost any public XMPP server.
--   Thoughout the session (if possible) Saros uses
+-   Throughout the session (if possible) Saros uses
     [Socks5](http://en.wikipedia.org/wiki/SOCKS) connections (direct
     or mediated) between the participants. Saros supports optional [UPnP
     port
@@ -162,7 +162,7 @@ Saros session?
 ### How to use a Google account / Google Talk service with Saros?
 
 We don't recommend to use you Google account for XMPP anymore, since
-Google has droped Google Talk XMPP support with the introduction of
+Google has dropped Google Talk XMPP support with the introduction of
 Google Hangouts.
 
 ### Is Saros language dependent or which languages does Saros support?

--- a/docs/documentation/features.md
+++ b/docs/documentation/features.md
@@ -18,12 +18,12 @@ Saros is designed to at least work with two participants in a session -
 as inherent for pair programming - but there is no maximum limit of
 participants.
 
-## Several concurrent writers
+## Several Concurrent Writers
 
 All participants with write-access can edit the shared files at the same
 time.
 
-## Various sharing options
+## Various Sharing Options
 
 You may share multiple projects within one session. You may also share
 only a selection of files of a project. If you create, delete or rename

--- a/docs/documentation/getting-started.md
+++ b/docs/documentation/getting-started.md
@@ -1,5 +1,5 @@
 ---
-title: Getting started
+title: Getting Started
 ---
 
 {% capture eclipse %}
@@ -25,7 +25,7 @@ To get familiar with this concept check out our comic:
 
 ------------------------------------------------------------------------
 
-## First steps
+## First Steps
 
 ### Step 1: Connecting
 
@@ -48,7 +48,7 @@ Saros &gt; Start Saros Configuration*)
 Server](images/1_GettingStartedCreateAccount_0.png)
 
 
-### Step 2: Adding contacts
+### Step 2: Adding Contacts
 
 To add a contact to your list you need to **know his/her XMPP ID**.
 
@@ -60,7 +60,7 @@ status in your contact list**.
 ![Adding
 buddies](images/2_GettingStartedAddContacts.png)
 
-### Step 3: Starting and joining sessions
+### Step 3: Starting and Joining Sessions
 
 You can work together with your contacts by either **starting your own
 session** or by **being invited to one**.
@@ -71,7 +71,7 @@ computer of your invited contacts.
 ![Share
 Projects](images/3_GettingStartedShareProjects_0.png)
 
-#### Start a session ([host](#the-host))
+#### Start a Session ([host](#the-host))
 
 1.  Right-click on...
     a.  a **project** in your **Package Explorer** and select *Share
@@ -85,7 +85,7 @@ Projects](images/3_GettingStartedShareProjects_0.png)
 Want to know more about the Saros host role? Check out our comic
 [here](host-comic.md).
 
-#### Join a session (client)
+#### Join a Session (Client)
 
 1.  Wait for a **session invitation** to appear on your screen
 2.  Click *Accept* to **accept the invitation**
@@ -97,7 +97,7 @@ Want to know more about the Saros host role? Check out our comic
 4.  Select *Finish* and wait for the project to be copied to your
     computer
 
-#### Additional information:
+#### Additional Information:
 
 -   If you accept an invitation and decide to synchronize the incoming
     project with your own copy, Saros will automatically add, change, or
@@ -220,7 +220,7 @@ File:**
 Gives you the opportunity to select a file to be sent to the selected
 participant.
 
-### Good to know
+### Good to Know
 
 #### User Roles
 
@@ -243,7 +243,7 @@ participant:
 -   As s/he scrolls through a file, the viewpoint is moved on your
     computer also, so that you see what s/he sees.
 
-#### Staying Aware of your Fellow Participants
+#### Staying Aware of Your Fellow Participants
 
 There are multiple ways of staying aware of what a driver is currently
 doing:
@@ -401,10 +401,12 @@ You can then delete the first account, add a new account with the right values, 
 - Click the option "Follow participant".
 
 ### Leaving the Follow Mode
+
 - Click the "Follow" button (![follow icon](images/icons-i/follow.png)).
 - Click the option "Leave follow mode".
 
 ### Resolving a Desynchronization
+
 By default, the synchronization button (![synchronization button off](images/icons-i/in_sync.png)) is disabled.
 If Saros detects that the local content has become out of sync with the host (i.e. differs in any way), it will notify the user and enable the synchronization button (![synchronization button on](images/icons-i/out_sync.png)).
 To resolve the desynchronization:
@@ -453,7 +455,6 @@ Saros/I does not currently share which resources are marked as 'Excluded' with o
 ### Number of Participants
 
 Currently, Saros/I is restricted to two-participant sessions, meaning you can only create session containing the host and a single client.
-
 
 ## Missing Features
 

--- a/docs/documentation/host-comic.md
+++ b/docs/documentation/host-comic.md
@@ -1,5 +1,5 @@
 ---
-title: A graphical introduction to the Saros Host concept.
+title: A Graphical Introduction to The Saros Host Concept
 toc: false
 ---
 

--- a/docs/documentation/index.md
+++ b/docs/documentation/index.md
@@ -42,9 +42,9 @@ toc: false
 *   That means for instance that it does not support joint
     interactive [testing](host-comic.md).
 
-## Saros can be used in various scenarios
+## Saros can be used in various scenarios.
 
-* **Joint review**                      
+* **Joint review**
 
   One participant (**"driver"**)
   reviews the contents of one or more
@@ -60,9 +60,9 @@ toc: false
   the mouse for all the others to
   see. Also, any participant can
   become driver at any time.
-                                        
 
-* **Introducing beginners**             
+
+* **Introducing beginners**
 
   Much like before, except that
   explaining rather than reviewing is
@@ -74,9 +74,9 @@ toc: false
   session for the others. To do that,
   s/he will temporarily leave follow
   mode.
-                                        
 
-* **Distributed Party Programming**     
+
+* **Distributed Party Programming**
 
   **Two or more participants work
   together in a loosely coupled
@@ -93,13 +93,12 @@ toc: false
   hour. Just think how this can speed
   up the coordination work just before
   release time after a code freeze!
-                                        
 
-* **Distributed Pair Programming **     
-  Is a particular form of Distributed
+
+* **Distributed Pair Programming **
+  is a particular form of Distributed
   Party Programming in which two
   people develop code or text in
   continuous close collaboration,
   discussing the approach and
   combining the best of their ideas.
-                                        

--- a/docs/documentation/saros-server.md
+++ b/docs/documentation/saros-server.md
@@ -2,7 +2,7 @@
 title: Saros-Server
 ---
 
-**Note**: This is an *alpha* feature and not intended for general use yet. However please feel free to play around and give some initial feedback. Contributers to the Saros-Server project are very welcome and might want to take a look at [contribution wiki](../contribute/saros-server.md) for further information.
+**Note**: This is an *alpha* feature and not intended for general use yet. However please feel free to play around and give some initial feedback. Contributors to the Saros-Server project are very welcome and might want to take a look at [contribution wiki](../contribute/saros-server.md) for further information.
 
 ## Use-case
 
@@ -10,7 +10,7 @@ The use-case of the server is to host session independently of any participant. 
 
 ## Usage
 
-The Saros-Server is currently available in version **0.1.0** as a standalone jar on [our Github Releases](https://github.com/saros-project/saros/releases).
+The Saros-Server is currently available in version **0.1.0** as a standalone jar on [our GitHub Releases](https://github.com/saros-project/saros/releases).
 
 The server needs it's own XMPP account and can then be started via:
 `java -Dsaros.server.jid=max@mustermann.de -Dsaros.server.password=1234 -jar saros.server.jar`

--- a/docs/documentation/setup-xmpp.md
+++ b/docs/documentation/setup-xmpp.md
@@ -1,5 +1,5 @@
 ---
-title: Setup Own XMPP Server
+title: Setup Your Own XMPP Server
 ---
 
 If you are an experienced user or if you want to use Saros in your
@@ -7,7 +7,7 @@ company and you want to use another XMPP Server or set up your own with
 Openfire, you will find information below.
 
 
-## XMPP servers
+## XMPP Servers
 
 In order to use Saros you need to configure an XMPP/Jabber account.
 
@@ -23,7 +23,7 @@ In order to use Saros you need to configure an XMPP/Jabber account.
     such as [ejabberd](https://www.process-one.net/en/ejabberd/) should
     be suitable as well)
 
-### Suitable Jabber servers
+### Suitable Jabber Servers
 
 *   The following public Jabber servers have been tested to **work
     reliably with no known problems**:
@@ -48,7 +48,7 @@ In order to use Saros you need to configure an XMPP/Jabber account.
 See [https://www.ejabberd.im](https://www.ejabberd.im/).
 
 
-## Openfire installation (Windows)
+## Openfire Installation (Windows)
 
 1.  Download [Openfire for
     Windows](http://www.igniterealtime.org/downloads/index.jsp)

--- a/docs/documentation/troubleshooting.md
+++ b/docs/documentation/troubleshooting.md
@@ -104,9 +104,9 @@ sides attempts to connect each other. This improves chances of one peer
 connect to the other one. You can check your contact list to see which
 bytestream type is established between you and a contact (if any).
 
-For further information check out data connections in Saros on our
-network layer
-page [here](../old/networklayer.md#Data%20connections%20in%20Saros).
+For further information check out data connections in Saros on our network layer page.
+**Important:** The page may be quite outdated as it is part of our legacy documentation and has not been migrated to our new documentation.
+It can be found [here](https://saros-project.github.io/legacy_docs/networklayer.html#Data%20connections%20in%20Saros).
 
 ## Known Issues
 

--- a/docs/documentation/troubleshooting.md
+++ b/docs/documentation/troubleshooting.md
@@ -2,9 +2,9 @@
 title: Troubleshooting
 ---
 
-## Technical Questions {#Technical_Questions}
+## Technical Questions
 
-### Setting up {#Setting_up}
+### Setting up
 
 #### Why is updating Saros over the Eclipse Update mechanism so slow?
 

--- a/docs/documentation/troubleshooting.md
+++ b/docs/documentation/troubleshooting.md
@@ -13,7 +13,7 @@ for updates to all plug-ins that you have installed. To work around this
 problem, uncheck "Contact all update sites during install to find
 required software" in Eclipse's installation dialog.
 
-#### I cannot connect with my jabber account?
+#### I can not connect with my jabber account.
 
 Go to Eclipse -&gt; Saros -&gt; Preferences -&gt; General -&gt; Network
 Connections and make sure, that there are no proxy settings checked.
@@ -54,11 +54,11 @@ selections, click the corresponding entry (e.g. "DPP Selection of buddy
 to repeat this step for all five buddies. The same goes for the
 "contributions" (that portion of source code someone authored).
 
-### Network issues
+### Network Issues
 
 #### I keep getting Mediated Socks5 or slower IBB connections. What am I doing wrong?
 
-#### Troubleshooting Socks5 Bytestream Establishment
+##### Troubleshooting Socks5 Bytestream Establishment
 
 If you keep getting Mediated Socks5 Bytestreams or In-Band Bytestreams,
 other peers cannot connect to you directly (cannot create a TCP
@@ -81,7 +81,7 @@ connection to you). What can you do to improve chances?
     gateway (e.g. Router) manual for port mapping or sometimes labelled
     virtual servers.
 
-#### What might stop you from using Socks5:
+##### What Might Stop You From Using Socks5
 
 Some factors might prevent you from using S5B. Lets have a quick look at
 the S5B protocol when you want connect a buddy.
@@ -105,14 +105,14 @@ connect to the other one. You can check your contact list to see which
 bytestream type is established between you and a contact (if any).
 
 For further information check out data connections in Saros on our
-networklayer
+network layer
 page [here](../old/networklayer.md#Data%20connections%20in%20Saros).
 
 ## Known Issues
 
-### About data transfer
+### About Data Transfer
 
-*   Transfering large amounts of data during session initiation
+*   Transferring large amounts of data during session initiation
     (project synchronization) can take a lot of time. Do as much of the
     synchronization via your version control repository as you can to
     keep session initiation fast by using "copy of existing project"
@@ -126,7 +126,7 @@ page [here](../old/networklayer.md#Data%20connections%20in%20Saros).
     such (possibly large) set of operations for each keypress. It is
     wise to avoid these operations.
 
-### Making your session mates aware of your actions
+### Making Your Session Mates Aware of Your Actions
 
 *   Be aware that Saros transfers only the text editor pane. When you
     use other elements of Eclipse, e.g. structure browsers or the HTML
@@ -134,13 +134,13 @@ page [here](../old/networklayer.md#Data%20connections%20in%20Saros).
     talking aloud about the things that you are doing there is probably
     required to make them aware of your actions.
 
-### Eclipse editor technicalities
+### Eclipse Editor Technicalities
 
 *   You and your session mates should use the same editor settings
     regarding formatting and encoding; in particular regarding TAB
     width, TAB/spaces handling and character encoding.
 
-### About Eclipse plugins
+### About Eclipse Plugins
 
 *   If you are sharing a project which is managed by a source code
     management system such as Subversion, make sure that all

--- a/docs/documentation/what-others-say.md
+++ b/docs/documentation/what-others-say.md
@@ -23,7 +23,7 @@ you.
 ## Magazines
 
 [Eclipse Magizine](http://it-republik.de/jaxenter/eclipse-magazin-ausgaben/Plug-in-Parade-000340.md)
-as part of issue number 2.10's cover-feature "Plug-in-Parade" (german)
+as part of issue number 2.10's cover-feature "Plug-in-Parade" (German)
 
 ## The Web
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,4 +2,4 @@
 layout: index
 ---
 
-The Open Source IDE plugin for distributed collaborative software development
+The Open Source IDE Plugin for Distributed Collaborative Software Development

--- a/docs/releases/saros-e_15.0.0.md
+++ b/docs/releases/saros-e_15.0.0.md
@@ -20,7 +20,7 @@ You may know the Saros whiteboard from the previous release.
 Due to stability issues we did not release the Whiteboard feature of Saros, which allowed to share drawings between Saros users.
 We plan to release a new whiteboard as soon as it works reliable.
 
-## JDK requirements
+## JDK Requirements
 Saros 15.0.0 requires JDK8+, since we switched to JDK8 internally.
 
 ## Feedback

--- a/docs/releases/saros-i_0.2.0.md
+++ b/docs/releases/saros-i_0.2.0.md
@@ -60,7 +60,7 @@ You can
 - add existing XMPP-accounts
 - start a session with another person
   - Sessions in Saros/I are currently limited to two participants (host and one client)
-- share exactly one module through Saros; the shared module must meet the restrictions described [here](#module-restrictions#how-to-use-sarosi)
+- share exactly one module through Saros; the shared module must meet the restrictions described [here](#module-restrictions)
 - transfer the initial content of the module shared by the host to all participating clients
 - work on shared resources
 - create, delete, and move resources in the shared module

--- a/docs/releases/saros-i_0.2.1.md
+++ b/docs/releases/saros-i_0.2.1.md
@@ -43,7 +43,7 @@ You can
 - add existing XMPP-accounts
 - start a session with another person
   - Sessions in Saros/I are currently limited to two participants (host and one client)
-- share exactly one module through Saros; the shared module must meet the restrictions described [here](#module-restrictions#how-to-use-sarosi)
+- share exactly one module through Saros; the shared module must meet the restrictions described [here](#module-restrictions)
 - transfer the initial content of the module shared by the host to all participating clients
 - work on shared resources
 - create, delete, and move resources in the shared module

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -31,7 +31,7 @@ Saros includes a statistical framework which is responsible for gathering inform
 ### Reviewed Research Articles
 * Lutz Prechelt and Karl Beecher. “[Four generic issues for tools-as-plugins illustrated by the distributed editor Saros.](http://dl.acm.org/citation.cfm?id=1984708.1984712)” In Proceeding of the 1st workshop on Developing tools as plug-ins, 9. ACM Press, 2011.
 * Lutz Prechelt. “[Some non-usage data for a distributed editor.](http://dl.acm.org/citation.cfm?id=1984642.1984651)” In Proceeding of the 4th international workshop on Cooperative and human aspects of software engineering, 48. ACM Press, 2011.
-* Edna Rosen, Stephan Salinger, and Christopher Oezbek. “[Project Kick-off with Distributed Pair Programming.](http://www.ppig.org/papers/22nd-SE-1.pdf)” In Proceedings of the 22nd Annual Workshop of Psychology of Programming Interest Group, 121-135. Leganès, Spain: Universidad Carlos III de Madrid, 2010.
+* Edna Rosen, Stephan Salinger, and Christopher Oezbek. “[Project Kick-off with Distributed Pair Programming.](http://www.ppig.org/sites/ppig.org/files/2010-PPIG-22nd-Rosen.pdf)” In Proceedings of the 22nd Annual Workshop of Psychology of Programming Interest Group, 121-135. Leganès, Spain: Universidad Carlos III de Madrid, 2010.
 * Stephan Salinger, Christopher Oezbek, Karl Beecher, and Julia Schenk. “[Saros: an eclipse plug-in for distributed party programming.](https://dl.acm.org/citation.cfm?id=1833319)” In Proceedings of the 2010 ICSE Workshop on Cooperative and Human Aspects of Software Engineering, 48-55. ACM Press, 2010.
 
 ### Unreviewed Research Articles

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -5,14 +5,14 @@ title: Research
 In the following you will find all information about Saros in the context of research.<br/>
 **If you are interested in using Saros as part of your own research, feel free to [contact us](../support).**
 
-## Research topics and questions
+## Research Topics and Questions
 The [AG SE (working group software engineering *@FU Berlin*)](http://www.inf.fu-berlin.de/w/SE/WebHome) has been doing research on pair programming for a number of years. Saros is a platform for extending this work to distributed pair programming (and general collaborative programming). We also investigate a number of research questions that concern the Saros tool itself (as well as similar tools).
  
-### How to introduce distributed pair programming? Effects? 
+### How to introduce distributed pair programming? What are the effects?
 We are working with companies that perform distributed software engineering and are interested in collaborative programming (via Saros) as a means for abating some of the problems that this tends to bring along.
 We are also studying how to introduce Saros and DPP into open-source projects and what effects the use of Saros has on such projects.
  
-### How should Saros work? 
+### How should Saros work?
 Saros has a number of interesting usability aspects in a number of areas, for instance:
 * learning its concepts and base operation
 * useful functionality beyond mere text editing
@@ -21,20 +21,20 @@ Saros has a number of interesting usability aspects in a number of areas, for in
 
 We are studying these aspects via multiple channels such as gathering written user feedback, collecting and analyzing fine-grained usage data, and explicit usability studies.
  
-### Saros usage statistics and diagrams 
+### Saros Usage Statistics and Diagrams
 Saros includes a statistical framework which is responsible for gathering information about the actual usage. This information ranges from the plain duration of a session to much more detailed facets such as role swaps performed or text edits contributed. For each session—assuming one allows the submission of this anonymous information—a session statistic is sent to our server.
 
 **The statistical framework is disabled in the current release**, because the corresponding infrastructure to process the gathered data is not currently set up. Furthermore, we currently don't have a use for the data. But we are open to re-integrate the service if this kind of data would become useful again. So, if you are interested in this kind of data, feel free to contact us so that we can discuss possible collaborations.
 
 ## Publications on Saros
 
-### Reviewed research articles
+### Reviewed Research Articles
 * Lutz Prechelt and Karl Beecher. “[Four generic issues for tools-as-plugins illustrated by the distributed editor Saros.](http://dl.acm.org/citation.cfm?id=1984708.1984712)” In Proceeding of the 1st workshop on Developing tools as plug-ins, 9. ACM Press, 2011.
 * Lutz Prechelt. “[Some non-usage data for a distributed editor.](http://dl.acm.org/citation.cfm?id=1984642.1984651)” In Proceeding of the 4th international workshop on Cooperative and human aspects of software engineering, 48. ACM Press, 2011.
 * Edna Rosen, Stephan Salinger, and Christopher Oezbek. “[Project Kick-off with Distributed Pair Programming.](http://www.ppig.org/papers/22nd-SE-1.pdf)” In Proceedings of the 22nd Annual Workshop of Psychology of Programming Interest Group, 121-135. Leganès, Spain: Universidad Carlos III de Madrid, 2010.
 * Stephan Salinger, Christopher Oezbek, Karl Beecher, and Julia Schenk. “[Saros: an eclipse plug-in for distributed party programming.](https://dl.acm.org/citation.cfm?id=1833319)” In Proceedings of the 2010 ICSE Workshop on Cooperative and Human Aspects of Software Engineering, 48-55. ACM Press, 2010.
 
-### Unreviewed research articles
+### Unreviewed Research Articles
 * Riad Djemili, Christopher Oezbek, and Stephan Salinger. “[Saros: Eine Eclipse-Erweiterung zur verteilten Paarprogrammierung.](http://www.inf.fu-berlin.de/inst/ag-se/pubs/saros-2007.pdf)” In Software Engineering 2007 - Beiträge zu den Workshops, P-106:317-320. GI-Edition - Lecture Notes in Informatics. Bonn: Köllen Verlag, 2007.
 
 ### Theses

--- a/docs/support/index.md
+++ b/docs/support/index.md
@@ -4,7 +4,7 @@ title: Support
 
 If you have problems while using Saros that cannot be solved via the [FAQ](../documentation/faq.md) or [troubleshooting](../documentation/troubleshooting.md) pages, you can contact the Saros team via:
 
-* our gitter user channel [![Gitter chat](https://badges.gitter.im/saros-project/user.png)](https://gitter.im/saros-project/saros/user)
+* our Gitter user channel [![Gitter chat](https://badges.gitter.im/saros-project/user.png)](https://gitter.im/saros-project/saros/user)
 * the [Saros user mailing list](https://groups.google.com/forum/#!forum/saros-user)
 * the [Saros developer mailing list](https://groups.google.com/forum/#!forum/saros-devel)
 


### PR DESCRIPTION
#### [DOC] Remove specific link address for sections in troubleshooting

#### [DOC] Fix title/heading capitalization

Correctly capitalizes the titles and headings for the website.

Fixes some minor typos and grammatical errors.

#### [DOC] Fix picture alignment in review documentation

#### [DOC] Fix broken references