### PR TITLE
Adjust consistency watchdog to work with normalized content

### DIFF
--- a/core/src/saros/concurrent/watchdog/ConsistencyWatchdogClient.java
+++ b/core/src/saros/concurrent/watchdog/ConsistencyWatchdogClient.java
@@ -286,26 +286,26 @@ public class ConsistencyWatchdogClient extends AbstractActivityProducer implemen
       return false;
     }
 
-    final String editorContent = editorManager.getContent(path);
+    final String normalizedEditorContent = editorManager.getNormalizedContent(path);
 
-    if (editorContent == null) {
+    if (normalizedEditorContent == null) {
       log.debug("Inconsistency detected -> no editor content found for resource: " + path);
 
       return true;
     }
 
-    if ((editorContent.length() != checksum.getLength())
-        || (editorContent.hashCode() != checksum.getHash())) {
+    if ((normalizedEditorContent.length() != checksum.getLength())
+        || (normalizedEditorContent.hashCode() != checksum.getHash())) {
 
       log.debug(
           String.format(
               "Inconsistency detected -> %s L(%d %s %d) H(%x %s %x)",
               path.toString(),
-              editorContent.length(),
-              editorContent.length() == checksum.getLength() ? "==" : "!=",
+              normalizedEditorContent.length(),
+              normalizedEditorContent.length() == checksum.getLength() ? "==" : "!=",
               checksum.getLength(),
-              editorContent.hashCode(),
-              editorContent.hashCode() == checksum.getHash() ? "==" : "!=",
+              normalizedEditorContent.hashCode(),
+              normalizedEditorContent.hashCode() == checksum.getHash() ? "==" : "!=",
               checksum.getHash()));
 
       return true;

--- a/core/src/saros/concurrent/watchdog/ConsistencyWatchdogHandler.java
+++ b/core/src/saros/concurrent/watchdog/ConsistencyWatchdogHandler.java
@@ -223,7 +223,10 @@ public final class ConsistencyWatchdogHandler extends AbstractActivityProducer
      */
 
     DocumentChecksum checksum = new DocumentChecksum(path);
-    checksum.update(text);
+
+    String normalizedText = editorManager.getNormalizedContent(path);
+
+    checksum.update(normalizedText);
 
     fireActivity(new ChecksumActivity(user, path, checksum.getHash(), checksum.getLength(), null));
   }

--- a/core/src/saros/concurrent/watchdog/ConsistencyWatchdogServer.java
+++ b/core/src/saros/concurrent/watchdog/ConsistencyWatchdogServer.java
@@ -264,9 +264,9 @@ public class ConsistencyWatchdogServer extends AbstractActivityProducer
       return;
     }
 
-    String content = editorManager.getContent(checksum.getPath());
+    String normalizedEditorContent = editorManager.getNormalizedContent(checksum.getPath());
 
-    if (content == null) {
+    if (normalizedEditorContent == null) {
       if (localEditors.contains(checksum.getPath())) {
         log.error(
             "EditorManager is in an inconsistent state. "
@@ -284,7 +284,7 @@ public class ConsistencyWatchdogServer extends AbstractActivityProducer
       }
     }
 
-    checksum.update(content);
+    checksum.update(normalizedEditorContent);
   }
 
   private void broadcastChecksum(SPath docPath) {

--- a/core/src/saros/editor/IEditorManager.java
+++ b/core/src/saros/editor/IEditorManager.java
@@ -6,6 +6,7 @@ import saros.editor.text.LineRange;
 import saros.editor.text.TextSelection;
 import saros.filesystem.IProject;
 import saros.session.User;
+import saros.util.LineSeparatorNormalizationUtil;
 
 /**
  * Tracks and provides access to editors for the set of files shared in the currently running
@@ -52,6 +53,19 @@ public interface IEditorManager {
    *     with the given path exists locally
    */
   String getContent(SPath path);
+
+  /**
+   * Returns the normalized text content of the local editor associated with the specified file, or
+   * the content of the file itself if there is currently no open editor for it.
+   *
+   * <p>Normalized text only contains Unix line separators.
+   *
+   * @param path path of the file whose content should be returned
+   * @return the normalized text content of the matching local editor or file or <code>null</code>
+   *     if no file with the given path exists locally
+   * @see LineSeparatorNormalizationUtil
+   */
+  String getNormalizedContent(SPath path);
 
   /**
    * Saves the local editors of all shared files belonging to the given project. If <code>null

--- a/core/src/saros/editor/IEditorManager.java
+++ b/core/src/saros/editor/IEditorManager.java
@@ -45,24 +45,26 @@ public interface IEditorManager {
   Set<SPath> getOpenEditors();
 
   /**
-   * Returns the text content of the local editor associated with the specified file, or the content
-   * of the file itself if there is currently no open editor for it.
+   * Returns the text content of the local document associated with the specified file.
+   *
+   * <p>The document content is the content that is displayed when the file is opened in a text
+   * editor.
    *
    * @param path path of the file whose content should be returned
-   * @return the text content of the matching local editor or file, or <code>null</code> if no file
-   *     with the given path exists locally
+   * @return the text content of the matching local document or <code>null</code> if the file does
+   *     not exist or no document could be obtained for the file
    */
   String getContent(SPath path);
 
   /**
-   * Returns the normalized text content of the local editor associated with the specified file, or
-   * the content of the file itself if there is currently no open editor for it.
+   * Returns the normalized result of {@link #getContent(SPath)}.
    *
    * <p>Normalized text only contains Unix line separators.
    *
    * @param path path of the file whose content should be returned
-   * @return the normalized text content of the matching local editor or file or <code>null</code>
-   *     if no file with the given path exists locally
+   * @return the normalized text content of the matching local document or <code>null</code> if the
+   *     file does not exist or no document could be obtained for the file
+   * @see #getContent(SPath)
    * @see LineSeparatorNormalizationUtil
    */
   String getNormalizedContent(SPath path);

--- a/eclipse/src/saros/editor/EditorManager.java
+++ b/eclipse/src/saros/editor/EditorManager.java
@@ -462,6 +462,21 @@ public class EditorManager implements IEditorManager {
   }
 
   @Override
+  public String getNormalizedContent(SPath path) {
+    String content = getContent(path);
+
+    if (content == null) {
+      return null;
+    }
+
+    IFile file = ((EclipseFileImpl) path.getFile()).getDelegate();
+
+    String lineSeparator = FileUtil.getLineSeparator(file);
+
+    return LineSeparatorNormalizationUtil.normalize(content, lineSeparator);
+  }
+
+  @Override
   public Set<SPath> getOpenEditors() {
     return openEditorPaths;
   }

--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -706,6 +706,12 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
   }
 
   @Override
+  public String getNormalizedContent(SPath path) {
+    // Intellij editor content is already normalized
+    return getContent(path);
+  }
+
+  @Override
   public void addSharedEditorListener(ISharedEditorListener listener) {
     editorListenerDispatch.add(listener);
   }

--- a/server/src/saros/server/editor/ServerEditorManager.java
+++ b/server/src/saros/server/editor/ServerEditorManager.java
@@ -15,11 +15,13 @@ import saros.activities.TextEditActivity;
 import saros.editor.IEditorManager;
 import saros.editor.ISharedEditorListener;
 import saros.editor.text.LineRange;
+import saros.editor.text.TextPositionUtils;
 import saros.editor.text.TextSelection;
 import saros.filesystem.IFile;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
 import saros.session.User;
+import saros.util.LineSeparatorNormalizationUtil;
 
 /** Server implementation of the {@link IEditorManager} interface */
 public class ServerEditorManager implements IEditorManager {
@@ -50,6 +52,19 @@ public class ServerEditorManager implements IEditorManager {
     } catch (IOException e) {
       return null;
     }
+  }
+
+  @Override
+  public String getNormalizedContent(SPath path) {
+    String content = getContent(path);
+
+    if (content == null) {
+      return null;
+    }
+
+    String lineSeparator = TextPositionUtils.guessLineSeparator(content);
+
+    return LineSeparatorNormalizationUtil.normalize(content, lineSeparator);
   }
 
   @Override


### PR DESCRIPTION
#### [INTERNAL] Add IEditorManager.getNormalizedContent(SPath)

Adds the method IEditorManager.getNormalizedContent(SPath). The method
provides access to normalized representations of the resource content,
i.e. the content only containing Unix line separators.

It is necessary for an upcoming adjustment of the consistency watchdog
logic to work with normalized resource contents.

#### [INTERNAL][CORE] Use normalized content for checksum creation

Adjusts the consistency watchdog to use normalized file contents for
checksum creation. This is necessary as IntelliJ normalizes content line
endings internally, meaning the watchdog always works on normalized line
endings in Saros/I. For IDE cross-compatibility, other IDE
implementations must also use normalized content for the checksum
creation in order for the checksums to match correctly.

This also resolves an issue introduced with #877 where adding a newline
to an empty file would lead to a desynchronization according to the
consistency watchdog if the participants had differing settings on which
line separator to use.