### PR TITLE
[E] Replace Roster call with ContactsService

### DIFF
--- a/eclipse/src/saros/ui/expressions/ContactPropertyTester.java
+++ b/eclipse/src/saros/ui/expressions/ContactPropertyTester.java
@@ -1,10 +1,9 @@
 package saros.ui.expressions;
 
 import org.eclipse.core.expressions.PropertyTester;
-import org.jivesoftware.smack.Roster;
 import saros.SarosPluginContext;
 import saros.net.xmpp.JID;
-import saros.net.xmpp.XMPPConnectionService;
+import saros.net.xmpp.contact.XMPPContactsService;
 import saros.repackaged.picocontainer.annotations.Inject;
 import saros.session.ISarosSession;
 import saros.session.ISarosSessionManager;
@@ -13,7 +12,7 @@ import saros.session.ISarosSessionManager;
 public class ContactPropertyTester extends PropertyTester {
 
   @Inject private ISarosSessionManager sessionManager;
-  @Inject private XMPPConnectionService connectionService;
+  @Inject private XMPPContactsService contactsService;
 
   public ContactPropertyTester() {
     SarosPluginContext.initComponent(this);
@@ -32,10 +31,10 @@ public class ContactPropertyTester extends PropertyTester {
 
       return session != null && session.getUsers().stream().anyMatch(u -> u.getJID().equals(jid));
     } else if ("isOnline".equals(property)) {
-
-      final Roster roster = connectionService.getRoster();
-
-      return roster != null && roster.getPresence(jid.getBareJID().toString()).isAvailable();
+      return contactsService
+          .getContact(jid.getBase())
+          .map(contact -> contact.getStatus().isOnline())
+          .orElse(false);
     }
 
     return false;


### PR DESCRIPTION
ContactPropertyTester was using a direct call to smack roster.