### PR TITLE
[DOC][S] Add information on building the Saros server yourself

### DIFF
--- a/docs/documentation/saros-server.md
+++ b/docs/documentation/saros-server.md
@@ -12,6 +12,10 @@ The use-case of the server is to host session independently of any participant. 
 
 The Saros-Server is currently not available for download, but is scheduled to be on the next Saros/E Release (no ETA).
 
+If you would like to use the server in the meantime, you will have to build it yourself.
+Furthermore, to start a session with the server through the Saros/E GUI, you will also have to build the Saros/E versions you want to use with the server yourself.
+A guide on how to build Saros (and its different components) is given [here](../contribute/development-environment.md).
+
 The server needs it's own XMPP account and can then be started via:
 `java -Dsaros.server.jid=max@mustermann.de -Dsaros.server.password=1234 -jar saros.server.jar`
 


### PR DESCRIPTION
Adds a note that the Saros server has to be build manually if you would
like to use it before it is released with the next Saros/E minor
release. Also adds a note on the necessity to also build Saros/E to
access some server-related GUI features.

This was done to avoid future confusion on how to obtain a version of
the Saros server.