### PR TITLE
[DOC] Remove server release link

### DIFF
--- a/docs/documentation/saros-server.md
+++ b/docs/documentation/saros-server.md
@@ -10,7 +10,7 @@ The use-case of the server is to host session independently of any participant. 
 
 ## Usage
 
-The Saros-Server is currently available in version **0.1.0** as a standalone jar on [our GitHub Releases](https://github.com/saros-project/saros/releases).
+The Saros-Server is currently not available for download, but is scheduled to be on the next Saros/E Release (no ETA).
 
 The server needs it's own XMPP account and can then be started via:
 `java -Dsaros.server.jid=max@mustermann.de -Dsaros.server.password=1234 -jar saros.server.jar`


### PR DESCRIPTION
The Server was about the be released, when these lines were written, but the release was delayed until the next Saros/E release for an important bugfix. This commit reflects this in the documentation.

Fixes #762
