### PR TITLE
Fix handling of non-text editors

### DIFF
--- a/intellij/src/saros/intellij/editor/DocumentAPI.java
+++ b/intellij/src/saros/intellij/editor/DocumentAPI.java
@@ -53,6 +53,29 @@ public class DocumentAPI {
   }
 
   /**
+   * Returns whether the document corresponding to the given file has unsaved changes.
+   *
+   * <p>Resources that don't have a matching document (i.e. that can't be opened in a text editor)
+   * are always seen as unmodified.
+   *
+   * @param file the file to check for unsaved changes
+   * @return whether the document corresponding to the given file has unsaved changes
+   */
+  public static boolean hasUnsavedChanges(@NotNull VirtualFile file) {
+    return fileDocumentManager.isFileModified(file);
+  }
+
+  /**
+   * Returns whether the given document has unsaved changes.
+   *
+   * @param document the document to check for unsaved changes
+   * @return whether the given document has unsaved changes
+   */
+  public static boolean hasUnsavedChanges(@NotNull Document document) {
+    return fileDocumentManager.isDocumentUnsaved(document);
+  }
+
+  /**
    * Saves the given document in the UI thread.
    *
    * @param document the document to save.

--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -396,7 +396,8 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
   }
 
   /**
-   * Adds all currently open editors belonging to the passed project to the pool of open editors.
+   * Adds all currently open text editors belonging to the passed project to the pool of open
+   * editors.
    *
    * @param project the added project
    */
@@ -437,7 +438,9 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
         Editor editor = localEditorHandler.openEditor(openFile, project, false);
 
-        openFileMapping.put(path, editor);
+        if (editor != null) {
+          openFileMapping.put(path, editor);
+        }
       }
 
     } finally {
@@ -999,7 +1002,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
    * @see #openEditor(SPath, boolean)
    * @see #startEditor(Editor)
    */
-  public void addEditorMapping(SPath file, Editor editor) {
+  public void addEditorMapping(@NotNull SPath file, @NotNull Editor editor) {
     startEditor(editor);
     editorPool.add(file, editor);
   }

--- a/intellij/src/saros/intellij/editor/LocalEditorHandler.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorHandler.java
@@ -70,8 +70,10 @@ public class LocalEditorHandler {
   }
 
   /**
-   * Opens an editor for the passed virtualFile, adds it to the pool of currently open editors and
-   * calls {@link EditorManager#startEditor(Editor)} with it.
+   * Opens an editor for the passed virtualFile.
+   *
+   * <p>If the editor is a text editor, it is also added to the pool of currently open editors and
+   * {@link EditorManager#startEditor(Editor)} is called with it.
    *
    * <p><b>Note:</b> This only works for shared resources that belong to the given module.
    *
@@ -79,7 +81,7 @@ public class LocalEditorHandler {
    * @param project module the file belongs to
    * @param activate activate editor after opening
    * @return the opened <code>Editor</code> or <code>null</code> if the given file does not belong
-   *     to a shared module
+   *     to a shared module or can not be represented by a text editor
    */
   @Nullable
   public Editor openEditor(
@@ -101,8 +103,10 @@ public class LocalEditorHandler {
   }
 
   /**
-   * Opens an editor for the passed virtualFile, adds it to the pool of currently open editors and
-   * calls {@link EditorManager#startEditor(Editor)} with it.
+   * Opens an editor for the passed virtualFile.
+   *
+   * <p>If the editor is a text editor, it is also added to the pool of currently open editors and
+   * {@link EditorManager#startEditor(Editor)} is called with it.
    *
    * <p><b>Note:</b> This only works for shared resources.
    *
@@ -113,7 +117,7 @@ public class LocalEditorHandler {
    * @param path saros resource representation of the file
    * @param activate activate editor after opening
    * @return the opened <code>Editor</code> or <code>null</code> if the given file does not exist or
-   *     does not belong to a shared module
+   *     does not belong to a shared module or can not be represented by a text editor
    */
   @Nullable
   private Editor openEditor(
@@ -133,6 +137,12 @@ public class LocalEditorHandler {
     Project project = path.getProject().adaptTo(IntelliJProjectImpl.class).getModule().getProject();
 
     Editor editor = ProjectAPI.openEditor(project, virtualFile, activate);
+
+    if (editor == null) {
+      LOG.debug("Ignoring non-text editor for file " + virtualFile);
+
+      return null;
+    }
 
     editorPool.add(path, editor);
     manager.startEditor(editor);

--- a/intellij/src/saros/intellij/editor/LocalEditorHandler.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorHandler.java
@@ -153,7 +153,9 @@ public class LocalEditorHandler {
   }
 
   /**
-   * Removes a file from the editorPool and calls {@link EditorManager#generateEditorClosed(SPath)}
+   * Removes a file from the editorPool and calls {@link EditorManager#generateEditorClosed(SPath)}.
+   *
+   * <p>Does nothing if the file is not shared.
    *
    * @param project the project in which to close the editor
    * @param virtualFile the file for which to close the editor

--- a/intellij/src/saros/intellij/editor/ProjectAPI.java
+++ b/intellij/src/saros/intellij/editor/ProjectAPI.java
@@ -2,8 +2,10 @@ package saros.intellij.editor;
 
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.OpenFileDescriptor;
+import com.intellij.openapi.fileEditor.TextEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -45,6 +47,27 @@ public class ProjectAPI {
     }
 
     return isOpen(project, file);
+  }
+
+  /**
+   * Returns whether there is an open text editor for the given file.
+   *
+   * @param project the project in which to check
+   * @param file the file to check
+   * @return whether there is an open text editor for the given file
+   */
+  public static boolean isOpenInTextEditor(@NotNull Project project, @NotNull VirtualFile file) {
+    FileEditorManager fileEditorManager = getFileEditorManager(project);
+
+    FileEditor[] fileEditors = EDTExecutor.invokeAndWait(() -> fileEditorManager.getEditors(file));
+
+    for (FileEditor fileEditor : fileEditors) {
+      if (fileEditor instanceof TextEditor) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   /**

--- a/intellij/src/saros/intellij/editor/ProjectAPI.java
+++ b/intellij/src/saros/intellij/editor/ProjectAPI.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import saros.intellij.runtime.EDTExecutor;
 import saros.intellij.runtime.FilesystemRunner;
 
@@ -52,8 +53,10 @@ public class ProjectAPI {
    * @param project the project in which to open the editor
    * @param virtualFile file for which to open an editor
    * @param activate activate editor after opening
-   * @return Editor managing the passed file
+   * @return text editor managing the passed file or <code>null</code> if the opened editor is not a
+   *     text editor
    */
+  @Nullable
   public static Editor openEditor(
       @NotNull Project project, @NotNull VirtualFile virtualFile, final boolean activate) {
 

--- a/intellij/src/saros/intellij/eventhandler/editor/editorstate/EditorStatusChangeActivityDispatcher.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/editorstate/EditorStatusChangeActivityDispatcher.java
@@ -1,17 +1,24 @@
 package saros.intellij.eventhandler.editor.editorstate;
 
+import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent;
 import com.intellij.openapi.fileEditor.FileEditorManagerListener;
+import com.intellij.openapi.fileEditor.TextEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.messages.MessageBusConnection;
 import org.jetbrains.annotations.NotNull;
 import saros.intellij.editor.LocalEditorHandler;
+import saros.intellij.editor.ProjectAPI;
 
 /**
  * Dispatches matching editor activities when an editor for a shared file is opened/selected or
  * closed.
+ *
+ * <p>The listener for closed editors is called before the editor is closed. This gives us the
+ * change to check the type of the editor before it is actually closed, which is necessary as we
+ * only care about text editors.
  */
 public class EditorStatusChangeActivityDispatcher extends AbstractLocalEditorStatusChangeHandler {
 
@@ -20,17 +27,20 @@ public class EditorStatusChangeActivityDispatcher extends AbstractLocalEditorSta
   private final FileEditorManagerListener fileEditorManagerListener =
       new FileEditorManagerListener() {
         @Override
-        public void fileClosed(@NotNull FileEditorManager source, @NotNull VirtualFile file) {
-          assert isEnabled() : "the file closed listener was triggered while it was disabled";
-
-          generateEditorClosedActivity(file);
-        }
-
-        @Override
         public void selectionChanged(@NotNull FileEditorManagerEvent event) {
           assert isEnabled() : "the selection changed listener was triggered while it was disabled";
 
           generateEditorActivatedActivity(event);
+        }
+      };
+
+  private final FileEditorManagerListener.Before beforeFileEditorManagerListener =
+      new FileEditorManagerListener.Before() {
+        @Override
+        public void beforeFileClosed(@NotNull FileEditorManager source, @NotNull VirtualFile file) {
+          assert isEnabled() : "the file closed listener was triggered while it was disabled";
+
+          generateEditorClosedActivity(file);
         }
       };
 
@@ -45,26 +55,39 @@ public class EditorStatusChangeActivityDispatcher extends AbstractLocalEditorSta
   /**
    * Calls {@link LocalEditorHandler#closeEditor(Project, VirtualFile)}.
    *
+   * <p>Does nothing if the closed editor is not a text editor.
+   *
    * @param virtualFile the file whose editor was closed
    * @see FileEditorManagerListener#fileClosed(FileEditorManager, VirtualFile)
    */
   private void generateEditorClosedActivity(@NotNull VirtualFile virtualFile) {
-    localEditorHandler.closeEditor(project, virtualFile);
+    if (ProjectAPI.isOpenInTextEditor(project, virtualFile)) {
+      localEditorHandler.closeEditor(project, virtualFile);
+    }
   }
 
   /**
    * Calls {@link LocalEditorHandler#activateEditor(Project, VirtualFile)}.
    *
+   * <p>Does nothing if the opened editor is not a text editor.
+   *
    * @param event the event to react to
    * @see FileEditorManagerListener#selectionChanged(FileEditorManagerEvent)
    */
   private void generateEditorActivatedActivity(@NotNull FileEditorManagerEvent event) {
-    localEditorHandler.activateEditor(project, event.getNewFile());
+    FileEditor newEditor = event.getNewEditor();
+
+    if (newEditor == null || newEditor instanceof TextEditor) {
+      localEditorHandler.activateEditor(project, event.getNewFile());
+    }
   }
 
   @Override
   void registerListeners(@NotNull MessageBusConnection messageBusConnection) {
     messageBusConnection.subscribe(
         fileEditorManagerListener.FILE_EDITOR_MANAGER, fileEditorManagerListener);
+
+    messageBusConnection.subscribe(
+        beforeFileEditorManagerListener.FILE_EDITOR_MANAGER, beforeFileEditorManagerListener);
   }
 }

--- a/intellij/src/saros/intellij/eventhandler/editor/editorstate/ViewportAdjustmentExecutor.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/editorstate/ViewportAdjustmentExecutor.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.messages.MessageBusConnection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import saros.editor.text.LineRange;
@@ -22,6 +23,8 @@ import saros.intellij.runtime.EDTExecutor;
  * adjustment once the corresponding editor is selected.
  */
 public class ViewportAdjustmentExecutor extends AbstractLocalEditorStatusChangeHandler {
+  private static final Logger log = Logger.getLogger(ViewportAdjustmentExecutor.class);
+
   private final LocalEditorManipulator localEditorManipulator;
 
   private static final Map<String, QueuedViewPortChange> queuedViewPortChanges =
@@ -79,6 +82,14 @@ public class ViewportAdjustmentExecutor extends AbstractLocalEditorStatusChangeH
 
     } else {
       editor = ProjectAPI.openEditor(project, virtualFile, false);
+
+      if (editor == null) {
+        log.warn(
+            "Failed to apply queued viewport change as no text editor could be obtained for "
+                + virtualFile);
+
+        return;
+      }
     }
 
     EDTExecutor.invokeAndWait(

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -1070,9 +1070,18 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
    * resource move is executed, meaning the new resource does not exist yet. The editor for the old
    * resource does however already exist. As the existing editor will be used for the new resource
    * once it is moved, we have to add the mapping for the new file onto the "old" editor manually.
+   *
+   * <p>Does nothing besides opening the editor if the moved file is not represented by a text
+   * editor.
    */
   private void setUpMovedEditorState(@NotNull VirtualFile oldFile, @NotNull SPath newFilePath) {
     Editor editor = ProjectAPI.openEditor(project, oldFile, false);
+
+    if (editor == null) {
+      LOG.debug("Ignoring non-text editor of moved file " + oldFile);
+
+      return;
+    }
 
     editorManager.addEditorMapping(newFilePath, editor);
   }

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -745,7 +745,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
       }
     }
 
-    boolean fileIsOpen = ProjectAPI.isOpen(project, oldFile);
+    boolean isOpenInTextEditor = ProjectAPI.isOpenInTextEditor(project, oldFile);
 
     IPath relativePath = getRelativePath(oldBaseParent, oldFile);
 
@@ -803,7 +803,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
               fileContent,
               encoding);
 
-      if (fileIsOpen) {
+      if (isOpenInTextEditor) {
         setUpMovedEditorState(oldFile, newFilePath);
       }
 
@@ -832,14 +832,14 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
     dispatchActivity(activity);
 
-    if (oldPathIsShared && fileIsOpen) {
+    if (oldPathIsShared && isOpenInTextEditor) {
       EditorActivity closeOldEditorActivity =
           new EditorActivity(user, EditorActivity.Type.CLOSED, oldFilePath);
 
       dispatchActivity(closeOldEditorActivity);
     }
 
-    if (newPathIsShared && fileIsOpen) {
+    if (newPathIsShared && isOpenInTextEditor) {
       SPath newFilePath =
           new SPath(
               newParentPath.getProject(),


### PR DESCRIPTION
#### [FIX][I] #711 Add null checks for logic opening editors

Adjusts the logic opening editors and using the obtained editor objects
to correctly handle null return values.

Adds missing Nullable annotations to the corresponding methods.

Adjusts the corresponding methods javadocs to better reflect the
possible return values in different cases.

Partial fix for #711.

#### [FIX][I] Only save modified documents

Adjusts the logic to only save documents whose content has been
modified.

Adds the logic to check whether a document or virtual file is seen as
modified to the DocumentAPI.

This was introduced to avoid save operations on resources that can not
be represented by a document (e.g. binary files). Such cases are now
filtered out as such files will always be seen as unmodified by the API,
creating a better handling of such cases.

#### [FIX][I] Only set up user editor state for moved text files

Adjusts the logic handling the user editor state of moved resources to
only act if the resource is currently open in a text editor.

This change ensures that only the state of text editors is shared with
other Saros instances.

#### [FIX][I] #711 Ignore non-text editors for editor state

Adjusts the logic sharing the local editor state to ignore the opening
of non-text editors.

Adjusts the logic sharing the local editor state to ignore the closing
of non-text editors.

Moves the closing logic to the before listener to allow us to access the
editor before it is actually closed. This is needed to check the editor
type.

With this change, non-text editors are completely ignored by Saros/I.
This was done to match the Eclipse handling of such non-text editors.

Partial fix for #711.