### PR TITLE
[BUILD] Avoid redundant jars in intellij zip

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,3 +1,7 @@
+configurations {
+  plain
+}
+
 sarosEclipse {
   manifest = file('META-INF/MANIFEST.MF')
   createBundleJar = true
@@ -24,17 +28,30 @@ dependencies {
   releaseDep files('libs/smackx-3.4.1.jar')
 
   compile configurations.releaseDep
+  plain configurations.compile
   testCompile configurations.testConfig
 }
 
 sourceSets.main.java.srcDirs = ['src', 'patches']
 sourceSets.test.java.srcDir 'test/junit'
 
+// Jar tasks
+
 task testJar(type: Jar) {
   classifier = 'tests'
   from sourceSets.test.output
 }
 
+// Jar containing only the core code (the default jar is an osgi bundle
+// containing a lib dir with all dependency jars)
+task plainJar(type: Jar) {
+  manifest {
+    from 'META-INF/MANIFEST.MF'
+  }
+  from sourceSets.main.output
+}
+
 artifacts {
   testing testJar
+  plain plainJar
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -49,6 +49,7 @@ task plainJar(type: Jar) {
     from 'META-INF/MANIFEST.MF'
   }
   from sourceSets.main.output
+  classifier = 'plain'
 }
 
 artifacts {

--- a/intellij/build.gradle
+++ b/intellij/build.gradle
@@ -17,7 +17,7 @@ runIde {
 }
 
 dependencies {
-  compile project(':saros.core')
+  compile project(path: ':saros.core', configuration: 'plain')
 
   compile 'org.easytesting:fest-assert:1.2'
   compile 'org.easytesting:fest-reflect:1.2'


### PR DESCRIPTION
Fix #830

I tested:
* local execution
* import and build in IntelliJ
* import and build in Eclipse + launch config
