### PR TITLE
Remove failing test tag

### DIFF
--- a/stf.test/build.gradle
+++ b/stf.test/build.gradle
@@ -58,16 +58,16 @@ task stfTest (type: StfTest, dependsOn: [':saros.eclipse:build']) {
     classpath = sourceSets.stfTest.runtimeClasspath
 
     useJUnit {
-        excludeCategories 'saros.stf.test.categories.FlakyTests', 'saros.stf.test.categories.FailingTests'
+        excludeCategories 'saros.stf.test.categories.FlakyTests'
     }
 }
 
-task stfFlakyAndFailingTest (type: StfTest, dependsOn: [':saros.eclipse:build']) {
+task stfFlakyTest (type: StfTest, dependsOn: [':saros.eclipse:build']) {
     testClassesDirs = sourceSets.stfTest.output.classesDirs
     classpath = sourceSets.stfTest.runtimeClasspath
     ignoreFailures = true
-    
+
     useJUnit {
-        includeCategories 'saros.stf.test.categories.FlakyTests', 'saros.stf.test.categories.FailingTests'
+        includeCategories 'saros.stf.test.categories.FlakyTests'
     }
 }

--- a/stf.test/test/saros/stf/test/categories/FailingTests.java
+++ b/stf.test/test/saros/stf/test/categories/FailingTests.java
@@ -1,9 +1,0 @@
-package saros.stf.test.categories;
-
-/**
- * Marks tests are always failing and have to be fixed! Create an issue "Fix STF failing test
- * <Testname>" before using this marker
- */
-public interface FailingTests {
-  /* category marker */
-}

--- a/stf.test/test/saros/stf/test/consistency/CreateSameFileAtOnceTest.java
+++ b/stf.test/test/saros/stf/test/consistency/CreateSameFileAtOnceTest.java
@@ -9,13 +9,11 @@ import static saros.stf.client.tester.SarosTester.CARL;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import saros.stf.annotation.TestLink;
 import saros.stf.client.StfTestCase;
 import saros.stf.client.tester.AbstractTester;
 import saros.stf.client.util.Util;
 import saros.stf.shared.Constants.TypeOfCreateProject;
-import saros.stf.test.categories.FailingTests;
 
 @TestLink(id = "Saros-131_create_same_file_at_once")
 public class CreateSameFileAtOnceTest extends StfTestCase {
@@ -31,7 +29,6 @@ public class CreateSameFileAtOnceTest extends StfTestCase {
     CARL.controlBot().getNetworkManipulator().unblockOutgoingSessionPackets();
   }
 
-  @Category(FailingTests.class)
   @Test
   public void testCreateSameFileAtOnce() throws Exception {
     ALICE.superBot().internal().createProject("foo");

--- a/travis/script/stf/master/start_stf_tests.sh
+++ b/travis/script/stf/master/start_stf_tests.sh
@@ -12,4 +12,4 @@ timeout -t 3600 ./gradlew \
   -Dstf.client.configuration.files=/home/ci/saros_src/travis/config/stf_config \
   -PskipSTFTests=false \
   -PuseBuildScan=true \
-  cleanAll :saros.stf.test:stfTest :saros.stf.test:stfFlakyAndFailingTest
+  cleanAll :saros.stf.test:stfTest :saros.stf.test:stfFlakyTest


### PR DESCRIPTION
#### [INTERNAL][STF] Remove failing tag from CreateSameFileAtOnceTest

Removes the FailingTest tag from the CreateSameFileAtOnceTest as it
should be fixed with #867.

Closes #854.

#### [BUILD][STF] Remove the category failing test

Removes the category failing test as it is now no longer used.

Renames the test run from 'flakyAndFailingTest' to 'flakyTest'.