### PR TITLE
Minor installation guide adjustment

### DIFF
--- a/docs/documentation/getting-started.md
+++ b/docs/documentation/getting-started.md
@@ -33,6 +33,9 @@ You need an **XMPP account** to use Saros.
 
 1.  You can **create a new account** within Saros by using the
     FU-Berlin servers.
+  - **Note:** Due to abuse by spammers, we had to disable in-band registration.
+    As a consequence, the "Create New Account..." button currently no longer works.
+    Instead, to create an account on our XMPP server, you can **visit our [signup page](https://saros-con.imp.fu-berlin.de:5280/register/new)**.
 2.  You can **use an existing account.**
     For example your Google mail address. **This is a
     valid XMPP accounts**.
@@ -302,6 +305,13 @@ Most interactions with the Saros session logic (like starting or ending a sessio
 This window is attached to the bottom right of the IDE by default.
 It is marked with the title "Saros" and the Saros icon (![saros icon](images/icons-i/saros.png)).
 All actions described in the following sections take place in this tool window.
+
+### Creating an XMPP Account
+
+Saros requires an XMPP account to connect to and communicate with other users. You can use an openly available XMPP server or [setup your own XMPP server](https://www.saros-project.org/documentation/setup-xmpp.html).
+
+Furthermore, we also host an XMPP server (`saros-con.imp.fu-berlin.de`) specifically for the purpose of Saros that is freely available.
+To use it, you will first have to create an account using the [signup page](https://saros-con.imp.fu-berlin.de:5280/register/new).
 
 ### Adding an XMPP Account
 

--- a/docs/documentation/getting-started.md
+++ b/docs/documentation/getting-started.md
@@ -363,7 +363,9 @@ You can then delete the first account, add a new account with the right values, 
 
 ### Changing User Colors
 
-- Open the IntelliJ settings and navigate to `"Editor" > "Color Scheme" > "Saros"`.
+
+- Open the [IntelliJ settings/preferences menu](https://www.jetbrains.com/help/idea/settings-preferences-dialog.html).
+- Navigate to `"Editor" > "Color Scheme" > "Saros"`.
 - Select the color scheme to change the colors for.
 - Expand the user whose colors to change.
   - Currently, Saros internally has the concept of 5 user colors that will be used locally. These will be negotiated and assigned to the session participants when a session is started. As a consequence, the other user in a two-user-session will not necessarily have the user color 1.

--- a/docs/documentation/installation.md
+++ b/docs/documentation/installation.md
@@ -84,8 +84,9 @@ Saros/I can be installed from the JetBrains plugin repository or from disk.
 
 Saros/I is currently released through the `alpha` release channel. To be able find the plugin on the market place, you will first have to add the `alpha` release channel to your list of plugin repositories. A guide on how to do this is given [here](https://plugins.jetbrains.com/docs/marketplace/custom-release-channels.html#CustomReleaseChannels-ConfiguringaCustomChannelinIntelliJPlatformBasedIDEs).
 
-- Choose "Settings..." > "Plugins".
-- Select the tab "Marketplace"
+- Open the [IntelliJ settings/preferences menu](https://www.jetbrains.com/help/idea/settings-preferences-dialog.html).
+- Select the "Plugins" section.
+- Select the tab "Marketplace".
 - Search for "Saros" in the search bar and select the entry from the list.
 - Click the "Install" button.
 - Close the settings menu.
@@ -95,7 +96,9 @@ Saros/I is currently released through the `alpha` release channel. To be able fi
 ### From Disk
 The zip file containing the plugin can be downloaded from our [release page](https://github.com/saros-project/saros/releases).
 
-- Choose "Settings..." > "Plugins".
+
+- Open the [IntelliJ settings/preferences menu](https://www.jetbrains.com/help/idea/settings-preferences-dialog.html).
+- Select the "Plugins" section.
 - Click the settings icon (gear/cog) and choose "Install plugin from disk...".
 - Navigate to the directory containing the plugin zip.
 - Select the zip file.


### PR DESCRIPTION
#### [DOC][I] Link to guide on how to access the IntelliJ settings menu

Removes the old working referencing how to open the settings menu as it
was missing a modifier. The documentation now instead just references
the official IntelliJ help page on how to access the settings page.

#### [DOC] Add description on how to create XMPP accounts on our server

In-band registration no longer works as it was disabled to protect
against abuse by spammers. This makes the "Create New Account..." button
in the Saros/E dialog no longer usable.

Adjusts the documentation to reflect this fact. Furthermore, it now
links to our signup page.