### PR TITLE
[UI][I] Add "Create Account" entry referring to website

### DIFF
--- a/intellij/src/saros/intellij/ui/Messages.java
+++ b/intellij/src/saros/intellij/ui/Messages.java
@@ -62,6 +62,7 @@ public class Messages {
 
   public static String ConnectButton_tooltip;
   public static String ConnectButton_add_account;
+  public static String ConnectButton_create_account;
   public static String ConnectButton_configure_accounts;
   public static String ConnectButton_disconnect;
   public static String ConnectButton_account_creation_jid_title;
@@ -85,6 +86,8 @@ public class Messages {
   public static String ConnectButton_account_creation_xmpp_server_invalid_port_message;
   public static String ConnectButton_connect_to_new_account_title;
   public static String ConnectButton_connect_to_new_account_message;
+  public static String ConnectButton_create_account_title;
+  public static String ConnectButton_create_account_message;
 
   public static String AddContactButton_tooltip;
   public static String AddContactButton_contact_jid_dialog_title;

--- a/intellij/src/saros/intellij/ui/messages.properties
+++ b/intellij/src/saros/intellij/ui/messages.properties
@@ -49,6 +49,7 @@ LeaveSessionButton_terminate_tooltip=Terminate the current session
 
 ConnectButton_tooltip=Connect to and add XMPP accounts
 ConnectButton_add_account=Add account...
+ConnectButton_create_account=Create account...
 ConnectButton_configure_accounts=Configure accounts...
 ConnectButton_disconnect=Disconnect
 ConnectButton_account_creation_jid_title=Login
@@ -72,6 +73,8 @@ ConnectButton_account_creation_xmpp_server_invalid_port_title=Account Creation A
 ConnectButton_account_creation_xmpp_server_invalid_port_message=No valid server port entered.
 ConnectButton_connect_to_new_account_title=Connect to New Account?
 ConnectButton_connect_to_new_account_message=Connect to the created Account?\nNOTE: This will remove you from any sessions that are currently running without correctly informing the other participants.
+ConnectButton_create_account_title=In-Plugin Account Creation Not Supported
+ConnectButton_create_account_message=In-plugin account creation is currently not supported.\n\nTo create an account on our XMPP server 'saros-con.imp.fu-berlin.de', please visit the website \"https://saros-con.imp.fu-berlin.de:5280/register/new\".
 
 AddContactButton_tooltip=Add a contact to the currently connected account.
 AddContactButton_contact_jid_dialog_title=Add Contact – User-ID

--- a/intellij/src/saros/intellij/ui/util/SafeDialogUtils.java
+++ b/intellij/src/saros/intellij/ui/util/SafeDialogUtils.java
@@ -124,6 +124,21 @@ public class SafeDialogUtils {
   }
 
   /**
+   * Asynchronously shows an info dialog.
+   *
+   * @param project the project used as a reference to generate and position the dialog
+   * @param message the text displayed as the message of the dialog
+   * @param title the text displayed as the title of the dialog
+   */
+  public static void showInfo(Project project, final String message, final String title) {
+    LOG.info("Showing info dialog: " + title + " - " + message);
+
+    application.invokeLater(
+        () -> Messages.showInfoMessage(project, message, title),
+        ModalityState.defaultModalityState());
+  }
+
+  /**
    * Asynchronously shows an error dialog.
    *
    * @param project the project used as a reference to generate and position the dialog

--- a/intellij/src/saros/intellij/ui/views/buttons/ConnectButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/ConnectButton.java
@@ -35,6 +35,7 @@ public class ConnectButton extends AbstractToolbarButton {
   private final JPopupMenu popupMenu;
 
   private final JMenuItem addAccountItem;
+  private final JMenuItem createAccountItem;
   private final JMenuItem configureAccountItem;
   private final JMenuItem disconnectItem;
 
@@ -71,6 +72,7 @@ public class ConnectButton extends AbstractToolbarButton {
     popupMenu = new JBPopupMenu();
 
     addAccountItem = createAddAccountMenuItem();
+    createAccountItem = createCreateAccountMenuItem();
     configureAccountItem = createConfigureAccountMenuItem();
     disconnectItem = createDisconnectMenuItem();
 
@@ -116,6 +118,19 @@ public class ConnectButton extends AbstractToolbarButton {
     return addAccountItem;
   }
 
+  private JMenuItem createCreateAccountMenuItem() {
+    JMenuItem createAccountItem = getPreconfiguredMenuItem(Messages.ConnectButton_create_account);
+
+    createAccountItem.addActionListener(
+        (actionEvent) ->
+            SafeDialogUtils.showInfo(
+                project,
+                Messages.ConnectButton_create_account_message,
+                Messages.ConnectButton_create_account_title));
+
+    return createAccountItem;
+  }
+
   private JMenuItem createConfigureAccountMenuItem() {
     JMenuItem configureAccountItem =
         getPreconfiguredMenuItem(Messages.ConnectButton_configure_accounts);
@@ -146,6 +161,7 @@ public class ConnectButton extends AbstractToolbarButton {
 
     popupMenu.addSeparator();
     popupMenu.add(addAccountItem);
+    popupMenu.add(createAccountItem);
 
     if (ENABLE_CONFIGURE_ACCOUNTS) {
       popupMenu.add(configureAccountItem);


### PR DESCRIPTION
Adds an entry "Create Account" to the connection menu.

The entry opens a dialog referring the user to our account creation
website.

The option was added to better guide users to the account creation
website and provide at least some kind of integration while we are not
able to provide in-plugin account creation.