### PR TITLE
Update to Eclipse 4.8

### DIFF
--- a/buildSrc/src/main/java/saros/gradle/eclipse/SarosEclipseExtension.java
+++ b/buildSrc/src/main/java/saros/gradle/eclipse/SarosEclipseExtension.java
@@ -24,7 +24,7 @@ import java.util.List;
  */
 public class SarosEclipseExtension {
   private File manifest = null;
-  private String eclipseVersion = "4.6.3";
+  private String eclipseVersion = "4.8.0";
   private List<String> excludeManifestDependencies = new ArrayList<>();
   private boolean addDependencies = false;
   private boolean addPdeNature = false;

--- a/stf.test/test/saros/stf/test/chatview/ChatViewFunctionsTest.java
+++ b/stf.test/test/saros/stf/test/chatview/ChatViewFunctionsTest.java
@@ -127,6 +127,8 @@ public class ChatViewFunctionsTest extends StfTestCase {
             .getChatMessage());
   }
 
+  // TODO: The test fails in single execution and succeeds
+  //       if the whole test class is executed.
   @Test
   public void testVisualChatNotification() throws Exception {
 

--- a/stf.test/test/saros/stf/test/session/EstablishSessionWithDifferentTransportModesTest.java
+++ b/stf.test/test/saros/stf/test/session/EstablishSessionWithDifferentTransportModesTest.java
@@ -3,11 +3,11 @@ package saros.stf.test.session;
 import static org.junit.Assert.assertEquals;
 import static saros.stf.client.tester.SarosTester.ALICE;
 import static saros.stf.client.tester.SarosTester.BOB;
+import static saros.stf.shared.Constants.APPLY_AND_CLOSE;
 import static saros.stf.shared.Constants.MENU_PREFERENCES;
 import static saros.stf.shared.Constants.MENU_SAROS;
 import static saros.stf.shared.Constants.NODE_SAROS;
 import static saros.stf.shared.Constants.NODE_SAROS_NETWORK;
-import static saros.stf.shared.Constants.OK;
 import static saros.stf.shared.Constants.PREF_NODE_SAROS_NETWORK_TRANSPORT_MODE_GROUP;
 import static saros.stf.shared.Constants.PREF_NODE_SAROS_NETWORK_TRANSPORT_MODE_IBB_CHECKBOX;
 import static saros.stf.shared.Constants.PREF_NODE_SAROS_NETWORK_TRANSPORT_MODE_SOCKS5_MEDIATED_CHECKBOX;
@@ -127,7 +127,7 @@ public class EstablishSessionWithDifferentTransportModesTest extends StfTestCase
             .select();
       }
 
-      shell.bot().button(OK).click();
+      shell.bot().button(APPLY_AND_CLOSE).click();
       shell.waitShortUntilIsClosed();
     }
   }

--- a/stf/src/saros/stf/server/rmi/superbot/component/menubar/menu/submenu/impl/SarosPreferences.java
+++ b/stf/src/saros/stf/server/rmi/superbot/component/menubar/menu/submenu/impl/SarosPreferences.java
@@ -50,7 +50,7 @@ public final class SarosPreferences extends StfRemoteObject implements ISarosPre
     createAccountShell.bot().button(NEXT).click();
     createAccountShell.bot().button(FINISH).click();
     createAccountShell.bot().button(APPLY).click();
-    createAccountShell.bot().button(OK).click();
+    createAccountShell.bot().button(APPLY_AND_CLOSE).click();
 
     preferencesShell.bot().waitUntil(SarosConditions.isShellClosed(preferencesShell));
   }
@@ -63,7 +63,7 @@ public final class SarosPreferences extends StfRemoteObject implements ISarosPre
     SuperBot.getInstance().confirmShellAddXMPPAccount(jid, password);
 
     shell.bot().button(APPLY).click();
-    shell.bot().button(OK).click();
+    shell.bot().button(APPLY_AND_CLOSE).click();
     shell.bot().waitUntil(SarosConditions.isShellClosed(shell));
   }
 
@@ -90,7 +90,7 @@ public final class SarosPreferences extends StfRemoteObject implements ISarosPre
     assert shell.bot().label(LABEL_ACTIVE_ACCOUNT_PREFIX + jid.getBase()).isVisible();
 
     shell.bot().button(APPLY).click();
-    shell.bot().button(OK).click();
+    shell.bot().button(APPLY_AND_CLOSE).click();
     shell.bot().waitUntil(SarosConditions.isShellClosed(shell));
   }
 
@@ -103,7 +103,7 @@ public final class SarosPreferences extends StfRemoteObject implements ISarosPre
     shell.bot().buttonInGroup(BUTTON_EDIT_ACCOUNT, GROUP_TITLE_XMPP_JABBER_ACCOUNTS).click();
     SuperBot.getInstance().confirmShellEditXMPPAccount(newXmppJabberID, newPassword);
     shell.bot().button(APPLY).click();
-    shell.bot().button(OK).click();
+    shell.bot().button(APPLY_AND_CLOSE).click();
     shell.bot().waitUntil(SarosConditions.isShellClosed(shell));
   }
 
@@ -129,7 +129,7 @@ public final class SarosPreferences extends StfRemoteObject implements ISarosPre
           .waitUntil(Conditions.shellCloses(removeAccountConfirmationShell));
 
       shell.bot().button(APPLY).click();
-      shell.bot().button(OK).click();
+      shell.bot().button(APPLY_AND_CLOSE).click();
       shell.bot().waitUntil(Conditions.shellCloses(shell));
     } else throw new RuntimeException("button to delete an account is not enabled");
   }
@@ -166,7 +166,7 @@ public final class SarosPreferences extends StfRemoteObject implements ISarosPre
     assert shell.bot().listInGroup(GROUP_TITLE_XMPP_JABBER_ACCOUNTS).itemCount() == 1;
 
     shell.bot().button(APPLY).click();
-    shell.bot().button(OK).click();
+    shell.bot().button(APPLY_AND_CLOSE).click();
     shell.bot().waitUntil(Conditions.shellCloses(shell));
   }
 
@@ -202,7 +202,7 @@ public final class SarosPreferences extends StfRemoteObject implements ISarosPre
     else checkBox.deselect();
 
     shell.bot().button(APPLY).click();
-    shell.bot().button(OK).click();
+    shell.bot().button(APPLY_AND_CLOSE).click();
 
     shell.bot().waitUntil(SarosConditions.isShellClosed(shell));
   }
@@ -223,7 +223,7 @@ public final class SarosPreferences extends StfRemoteObject implements ISarosPre
               Messages.getString("feedback.page.group.interval"))
           .click();
       shell.bot().button(APPLY).click();
-      shell.bot().button(OK).click();
+      shell.bot().button(APPLY_AND_CLOSE).click();
       shell.bot().waitUntil(SarosConditions.isShellClosed(shell));
     }
   }
@@ -379,7 +379,7 @@ public final class SarosPreferences extends StfRemoteObject implements ISarosPre
     else checkBox.deselect();
 
     shell.bot().button(APPLY).click();
-    shell.bot().button(OK).click();
+    shell.bot().button(APPLY_AND_CLOSE).click();
 
     shell.bot().waitUntil(SarosConditions.isShellClosed(shell));
   }
@@ -389,7 +389,7 @@ public final class SarosPreferences extends StfRemoteObject implements ISarosPre
     SWTBotShell shell = preCondition();
     shell.bot().button(RESTORE_DEFAULTS).click();
     shell.bot().button(APPLY).click();
-    shell.bot().button(OK).click();
+    shell.bot().button(APPLY_AND_CLOSE).click();
     shell.bot().waitUntil(SarosConditions.isShellClosed(shell));
   }
 }

--- a/stf/src/saros/stf/shared/Constants.java
+++ b/stf/src/saros/stf/shared/Constants.java
@@ -48,6 +48,7 @@ public interface Constants {
   // Title of Buttons
   public static final String YES = "Yes";
   public static final String OK = "OK";
+  public static final String APPLY_AND_CLOSE = "Apply and Close";
   public static final String NO = "No";
   public static final String CANCEL = "Cancel";
   public static final String FINISH = "Finish";

--- a/travis/script/stf/shared_vars.sh
+++ b/travis/script/stf/shared_vars.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
-stf_master_image="saros/ci_build:0.4"
-stf_slave_image="saros/stf_test_slave:0.4"
-stf_xmpp_image="saros/stf_xmpp_server:0.4"
+stf_master_image="saros/ci_build:0.5"
+stf_slave_image="saros/stf_test_slave:0.5"
+stf_xmpp_image="saros/stf_xmpp_server:0.5"
 
 stf_master_name="stf_master"
 stf_network_name="stf_test_network"


### PR DESCRIPTION
#### [BUILD] Switch to eclipse 4.8.0 (Oxygen)

#### [STF] Use renamed preference button

After eclipse 4.6 the button "Ok" was
renamed to "Apply and Close".