### PR TITLE
[FIX][CORE] Fix wrong split operation combination

### DIFF
--- a/core/src/saros/concurrent/jupiter/internal/text/SplitOperation.java
+++ b/core/src/saros/concurrent/jupiter/internal/text/SplitOperation.java
@@ -185,7 +185,10 @@ public class SplitOperation implements Operation {
       // Ins(2,"ab") + Ins(4,"cd") -> Ins(2,"abcd")
       if (insert1.getPosition() + insert1.getTextLength() == insert2.getPosition()) {
         return new InsertOperation(insert1.getPosition(), insert1.getText() + insert2.getText());
-      } else if (insert1.getPosition() == insert2.getPosition() + insert2.getTextLength()) {
+      }
+
+      // Ins(2,"cd") + Ins(2,"ab") -> Ins(2,"abcd")
+      if (insert1.getPosition() == insert2.getPosition()) {
         return new InsertOperation(insert2.getPosition(), insert2.getText() + insert1.getText());
       }
 

--- a/core/test/junit/saros/concurrent/SplitOperationTest.java
+++ b/core/test/junit/saros/concurrent/SplitOperationTest.java
@@ -21,7 +21,12 @@ import saros.concurrent.jupiter.test.util.PathFake;
 import saros.filesystem.IProject;
 import saros.session.User;
 
-/** testing SplitOperation.toTextEdit() */
+/**
+ * Tests the logic that combines the contained operations if possible when creating text activities
+ * from split operations.
+ *
+ * @see SplitOperation#toTextEdit(SPath, User)
+ */
 public class SplitOperationTest {
 
   protected IProject project;
@@ -72,6 +77,7 @@ public class SplitOperationTest {
     TextEditActivity expected1 = new TextEditActivity(source, 5, "", "abcde", path);
     assertEquals(Collections.singletonList(expected1), split1.toTextEdit(path, source));
 
+    // Del(5,"cde") + Del(5,"ab") -> Del(5,"cdeab")
     Operation split2 = S(D(5, "cde"), D(5, "ab"));
     TextEditActivity expected2 = new TextEditActivity(source, 5, "", "cdeab", path);
     assertEquals(Collections.singletonList(expected2), split2.toTextEdit(path, source));
@@ -84,6 +90,7 @@ public class SplitOperationTest {
     TextEditActivity expected1 = new TextEditActivity(source, 5, "", "cd", path);
     assertEquals(Collections.singletonList(expected1), split1.toTextEdit(path, source));
 
+    // Ins(5,"abcde") + Del(5,"abcd") -> Ins(5,"e")
     Operation split2 = S(I(5, "abcde"), D(5, "abcd"));
     TextEditActivity expected2 = new TextEditActivity(source, 5, "e", "", path);
     assertEquals(Collections.singletonList(expected2), split2.toTextEdit(path, source));
@@ -110,7 +117,7 @@ public class SplitOperationTest {
     // Split(Split(A,B), Split(C,D)) with B and C can be combined
     Operation split = S(S(D(8, "uvw"), I(2, "abcde")), S(D(2, "abcd"), D(15, "xyz")));
 
-    List<TextEditActivity> expected = new LinkedList<TextEditActivity>();
+    List<TextEditActivity> expected = new LinkedList<>();
     expected.add(new TextEditActivity(source, 8, "", "uvw", path));
     expected.add(new TextEditActivity(source, 2, "e", "", path));
     expected.add(new TextEditActivity(source, 15, "", "xyz", path));
@@ -123,7 +130,7 @@ public class SplitOperationTest {
     // Split(Split(A,B), Split(C,D)) with B, C and D can be combined
     Operation split = S(S(D(8, "uvw"), I(2, "abcde")), S(D(2, "abcd"), I(3, "xyz")));
 
-    List<TextEditActivity> expected = new LinkedList<TextEditActivity>();
+    List<TextEditActivity> expected = new LinkedList<>();
     expected.add(new TextEditActivity(source, 8, "", "uvw", path));
     expected.add(new TextEditActivity(source, 2, "exyz", "", path));
 
@@ -135,7 +142,7 @@ public class SplitOperationTest {
     // Split(Split(A,B), Split(C,D)) with A, B, C and D can be combined
     Operation split = S(S(D(8, "abc"), D(8, "defg")), S(I(8, "1234"), I(12, "56")));
 
-    List<TextEditActivity> expected = new LinkedList<TextEditActivity>();
+    List<TextEditActivity> expected = new LinkedList<>();
     expected.add(new TextEditActivity(source, 8, "123456", "abcdefg", path));
 
     assertEquals(expected, split.toTextEdit(path, source));

--- a/core/test/junit/saros/concurrent/SplitOperationTest.java
+++ b/core/test/junit/saros/concurrent/SplitOperationTest.java
@@ -59,8 +59,8 @@ public class SplitOperationTest {
     TextEditActivity expected1 = new TextEditActivity(source, 4, "0abcd", "", path);
     assertEquals(Collections.singletonList(expected1), split1.toTextEdit(path, source));
 
-    // vice versa
-    Operation split2 = S(I(6, "0ab"), I(4, "cd"));
+    // Ins(4,"0ab") + Ins(4,"cd") -> Ins(4,"cd0ab")
+    Operation split2 = S(I(4, "0ab"), I(4, "cd"));
     TextEditActivity expected2 = new TextEditActivity(source, 4, "cd0ab", "", path);
     assertEquals(Collections.singletonList(expected2), split2.toTextEdit(path, source));
   }


### PR DESCRIPTION
Fixes error in split operation combination logic dealing with two
insertions.

The existing logic incorrectly correlates the two insertions by the
start of the first and end of the second insertion and assumes that they
can then be combined.

When actually applying two activities matching this criteria, the
result, however, is not combinable:
```
Example: ins(5,"cd") + ins(3,"ab")
  Start ins1 = 5
  End ins2 = 5
  -> Defined result: ins(3,"abcd)

Actual result when applying ins1 and ins2:

  position  0123456789
  start:   "          "
  ins1:    "     cd   "
  ins2:    "   ab  cd "
  -> Does not match defined result
```
The actual result can not be defined through a single insertion as it is
not continuous.

Fixes the issue by instead requiring that both insertions have the same
start value.
```
Example: ins(3,"cd") + in(3,"ab")
  Start ins1=3
  Start ins2=3
  -> Defined result: ins(3,"abcd")

  position  0123456789
  start:   "          "
  ins1:    "   cd     "
  ins2:    "   abcd   "
  -> Matches defined result
```
As the adjusted optimization logic is incomplete (i.e. does not cover
all cases), I just picked a similar case to the faulty one for the
adjusted logic. Other cases would also have been possible.