### PR TITLE
[E] Always Open Contact List for New Contact

### DIFF
--- a/eclipse/src/saros/ui/model/session/SessionContentProvider.java
+++ b/eclipse/src/saros/ui/model/session/SessionContentProvider.java
@@ -11,6 +11,7 @@ import saros.editor.FollowModeManager;
 import saros.editor.IFollowModeListener;
 import saros.editor.ISharedEditorListener;
 import saros.net.xmpp.contact.IContactsUpdate;
+import saros.net.xmpp.contact.IContactsUpdate.UpdateType;
 import saros.net.xmpp.contact.XMPPContactsService;
 import saros.repackaged.picocontainer.annotations.Inject;
 import saros.session.ISarosSession;
@@ -97,7 +98,10 @@ public class SessionContentProvider extends TreeContentProvider {
 
   // TODO call update and not refresh
   private final IContactsUpdate contactsUpdate =
-      (contact, type) -> ViewerUtils.refresh(viewer, true);
+      (contact, type) -> {
+        if (type == UpdateType.ADDED) ViewerUtils.expandAll(viewer);
+        ViewerUtils.refresh(viewer, true);
+      };
 
   /*
    * as we have a filter installed that will hide contacts from the contact
@@ -200,7 +204,6 @@ public class SessionContentProvider extends TreeContentProvider {
 
   // TODO abstract !
   private void createHeaders(SessionInput input) {
-
     sessionHeaderElement =
         new SessionHeaderElement(viewer.getControl().getFont(), input, editorManager, collector);
 

--- a/eclipse/src/saros/ui/widgets/viewer/session/XMPPSessionDisplayComposite.java
+++ b/eclipse/src/saros/ui/widgets/viewer/session/XMPPSessionDisplayComposite.java
@@ -1,11 +1,7 @@
 package saros.ui.widgets.viewer.session;
 
-import org.apache.log4j.Logger;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.swt.widgets.Composite;
-import saros.communication.connection.ConnectionHandler;
-import saros.communication.connection.IConnectionStateListener;
-import saros.net.ConnectionState;
 import saros.net.xmpp.contact.XMPPContactsService;
 import saros.repackaged.picocontainer.annotations.Inject;
 import saros.session.internal.SarosSession;
@@ -15,7 +11,6 @@ import saros.ui.model.roster.RosterContentProvider;
 import saros.ui.model.session.SessionComparator;
 import saros.ui.model.session.SessionContentProvider;
 import saros.ui.model.session.SessionInput;
-import saros.ui.util.SWTUtils;
 
 /**
  * This {@link Composite} displays the {@link SarosSession} and the Contact list in parallel.
@@ -33,33 +28,13 @@ import saros.ui.util.SWTUtils;
  */
 public final class XMPPSessionDisplayComposite extends SessionDisplayComposite {
 
-  private static final Logger LOG = Logger.getLogger(XMPPSessionDisplayComposite.class);
-
-  @Inject private ConnectionHandler connectionHandler;
   @Inject private XMPPContactsService contactsService;
-
-  private final IConnectionStateListener connectionListener =
-      (state, error) -> {
-        if (state == ConnectionState.CONNECTED || state == ConnectionState.NOT_CONNECTED) {
-          SWTUtils.runSafeSWTAsync(
-              LOG,
-              () -> {
-                if (getViewer().getControl().isDisposed()) return;
-
-                updateViewer();
-                getViewer().expandAll();
-              });
-        }
-      };
 
   public XMPPSessionDisplayComposite(Composite parent, int style) {
     super(parent, style);
-    connectionHandler.addConnectionStateListener(connectionListener);
 
     addDisposeListener(
         e -> {
-          connectionHandler.removeConnectionStateListener(connectionListener);
-          connectionHandler = null;
           contactsService = null;
         });
   }


### PR DESCRIPTION
 #### [E] Always Open Contact List for New Contact

Always open the UI contact list when a new contact was presented by the
XMPPContactsService. This fixes #796 where this wasn't done after
connecting (introduced with changes for ContactService) and also fixes
an older STF Problem / UI Problem when the list stayed collapsed due to
be empty before.

#### [E] Remove Unnecessary Hook to Expand Contact List 