### PR TITLE
[INTERNAL][CORE] Remove text edit listener from FollowModeManager

### DIFF
--- a/core/src/saros/editor/FollowModeManager.java
+++ b/core/src/saros/editor/FollowModeManager.java
@@ -10,7 +10,6 @@ import saros.activities.IActivity;
 import saros.activities.SPath;
 import saros.activities.StartFollowingActivity;
 import saros.activities.StopFollowingActivity;
-import saros.activities.TextEditActivity;
 import saros.activities.TextSelectionActivity;
 import saros.activities.ViewportActivity;
 import saros.context.IContextFactory;
@@ -171,21 +170,6 @@ public class FollowModeManager implements Startable {
         @Override
         public void receive(TextSelectionActivity activity) {
           TextSelection selection = new TextSelection(activity.getOffset(), activity.getLength());
-
-          editorManager.adjustViewport(activity.getPath(), followeeRange(), selection);
-        }
-
-        /**
-         * {@inheritDoc}
-         *
-         * <p>TODO Find out whether this is actually necessary. If we receive a
-         * TextSelectionActivity for each cursor movement, then we don't need to listen for edits as
-         * well.
-         */
-        @Override
-        public void receive(TextEditActivity activity) {
-          int cursorOffset = activity.getOffset() + activity.getText().length();
-          TextSelection selection = new TextSelection(cursorOffset, 0);
 
           editorManager.adjustViewport(activity.getPath(), followeeRange(), selection);
         }


### PR DESCRIPTION
Removes the logic listening for text edits and adjusting the viewport
accordingly from the FollowModeManager.

As the comment on the corresponding method already states, the listener
is not necessary as the viewport will be updated anyways for the text
selection activity caused by the caret movement (that in turn is caused
by the text edit).

The only advantage this logic would offer is that it speeds up the
viewport adjustment. As the selection activity is processed after the
text edit activity, the text edit will be applied before the viewport is
adjusted. But, as the delay is very short and the edited text will be
highlighted anyways, this advantage is negligible.