### PR TITLE
[FIX][I] #819 Only attribute undoable action to modified editor

### DIFF
--- a/intellij/src/saros/intellij/editor/DocumentAPI.java
+++ b/intellij/src/saros/intellij/editor/DocumentAPI.java
@@ -100,7 +100,7 @@ public class DocumentAPI {
               commandName,
               commandProcessor.getCurrentCommandGroupId(),
               UndoConfirmationPolicy.REQUEST_CONFIRMATION,
-              document);
+              false);
         };
 
     Filesystem.runWriteAction(insertCommand, ModalityState.defaultModalityState());
@@ -114,18 +114,18 @@ public class DocumentAPI {
    * project.
    *
    * @param project the project to assign the resulting deletion action to
-   * @param doc the document to delete text from
+   * @param document the document to delete text from
    * @param start the start offset of the range to delete
    * @param end the end offset of the range to delete
    * @see Document#deleteString(int, int)
    * @see CommandProcessor
    */
   static void deleteText(
-      @NotNull Project project, @NotNull final Document doc, final int start, final int end) {
+      @NotNull Project project, @NotNull final Document document, final int start, final int end) {
 
     Runnable deletionCommand =
         () -> {
-          Runnable deleteRange = () -> doc.deleteString(start, end);
+          Runnable deleteRange = () -> document.deleteString(start, end);
 
           String commandName = "Saros text deletion from index " + start + " to " + end;
 
@@ -135,7 +135,7 @@ public class DocumentAPI {
               commandName,
               commandProcessor.getCurrentCommandGroupId(),
               UndoConfirmationPolicy.REQUEST_CONFIRMATION,
-              doc);
+              false);
         };
 
     Filesystem.runWriteAction(deletionCommand, ModalityState.defaultModalityState());


### PR DESCRIPTION
Adjusts the call to the command processor to execute document
modification in order to assure that the modification is only attributed
to the modified document and not also the currently selected/active
document.

This was done to prevent remote actions being attributed to the undo
stack of the currently selected document, even though the actions were
completely unrelated.

Fixes #819.