### PR TITLE
[BUILD][I] Adjust maximum heap size for 'runIDE' task

### DIFF
--- a/intellij/build.gradle
+++ b/intellij/build.gradle
@@ -6,6 +6,12 @@ sarosIntellij {
   intellijVersion = 'IC-2019.3'
 }
 
+runIde {
+  // set heap size for the test JVM(s)
+  minHeapSize = "128m"
+  maxHeapSize = "2048m"
+}
+
 dependencies {
   compile project(':saros.core')
 


### PR DESCRIPTION
Sets the maximum JVM heap size to 2048m. This is needed to not run into
issues when loading/indexing larger projects. In particular, it is
needed to avoid issues when loading the Saros sources in a test
instance.