### PR TITLE
Avoid not disappearing contribution annotations

### DIFF
--- a/eclipse/src/saros/editor/EditorManager.java
+++ b/eclipse/src/saros/editor/EditorManager.java
@@ -1055,7 +1055,7 @@ public class EditorManager implements IEditorManager {
       // Try to replace
       try {
         // Attention: This method also alters the annotation model if an
-        // annotation exists at the offset and the length &gt; 1
+        // annotation exists at the offset and the length > 1
         doc.replace(offset, replacedText.length(), text);
       } catch (BadLocationException e) {
         LOG.error(

--- a/eclipse/src/saros/editor/EditorManager.java
+++ b/eclipse/src/saros/editor/EditorManager.java
@@ -1074,9 +1074,6 @@ public class EditorManager implements IEditorManager {
           contributionAnnotationManager.insertAnnotation(model, offset, text.length(), source);
         }
       }
-
-      IAnnotationModel model = provider.getAnnotationModel(input);
-      contributionAnnotationManager.insertAnnotation(model, offset, text.length(), source);
     } finally {
       provider.disconnect(input);
     }

--- a/eclipse/src/saros/editor/EditorManager.java
+++ b/eclipse/src/saros/editor/EditorManager.java
@@ -633,14 +633,6 @@ public class EditorManager implements IEditorManager {
 
     // inform all registered ISharedEditorListeners about this text edit
     editorListenerDispatch.textEdited(textEdit);
-
-    /*
-     * TODO Investigate if this is really needed here
-     */
-    IEditorInput input = changedEditor.getEditorInput();
-    IDocumentProvider provider = EditorAPI.getDocumentProvider(input);
-    IAnnotationModel model = provider.getAnnotationModel(input);
-    contributionAnnotationManager.splitAnnotation(model, offset);
   }
 
   private void execEditorActivity(EditorActivity editorActivity) {

--- a/eclipse/src/saros/editor/EditorManager.java
+++ b/eclipse/src/saros/editor/EditorManager.java
@@ -1054,6 +1054,8 @@ public class EditorManager implements IEditorManager {
 
       // Try to replace
       try {
+        // Attention: This method also alters the annotation model if an
+        // annotation exists at the offset and the length &gt; 1
         doc.replace(offset, replacedText.length(), text);
       } catch (BadLocationException e) {
         LOG.error(

--- a/eclipse/src/saros/editor/internal/ContributionAnnotationHistory.java
+++ b/eclipse/src/saros/editor/internal/ContributionAnnotationHistory.java
@@ -2,6 +2,7 @@ package saros.editor.internal;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Queue;
@@ -85,6 +86,10 @@ class ContributionAnnotationHistory {
             + oldAnnotation
             + " in the current history for user: "
             + oldAnnotation.getSource());
+  }
+
+  protected void addNewEntry(ContributionAnnotation annotation) {
+    addNewEntry(Arrays.asList(annotation));
   }
 
   protected void addNewEntry(List<ContributionAnnotation> annotations) {

--- a/eclipse/src/saros/editor/internal/ContributionAnnotationHistory.java
+++ b/eclipse/src/saros/editor/internal/ContributionAnnotationHistory.java
@@ -1,0 +1,98 @@
+package saros.editor.internal;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Queue;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.log4j.Logger;
+import org.eclipse.jface.text.source.IAnnotationModel;
+import saros.editor.annotations.ContributionAnnotation;
+
+/** */
+class ContributionAnnotationHistory {
+
+  private static final Logger log = Logger.getLogger(ContributionAnnotationHistory.class);
+  Queue<List<ContributionAnnotation>> queue;
+  private int maxHistoryLength;
+
+  protected ContributionAnnotationHistory(int maxHistoryLength) {
+    this.queue = new ArrayDeque<>(maxHistoryLength);
+    this.maxHistoryLength = maxHistoryLength;
+  }
+
+  /**
+   * Removes all entries in the history and returns an aggregated list of all contribution
+   * annotations in the history.
+   *
+   * @return A flattened all history entries
+   */
+  protected List<ContributionAnnotation> clear() {
+    List<ContributionAnnotation> content = new ArrayList<>();
+    while (!queue.isEmpty()) {
+      content.addAll(queue.remove());
+    }
+    return content;
+  }
+
+  /** If the history */
+  protected Pair<IAnnotationModel, List<ContributionAnnotation>> removeHistoryEntry() {
+
+    Pair<IAnnotationModel, List<ContributionAnnotation>> removedEntry = null;
+
+    if (queue.size() == maxHistoryLength) {
+      List<ContributionAnnotation> annotations = queue.remove();
+      IAnnotationModel model = annotations.get(0).getModel();
+      for (ContributionAnnotation a : annotations) {
+        if (a.getModel() != model) throw new RuntimeException("Different Models");
+      }
+      removedEntry = new ImmutablePair<>(model, annotations);
+    }
+
+    return removedEntry;
+  }
+
+  /*
+   * Replaces the an annotation in the history with another one.
+   * E.g. if we want to replace the annotation D with D':
+   * [[A, B], [C], [D, E], [F], [G]] -> [[A, B], [C], [D', E], [F], [G]]
+   *
+   */
+  protected void replaceInHistory(
+      final ContributionAnnotation oldAnnotation, final ContributionAnnotation newAnnotation) {
+
+    for (List<ContributionAnnotation> entry : queue) {
+
+      for (final ListIterator<ContributionAnnotation> annotationsLit = entry.listIterator();
+          annotationsLit.hasNext(); ) {
+        final ContributionAnnotation annotation = annotationsLit.next();
+
+        if (annotation.equals(oldAnnotation)) {
+          annotationsLit.remove();
+
+          assert oldAnnotation.getSource().equals(newAnnotation.getSource());
+
+          annotationsLit.add(newAnnotation);
+          return;
+        }
+      }
+    }
+
+    log.warn(
+        "could not find annotation "
+            + oldAnnotation
+            + " in the current history for user: "
+            + oldAnnotation.getSource());
+  }
+
+  protected void addNewEntry(List<ContributionAnnotation> annotations) {
+    if (queue.size() >= maxHistoryLength) {
+      throw new IllegalStateException(
+          "The queue already contains the " + "allowed number of annotations.");
+    }
+
+    queue.add(annotations);
+  }
+}

--- a/eclipse/src/saros/editor/internal/ContributionAnnotationManager.java
+++ b/eclipse/src/saros/editor/internal/ContributionAnnotationManager.java
@@ -117,7 +117,7 @@ public class ContributionAnnotationManager {
 
     if (length > 1) {
       // Correct current model state to match with the assumption that all
-      // annotations have length &lt;= 1.
+      // annotations have length <= 1.
       enforceAnnotationsWithLengthOne(model);
     }
 
@@ -178,7 +178,7 @@ public class ContributionAnnotationManager {
       if (p.getLength() > 1) {
         annotationsToRemove.add(contrAnnotation);
 
-        // Expect only one annotation with length &gt; 1 created by
+        // Expect only one annotation with length > 1 created by
         // callers content change.
         break;
       }

--- a/eclipse/test/junit/saros/editor/internal/ContributionAnnotationHistoryTest.java
+++ b/eclipse/test/junit/saros/editor/internal/ContributionAnnotationHistoryTest.java
@@ -1,0 +1,109 @@
+package saros.editor.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.jface.text.source.AnnotationModel;
+import org.eclipse.jface.text.source.IAnnotationModel;
+import org.junit.Before;
+import org.junit.Test;
+import saros.editor.annotations.ContributionAnnotation;
+import saros.net.xmpp.JID;
+import saros.session.User;
+
+public class ContributionAnnotationHistoryTest {
+  private ContributionAnnotationHistory history;
+  private AnnotationModel testModel;
+  private static final int MAX_HISTORY_LENGTH = 20;
+
+  @Before
+  public void setUp() {
+    history = new ContributionAnnotationHistory(MAX_HISTORY_LENGTH);
+    testModel = new AnnotationModel();
+  }
+
+  @Test
+  public void testRemoveHistoryEntriesWithEmptyHistory() {
+    Pair<IAnnotationModel, List<ContributionAnnotation>> annotationsToRemove =
+        history.removeHistoryEntry();
+
+    assertNull(annotationsToRemove);
+  }
+
+  @Test
+  public void testAddEntries() {
+    final int nrOfEnries = 3;
+    fillHistory(nrOfEnries, testModel);
+
+    assertEquals(nrOfEnries, history.queue.size());
+  }
+
+  @Test
+  public void testRemoveHistoryEntriesWithPartiallyFilledHistory() {
+    final int nrOfEnries = 3;
+    fillHistory(nrOfEnries, testModel);
+
+    Pair<IAnnotationModel, List<ContributionAnnotation>> annotationsToRemove =
+        history.removeHistoryEntry();
+
+    assertNull(annotationsToRemove);
+    assertEquals(nrOfEnries, history.queue.size());
+  }
+
+  @Test
+  public void testRemoveHistoryEntriesWithFilledHistory() {
+    final int nrOfEnries = MAX_HISTORY_LENGTH - 1;
+    fillHistory(nrOfEnries, testModel);
+
+    Pair<IAnnotationModel, List<ContributionAnnotation>> annotationsToRemove =
+        history.removeHistoryEntry();
+
+    assertNull(annotationsToRemove);
+    assertEquals(nrOfEnries, history.queue.size());
+  }
+
+  @Test
+  public void testRemoveHistoryEntriesWithOverfilledHistory() {
+    final int nrOfEnries = MAX_HISTORY_LENGTH;
+    fillHistory(nrOfEnries, testModel);
+
+    Pair<IAnnotationModel, List<ContributionAnnotation>> annotationsToRemove =
+        history.removeHistoryEntry();
+
+    assertEquals(1, annotationsToRemove.getRight().size());
+    assertEquals(MAX_HISTORY_LENGTH - 1, history.queue.size());
+  }
+
+  @Test
+  public void testRemoveHistoryEntriesWithMultipleModels() {
+    AnnotationModel testModel2 = new AnnotationModel();
+
+    fillHistory(1, testModel2);
+    fillHistory(MAX_HISTORY_LENGTH - 1, testModel);
+
+    Pair<IAnnotationModel, List<ContributionAnnotation>> annotationsToRemove =
+        history.removeHistoryEntry();
+
+    assertEquals(testModel2, annotationsToRemove.getLeft());
+
+    fillHistory(1, testModel);
+    annotationsToRemove = history.removeHistoryEntry();
+
+    assertEquals(testModel, annotationsToRemove.getLeft());
+  }
+
+  private void fillHistory(int numberOfEntries, AnnotationModel model) {
+    for (int i = 0; i < numberOfEntries; i++) {
+      history.addNewEntry(createDummyAnnotation(model));
+    }
+  }
+
+  private List<ContributionAnnotation> createDummyAnnotation(AnnotationModel model) {
+    User dummyUser = new User(new JID("alice@test"), false, false, null);
+    ContributionAnnotation dummyAnnotation = new ContributionAnnotation(dummyUser, model);
+    return Arrays.asList(dummyAnnotation);
+  }
+}

--- a/eclipse/test/junit/saros/editor/internal/ContributionAnnotationManagerTest.java
+++ b/eclipse/test/junit/saros/editor/internal/ContributionAnnotationManagerTest.java
@@ -37,16 +37,28 @@ public class ContributionAnnotationManagerTest {
   private ContributionAnnotationManager manager;
   private ISarosSession sessionMock;
   private IPreferenceStore store;
+  private IAnnotationModel model;
 
   private Capture<ISessionListener> sessionListenerCapture;
 
   private static final int MAX_HISTORY_LENGTH = ContributionAnnotationManager.MAX_HISTORY_LENGTH;
+  private static final User ALICE_TEST_USER =
+      new User(new JID("ALICE_TEST_USER@test"), false, false, null);
+  private static final User BOB_TEST_USER = new User(new JID("bob@test"), false, false, null);
+  private static final User CARL_TEST_USER = new User(new JID("carl@test"), false, false, null);
+  private static final User DAVE_TEST_USER = new User(new JID("dave@test"), false, false, null);
 
   @Before
   public void setUp() {
     store = new PreferenceStore();
     store.setValue(EclipsePreferenceConstants.SHOW_CONTRIBUTION_ANNOTATIONS, true);
+    createListenerMocks();
 
+    manager = new ContributionAnnotationManager(sessionMock, store);
+    model = new AnnotationModel();
+  }
+
+  private void createListenerMocks() {
     sessionListenerCapture = EasyMock.newCapture();
 
     sessionMock = EasyMock.createNiceMock(ISarosSession.class);
@@ -70,22 +82,16 @@ public class ContributionAnnotationManagerTest {
         .anyTimes();
 
     PowerMock.replayAll(sessionMock);
-
-    manager = new ContributionAnnotationManager(sessionMock, store);
   }
 
   @Test
   public void testHistoryRemoval() {
-
-    User alice = new User(new JID("alice@test"), false, false, null);
-
-    AnnotationModel model = new AnnotationModel();
-
-    for (int i = 0; i <= MAX_HISTORY_LENGTH + 1; i++) manager.insertAnnotation(model, i, 1, alice);
+    for (int i = 0; i <= MAX_HISTORY_LENGTH + 1; i++)
+      manager.insertAnnotation(model, i, 1, ALICE_TEST_USER);
 
     assertEquals(MAX_HISTORY_LENGTH, getAnnotationCount(model));
 
-    manager.insertAnnotation(model, MAX_HISTORY_LENGTH, 1, alice);
+    manager.insertAnnotation(model, MAX_HISTORY_LENGTH, 1, ALICE_TEST_USER);
 
     assertEquals(MAX_HISTORY_LENGTH, getAnnotationCount(model));
 
@@ -96,15 +102,12 @@ public class ContributionAnnotationManagerTest {
 
   @Test
   public void testHistoryRemovalAfterRefresh() {
-    User alice = new User(new JID("alice@test"), false, false, null);
-
-    AnnotationModel model = new AnnotationModel();
-
-    for (int i = 0; i <= MAX_HISTORY_LENGTH; i++) manager.insertAnnotation(model, i, 1, alice);
+    for (int i = 0; i <= MAX_HISTORY_LENGTH; i++)
+      manager.insertAnnotation(model, i, 1, ALICE_TEST_USER);
 
     manager.refreshAnnotations(model);
 
-    manager.insertAnnotation(model, MAX_HISTORY_LENGTH + 1, 1, alice);
+    manager.insertAnnotation(model, MAX_HISTORY_LENGTH + 1, 1, ALICE_TEST_USER);
 
     assertFalse(
         "oldest annotation was not removed after refresh",
@@ -112,87 +115,124 @@ public class ContributionAnnotationManagerTest {
   }
 
   @Test
-  public void testHistoryAfterSplit() {
+  public void testHistoryRemovelWithLengthGreaterOne() {
+    final int annotationLength = 3;
 
-    final User alice = new User(new JID("alice@test"), false, false, null);
-    final User bob = new User(new JID("bob@test"), false, false, null);
-
-    final AnnotationModel model = new AnnotationModel();
-
-    manager.insertAnnotation(model, 5, 7, alice);
-    manager.insertAnnotation(model, 2, 15, bob);
-
-    manager.splitAnnotation(model, 9);
-
-    assertEquals("split does not affected all annotations", 4, getAnnotationCount(model));
-
-    int startIndex = 100;
-
-    for (int i = 0; i < MAX_HISTORY_LENGTH - 1; i++, startIndex++)
-      manager.insertAnnotation(model, startIndex, 1, alice);
+    for (int i = 0; i < MAX_HISTORY_LENGTH; i++) {
+      manager.insertAnnotation(model, i * annotationLength, annotationLength, ALICE_TEST_USER);
+    }
 
     assertEquals(
-        "splitted annotions should count as one annotion for the history",
-        4 + MAX_HISTORY_LENGTH - 1,
+        "Inserted not as much annotations as expected",
+        annotationLength * MAX_HISTORY_LENGTH,
         getAnnotationCount(model));
 
-    manager.insertAnnotation(model, startIndex++, 1, alice);
-
+    manager.insertAnnotation(model, annotationLength * MAX_HISTORY_LENGTH + 1, 1, ALICE_TEST_USER);
     assertEquals(
-        "splitted annotions are not correctly removed from the history",
-        4 + MAX_HISTORY_LENGTH - 1 - 1,
-        getAnnotationCount(model));
-
-    for (int i = 0; i < MAX_HISTORY_LENGTH; i++, startIndex++)
-      manager.insertAnnotation(model, startIndex, 1, bob);
-
-    assertEquals(
-        "splitted annotions are not correctly removed from the history",
-        2 * MAX_HISTORY_LENGTH,
+        "Inserting an annotation of length 1 should have remove another annotation of length > 1",
+        annotationLength * (MAX_HISTORY_LENGTH - 1) + 1,
         getAnnotationCount(model));
   }
 
   @Test
-  public void testAnnotationSplit() {
+  public void testHistoryRemovelWithDifferentLengths() {
+    final int annotationLength1 = 3;
+    int offset = 0;
+    final int numberOfEntries = 5;
+    for (int i = 0; i < numberOfEntries; i++) {
+      manager.insertAnnotation(model, offset, annotationLength1, ALICE_TEST_USER);
+      offset += annotationLength1;
+    }
 
-    final User alice = new User(new JID("alice@test"), false, false, null);
-    final User bob = new User(new JID("bob@test"), false, false, null);
+    final int annotationLength2 = 5;
 
-    final AnnotationModel model = new AnnotationModel();
+    for (int i = 0; i < numberOfEntries; i++) {
+      manager.insertAnnotation(model, offset, annotationLength2, ALICE_TEST_USER);
+      offset += annotationLength2;
+    }
 
-    manager.insertAnnotation(model, 5, 7, alice);
-    manager.insertAnnotation(model, 2, 15, bob);
+    final int annotationLength3 = 10;
 
-    manager.splitAnnotation(model, 9);
+    final int remainingNumberOfEntries = MAX_HISTORY_LENGTH - 2 * numberOfEntries;
+    for (int i = 0; i < remainingNumberOfEntries; i++) {
+      manager.insertAnnotation(model, offset, annotationLength3, ALICE_TEST_USER);
+      offset += annotationLength3;
+    }
 
-    final List<Position> positions = getAnnotationPositions(model);
+    int expectedAnnotationCount =
+        numberOfEntries * annotationLength1
+            + numberOfEntries * annotationLength2
+            + remainingNumberOfEntries * annotationLength3;
+    assertEquals(expectedAnnotationCount, getAnnotationCount(model));
 
-    assertEquals("split does not affected all annotations", 4, getAnnotationCount(model));
+    final int newAnnotationLength = 1;
+    for (int i = 0; i < numberOfEntries; i++) {
+      manager.insertAnnotation(model, offset, newAnnotationLength, ALICE_TEST_USER);
+      offset += annotationLength1;
+    }
 
-    final Position expectA0 = new Position(5, 4); // 9 = 5 + 4
-    final Position expectA1 = new Position(9, 3); // 9 + 3 = 5 + 7
-    final Position expectB0 = new Position(2, 7); // 9 = 2 + 7
-    final Position expectB1 = new Position(9, 8); // 9 + 8 = 2 + 15
+    expectedAnnotationCount =
+        numberOfEntries * newAnnotationLength
+            + numberOfEntries * annotationLength2
+            + remainingNumberOfEntries * annotationLength3;
+    assertEquals(expectedAnnotationCount, getAnnotationCount(model));
+  }
 
-    assertTrue("expected annotation region not found: " + expectA0, positions.contains(expectA0));
-    assertTrue("expected annotation region not found: " + expectA1, positions.contains(expectA1));
-    assertTrue("expected annotation region not found: " + expectB0, positions.contains(expectB0));
-    assertTrue("expected annotation region not found: " + expectB1, positions.contains(expectB1));
+  @Test
+  public void testHistoryRemovalWithMultipleModels() {
+    final AnnotationModel model2 = new AnnotationModel();
+    final AnnotationModel model3 = new AnnotationModel();
+    final int numberOfInsertions = 5;
+
+    // Fill history
+    for (int i = 0; i < numberOfInsertions; i++) {
+      manager.insertAnnotation(model2, i, 1, ALICE_TEST_USER);
+    }
+
+    for (int i = 0; i < numberOfInsertions; i++) {
+      manager.insertAnnotation(model3, i, 1, ALICE_TEST_USER);
+    }
+
+    int offset = 0;
+    final int remainingInsertions = MAX_HISTORY_LENGTH - 2 * numberOfInsertions;
+    for (int i = 0; i < remainingInsertions; i++, offset++) {
+      manager.insertAnnotation(model, offset, 1, ALICE_TEST_USER);
+    }
+
+    assertEquals(remainingInsertions, getAnnotationCount(model));
+    assertEquals(numberOfInsertions, getAnnotationCount(model2));
+    assertEquals(numberOfInsertions, getAnnotationCount(model3));
+
+    for (int i = 0; i < numberOfInsertions; i++, offset++) {
+      manager.insertAnnotation(model, offset, 1, ALICE_TEST_USER);
+    }
+
+    assertEquals(remainingInsertions + numberOfInsertions, getAnnotationCount(model));
+    assertEquals(
+        "Insertions in another model should lead to removing all annotations in the model",
+        0,
+        getAnnotationCount(model2));
+    assertEquals(numberOfInsertions, getAnnotationCount(model3));
+
+    for (int i = 0; i < numberOfInsertions; i++, offset++) {
+      manager.insertAnnotation(model, offset, 1, ALICE_TEST_USER);
+    }
+
+    assertEquals(remainingInsertions + 2 * numberOfInsertions, getAnnotationCount(model));
+    assertEquals(0, getAnnotationCount(model2));
+    assertEquals(
+        "Insertions in another model should lead to removing all annotations in the model",
+        0,
+        getAnnotationCount(model3));
   }
 
   @Test
   public void testRemoveAllAnnotationsBySwitchingProperty() {
 
     final List<User> users =
-        Arrays.asList(
-            new User(new JID("alice@test"), false, false, null),
-            new User(new JID("bob@test"), false, false, null),
-            new User(new JID("carl@test"), false, false, null),
-            new User(new JID("dave@test"), false, false, null));
+        Arrays.asList(ALICE_TEST_USER, BOB_TEST_USER, CARL_TEST_USER, DAVE_TEST_USER);
 
     int idx = 0;
-
-    final AnnotationModel model = new AnnotationModel();
 
     for (final User user : users)
       for (int i = 0; i < MAX_HISTORY_LENGTH; i++, idx++)
@@ -210,12 +250,10 @@ public class ContributionAnnotationManagerTest {
 
     final List<User> users = new ArrayList<>();
 
-    users.add(new User(new JID("alice@test"), false, false, null));
-    users.add(new User(new JID("bob@test"), false, false, null));
+    users.add(ALICE_TEST_USER);
+    users.add(BOB_TEST_USER);
 
     int idx = 0;
-
-    final AnnotationModel model = new AnnotationModel();
 
     for (final User user : users)
       for (int i = 0; i < MAX_HISTORY_LENGTH; i++, idx++)
@@ -234,14 +272,33 @@ public class ContributionAnnotationManagerTest {
     }
   }
 
+  @Test
+  public void testInsertAnnotationWithLengthGreaterOne() {
+    final int annotationLength = 3;
+
+    manager.insertAnnotation(model, 5, annotationLength, ALICE_TEST_USER);
+
+    final List<Position> annotationPositions = getAnnotationPositions(model);
+
+    assertEquals(
+        "Annotation was not split into multiple annotation of length 1",
+        annotationLength,
+        annotationPositions.size());
+    assertTrue(annotationPositions.contains(new Position(5, 1)));
+    assertTrue(annotationPositions.contains(new Position(6, 1)));
+    assertTrue(annotationPositions.contains(new Position(7, 1)));
+  }
+
+  @Test
+  public void testInsertAnnotationWithLengthZero() {
+    manager.insertAnnotation(model, 3, 0, ALICE_TEST_USER);
+    assertEquals("Annotation with length 0 was inserted", 0, getAnnotationCount(model));
+  }
+
   public void testInsertWhileNotEnable() {
     store.setValue(EclipsePreferenceConstants.SHOW_CONTRIBUTION_ANNOTATIONS, false);
 
-    final User alice = new User(new JID("alice@test"), false, false, null);
-
-    final AnnotationModel model = new AnnotationModel();
-
-    manager.insertAnnotation(model, 5, 7, alice);
+    manager.insertAnnotation(model, 5, 7, ALICE_TEST_USER);
 
     assertEquals(0, getAnnotationCount(model));
   }
@@ -251,12 +308,10 @@ public class ContributionAnnotationManagerTest {
 
     final List<User> users = new ArrayList<>();
 
-    users.add(new User(new JID("alice@test"), false, false, null));
-    users.add(new User(new JID("bob@test"), false, false, null));
+    users.add(ALICE_TEST_USER);
+    users.add(BOB_TEST_USER);
 
     int idx = 0;
-
-    final AnnotationModel model = new AnnotationModel();
 
     for (final User user : users)
       for (int i = 0; i < MAX_HISTORY_LENGTH; i++, idx++)
@@ -269,10 +324,10 @@ public class ContributionAnnotationManagerTest {
     assertEquals(0, getAnnotationCount(model));
   }
 
-  private int getAnnotationCount(IAnnotationModel model) {
+  private int getAnnotationCount(final IAnnotationModel model) {
     int count = 0;
 
-    Iterator<Annotation> it = model.getAnnotationIterator();
+    final Iterator<Annotation> it = model.getAnnotationIterator();
 
     while (it.hasNext()) {
       count++;
@@ -282,14 +337,14 @@ public class ContributionAnnotationManagerTest {
     return count;
   }
 
-  private List<Position> getAnnotationPositions(AnnotationModel model) {
+  private List<Position> getAnnotationPositions(final IAnnotationModel model) {
 
-    List<Position> positions = new ArrayList<Position>();
+    final List<Position> positions = new ArrayList<Position>();
 
-    Iterator<Annotation> it = model.getAnnotationIterator();
+    final Iterator<Annotation> it = model.getAnnotationIterator();
 
     while (it.hasNext()) {
-      Annotation annotation = it.next();
+      final Annotation annotation = it.next();
       positions.add(model.getPosition(annotation));
     }
 

--- a/eclipse/test/junit/saros/editor/internal/ContributionAnnotationManagerTest.java
+++ b/eclipse/test/junit/saros/editor/internal/ContributionAnnotationManagerTest.java
@@ -40,6 +40,8 @@ public class ContributionAnnotationManagerTest {
 
   private Capture<ISessionListener> sessionListenerCapture;
 
+  private static final int MAX_HISTORY_LENGTH = ContributionAnnotationManager.MAX_HISTORY_LENGTH;
+
   @Before
   public void setUp() {
     store = new PreferenceStore();
@@ -79,14 +81,13 @@ public class ContributionAnnotationManagerTest {
 
     AnnotationModel model = new AnnotationModel();
 
-    for (int i = 0; i <= ContributionAnnotationManager.MAX_HISTORY_LENGTH; i++)
-      manager.insertAnnotation(model, i, 1, alice);
+    for (int i = 0; i <= MAX_HISTORY_LENGTH + 1; i++) manager.insertAnnotation(model, i, 1, alice);
 
-    assertEquals(ContributionAnnotationManager.MAX_HISTORY_LENGTH, getAnnotationCount(model));
+    assertEquals(MAX_HISTORY_LENGTH, getAnnotationCount(model));
 
-    manager.insertAnnotation(model, ContributionAnnotationManager.MAX_HISTORY_LENGTH + 1, 1, alice);
+    manager.insertAnnotation(model, MAX_HISTORY_LENGTH, 1, alice);
 
-    assertEquals(ContributionAnnotationManager.MAX_HISTORY_LENGTH, getAnnotationCount(model));
+    assertEquals(MAX_HISTORY_LENGTH, getAnnotationCount(model));
 
     assertFalse(
         "oldest annotation was not removed",
@@ -99,12 +100,11 @@ public class ContributionAnnotationManagerTest {
 
     AnnotationModel model = new AnnotationModel();
 
-    for (int i = 0; i <= ContributionAnnotationManager.MAX_HISTORY_LENGTH; i++)
-      manager.insertAnnotation(model, i, 1, alice);
+    for (int i = 0; i <= MAX_HISTORY_LENGTH; i++) manager.insertAnnotation(model, i, 1, alice);
 
     manager.refreshAnnotations(model);
 
-    manager.insertAnnotation(model, ContributionAnnotationManager.MAX_HISTORY_LENGTH + 1, 1, alice);
+    manager.insertAnnotation(model, MAX_HISTORY_LENGTH + 1, 1, alice);
 
     assertFalse(
         "oldest annotation was not removed after refresh",
@@ -128,27 +128,27 @@ public class ContributionAnnotationManagerTest {
 
     int startIndex = 100;
 
-    for (int i = 0; i < ContributionAnnotationManager.MAX_HISTORY_LENGTH - 1; i++, startIndex++)
+    for (int i = 0; i < MAX_HISTORY_LENGTH - 1; i++, startIndex++)
       manager.insertAnnotation(model, startIndex, 1, alice);
 
     assertEquals(
         "splitted annotions should count as one annotion for the history",
-        4 + ContributionAnnotationManager.MAX_HISTORY_LENGTH - 1,
+        4 + MAX_HISTORY_LENGTH - 1,
         getAnnotationCount(model));
 
     manager.insertAnnotation(model, startIndex++, 1, alice);
 
     assertEquals(
         "splitted annotions are not correctly removed from the history",
-        4 + ContributionAnnotationManager.MAX_HISTORY_LENGTH - 1 - 1,
+        4 + MAX_HISTORY_LENGTH - 1 - 1,
         getAnnotationCount(model));
 
-    for (int i = 0; i < ContributionAnnotationManager.MAX_HISTORY_LENGTH; i++, startIndex++)
+    for (int i = 0; i < MAX_HISTORY_LENGTH; i++, startIndex++)
       manager.insertAnnotation(model, startIndex, 1, bob);
 
     assertEquals(
         "splitted annotions are not correctly removed from the history",
-        2 * ContributionAnnotationManager.MAX_HISTORY_LENGTH,
+        2 * MAX_HISTORY_LENGTH,
         getAnnotationCount(model));
   }
 
@@ -195,11 +195,10 @@ public class ContributionAnnotationManagerTest {
     final AnnotationModel model = new AnnotationModel();
 
     for (final User user : users)
-      for (int i = 0; i < ContributionAnnotationManager.MAX_HISTORY_LENGTH; i++, idx++)
+      for (int i = 0; i < MAX_HISTORY_LENGTH; i++, idx++)
         manager.insertAnnotation(model, idx, 1, user);
 
-    assertEquals(
-        ContributionAnnotationManager.MAX_HISTORY_LENGTH * users.size(), getAnnotationCount(model));
+    assertEquals(MAX_HISTORY_LENGTH * users.size(), getAnnotationCount(model));
 
     store.setValue(EclipsePreferenceConstants.SHOW_CONTRIBUTION_ANNOTATIONS, false);
 
@@ -219,11 +218,10 @@ public class ContributionAnnotationManagerTest {
     final AnnotationModel model = new AnnotationModel();
 
     for (final User user : users)
-      for (int i = 0; i < ContributionAnnotationManager.MAX_HISTORY_LENGTH; i++, idx++)
+      for (int i = 0; i < MAX_HISTORY_LENGTH; i++, idx++)
         manager.insertAnnotation(model, idx, 1, user);
 
-    assertEquals(
-        ContributionAnnotationManager.MAX_HISTORY_LENGTH * users.size(), getAnnotationCount(model));
+    assertEquals(MAX_HISTORY_LENGTH * users.size(), getAnnotationCount(model));
 
     final ISessionListener sessionListener = sessionListenerCapture.getValue();
 
@@ -232,9 +230,7 @@ public class ContributionAnnotationManagerTest {
     while (!users.isEmpty()) {
       sessionListener.userLeft(users.remove(0));
 
-      assertEquals(
-          ContributionAnnotationManager.MAX_HISTORY_LENGTH * users.size(),
-          getAnnotationCount(model));
+      assertEquals(MAX_HISTORY_LENGTH * users.size(), getAnnotationCount(model));
     }
   }
 
@@ -263,11 +259,10 @@ public class ContributionAnnotationManagerTest {
     final AnnotationModel model = new AnnotationModel();
 
     for (final User user : users)
-      for (int i = 0; i < ContributionAnnotationManager.MAX_HISTORY_LENGTH; i++, idx++)
+      for (int i = 0; i < MAX_HISTORY_LENGTH; i++, idx++)
         manager.insertAnnotation(model, idx, 1, user);
 
-    assertEquals(
-        ContributionAnnotationManager.MAX_HISTORY_LENGTH * users.size(), getAnnotationCount(model));
+    assertEquals(MAX_HISTORY_LENGTH * users.size(), getAnnotationCount(model));
 
     manager.dispose();
 


### PR DESCRIPTION
The PR splits all annotations in annotations of size 1 and removes the old splitting logic. This is much easier and fixes the issue. However, I would assume that this was the initial solution in Saros and the split logic was an optimization, but during my tests (manual and with stf) I had not the impression that my change worsens the user experiences.

Furthermore, this slightly changes the history handling, because text insertions are multiple annotation insertions. Therefore a long insertion is only annotated at the end. This leads to the question "How should this feature work?".

@srossbach What are your thoughts? Did I miss a corner case that requires the other handling?