### PR TITLE
Enable gradle build scan for github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,7 @@ jobs:
       run: |
         ./gradlew \
           -PskipTestSuites=true \
+          -PuseBuildScan=true \
           -PaggregateTestResults=true \
           -PversionQualifier=DEV-$SHORT_SHA \
           -DmaxParallelForks=4 \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
 
     # Uncomment <depends> entries in order to make Saros/I installable in all JetBrains IDEs
     - name: Prepare Saros/I plugin.xml
+      if: github.ref == 'refs/heads/master'
       run: |
         sed -i 's/<!--depends/<depends/g' intellij/resources/META-INF/plugin.xml
         sed -i 's/depends-->/depends>/g' intellij/resources/META-INF/plugin.xml


### PR DESCRIPTION
#### [FIX][BUILD] Enable gradle build scan for github builds

#### [BUILD][I] Only adjust plugin.xml on master builds

Adjusts the logic modifying the plugin.xml to only run when building on
the master branch.

The plugin.xml is adjusted to enable compatibility with all JetBrains
IDEs for dev builds. Therefore, this adjustment is only needed when
actually publishing the artifacts, i.e. when building the master branch.

Otherwise, this is only included as a superfluous build step cluttering
up the log.