### PR TITLE
[BUILD] Build documentation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,6 @@ jobs:
 
   formatter:
     runs-on: ubuntu-latest
-    name: Check java format
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,4 @@
+# Has to be the same name as in build_doc in order to require the same check in GitHub
 name: Build
 
 on:

--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -1,0 +1,21 @@
+# Has to be the same name as in build in order to require the same check in GitHub
+name: Build
+
+on:
+  push:
+    paths:
+    - 'docs/**'
+  pull_request:
+    paths:
+    - 'docs/**'
+
+jobs: 
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Building jekyll documentation
+        uses: agentd00nut/jekyll-build-optional-deploy-gh-pages@v1
+        env: 
+          JEKYLL_ROOT: "docs/"
+          DEPLOY_SITE: "false"

--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -9,13 +9,22 @@ on:
     paths:
     - 'docs/**'
 
-jobs: 
+jobs:
+
+  formatter:
+    runs-on: ubuntu-latest
+    steps:
+      # NOP job needed to also have a formatter stage for doc builds
+      - name: NOP
+        run: echo "NOP"
+        shell: 'bash'
+
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Building jekyll documentation
         uses: agentd00nut/jekyll-build-optional-deploy-gh-pages@v1
-        env: 
+        env:
           JEKYLL_ROOT: "docs/"
           DEPLOY_SITE: "false"


### PR DESCRIPTION
#315 Build documentation via GitHub pages.
In order to avoid that we introduce broken
documentation into the master branch, this
workflow builds the jekyll pages.