### PR TITLE
[BUILD] Add jdk 11 cron build

### DIFF
--- a/.github/workflows/build_jdk11.yml
+++ b/.github/workflows/build_jdk11.yml
@@ -1,0 +1,33 @@
+# Has to be the same name as in build_doc in order to require the same check in GitHub
+name: Build JDK 11
+
+on:
+  schedule:
+    # Monday at 8:00
+    - cron: '0 8 * * 1'
+
+jobs:
+
+  build_jdk_11:
+    runs-on: ubuntu-latest
+
+    steps:
+    # Pre-Build
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+
+    # Build
+    - name: Build and test with Gradle
+      run: |
+        ./gradlew \
+          -PskipTestSuites=true \
+          -PuseBuildScan=true \
+          -PaggregateTestResults=true \
+          -PversionQualifier=DEV-$SHORT_SHA \
+          -DmaxParallelForks=4 \
+          --no-daemon \
+          --parallel \
+          sarosEclipse sarosIntellij sarosServer sarosLsp


### PR DESCRIPTION
In order to verify the compatibility of the Saros project
with JDK 11 we build the project each week with it.
