### PR TITLE
[BUILD] Avoid duplicate content root entries

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -25,7 +25,6 @@
       <module name="saros.server_main" target="1.8" />
       <module name="saros.server_test" target="1.8" />
       <module name="saros.stf.test_main" target="1.8" />
-      <module name="saros.stf.test_stfFlakyAndFailingTest" target="1.8" />
       <module name="saros.stf.test_stfTest" target="1.8" />
       <module name="saros.stf.test_test" target="1.8" />
       <module name="saros.stf_main" target="1.8" />

--- a/stf.test/build.gradle
+++ b/stf.test/build.gradle
@@ -6,14 +6,10 @@ sarosEclipse {
 
 configurations {
     stfTest
-    stfFlakyAndFailingTest
 }
 
 sourceSets {
     stfTest {
-        java.srcDir 'test'
-    }
-    stfFlakyAndFailingTest {
         java.srcDir 'test'
     }
 }
@@ -25,12 +21,6 @@ dependencies {
     // TODO: The custom saros eclipse plugin adds all dependencies to implementation
     stfTestCompile configurations.implementation
     testCompile configurations.stfTestCompile // for running the tests in eclipse
-
-    stfFlakyAndFailingTestCompile project(':saros.stf')
-    stfFlakyAndFailingTestCompile project(path: ':saros.stf', configuration: 'testing')
-    stfFlakyAndFailingTestCompile configurations.testConfig
-    stfFlakyAndFailingTestCompile configurations.implementation
-    testCompile configurations.stfFlakyAndFailingTestCompile // for running the tests in eclipse
 }
 
 class StfTest extends Test {
@@ -73,8 +63,8 @@ task stfTest (type: StfTest, dependsOn: [':saros.eclipse:build']) {
 }
 
 task stfFlakyAndFailingTest (type: StfTest, dependsOn: [':saros.eclipse:build']) {
-    testClassesDirs = sourceSets.stfFlakyAndFailingTest.output.classesDirs
-    classpath = sourceSets.stfFlakyAndFailingTest.runtimeClasspath
+    testClassesDirs = sourceSets.stfTest.output.classesDirs
+    classpath = sourceSets.stfTest.runtimeClasspath
     ignoreFailures = true
     
     useJUnit {


### PR DESCRIPTION
Remove superfluous configuration that causes issues in eclipse and IntelliJ
fix #859 