### PR TITLE
Introduce text edit content normalization

### DIFF
--- a/core/src/saros/concurrent/jupiter/internal/text/DeleteOperation.java
+++ b/core/src/saros/concurrent/jupiter/internal/text/DeleteOperation.java
@@ -34,10 +34,17 @@ import saros.activities.TextEditActivity;
 import saros.editor.text.TextPosition;
 import saros.misc.xstream.UrlEncodingStringConverter;
 import saros.session.User;
+import saros.util.LineSeparatorNormalizationUtil;
 
 /**
  * The DeleteOperation is used to hold a text together with its position that is to be deleted in
  * the document model.
+ *
+ * <p>The text contained in delete operations only uses normalized line separators, meaning it
+ * doesn't contain any line separators besides the {@link
+ * LineSeparatorNormalizationUtil#NORMALIZED_LINE_SEPARATOR}.
+ *
+ * @see LineSeparatorNormalizationUtil
  */
 @XStreamAlias("deleteOp")
 public class DeleteOperation implements ITextOperation {
@@ -74,10 +81,15 @@ public class DeleteOperation implements ITextOperation {
   /**
    * Instantiates a new delete operation using the given parameters.
    *
+   * <p>The given replaced text must only use normalized line separators, meaning it must not
+   * contain any line separators besides the {@link
+   * LineSeparatorNormalizationUtil#NORMALIZED_LINE_SEPARATOR}.
+   *
    * @param startPosition the start position of the delete operation
    * @param lineDelta how many lines are deleted by the operation
    * @param offsetDelta the offset delta in the last modified line
    * @param replacedText the text removed by this operation
+   * @see LineSeparatorNormalizationUtil
    */
   public DeleteOperation(
       TextPosition startPosition, int lineDelta, int offsetDelta, String replacedText) {
@@ -137,7 +149,11 @@ public class DeleteOperation implements ITextOperation {
   /**
    * Returns the text to be deleted.
    *
+   * <p>The returned text only uses normalized line separators, meaning it doesn't contain any line
+   * separators besides the {@link LineSeparatorNormalizationUtil#NORMALIZED_LINE_SEPARATOR}.
+   *
    * @return the text to be deleted
+   * @see LineSeparatorNormalizationUtil
    */
   @Override
   public String getText() {

--- a/core/src/saros/concurrent/jupiter/internal/text/GOTOInclusionTransformation.java
+++ b/core/src/saros/concurrent/jupiter/internal/text/GOTOInclusionTransformation.java
@@ -20,13 +20,14 @@
  */
 package saros.concurrent.jupiter.internal.text;
 
+import static saros.util.LineSeparatorNormalizationUtil.NORMALIZED_LINE_SEPARATOR;
+
 import java.security.InvalidParameterException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import saros.concurrent.jupiter.InclusionTransformation;
 import saros.concurrent.jupiter.Operation;
 import saros.editor.text.TextPosition;
-import saros.editor.text.TextPositionUtils;
 
 /**
  * Implementation of the GOTO operational transformation functions. The pseudo code can be found in
@@ -451,17 +452,15 @@ public class GOTOInclusionTransformation implements InclusionTransformation {
       } else {
         offsetDeltaBeforeSplit = inLineOffsetStartB;
 
-        // TODO remove guess once we have implemented content normalization
-        String lineSeparator = TextPositionUtils.guessLineSeparator(text);
-
-        int splitLineOffset = StringUtils.ordinalIndexOf(text, lineSeparator, lineDeltaBeforeSplit);
+        int splitLineOffset =
+            StringUtils.ordinalIndexOf(text, NORMALIZED_LINE_SEPARATOR, lineDeltaBeforeSplit);
 
         if (splitLineOffset == -1) {
           throw new IllegalStateException(
               "Could not find line separator " + lineDeltaBeforeSplit + " in text");
         }
 
-        splitOffset = splitLineOffset + lineSeparator.length() + offsetDeltaBeforeSplit;
+        splitOffset = splitLineOffset + NORMALIZED_LINE_SEPARATOR.length() + offsetDeltaBeforeSplit;
       }
 
       String textBeforeSplit = text.substring(0, splitOffset);
@@ -647,17 +646,15 @@ public class GOTOInclusionTransformation implements InclusionTransformation {
       adjustedLineDelta = lineDeltaA;
 
     } else {
-      // TODO remove guess once we have implemented content normalization
-      String lineSeparator = TextPositionUtils.guessLineSeparator(text);
-
-      int splitLineOffset = StringUtils.ordinalIndexOf(text, lineSeparator, droppedLines);
+      int splitLineOffset =
+          StringUtils.ordinalIndexOf(text, NORMALIZED_LINE_SEPARATOR, droppedLines);
 
       if (splitLineOffset == -1) {
         throw new IllegalStateException(
             "Could not find line separator " + droppedLines + " in text");
       }
 
-      int newStartOffset = splitLineOffset + lineSeparator.length() + inLineOffsetEndB;
+      int newStartOffset = splitLineOffset + NORMALIZED_LINE_SEPARATOR.length() + inLineOffsetEndB;
 
       adjustedText = text.substring(newStartOffset);
 
@@ -727,17 +724,16 @@ public class GOTOInclusionTransformation implements InclusionTransformation {
         adjustedText = text.substring(0, adjustedOffsetDelta);
 
       } else {
-        // TODO remove guess once we have implemented content normalization
-        String lineSeparator = TextPositionUtils.guessLineSeparator(text);
-
-        int splitLineOffset = StringUtils.ordinalIndexOf(text, lineSeparator, adjustedLineDelta);
+        int splitLineOffset =
+            StringUtils.ordinalIndexOf(text, NORMALIZED_LINE_SEPARATOR, adjustedLineDelta);
 
         if (splitLineOffset == -1) {
           throw new IllegalStateException(
               "Could not find line separator " + adjustedLineDelta + " in text");
         }
 
-        int newEndOffset = splitLineOffset + lineSeparator.length() + inLineOffsetStartB;
+        int newEndOffset =
+            splitLineOffset + NORMALIZED_LINE_SEPARATOR.length() + inLineOffsetStartB;
 
         adjustedText = text.substring(0, newEndOffset);
 

--- a/core/src/saros/concurrent/jupiter/internal/text/InsertOperation.java
+++ b/core/src/saros/concurrent/jupiter/internal/text/InsertOperation.java
@@ -34,6 +34,7 @@ import saros.activities.TextEditActivity;
 import saros.editor.text.TextPosition;
 import saros.misc.xstream.UrlEncodingStringConverter;
 import saros.session.User;
+import saros.util.LineSeparatorNormalizationUtil;
 
 /**
  * The InsertOperation is used to hold a text together with its position index. The text is to be
@@ -44,6 +45,12 @@ import saros.session.User;
  * concept could be extended in such a way that two origin positions could be compared to each other
  * based on the same context. Therefore, if the two positions do not relate on the same document
  * context, a least synchronization point (LSP) would have to be determined.
+ *
+ * <p>The text contained in insert operations only uses normalized line separators, meaning it
+ * doesn't contain any line separators besides the {@link
+ * LineSeparatorNormalizationUtil#NORMALIZED_LINE_SEPARATOR}.
+ *
+ * @see LineSeparatorNormalizationUtil
  */
 @XStreamAlias("insertOp")
 public class InsertOperation implements ITextOperation {
@@ -90,11 +97,15 @@ public class InsertOperation implements ITextOperation {
    *
    * <p>Uses the given start position as the origin start position.
    *
+   * <p>The given new text must only use normalized line separators, meaning it must not contain any
+   * line separators besides the {@link LineSeparatorNormalizationUtil#NORMALIZED_LINE_SEPARATOR}.
+   *
    * @param startPosition the start position of the insert operation
    * @param lineDelta how many lines are added by the operation
    * @param offsetDelta the offset delta in the last modified line
    * @param text the text added by this operation
    * @see #InsertOperation(TextPosition, int, int, String, TextPosition)
+   * @see LineSeparatorNormalizationUtil
    */
   public InsertOperation(TextPosition startPosition, int lineDelta, int offsetDelta, String text) {
     this(startPosition, lineDelta, offsetDelta, text, startPosition);
@@ -103,13 +114,16 @@ public class InsertOperation implements ITextOperation {
   /**
    * Instantiates a new insert operation using the given parameters.
    *
+   * <p>The given new text must only use normalized line separators, meaning it must not contain any
+   * line separators besides the {@link LineSeparatorNormalizationUtil#NORMALIZED_LINE_SEPARATOR}.
+   *
    * @param startPosition the start position of the insert operation
    * @param lineDelta how many lines are added by the operation
    * @param offsetDelta the offset delta in the last modified line
    * @param text the text added by this operation
    * @param originStartPosition the original start position the insert operation was meant for; see
    *     {@link #getOriginStartPosition()}
-   * @see #InsertOperation(TextPosition, int, int, String, TextPosition)
+   * @see LineSeparatorNormalizationUtil
    */
   public InsertOperation(
       TextPosition startPosition,
@@ -193,7 +207,11 @@ public class InsertOperation implements ITextOperation {
   /**
    * Returns the text to be added by the operation.
    *
+   * <p>The returned text only uses normalized line separators, meaning it doesn't contain any line
+   * separators besides the {@link LineSeparatorNormalizationUtil#NORMALIZED_LINE_SEPARATOR}.
+   *
    * @return the text to be added by the operation
+   * @see LineSeparatorNormalizationUtil
    */
   @Override
   public String getText() {

--- a/core/src/saros/editor/text/TextPositionUtils.java
+++ b/core/src/saros/editor/text/TextPositionUtils.java
@@ -21,32 +21,6 @@ public class TextPositionUtils {
    * Calculates the offset of the given text position in the given text using the given line
    * separator.
    *
-   * <p>Tries to guess the used line separator by checking for Windows (<code>\r\n</code>) or Unix
-   * line separators (<code>\n</code>) in the text.
-   *
-   * @param text the text with which to calculate the offset
-   * @param position the position for which to calculate the offset
-   * @return the offset of the given text position in the given text
-   * @throws NullPointerException if the given text position, text, or line separator is <code>null
-   *     </code>
-   * @throws IllegalArgumentException if the given text position is invalid
-   * @throws IllegalStateException if the given text contains fewer lines than specified by the text
-   *     position
-   * @see #guessLineSeparator(String)
-   */
-  public static int calculateOffset(String text, TextPosition position) {
-
-    Objects.requireNonNull(text, "The given text must not be null");
-
-    String lineSeparator = guessLineSeparator(text);
-
-    return calculateOffset(text, position, lineSeparator);
-  }
-
-  /**
-   * Calculates the offset of the given text position in the given text using the given line
-   * separator.
-   *
    * @param text the text with which to calculate the offset
    * @param position the position for which to calculate the offset
    * @param lineSeparator the line separator used in the text
@@ -90,28 +64,6 @@ public class TextPositionUtils {
     int lineStartOffset = previousLineEndOffset + lineSeparator.length();
 
     return lineStartOffset + position.getInLineOffset();
-  }
-
-  /**
-   * Calculates the line and offset delta contained in the text, i.e. how many lines the text
-   * contains and how many characters it contains in the last line.
-   *
-   * <p>Tries to guess the used line separator by checking for Windows (<code>\r\n</code>) or Unix
-   * line separators (<code>\n</code>) in the text.
-   *
-   * @param text the text for which to calculate the deltas
-   * @return a pair containing the line delta as the first/left element and the offset delta as the
-   *     second/right element
-   * @throws NullPointerException if the given text is <code>null</code>
-   * @see #guessLineSeparator(String)
-   */
-  // TODO remove different line separator handling once internal normalization is set up
-  public static Pair<Integer, Integer> calculateDeltas(String text) {
-    Objects.requireNonNull(text, "The given text must not be null");
-
-    String lineSeparator = guessLineSeparator(text);
-
-    return calculateDeltas(text, lineSeparator);
   }
 
   /**

--- a/core/src/saros/util/LineSeparatorNormalizationUtil.java
+++ b/core/src/saros/util/LineSeparatorNormalizationUtil.java
@@ -1,0 +1,82 @@
+package saros.util;
+
+import java.util.Objects;
+
+/**
+ * Utility class offering methods to normalize and denormalize text by replacing the used line
+ * separators.
+ *
+ * <p>The default line separator used for normalized content is the Unix line separator.
+ *
+ * @see #NORMALIZED_LINE_SEPARATOR
+ */
+public class LineSeparatorNormalizationUtil {
+
+  /**
+   * The line separator used in normalized content.
+   *
+   * <p>The default Unix line separator.
+   */
+  public static final String NORMALIZED_LINE_SEPARATOR = "\n";
+
+  private LineSeparatorNormalizationUtil() {
+    // NOP
+  }
+
+  /**
+   * Normalizes the line endings in the given text by replacing all occurrences of the passed line
+   * separator with Unix line separator.
+   *
+   * <p>Does nothing if the given line separator is the Unix line separator or is not contained in
+   * the given text.
+   *
+   * @param text the text to normalize
+   * @param usedLineSeparator the line separator used in the given text
+   * @return the normalized text containing only Unix line endings
+   * @throws NullPointerException if the given text or line separator to use is <code>null</code>
+   * @throws IllegalArgumentException if the given line separator to use is empty
+   * @see #NORMALIZED_LINE_SEPARATOR
+   */
+  public static String normalize(String text, String usedLineSeparator) {
+    Objects.requireNonNull(text, "The given text must not be null");
+    Objects.requireNonNull(usedLineSeparator, "The given line separator must not be null");
+
+    if (usedLineSeparator.isEmpty()) {
+      throw new IllegalArgumentException("The given line separator must not be empty.");
+    }
+
+    if (text.isEmpty() || usedLineSeparator.equals(NORMALIZED_LINE_SEPARATOR)) {
+      return text;
+    }
+
+    return text.replace(usedLineSeparator, NORMALIZED_LINE_SEPARATOR);
+  }
+
+  /**
+   * Reverts the line separator normalization by replacing all occurrences of the Unix line
+   * separator with the given line separator.
+   *
+   * <p>Does nothing if the passed line separator is the Unix line separator.
+   *
+   * @param text the text whose line ending normalization to revert
+   * @param lineSeparatorToUse the line separator to use in the text
+   * @return the denormalized text using only the given line separator
+   * @throws NullPointerException if the given text or line separator to use is <code>null</code>
+   * @throws IllegalArgumentException if the given line separator to use is empty
+   * @see #NORMALIZED_LINE_SEPARATOR
+   */
+  public static String revertNormalization(String text, String lineSeparatorToUse) {
+    Objects.requireNonNull(text, "The given text must not be null");
+    Objects.requireNonNull(lineSeparatorToUse, "The given line separator must not be null");
+
+    if (lineSeparatorToUse.isEmpty()) {
+      throw new IllegalArgumentException("The given line separator must not be empty.");
+    }
+
+    if (text.isEmpty() || lineSeparatorToUse.equals(NORMALIZED_LINE_SEPARATOR)) {
+      return text;
+    }
+
+    return text.replace(NORMALIZED_LINE_SEPARATOR, lineSeparatorToUse);
+  }
+}

--- a/core/test/junit/saros/editor/text/TextPositionUtilsTest.java
+++ b/core/test/junit/saros/editor/text/TextPositionUtilsTest.java
@@ -132,27 +132,6 @@ public class TextPositionUtilsTest {
   }
 
   @Test
-  public void testLineEndingDetection() {
-    TextPosition position = new TextPosition(10, 24);
-
-    int detectedUnixOffset = TextPositionUtils.calculateOffset(UNIX_TEST_STRING, position);
-    int unixOffset = calculateUnixOffset(position);
-
-    assertEquals(
-        "method using line separator detection returned wrong offset for Unix line separators",
-        unixOffset,
-        detectedUnixOffset);
-
-    int detectedWindowsOffset = TextPositionUtils.calculateOffset(WINDOWS_TEST_STRING, position);
-    int windowsOffset = calculateWindowsOffset(position);
-
-    assertEquals(
-        "method using line separator detection returned wrong offset for Windows line separators",
-        windowsOffset,
-        detectedWindowsOffset);
-  }
-
-  @Test
   public void testUnixPositionCalculation() {
     int realUnixOffset;
     TextPosition position;

--- a/core/test/junit/saros/test/util/OperationHelper.java
+++ b/core/test/junit/saros/test/util/OperationHelper.java
@@ -212,11 +212,11 @@ public class OperationHelper {
    * @param replacedText the replaced text to use for the activity
    * @param path the path to use for the activity
    * @return a text edit activity with the given parameters
-   * @see TextEditActivity#buildTextEditActivity(User, TextPosition, String, String, SPath, String)
+   * @see TextEditActivity#buildTextEditActivity(User, TextPosition, String, String, SPath)
    */
   public static TextEditActivity T(
       User source, TextPosition position, String text, String replacedText, SPath path) {
 
-    return TextEditActivity.buildTextEditActivity(source, position, text, replacedText, path, EOL);
+    return TextEditActivity.buildTextEditActivity(source, position, text, replacedText, path);
   }
 }

--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -879,7 +879,10 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
     TextPosition startPosition = EditorAPI.calculatePosition(editor, offset);
 
-    // Intellij internally always used UNIX line separators
+    /*
+     * Intellij internally always uses UNIX line separators for editor content
+     * -> no line ending normalization necessary as content already normalized
+     */
     String lineSeparator = TextPositionUtils.UNIX_LINE_SEPARATOR;
 
     TextEditActivity textEdit =

--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -35,7 +35,6 @@ import saros.editor.remote.EditorState;
 import saros.editor.remote.UserEditorStateManager;
 import saros.editor.text.LineRange;
 import saros.editor.text.TextPosition;
-import saros.editor.text.TextPositionUtils;
 import saros.editor.text.TextSelection;
 import saros.filesystem.IFile;
 import saros.filesystem.IProject;
@@ -883,11 +882,9 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
      * Intellij internally always uses UNIX line separators for editor content
      * -> no line ending normalization necessary as content already normalized
      */
-    String lineSeparator = TextPositionUtils.UNIX_LINE_SEPARATOR;
-
     TextEditActivity textEdit =
         TextEditActivity.buildTextEditActivity(
-            session.getLocalUser(), startPosition, newText, replacedText, path, lineSeparator);
+            session.getLocalUser(), startPosition, newText, replacedText, path);
 
     if (!hasWriteAccess || isLocked) {
       /*

--- a/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
+++ b/intellij/src/saros/intellij/editor/LocalEditorManipulator.java
@@ -158,6 +158,10 @@ public class LocalEditorManipulator {
         int start = EditorAPI.calculateOffset(calculationEditor, op.getStartPosition());
         int end = EditorAPI.calculateOffset(calculationEditor, op.getEndPosition());
 
+        /*
+         * Intellij internally always uses UNIX line separators for editor content
+         * -> no line ending denormalization necessary as normalized format matches editor format
+         */
         if (op instanceof DeleteOperation) {
           DocumentAPI.deleteText(project, doc, start, end);
 


### PR DESCRIPTION
#### [INTERNAL][CORE] Add LineSeparatorNormalizationUtils

Adds LineSeparatorNormalizationUtils offering utility methods to
normalize and denormalize the line separators for a given text.

This utility will be used in upcoming commits to normalize content
before passing it to the core, thereby allowing for a unified line
separator handling.

#### [INTERNAL] Normalize line separators for text edit content

Adjusts the logic handling text edit activities to normalize line
separators before creating text edit activities and to revert the
normalization when applying received text edit activities.

No adjustment was necessary for Saros/I as the editors already work on
normalized Unix line separators.

This adds a new corner case that can lead to session desynchronizations
between two Saros/E instances: When two participants with different line
endings settings add content to an empty shared file, the line separator
settings will be honored. As the watchdog checks the editor content
including the line endings, this will lead to a perceived
desynchronization.
This issue will be fixed once the content handling is completely
normalized and the watchdog works on normalized content as well.

#### [INTERNAL][CORE] Introduce assumption that text edits are normalized

Adjusts the internal logic handling text edit activities under the
assumption that all text passed to them is normalized, i.e. only uses
Unix line separators.

Adjusts the logic by replacing logic checking which line separator to
use with directly using the normalization line separator.

Removes now no longer necessary utility methods guessing the used line
separator.

Extends the TextEditActivity constructor javadoc to state that passed
content must be normalized.
Also adds assertions to the text edit activity constructor ensuring that
the passed content does not contain any Windows line separators.