### PR TITLE
[BUILD] Rename intellij zip to saros-intellij.zip

### DIFF
--- a/buildSrc/src/main/java/saros/gradle/intellij/IntellijConfigurator.java
+++ b/buildSrc/src/main/java/saros/gradle/intellij/IntellijConfigurator.java
@@ -56,7 +56,6 @@ class IntellijConfigurator {
   private void configureDefaultParams(
       IntelliJPluginExtension intellijExtension, SarosIntellijExtension sarosExtension) {
     intellijExtension.setUpdateSinceUntilBuild(false);
-    intellijExtension.setPluginName(sarosExtension.getPluginName());
   }
 
   /**

--- a/buildSrc/src/main/java/saros/gradle/intellij/SarosIntellijExtension.java
+++ b/buildSrc/src/main/java/saros/gradle/intellij/SarosIntellijExtension.java
@@ -21,7 +21,6 @@ public class SarosIntellijExtension {
   private File sandboxBaseDir;
   private File localIntellijHome;
   private String intellijVersion;
-  private String pluginName = "Saros";
 
   /**
    * Set directory which contains the intellij sandbox directories.
@@ -63,18 +62,5 @@ public class SarosIntellijExtension {
 
   public String getIntellijVersion() {
     return intellijVersion;
-  }
-
-  /**
-   * Set the plugin name which is used in the build plugin.
-   *
-   * @param pluginName Name of the Intellij IDEA plugin
-   */
-  public void setPluginName(String pluginName) {
-    this.pluginName = pluginName;
-  }
-
-  public String getPluginName() {
-    return pluginName;
   }
 }

--- a/intellij/build.gradle
+++ b/intellij/build.gradle
@@ -6,6 +6,10 @@ sarosIntellij {
   intellijVersion = 'IC-2019.3'
 }
 
+intellij {
+  pluginName = 'saros-intellij'
+}
+
 runIde {
   // set heap size for the test JVM(s)
   minHeapSize = "128m"


### PR DESCRIPTION
Removed the pluginName of the custom gradle plugin,
because wrapping the whole intellij plugin is not useful.
Set the pluginName properties to the new name.
