### PR TITLE
Fix wrong message name introduced in refactoring #814

### DIFF
--- a/intellij/src/saros/core/ui/eventhandler/UserStatusChangeHandler.java
+++ b/intellij/src/saros/core/ui/eventhandler/UserStatusChangeHandler.java
@@ -54,7 +54,7 @@ public class UserStatusChangeHandler {
         @Override
         public void userLeft(User user) {
           NotificationPanel.showInformation(
-              CoreUtils.format(Messages.UserStatusChangeHandler_user_left_text_message, user),
+              CoreUtils.format(Messages.UserStatusChangeHandler_user_left_message, user),
               Messages.UserStatusChangeHandler_user_left_title);
         }
       };

--- a/intellij/src/saros/intellij/ui/Messages.java
+++ b/intellij/src/saros/intellij/ui/Messages.java
@@ -124,7 +124,7 @@ public class Messages {
   public static String UserStatusChangeHandler_user_joined_title;
   public static String UserStatusChangeHandler_user_joined_message;
   public static String UserStatusChangeHandler_user_left_title;
-  public static String UserStatusChangeHandler_user_left_text_message;
+  public static String UserStatusChangeHandler_user_left_message;
   public static String UserStatusChangeHandler_permission_changed_title;
   public static String UserStatusChangeHandler_he_has_now_access_message;
   public static String UserStatusChangeHandler_you_have_now_access_message;

--- a/intellij/src/saros/intellij/util/MessageUtils.java
+++ b/intellij/src/saros/intellij/util/MessageUtils.java
@@ -32,7 +32,7 @@ public class MessageUtils {
         }
       }
     } catch (Exception e) {
-      // it can not happen anyway!
+      log.error("Failed to initialize messages", e);
     }
   }
 }


### PR DESCRIPTION
#### [FIX][I] Fix wrong message name introduced in refactoring #814

#### [FIX][I] Log exceptions thrown during initialization of messages

Such exceptions can actually be thrown if there is an entry in
Messages.java that is not present in the matching messages.properties
file.