### PR TITLE
Refactor EDT handling

### DIFF
--- a/intellij/src/saros/core/ui/eventhandler/NegotiationHandler.java
+++ b/intellij/src/saros/core/ui/eventhandler/NegotiationHandler.java
@@ -1,6 +1,5 @@
 package saros.core.ui.eventhandler;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.WindowManager;
@@ -10,6 +9,7 @@ import org.apache.log4j.Logger;
 import saros.core.monitoring.IStatus;
 import saros.core.monitoring.Status;
 import saros.intellij.SarosComponent;
+import saros.intellij.runtime.EDTExecutor;
 import saros.intellij.runtime.UIMonitoredJob;
 import saros.intellij.ui.Messages;
 import saros.intellij.ui.util.NotificationPanel;
@@ -78,30 +78,28 @@ public class NegotiationHandler implements INegotiationHandler {
   private void showIncomingInvitationUI(
       Project project, final IncomingSessionNegotiation negotiation) {
 
-    ApplicationManager.getApplication()
-        .invokeLater(
-            () -> {
-              JoinSessionWizard wizard =
-                  new JoinSessionWizard(project, getWindow(project), negotiation);
-              wizard.setModal(true);
-              wizard.open();
-            },
-            ModalityState.defaultModalityState());
+    EDTExecutor.invokeLater(
+        () -> {
+          JoinSessionWizard wizard =
+              new JoinSessionWizard(project, getWindow(project), negotiation);
+          wizard.setModal(true);
+          wizard.open();
+        },
+        ModalityState.defaultModalityState());
   }
 
   private void showIncomingProjectUI(
       Project project, final AbstractIncomingProjectNegotiation negotiation) {
 
-    ApplicationManager.getApplication()
-        .invokeLater(
-            () -> {
-              AddProjectToSessionWizard wizard =
-                  new AddProjectToSessionWizard(project, getWindow(project), negotiation);
+    EDTExecutor.invokeLater(
+        () -> {
+          AddProjectToSessionWizard wizard =
+              new AddProjectToSessionWizard(project, getWindow(project), negotiation);
 
-              wizard.setModal(false);
-              wizard.open();
-            },
-            ModalityState.defaultModalityState());
+          wizard.setModal(false);
+          wizard.open();
+        },
+        ModalityState.defaultModalityState());
   }
 
   private Window getWindow(Project project) {
@@ -215,11 +213,7 @@ public class NegotiationHandler implements INegotiationHandler {
                 MessageFormat.format(
                     Messages.NegotiationHandler_project_sharing_canceled_message, peerName);
 
-            ApplicationManager.getApplication()
-                .invokeLater(
-                    () ->
-                        NotificationPanel.showInformation(
-                            message, "Project sharing canceled remotely"));
+            NotificationPanel.showInformation(message, "Project sharing canceled remotely");
 
             return new Status(IStatus.CANCEL, SarosComponent.PLUGIN_ID, message);
 

--- a/intellij/src/saros/core/ui/eventhandler/XMPPAuthorizationHandler.java
+++ b/intellij/src/saros/core/ui/eventhandler/XMPPAuthorizationHandler.java
@@ -1,8 +1,8 @@
 package saros.core.ui.eventhandler;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import java.text.MessageFormat;
+import saros.intellij.runtime.EDTExecutor;
 import saros.intellij.ui.Messages;
 import saros.intellij.ui.util.DialogUtils;
 import saros.intellij.ui.util.UIProjectUtils;
@@ -22,9 +22,7 @@ public class XMPPAuthorizationHandler {
         public void subscriptionRequestReceived(final JID jid) {
 
           projectUtils.runWithProject(
-              project ->
-                  ApplicationManager.getApplication()
-                      .invokeLater(() -> handleAuthorizationRequest(project, jid)));
+              project -> EDTExecutor.invokeLater(() -> handleAuthorizationRequest(project, jid)));
         }
       };
 

--- a/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
+++ b/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
@@ -22,7 +22,7 @@ import saros.intellij.preferences.PropertiesComponentAdapter;
 import saros.intellij.project.filesystem.IntelliJWorkspaceImpl;
 import saros.intellij.project.filesystem.IntelliJWorkspaceRootImpl;
 import saros.intellij.project.filesystem.PathFactory;
-import saros.intellij.runtime.IntelliJSynchronizer;
+import saros.intellij.runtime.IntellijUISynchronizer;
 import saros.intellij.ui.eventhandler.SessionStatusChangeHandler;
 import saros.intellij.ui.util.UIProjectUtils;
 import saros.monitoring.remote.IRemoteProgressIndicatorFactory;
@@ -57,7 +57,7 @@ public class SarosIntellijContextFactory extends AbstractContextFactory {
       Component.create(XMPPAuthorizationHandler.class),
       Component.create(SessionStatusChangeHandler.class),
       Component.create(IChecksumCache.class, NullChecksumCache.class),
-      Component.create(UISynchronizer.class, IntelliJSynchronizer.class),
+      Component.create(UISynchronizer.class, IntellijUISynchronizer.class),
       Component.create(IPreferenceStore.class, PropertiesComponentAdapter.class),
       Component.create(Preferences.class, IntelliJPreferences.class),
       Component.create(

--- a/intellij/src/saros/intellij/editor/DocumentAPI.java
+++ b/intellij/src/saros/intellij/editor/DocumentAPI.java
@@ -9,7 +9,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import saros.intellij.filesystem.Filesystem;
+import saros.intellij.runtime.FilesystemRunner;
 
 /**
  * Wrapper for interacting with the Intellij document API.
@@ -37,7 +37,7 @@ public class DocumentAPI {
       return null;
     }
 
-    return Filesystem.runReadAction(() -> fileDocumentManager.getDocument(virtualFile));
+    return FilesystemRunner.runReadAction(() -> fileDocumentManager.getDocument(virtualFile));
   }
 
   /**
@@ -58,13 +58,13 @@ public class DocumentAPI {
    * @param document the document to save.
    */
   public static void saveDocument(final Document document) {
-    Filesystem.runWriteAction(
+    FilesystemRunner.runWriteAction(
         () -> fileDocumentManager.saveDocument(document), ModalityState.NON_MODAL);
   }
 
   /** Saves all documents in the UI thread. */
   public static void saveAllDocuments() {
-    Filesystem.runWriteAction(fileDocumentManager::saveAllDocuments, ModalityState.NON_MODAL);
+    FilesystemRunner.runWriteAction(fileDocumentManager::saveAllDocuments, ModalityState.NON_MODAL);
   }
 
   /**
@@ -103,7 +103,7 @@ public class DocumentAPI {
               false);
         };
 
-    Filesystem.runWriteAction(insertCommand, ModalityState.defaultModalityState());
+    FilesystemRunner.runWriteAction(insertCommand, ModalityState.defaultModalityState());
   }
 
   /**
@@ -138,6 +138,6 @@ public class DocumentAPI {
               false);
         };
 
-    Filesystem.runWriteAction(deletionCommand, ModalityState.defaultModalityState());
+    FilesystemRunner.runWriteAction(deletionCommand, ModalityState.defaultModalityState());
   }
 }

--- a/intellij/src/saros/intellij/editor/EditorAPI.java
+++ b/intellij/src/saros/intellij/editor/EditorAPI.java
@@ -1,7 +1,5 @@
 package saros.intellij.editor;
 
-import com.intellij.openapi.application.Application;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.LogicalPosition;
@@ -11,6 +9,7 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import org.jetbrains.annotations.NotNull;
 import saros.editor.text.LineRange;
+import saros.intellij.runtime.EDTExecutor;
 
 /**
  * IntellJ editor API. An Editor is a window for editing source files.
@@ -18,8 +17,6 @@ import saros.editor.text.LineRange;
  * <p>Performs IntelliJ editor related actions in the UI thread.
  */
 public class EditorAPI {
-
-  private static final Application application = ApplicationManager.getApplication();
 
   private EditorAPI() {
     // NOP
@@ -40,7 +37,7 @@ public class EditorAPI {
    * @see LogicalPosition
    */
   static void scrollToViewPortCenter(final Editor editor, final int line) {
-    application.invokeAndWait(
+    EDTExecutor.invokeAndWait(
         () -> {
           LogicalPosition logicalPosition = new LogicalPosition(line, 0);
 

--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -1,6 +1,5 @@
 package saros.intellij.editor;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
@@ -43,6 +42,7 @@ import saros.intellij.eventhandler.IProjectEventHandler.ProjectEventHandlerType;
 import saros.intellij.eventhandler.editor.editorstate.ViewportAdjustmentExecutor;
 import saros.intellij.filesystem.IntelliJProjectImpl;
 import saros.intellij.filesystem.VirtualFileConverter;
+import saros.intellij.runtime.EDTExecutor;
 import saros.intellij.runtime.FilesystemRunner;
 import saros.observables.FileReplacementInProgressObservable;
 import saros.session.AbstractActivityConsumer;
@@ -892,8 +892,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
   }
 
   private void executeInUIThreadSynchronous(Runnable runnable) {
-    ApplicationManager.getApplication()
-        .invokeAndWait(runnable, ModalityState.defaultModalityState());
+    EDTExecutor.invokeAndWait(runnable, ModalityState.defaultModalityState());
   }
 
   @Override

--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -41,9 +41,9 @@ import saros.intellij.context.SharedIDEContext;
 import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.eventhandler.IProjectEventHandler.ProjectEventHandlerType;
 import saros.intellij.eventhandler.editor.editorstate.ViewportAdjustmentExecutor;
-import saros.intellij.filesystem.Filesystem;
 import saros.intellij.filesystem.IntelliJProjectImpl;
 import saros.intellij.filesystem.VirtualFileConverter;
+import saros.intellij.runtime.FilesystemRunner;
 import saros.observables.FileReplacementInProgressObservable;
 import saros.session.AbstractActivityConsumer;
 import saros.session.AbstractActivityProducer;
@@ -408,7 +408,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
     Set<VirtualFile> openFiles = new HashSet<>();
 
     for (VirtualFile openFile : ProjectAPI.getOpenFiles(intellijProject)) {
-      if (Filesystem.runReadAction(() -> moduleFileIndex.isInContent(openFile))) {
+      if (FilesystemRunner.runReadAction(() -> moduleFileIndex.isInContent(openFile))) {
         openFiles.add(openFile);
       }
     }
@@ -596,7 +596,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
   @Override
   public String getContent(final SPath path) {
-    return Filesystem.runReadAction(
+    return FilesystemRunner.runReadAction(
         () -> {
           VirtualFile virtualFile = VirtualFileConverter.convertToVirtualFile(path);
 

--- a/intellij/src/saros/intellij/editor/ProjectAPI.java
+++ b/intellij/src/saros/intellij/editor/ProjectAPI.java
@@ -8,6 +8,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
+import saros.intellij.runtime.EDTExecutor;
 import saros.intellij.runtime.FilesystemRunner;
 
 /** Static utility class for interacting with the project-level Intellij editor API. */
@@ -55,10 +56,13 @@ public class ProjectAPI {
    */
   public static Editor openEditor(
       @NotNull Project project, @NotNull VirtualFile virtualFile, final boolean activate) {
-    return FilesystemRunner.runReadAction(
+
+    FileEditorManager fileEditorManager = getFileEditorManager(project);
+
+    return EDTExecutor.invokeAndWait(
         () ->
-            getFileEditorManager(project)
-                .openTextEditor(new OpenFileDescriptor(project, virtualFile), activate));
+            fileEditorManager.openTextEditor(
+                new OpenFileDescriptor(project, virtualFile), activate));
   }
 
   /**
@@ -68,7 +72,9 @@ public class ProjectAPI {
    * @param virtualFile the file whose editor to close
    */
   public static void closeEditor(@NotNull Project project, @NotNull final VirtualFile virtualFile) {
-    FilesystemRunner.runReadAction(() -> getFileEditorManager(project).closeFile(virtualFile));
+    FileEditorManager fileEditorManager = getFileEditorManager(project);
+
+    EDTExecutor.invokeAndWait(() -> fileEditorManager.closeFile(virtualFile));
   }
 
   /**
@@ -89,7 +95,9 @@ public class ProjectAPI {
    * @return the currently selected editor
    */
   public static Editor getActiveEditor(@NotNull Project project) {
-    return getFileEditorManager(project).getSelectedTextEditor();
+    FileEditorManager fileEditorManager = getFileEditorManager(project);
+
+    return EDTExecutor.invokeAndWait(fileEditorManager::getSelectedTextEditor);
   }
 
   /**

--- a/intellij/src/saros/intellij/editor/ProjectAPI.java
+++ b/intellij/src/saros/intellij/editor/ProjectAPI.java
@@ -8,7 +8,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
-import saros.intellij.filesystem.Filesystem;
+import saros.intellij.runtime.FilesystemRunner;
 
 /** Static utility class for interacting with the project-level Intellij editor API. */
 public class ProjectAPI {
@@ -55,7 +55,7 @@ public class ProjectAPI {
    */
   public static Editor openEditor(
       @NotNull Project project, @NotNull VirtualFile virtualFile, final boolean activate) {
-    return Filesystem.runReadAction(
+    return FilesystemRunner.runReadAction(
         () ->
             getFileEditorManager(project)
                 .openTextEditor(new OpenFileDescriptor(project, virtualFile), activate));
@@ -68,7 +68,7 @@ public class ProjectAPI {
    * @param virtualFile the file whose editor to close
    */
   public static void closeEditor(@NotNull Project project, @NotNull final VirtualFile virtualFile) {
-    Filesystem.runReadAction(() -> getFileEditorManager(project).closeFile(virtualFile));
+    FilesystemRunner.runReadAction(() -> getFileEditorManager(project).closeFile(virtualFile));
   }
 
   /**
@@ -118,6 +118,6 @@ public class ProjectAPI {
    */
   public static boolean isExcluded(@NotNull Project project, @NotNull VirtualFile virtualFile) {
     ProjectFileIndex projectFileIndex = ProjectFileIndex.getInstance(project);
-    return Filesystem.runReadAction(() -> projectFileIndex.isExcluded(virtualFile));
+    return FilesystemRunner.runReadAction(() -> projectFileIndex.isExcluded(virtualFile));
   }
 }

--- a/intellij/src/saros/intellij/eventhandler/editor/editorstate/ViewportAdjustmentExecutor.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/editorstate/ViewportAdjustmentExecutor.java
@@ -1,6 +1,6 @@
 package saros.intellij.eventhandler.editor.editorstate;
 
-import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent;
 import com.intellij.openapi.fileEditor.FileEditorManagerListener;
@@ -15,6 +15,7 @@ import saros.editor.text.LineRange;
 import saros.editor.text.TextSelection;
 import saros.intellij.editor.LocalEditorManipulator;
 import saros.intellij.editor.ProjectAPI;
+import saros.intellij.runtime.EDTExecutor;
 
 /**
  * Queues viewport adjustments for editors that are not currently visible and executes the queued
@@ -80,8 +81,9 @@ public class ViewportAdjustmentExecutor extends AbstractLocalEditorStatusChangeH
       editor = ProjectAPI.openEditor(project, virtualFile, false);
     }
 
-    ApplicationManager.getApplication()
-        .invokeAndWait(() -> localEditorManipulator.adjustViewport(editor, range, selection));
+    EDTExecutor.invokeAndWait(
+        () -> localEditorManipulator.adjustViewport(editor, range, selection),
+        ModalityState.defaultModalityState());
   }
 
   /**

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -1,6 +1,5 @@
 package saros.intellij.eventhandler.filesystem;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
@@ -46,6 +45,7 @@ import saros.intellij.eventhandler.IApplicationEventHandler;
 import saros.intellij.eventhandler.editor.document.LocalDocumentModificationHandler;
 import saros.intellij.filesystem.VirtualFileConverter;
 import saros.intellij.project.filesystem.IntelliJPathImpl;
+import saros.intellij.runtime.EDTExecutor;
 import saros.intellij.runtime.FilesystemRunner;
 import saros.observables.FileReplacementInProgressObservable;
 import saros.session.AbstractActivityProducer;
@@ -149,20 +149,18 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
   @Override
   public void initialize() {
-    ApplicationManager.getApplication()
-        .invokeAndWait(
-            () -> session.addActivityProducer(LocalFilesystemModificationHandler.this),
-            ModalityState.defaultModalityState());
+    EDTExecutor.invokeAndWait(
+        () -> session.addActivityProducer(LocalFilesystemModificationHandler.this),
+        ModalityState.defaultModalityState());
 
     setEnabled(true);
   }
 
   @Override
   public void dispose() {
-    ApplicationManager.getApplication()
-        .invokeAndWait(
-            () -> session.removeActivityProducer(LocalFilesystemModificationHandler.this),
-            ModalityState.defaultModalityState());
+    EDTExecutor.invokeAndWait(
+        () -> session.removeActivityProducer(LocalFilesystemModificationHandler.this),
+        ModalityState.defaultModalityState());
 
     disposed = true;
     setEnabled(false);

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -44,9 +44,9 @@ import saros.intellij.editor.ProjectAPI;
 import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.eventhandler.IApplicationEventHandler;
 import saros.intellij.eventhandler.editor.document.LocalDocumentModificationHandler;
-import saros.intellij.filesystem.Filesystem;
 import saros.intellij.filesystem.VirtualFileConverter;
 import saros.intellij.project.filesystem.IntelliJPathImpl;
+import saros.intellij.runtime.FilesystemRunner;
 import saros.observables.FileReplacementInProgressObservable;
 import saros.session.AbstractActivityProducer;
 import saros.session.ISarosSession;
@@ -662,7 +662,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
     }
 
     Module module =
-        Filesystem.runReadAction(() -> ModuleUtil.findModuleForFile(virtualFile, project));
+        FilesystemRunner.runReadAction(() -> ModuleUtil.findModuleForFile(virtualFile, project));
 
     if (module == null) {
       return false;
@@ -732,7 +732,8 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
     if (newPathIsShared) {
       Module targetModule =
-          Filesystem.runReadAction(() -> ModuleUtil.findModuleForFile(newBaseParent, project));
+          FilesystemRunner.runReadAction(
+              () -> ModuleUtil.findModuleForFile(newBaseParent, project));
 
       if (targetModule != null) {
         VirtualFile moduleFile = targetModule.getModuleFile();

--- a/intellij/src/saros/intellij/filesystem/IntelliJFileImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFileImpl.java
@@ -17,6 +17,7 @@ import saros.filesystem.IFile;
 import saros.filesystem.IPath;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
+import saros.intellij.runtime.FilesystemRunner;
 
 public final class IntelliJFileImpl extends IntelliJResourceImpl implements IFile {
 
@@ -97,7 +98,7 @@ public final class IntelliJFileImpl extends IntelliJResourceImpl implements IFil
   @Override
   public void delete(final int updateFlags) throws IOException {
 
-    Filesystem.runWriteAction(
+    FilesystemRunner.runWriteAction(
         new ThrowableComputable<Void, IOException>() {
 
           @Override
@@ -168,7 +169,7 @@ public final class IntelliJFileImpl extends IntelliJResourceImpl implements IFil
   public void setContents(final InputStream input, final boolean force, final boolean keepHistory)
       throws IOException {
 
-    Filesystem.runWriteAction(
+    FilesystemRunner.runWriteAction(
         new ThrowableComputable<Void, IOException>() {
 
           @Override
@@ -221,7 +222,7 @@ public final class IntelliJFileImpl extends IntelliJResourceImpl implements IFil
   @Override
   public void create(@Nullable final InputStream input, final boolean force) throws IOException {
 
-    Filesystem.runWriteAction(
+    FilesystemRunner.runWriteAction(
         new ThrowableComputable<Void, IOException>() {
 
           @Override

--- a/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
@@ -18,6 +18,7 @@ import saros.filesystem.IPath;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
 import saros.intellij.project.filesystem.IntelliJPathImpl;
+import saros.intellij.runtime.FilesystemRunner;
 
 public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IFolder {
 
@@ -57,7 +58,7 @@ public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IF
 
     for (final VirtualFile child : children) {
 
-      if (!Filesystem.runReadAction(() -> moduleFileIndex.isInContent(child))) {
+      if (!FilesystemRunner.runReadAction(() -> moduleFileIndex.isInContent(child))) {
 
         continue;
       }
@@ -151,7 +152,7 @@ public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IF
   @Override
   public void delete(final int updateFlags) throws IOException {
 
-    Filesystem.runWriteAction(
+    FilesystemRunner.runWriteAction(
         new ThrowableComputable<Void, IOException>() {
 
           @Override
@@ -204,7 +205,7 @@ public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IF
   @Override
   public void create(final boolean force, final boolean local) throws IOException {
 
-    Filesystem.runWriteAction(
+    FilesystemRunner.runWriteAction(
         new ThrowableComputable<Void, IOException>() {
 
           @Override

--- a/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
@@ -22,6 +22,7 @@ import saros.filesystem.IPath;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
 import saros.intellij.project.filesystem.IntelliJPathImpl;
+import saros.intellij.runtime.FilesystemRunner;
 
 /** A <code>IntelliJProjectImpl</code> represents a specific module loaded in a specific project. */
 public final class IntelliJProjectImpl extends IntelliJResourceImpl implements IProject {
@@ -124,7 +125,7 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
 
     for (final VirtualFile child : children) {
 
-      if (!Filesystem.runReadAction(() -> moduleFileIndex.isInContent(child))) {
+      if (!FilesystemRunner.runReadAction(() -> moduleFileIndex.isInContent(child))) {
         continue;
       }
 
@@ -199,7 +200,8 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
   @Nullable
   private IPath getProjectRelativePath(@NotNull VirtualFile file) {
     ProjectFileIndex projectFileIndex = ProjectFileIndex.getInstance(project);
-    Module fileModule = Filesystem.runReadAction(() -> projectFileIndex.getModuleForFile(file));
+    Module fileModule =
+        FilesystemRunner.runReadAction(() -> projectFileIndex.getModuleForFile(file));
 
     if (!module.equals(fileModule)) {
       return null;
@@ -373,7 +375,8 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
     }
 
     ModuleFileIndex moduleFileIndex = ModuleRootManager.getInstance(module).getFileIndex();
-    boolean isInContent = Filesystem.runReadAction(() -> moduleFileIndex.isInContent(virtualFile));
+    boolean isInContent =
+        FilesystemRunner.runReadAction(() -> moduleFileIndex.isInContent(virtualFile));
 
     return isInContent ? virtualFile : null;
   }

--- a/intellij/src/saros/intellij/filesystem/VirtualFileConverter.java
+++ b/intellij/src/saros/intellij/filesystem/VirtualFileConverter.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.Nullable;
 import saros.activities.SPath;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
+import saros.intellij.runtime.FilesystemRunner;
 
 /**
  * Provides static methods to convert VirtualFiles to Saros resource objects or Saros resources
@@ -58,7 +59,7 @@ public class VirtualFileConverter {
       @NotNull Project project, @NotNull VirtualFile virtualFile) {
 
     Module module =
-        Filesystem.runReadAction(() -> ModuleUtil.findModuleForFile(virtualFile, project));
+        FilesystemRunner.runReadAction(() -> ModuleUtil.findModuleForFile(virtualFile, project));
 
     if (module == null) {
       log.debug(

--- a/intellij/src/saros/intellij/project/SharedResourcesManager.java
+++ b/intellij/src/saros/intellij/project/SharedResourcesManager.java
@@ -1,6 +1,5 @@
 package saros.intellij.project;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -22,6 +21,7 @@ import saros.intellij.editor.SelectedEditorStateSnapshot;
 import saros.intellij.editor.SelectedEditorStateSnapshotFactory;
 import saros.intellij.editor.annotations.AnnotationManager;
 import saros.intellij.eventhandler.IApplicationEventHandler.ApplicationEventHandlerType;
+import saros.intellij.runtime.EDTExecutor;
 import saros.repackaged.picocontainer.Startable;
 import saros.session.AbstractActivityConsumer;
 import saros.session.IActivityConsumer;
@@ -46,18 +46,15 @@ public class SharedResourcesManager implements Startable {
 
   @Override
   public void start() {
-    ApplicationManager.getApplication()
-        .invokeAndWait(
-            () -> sarosSession.addActivityConsumer(consumer, Priority.ACTIVE),
-            ModalityState.defaultModalityState());
+    EDTExecutor.invokeAndWait(
+        () -> sarosSession.addActivityConsumer(consumer, Priority.ACTIVE),
+        ModalityState.defaultModalityState());
   }
 
   @Override
   public void stop() {
-    ApplicationManager.getApplication()
-        .invokeAndWait(
-            () -> sarosSession.removeActivityConsumer(consumer),
-            ModalityState.defaultModalityState());
+    EDTExecutor.invokeAndWait(
+        () -> sarosSession.removeActivityConsumer(consumer), ModalityState.defaultModalityState());
   }
 
   public SharedResourcesManager(

--- a/intellij/src/saros/intellij/runtime/EDTExecutor.java
+++ b/intellij/src/saros/intellij/runtime/EDTExecutor.java
@@ -1,0 +1,130 @@
+package saros.intellij.runtime;
+
+import com.intellij.openapi.application.Application;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.util.Computable;
+import com.intellij.openapi.util.ThrowableComputable;
+import java.util.concurrent.atomic.AtomicReference;
+import org.jetbrains.annotations.NotNull;
+
+/** Provides centralized methods to run code synchronously on the event dispatcher thread (EDT). */
+public class EDTExecutor {
+  private static final Application application;
+
+  static {
+    application = ApplicationManager.getApplication();
+  }
+
+  /**
+   * Runs the passed computation synchronously on the EDT and returns the result.
+   *
+   * <p>If an exception occurs during the execution it is thrown back to the caller, including
+   * <i>RuntimeException<i> and <i>Error</i>.
+   *
+   * @param computation the computation to run
+   * @param modalityState the modality state to use
+   * @param <T> the type of the result of the computation
+   * @param <E> the type of the exception that might be thrown by the computation
+   * @return returns the result of the computation
+   * @throws E any exception that occurs while executing the computation
+   * @see Application#invokeAndWait(Runnable,ModalityState)
+   */
+  @SuppressWarnings("unchecked")
+  public static <T, E extends Throwable> T invokeAndWait(
+      @NotNull ThrowableComputable<T, E> computation, @NotNull ModalityState modalityState)
+      throws E {
+
+    AtomicReference<T> result = new AtomicReference<>();
+    AtomicReference<Throwable> throwable = new AtomicReference<>();
+
+    application.invokeAndWait(
+        () -> {
+          try {
+            result.set(computation.compute());
+
+          } catch (Throwable t) {
+            throwable.set(t);
+          }
+        },
+        modalityState);
+
+    Throwable t = throwable.get();
+
+    if (t == null) return result.get();
+
+    if (t instanceof Error) throw (Error) t;
+
+    if (t instanceof RuntimeException) throw (RuntimeException) t;
+
+    throw (E) t;
+  }
+
+  /**
+   * Executes the given computation synchronously on the EDT using the given modality state and
+   * returns the result of the computation.
+   *
+   * @param computation the computation to run
+   * @param modalityState the modality state to use
+   * @param <T> the type of the result of the computation
+   * @return the result of the computation
+   * @see Application#invokeAndWait(Runnable, ModalityState)
+   */
+  public static <T> T invokeAndWait(
+      @NotNull Computable<T> computation, @NotNull ModalityState modalityState) {
+
+    AtomicReference<T> result = new AtomicReference<>();
+
+    application.invokeAndWait(() -> result.set(computation.compute()), modalityState);
+
+    return result.get();
+  }
+
+  /**
+   * Calls {@link #invokeAndWait(Computable, ModalityState)} with {@link
+   * ModalityState#defaultModalityState()}.
+   */
+  public static <T> T invokeAndWait(@NotNull Computable<T> computation) {
+    return invokeAndWait(computation, ModalityState.defaultModalityState());
+  }
+
+  /**
+   * Executes the given runnable synchronously on the EDT using the given modality state.
+   *
+   * @param runnable the runnable to execute
+   * @param modalityState the modality state to use
+   * @see Application#invokeAndWait(Runnable, ModalityState)
+   */
+  public static void invokeAndWait(
+      @NotNull Runnable runnable, @NotNull ModalityState modalityState) {
+
+    application.invokeAndWait(runnable, modalityState);
+  }
+
+  /**
+   * Calls {@link #invokeAndWait(Runnable, ModalityState)} with {@link
+   * ModalityState#defaultModalityState()}.
+   */
+  public static void invokeAndWait(@NotNull Runnable runnable) {
+    invokeAndWait(runnable, ModalityState.defaultModalityState());
+  }
+
+  /**
+   * Executes the runnable asynchronously on the EDT using the given modality state.
+   *
+   * @param runnable the runnable to execute
+   * @param modalityState the modality state to use
+   * @see Application#invokeAndWait(Runnable, ModalityState)
+   */
+  public static void invokeLater(@NotNull Runnable runnable, @NotNull ModalityState modalityState) {
+    application.invokeLater(runnable, modalityState);
+  }
+
+  /**
+   * Calls {@link #invokeLater(Runnable, ModalityState)} with {@link
+   * ModalityState#defaultModalityState()}.
+   */
+  public static void invokeLater(@NotNull Runnable runnable) {
+    invokeLater(runnable, ModalityState.defaultModalityState());
+  }
+}

--- a/intellij/src/saros/intellij/runtime/FilesystemRunner.java
+++ b/intellij/src/saros/intellij/runtime/FilesystemRunner.java
@@ -44,16 +44,12 @@ public class FilesystemRunner {
     final AtomicReference<Throwable> throwable = new AtomicReference<>();
 
     application.invokeAndWait(
-        new Runnable() {
+        () -> {
+          try {
+            result.set(application.runWriteAction(computation));
 
-          @Override
-          public void run() {
-            try {
-              result.set(application.runWriteAction(computation));
-
-            } catch (Throwable t) {
-              throwable.set(t);
-            }
+          } catch (Throwable t) {
+            throwable.set(t);
           }
         },
         chosenModalityState);
@@ -84,15 +80,7 @@ public class FilesystemRunner {
     final ModalityState chosenModalityState =
         modalityState != null ? modalityState : ModalityState.defaultModalityState();
 
-    application.invokeAndWait(
-        new Runnable() {
-
-          @Override
-          public void run() {
-            application.runWriteAction(runnable);
-          }
-        },
-        chosenModalityState);
+    application.invokeAndWait(() -> application.runWriteAction(runnable), chosenModalityState);
   }
 
   /** @see Application#runReadAction(Computable computation) */

--- a/intellij/src/saros/intellij/runtime/FilesystemRunner.java
+++ b/intellij/src/saros/intellij/runtime/FilesystemRunner.java
@@ -62,9 +62,4 @@ public class FilesystemRunner {
   public static <T> T runReadAction(@NotNull Computable<T> computation) {
     return application.runReadAction(computation);
   }
-
-  /** @see Application#runReadAction(Runnable runnable) */
-  public static void runReadAction(@NotNull final Runnable runnable) {
-    application.runReadAction(runnable);
-  }
 }

--- a/intellij/src/saros/intellij/runtime/FilesystemRunner.java
+++ b/intellij/src/saros/intellij/runtime/FilesystemRunner.java
@@ -1,4 +1,4 @@
-package saros.intellij.filesystem;
+package saros.intellij.runtime;
 
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /** Provides centralized methods for synchronized write and read actions. */
-public class Filesystem {
+public class FilesystemRunner {
 
   private static final Application application;
 
@@ -18,7 +18,7 @@ public class Filesystem {
     application = ApplicationManager.getApplication();
   }
 
-  private Filesystem() {
+  private FilesystemRunner() {
     // NOP
   }
 

--- a/intellij/src/saros/intellij/runtime/IntellijUISynchronizer.java
+++ b/intellij/src/saros/intellij/runtime/IntellijUISynchronizer.java
@@ -11,9 +11,9 @@ import saros.synchronize.UISynchronizer;
  * Class implements the {@link UISynchronizer} with {@link Application#invokeLater(Runnable)} and
  * {@link Application#invokeAndWait(Runnable, ModalityState)}.
  */
-public class IntelliJSynchronizer implements UISynchronizer {
+public class IntellijUISynchronizer implements UISynchronizer {
 
-  private static final Logger log = Logger.getLogger(IntelliJSynchronizer.class);
+  private static final Logger log = Logger.getLogger(IntellijUISynchronizer.class);
 
   @Override
   public void asyncExec(Runnable runnable) {

--- a/intellij/src/saros/intellij/runtime/IntellijUISynchronizer.java
+++ b/intellij/src/saros/intellij/runtime/IntellijUISynchronizer.java
@@ -1,15 +1,15 @@
 package saros.intellij.runtime;
 
-import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.progress.ProcessCanceledException;
 import org.apache.log4j.Logger;
 import saros.synchronize.UISynchronizer;
 
 /**
- * Class implements the {@link UISynchronizer} with {@link Application#invokeLater(Runnable)} and
- * {@link Application#invokeAndWait(Runnable, ModalityState)}.
+ * Class implements the {@link UISynchronizer} by executing the given runnable on the event
+ * dispatcher thread (EDT).
+ *
+ * @see EDTExecutor
  */
 public class IntellijUISynchronizer implements UISynchronizer {
 
@@ -17,30 +17,21 @@ public class IntellijUISynchronizer implements UISynchronizer {
 
   @Override
   public void asyncExec(Runnable runnable) {
-    exec(runnable, true);
+    EDTExecutor.invokeLater(runnable);
   }
 
   @Override
   public void syncExec(Runnable runnable) {
-    exec(runnable, false);
+    try {
+      EDTExecutor.invokeAndWait(runnable);
+
+    } catch (ProcessCanceledException e) {
+      log.error("Synchronous execution on EDT interrupted - " + runnable, e);
+    }
   }
 
   @Override
   public boolean isUIThread() {
     return ApplicationManager.getApplication().isDispatchThread();
-  }
-
-  private void exec(Runnable runnable, boolean async) {
-    Application application = ApplicationManager.getApplication();
-
-    if (async) {
-      application.invokeLater(runnable, ModalityState.defaultModalityState());
-    } else {
-      try {
-        application.invokeAndWait(runnable, ModalityState.defaultModalityState());
-      } catch (ProcessCanceledException e) {
-        log.error("Synchronous execution on EDT interrupted - " + runnable, e);
-      }
-    }
   }
 }

--- a/intellij/src/saros/intellij/ui/actions/ConsistencyAction.java
+++ b/intellij/src/saros/intellij/ui/actions/ConsistencyAction.java
@@ -1,7 +1,7 @@
 package saros.intellij.ui.actions;
 
-import com.intellij.openapi.application.ApplicationManager;
 import saros.concurrent.watchdog.ConsistencyWatchdogClient;
+import saros.intellij.runtime.EDTExecutor;
 import saros.intellij.ui.Messages;
 import saros.intellij.ui.widgets.progress.ProgressFrame;
 import saros.monitoring.IProgressMonitor;
@@ -29,8 +29,7 @@ public class ConsistencyAction extends AbstractSarosAction {
 
     final ProgressFrame progress = new ProgressFrame("Consistency action");
 
-    progress.setFinishListener(
-        () -> ApplicationManager.getApplication().invokeLater(this::actionPerformed));
+    progress.setFinishListener(() -> EDTExecutor.invokeLater(this::actionPerformed));
 
     ThreadUtils.runSafeAsync(
         LOG,

--- a/intellij/src/saros/intellij/ui/menu/ShareWithUserAction.java
+++ b/intellij/src/saros/intellij/ui/menu/ShareWithUserAction.java
@@ -14,8 +14,8 @@ import org.apache.log4j.Logger;
 import saros.core.ui.util.CollaborationUtils;
 import saros.filesystem.IResource;
 import saros.intellij.context.SharedIDEContext;
-import saros.intellij.filesystem.Filesystem;
 import saros.intellij.filesystem.IntelliJProjectImpl;
+import saros.intellij.runtime.FilesystemRunner;
 import saros.intellij.ui.Messages;
 import saros.intellij.ui.util.IconManager;
 import saros.intellij.ui.util.NotificationPanel;
@@ -90,7 +90,8 @@ public class ShareWithUserAction extends AnAction {
   private IResource getModuleForVirtualFile(VirtualFile virtualFile, Project project) {
     ProjectFileIndex projectFileIndex = ProjectFileIndex.getInstance(project);
 
-    Module module = Filesystem.runReadAction(() -> projectFileIndex.getModuleForFile(virtualFile));
+    Module module =
+        FilesystemRunner.runReadAction(() -> projectFileIndex.getModuleForFile(virtualFile));
 
     if (module == null) {
       // FIXME: Find way to select moduleName for non-module based IDEAs (Webstorm)

--- a/intellij/src/saros/intellij/ui/util/NotificationPanel.java
+++ b/intellij/src/saros/intellij/ui/util/NotificationPanel.java
@@ -6,9 +6,9 @@ import com.intellij.notification.NotificationGroup;
 import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
-import com.intellij.openapi.application.ApplicationManager;
 import org.apache.log4j.Logger;
 import saros.SarosPluginContext;
+import saros.intellij.runtime.EDTExecutor;
 import saros.repackaged.picocontainer.annotations.Inject;
 
 /** Class uses Intellij API to show notifications */
@@ -54,8 +54,8 @@ public class NotificationPanel {
           final Notification notification =
               GROUP_DISPLAY_ID_INFO.createNotification(
                   title, message, notificationType, URL_OPENING_LISTENER);
-          ApplicationManager.getApplication()
-              .invokeLater(() -> Notifications.Bus.notify(notification, project));
+
+          EDTExecutor.invokeLater(() -> Notifications.Bus.notify(notification, project));
         });
   }
 

--- a/intellij/src/saros/intellij/ui/views/buttons/ConsistencyButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/ConsistencyButton.java
@@ -1,6 +1,5 @@
 package saros.intellij.ui.views.buttons;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -13,6 +12,7 @@ import saros.activities.SPath;
 import saros.concurrent.watchdog.ConsistencyWatchdogClient;
 import saros.concurrent.watchdog.IsInconsistentObservable;
 import saros.filesystem.IResource;
+import saros.intellij.runtime.EDTExecutor;
 import saros.intellij.ui.Messages;
 import saros.intellij.ui.actions.ConsistencyAction;
 import saros.intellij.ui.util.DialogUtils;
@@ -184,7 +184,7 @@ public class ConsistencyButton extends AbstractSessionToolbarButton {
 
     LOG.debug("Inconsistency indicator goes: " + (isInconsistent ? "on" : "off"));
 
-    ApplicationManager.getApplication().invokeLater(() -> setInconsistent(isInconsistent));
+    EDTExecutor.invokeLater(() -> setInconsistent(isInconsistent));
 
     if (!isInconsistent) {
       if (!previouslyInConsistentState) {
@@ -207,22 +207,16 @@ public class ConsistencyButton extends AbstractSessionToolbarButton {
 
     final String files = createInconsistentPathsMessage(paths);
 
-    ApplicationManager.getApplication()
-        .invokeLater(
-            () -> {
-              if (files.isEmpty()) {
-                NotificationPanel.showWarning(
-                    Messages.ConsistencyButton_message_inconsistency_detected_no_files,
-                    Messages.ConsistencyButton_title_inconsistency_detected);
+    if (files.isEmpty()) {
+      NotificationPanel.showWarning(
+          Messages.ConsistencyButton_message_inconsistency_detected_no_files,
+          Messages.ConsistencyButton_title_inconsistency_detected);
 
-                return;
-              }
-
-              NotificationPanel.showWarning(
-                  MessageFormat.format(
-                      Messages.ConsistencyButton_message_inconsistency_detected, files),
-                  Messages.ConsistencyButton_title_inconsistency_detected);
-            });
+    } else {
+      NotificationPanel.showWarning(
+          MessageFormat.format(Messages.ConsistencyButton_message_inconsistency_detected, files),
+          Messages.ConsistencyButton_title_inconsistency_detected);
+    }
   }
 
   private String createConfirmationMessage(Set<SPath> paths) {

--- a/intellij/src/saros/intellij/ui/wizards/AddProjectToSessionWizard.java
+++ b/intellij/src/saros/intellij/ui/wizards/AddProjectToSessionWizard.java
@@ -34,10 +34,10 @@ import saros.filesystem.IChecksumCache;
 import saros.filesystem.IProject;
 import saros.intellij.context.SharedIDEContext;
 import saros.intellij.editor.DocumentAPI;
-import saros.intellij.filesystem.Filesystem;
 import saros.intellij.filesystem.IntelliJProjectImpl;
 import saros.intellij.negotiation.ModuleConfiguration;
 import saros.intellij.negotiation.ModuleConfigurationInitializer;
+import saros.intellij.runtime.FilesystemRunner;
 import saros.intellij.ui.Messages;
 import saros.intellij.ui.util.NotificationPanel;
 import saros.intellij.ui.widgets.progress.ProgessMonitorAdapter;
@@ -429,7 +429,7 @@ public class AddProjectToSessionWizard extends Wizard {
     }
 
     Module module =
-        Filesystem.runWriteAction(
+        FilesystemRunner.runWriteAction(
             new ThrowableComputable<Module, IOException>() {
 
               @Override


### PR DESCRIPTION
This PR is mainly a refactoring, so there isn't a lot of interest happening. The main thing is moving the EDT runner logic from `Filesystem` to the new class `EDTExecutor` and then replacing direct calls to the EDT logic with calls to the new class.

Furthermore, a minor issue is fixed where calls in`ProjectAPI` were not run from the EDT even though they were required to.

#### [REFACTOR][I] Rename Filesystem to FilesystemRunner

Renames Filesystem to FilesystemRunner to better represent the
functionality of the class.

Subsequently moves it to the runtime package.

#### [REFACTOR][I] Use lambdas in FilesystemRunner

#### [REFACTOR][I] Rename IntelliJSynchronizer to IntellijUISynchronizer

#### [INTERNAL][I] Add EDTExecutor

Adds the class EDTExecutor offering methods to synchronously or
asynchronously run tasks on the event dispatcher thread (EDT).

This class was added to unify the logic needing access to such
capabilities. A followup commit will replace all current usage of the
direct logic to run tasks on the EDT with calls to the EDTExecutor.

#### [REFACTOR][I] Use EDTExecutor

Replaces all direct calls to Application.invokeAndWait(...) and
Application.invokeLater(...) with calls to the EDTExecutor.

Removes a couple of execution blocks for code that does not need to be
executed on the EDT.

#### [FIX][I] Execute code in EDT where necessary in ProjectAPI methods

Fixes some methods of the ProjectAPI that did not correctly run certain
calls on the EDT as required by their documentations.

Subsequently removes a now unused method from the FilesystemRunner that
was previously erroneously used to run code on the EDT.