### PR TITLE
Remove partial sharing logic

### DIFF
--- a/core/src/saros/concurrent/management/JupiterServer.java
+++ b/core/src/saros/concurrent/management/JupiterServer.java
@@ -60,12 +60,6 @@ public class JupiterServer {
    *
    * @host
    */
-  /*
-   * TODO This solution currently just works for partial sharing by
-   * coincidence. To really fix the issue we have to expand the
-   * SarosSessionMapper to also track the resources and not just the projects
-   * that are already shared for every user individually.
-   */
   private synchronized JupiterDocumentServer getServer(final SPath path) {
 
     JupiterDocumentServer docServer = concurrentDocuments.get(path);

--- a/core/src/saros/negotiation/AbstractIncomingProjectNegotiation.java
+++ b/core/src/saros/negotiation/AbstractIncomingProjectNegotiation.java
@@ -189,22 +189,7 @@ public abstract class AbstractIncomingProjectNegotiation extends ProjectNegotiat
         final String projectID = entry.getKey();
         final IProject project = entry.getValue();
 
-        final boolean isPartialRemoteProject = getProjectNegotiationData(projectID).isPartial();
-
-        final FileList remoteFileList = getProjectNegotiationData(projectID).getFileList();
-
-        List<IResource> resources = null;
-
-        if (isPartialRemoteProject) {
-
-          final List<String> paths = remoteFileList.getPaths();
-
-          resources = new ArrayList<IResource>(paths.size());
-
-          for (final String path : paths) resources.add(getResource(project, path));
-        }
-
-        session.addSharedResources(project, projectID, resources);
+        session.addSharedProject(project, projectID);
       }
     } catch (Exception e) {
       exception = e;
@@ -360,26 +345,18 @@ public abstract class AbstractIncomingProjectNegotiation extends ProjectNegotiat
       final String id = entry.getKey();
       final IProject project = entry.getValue();
 
-      // TODO optimize for partial shared projects
-
       final FileList localProjectFileList =
           FileListFactory.createFileList(
               project,
-              null,
               checksumCache,
               new SubProgressMonitor(
                   monitor, 1 * MONITOR_WORK_SCALE, SubProgressMonitor.SUPPRESS_BEGINTASK));
 
       final ProjectNegotiationData data = getProjectNegotiationData(id);
 
-      final FileListDiff diff =
-          FileListDiff.diff(localProjectFileList, data.getFileList(), data.isPartial());
+      final FileListDiff diff = FileListDiff.diff(localProjectFileList, data.getFileList());
 
       checkCancellation(CancelOption.NOTIFY_PEER);
-
-      if (data.isPartial()
-          && (!diff.getRemovedFiles().isEmpty() || !diff.getRemovedFolders().isEmpty()))
-        throw new IllegalStateException("partial sharing cannot delete existing resources");
 
       result.put(id, diff);
     }

--- a/core/src/saros/negotiation/AbstractOutgoingProjectNegotiation.java
+++ b/core/src/saros/negotiation/AbstractOutgoingProjectNegotiation.java
@@ -17,7 +17,6 @@ import saros.exceptions.LocalCancellationException;
 import saros.exceptions.SarosCancellationException;
 import saros.filesystem.IChecksumCache;
 import saros.filesystem.IProject;
-import saros.filesystem.IResource;
 import saros.filesystem.IWorkspace;
 import saros.monitoring.IProgressMonitor;
 import saros.monitoring.SubProgressMonitor;
@@ -111,8 +110,7 @@ public abstract class AbstractOutgoingProjectNegotiation extends ProjectNegotiat
       if (!session.isHost()) {
         for (IProject project : projects) {
           String projectID = projects.getProjectID(project);
-          List<IResource> resources = projects.getResourcesToShare(project);
-          session.addSharedResources(project, projectID, resources);
+          session.addSharedProject(project, projectID);
         }
       }
 
@@ -328,7 +326,6 @@ public abstract class AbstractOutgoingProjectNegotiation extends ProjectNegotiat
         throw new LocalCancellationException(null, CancelOption.DO_NOT_NOTIFY_PEER);
       try {
         String projectID = projectSharingData.getProjectID(project);
-        List<IResource> resources = projectSharingData.getResourcesToShare(project);
 
         /*
          * force editor buffer flush because we read the files from the
@@ -339,7 +336,6 @@ public abstract class AbstractOutgoingProjectNegotiation extends ProjectNegotiat
         FileList projectFileList =
             FileListFactory.createFileList(
                 project,
-                resources,
                 checksumCache,
                 new SubProgressMonitor(
                     monitor,
@@ -347,15 +343,13 @@ public abstract class AbstractOutgoingProjectNegotiation extends ProjectNegotiat
                     SubProgressMonitor.SUPPRESS_BEGINTASK
                         | SubProgressMonitor.SUPPRESS_SETTASKNAME));
 
-        boolean partial = projectSharingData.shouldBeSharedPartially(project);
-
         projectFileList.setProjectID(projectID);
 
         Map<String, String> additionalProjectData = additionalProjectDataFactory.build(project);
 
         ProjectNegotiationData data =
             new ProjectNegotiationData(
-                projectID, project.getName(), partial, projectFileList, additionalProjectData);
+                projectID, project.getName(), projectFileList, additionalProjectData);
 
         negData.add(data);
 

--- a/core/src/saros/negotiation/FileListDiff.java
+++ b/core/src/saros/negotiation/FileListDiff.java
@@ -10,7 +10,7 @@ import saros.negotiation.FileList.MetaData;
 /**
  * A diff between two {@link FileList file lists}.
  *
- * @see #diff(FileList, FileList, boolean)
+ * @see #diff(FileList, FileList)
  */
 public class FileListDiff {
 
@@ -45,13 +45,10 @@ public class FileListDiff {
    *
    * @param base The base {@link FileList}.
    * @param target The {@link FileList} to compare to.
-   * @param excludeRemoved if <code>true</code> removed files and folders are not included in the
-   *     result
    * @return a new {@link FileListDiff} which contains the difference information of the two {@link
    *     FileList}s.
    */
-  public static FileListDiff diff(
-      final FileList base, final FileList target, final boolean excludeRemoved) {
+  public static FileListDiff diff(final FileList base, final FileList target) {
 
     FileListDiff result = new FileListDiff();
 
@@ -93,13 +90,11 @@ public class FileListDiff {
 
     result.addedFiles.addAll(complementSet);
 
-    if (!excludeRemoved) {
-      complementSet.clear();
-      complementSet.addAll(baseFiles);
-      complementSet.removeAll(targetFiles);
+    complementSet.clear();
+    complementSet.addAll(baseFiles);
+    complementSet.removeAll(targetFiles);
 
-      result.removedFiles.addAll(complementSet);
-    }
+    result.removedFiles.addAll(complementSet);
 
     final Set<String> intersectionSet =
         new HashSet<String>(max(targetFiles.size(), targetFolders.size()));
@@ -127,13 +122,11 @@ public class FileListDiff {
 
     result.addedFolders.addAll(complementSet);
 
-    if (!excludeRemoved) {
-      complementSet.clear();
-      complementSet.addAll(baseFolders);
-      complementSet.removeAll(targetFolders);
+    complementSet.clear();
+    complementSet.addAll(baseFolders);
+    complementSet.removeAll(targetFolders);
 
-      result.removedFolders.addAll(complementSet);
-    }
+    result.removedFolders.addAll(complementSet);
 
     intersectionSet.clear();
     intersectionSet.addAll(targetFolders);

--- a/core/src/saros/negotiation/FileListFactory.java
+++ b/core/src/saros/negotiation/FileListFactory.java
@@ -21,7 +21,7 @@ import saros.negotiation.FileList.MetaData;
  *
  * <p>
  * <li>Either an inexpensive one that rescans the whole project to gather meta data:<br>
- *     {@link #createFileList(IProject, List, IChecksumCache, IProgressMonitor)}
+ *     {@link #createFileList(IProject, IChecksumCache, IProgressMonitor)}
  * <li>Or a cheap one which requires the caller to take care of the validity of input data:<br>
  *     {@link #createFileList(List)}
  */
@@ -40,14 +40,10 @@ public class FileListFactory {
   }
 
   public static FileList createFileList(
-      IProject project,
-      List<IResource> resources,
-      IChecksumCache checksumCache,
-      IProgressMonitor monitor)
-      throws IOException {
+      IProject project, IChecksumCache checksumCache, IProgressMonitor monitor) throws IOException {
 
     FileListFactory fact = new FileListFactory(checksumCache, monitor);
-    return fact.build(project, resources);
+    return fact.build(project);
   }
 
   /**
@@ -72,16 +68,13 @@ public class FileListFactory {
     return new FileList();
   }
 
-  private FileList build(IProject project, List<IResource> resources) throws IOException {
+  private FileList build(IProject project) throws IOException {
 
     FileList list = new FileList();
 
-    if (resources == null) {
-      list.addEncoding(project.getDefaultCharset());
-      resources = Arrays.asList(project.members());
-    }
+    list.addEncoding(project.getDefaultCharset());
 
-    addMembersToList(list, resources);
+    addMembersToList(list, Arrays.asList(project.members()));
 
     return list;
   }

--- a/core/src/saros/negotiation/ProjectNegotiationCollector.java
+++ b/core/src/saros/negotiation/ProjectNegotiationCollector.java
@@ -1,12 +1,8 @@
 package saros.negotiation;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
+import java.util.HashSet;
+import java.util.Set;
 import saros.filesystem.IProject;
-import saros.filesystem.IResource;
 
 /**
  * This class collects resources that should be added to a session to add them at once in
@@ -14,45 +10,28 @@ import saros.filesystem.IResource;
  * running project negotiations per user.
  */
 public class ProjectNegotiationCollector {
-  private Map<IProject, List<IResource>> mapping = new HashMap<IProject, List<IResource>>();
+  private Set<IProject> projects = new HashSet<>();
 
   /**
-   * Add project resource mappings for the next project negotiation.
+   * Add projects for the next project negotiation.
    *
-   * @param projectResourcesMapping project resource mappings to add
+   * @param projectsToAdd projects to add
    */
-  public synchronized void add(Map<IProject, List<IResource>> projectResourcesMapping) {
-    for (Entry<IProject, List<IResource>> mapEntry : projectResourcesMapping.entrySet()) {
-      final IProject project = mapEntry.getKey();
-      final List<IResource> resources = mapEntry.getValue();
-
-      boolean alreadyFullShared = mapping.containsKey(project) && mapping.get(project) == null;
-
-      /* full shared project */
-      if (resources == null || alreadyFullShared) {
-        mapping.put(project, null);
-        continue;
-      }
-
-      /* update partial shared project */
-      List<IResource> mappedResources = mapping.get(project);
-      if (mappedResources == null) {
-        mapping.put(project, new ArrayList<IResource>(resources));
-      } else {
-        mappedResources.addAll(resources);
-      }
-    }
+  public synchronized void addProjects(Set<IProject> projectsToAdd) {
+    projects.addAll(projectsToAdd);
   }
 
   /**
-   * Returns a list of project resource mappings that should be handled by a project negotiation.
-   * Resets the Collector for next additions.
+   * Returns a set of projects that should be handled by a project negotiation.
    *
-   * @return project resource mappings to add
+   * <p>Resets the Collector for next additions.
+   *
+   * @return projects to add
    */
-  public synchronized Map<IProject, List<IResource>> get() {
-    Map<IProject, List<IResource>> tmp = mapping;
-    mapping = new HashMap<IProject, List<IResource>>();
+  public synchronized Set<IProject> getProjects() {
+    Set<IProject> tmp = projects;
+    projects = new HashSet<>();
+
     return tmp;
   }
 }

--- a/core/src/saros/negotiation/ProjectNegotiationData.java
+++ b/core/src/saros/negotiation/ProjectNegotiationData.java
@@ -8,8 +8,7 @@ import java.util.Map;
 /**
  * This class contains all the information that the remote user needs during a project negotiation.
  *
- * <p>It contains the local project name, session-wide project id, local file list, and whether the
- * project is completely or partially shared.
+ * <p>It contains the local project name, session-wide project id, and local file list.
  *
  * <p>Furthermore, it contains a map of additional options for the project. These parameters can be
  * used to provide additional, potentially IDE specific information about the project that are
@@ -29,10 +28,6 @@ public class ProjectNegotiationData {
   @XStreamAsAttribute
   private final String projectID;
 
-  @XStreamAlias("partial")
-  @XStreamAsAttribute
-  private final boolean partial;
-
   @XStreamAlias("filelist")
   private final FileList fileList;
 
@@ -48,14 +43,12 @@ public class ProjectNegotiationData {
   public ProjectNegotiationData(
       String projectID,
       String projectName,
-      boolean partial,
       FileList fileList,
       Map<String, String> additionalProjectData) {
 
     this.fileList = fileList;
     this.projectName = projectName;
     this.projectID = projectID;
-    this.partial = partial;
     this.additionalProjectData = additionalProjectData;
   }
 
@@ -69,10 +62,6 @@ public class ProjectNegotiationData {
 
   public String getProjectID() {
     return projectID;
-  }
-
-  public boolean isPartial() {
-    return partial;
   }
 
   /**

--- a/core/src/saros/negotiation/ProjectSharingData.java
+++ b/core/src/saros/negotiation/ProjectSharingData.java
@@ -3,35 +3,27 @@ package saros.negotiation;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import saros.filesystem.IProject;
-import saros.filesystem.IResource;
 
 /**
- * Defines which projects and *which of their resources) to share during a particular {@link
+ * Defines which projects and which of their resources) to share during a particular {@link
  * AbstractOutgoingProjectNegotiation}.
  */
 public class ProjectSharingData implements Iterable<IProject> {
 
   private Map<String, IProject> projectsById = new HashMap<>();
   private Map<IProject, String> idsByProject = new HashMap<>();
-  private Map<IProject, List<IResource>> resourcesToShareByProject = new HashMap<>();
 
   /**
-   * Declares that the passed project should be shared with the specified ID. Optionally, a subset
-   * of the project's resources may be passed, which means that only those resources should be
-   * shared (that is, the project should be shared partially).
+   * Declares that the passed project should be shared with the specified ID.
    *
    * @param project project that should be shared
    * @param projectId session-wide ID assigned to the project
-   * @param resourcesToShare the resources of the project to share , or null to share the project
-   *     completely
    */
-  public void addProject(IProject project, String projectId, List<IResource> resourcesToShare) {
+  public void addProject(IProject project, String projectId) {
     projectsById.put(projectId, project);
     idsByProject.put(project, projectId);
-    resourcesToShareByProject.put(project, resourcesToShare);
   }
 
   /**
@@ -61,7 +53,7 @@ public class ProjectSharingData implements Iterable<IProject> {
    * @return boolean indicating if the project is already contained in this collection
    */
   public boolean hasProject(IProject project) {
-    return resourcesToShareByProject.containsKey(project);
+    return idsByProject.containsKey(project);
   }
 
   /**
@@ -72,28 +64,6 @@ public class ProjectSharingData implements Iterable<IProject> {
    */
   public String getProjectID(IProject project) {
     return idsByProject.get(project);
-  }
-
-  /**
-   * Returns whether sharing of the specified project should be restricted to particular resources
-   * (which, if true, can be queried with {@link #getResourcesToShare(IProject)}.
-   *
-   * @param project one of the to-be-shared projects
-   * @return true if the project should be shared partially, false if completely
-   */
-  public boolean shouldBeSharedPartially(IProject project) {
-    return getResourcesToShare(project) != null;
-  }
-
-  /**
-   * Returns a list of the resources to share from the specified project if that project is to be
-   * shared only partially. If not, null is returned instead.
-   *
-   * @param project one of the to-be-shared projects
-   * @return resources to share, or null if the project should be shared completely
-   */
-  public List<IResource> getResourcesToShare(IProject project) {
-    return resourcesToShareByProject.get(project);
   }
 
   /**

--- a/core/src/saros/negotiation/hooks/ISessionNegotiationHook.java
+++ b/core/src/saros/negotiation/hooks/ISessionNegotiationHook.java
@@ -1,6 +1,7 @@
 package saros.negotiation.hooks;
 
 import java.util.Map;
+import java.util.Set;
 import saros.negotiation.IncomingSessionNegotiation;
 import saros.negotiation.OutgoingSessionNegotiation;
 import saros.net.xmpp.JID;
@@ -33,7 +34,7 @@ public interface ISessionNegotiationHook {
    * Sets the host preferences that are needed before the session negotiation is started.
    *
    * <p>This method will be called on the <b>host</b> side during the session creation as part of
-   * {@link SarosSessionManager#startSession(Map)}).
+   * {@link SarosSessionManager#startSession(Set)}).
    *
    * @param hostPreferences The session preference store that corresponds to the host. May be used
    *     to store the initial host properties so they can be accessed by other components.

--- a/core/src/saros/session/ISarosSession.java
+++ b/core/src/saros/session/ISarosSession.java
@@ -20,7 +20,6 @@
 package saros.session;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import saros.activities.IActivity;
@@ -291,14 +290,6 @@ public interface ISarosSession {
   public boolean isShared(IResource resource);
 
   /**
-   * Checks if selected project is a complete shared one or partial shared.
-   *
-   * @param project
-   * @return <code>true</code> if complete, <code>false</code> if partial
-   */
-  public boolean isCompletelyShared(IProject project);
-
-  /**
    * Returns the global ID of the project.
    *
    * @return the global ID of the project or <code>null</code> if this project is not shared
@@ -313,36 +304,12 @@ public interface ISarosSession {
   public IProject getProject(String projectID);
 
   /**
-   * Adds the specified project and/or resources to this session.
+   * Adds the specified project to this session.
    *
-   * @param project The project to share.
-   * @param projectID The global project ID.
-   * @param dependentResources The project dependent resources.
+   * @param project The project to share
+   * @param projectID The global project ID
    */
-  public void addSharedResources(
-      IProject project, String projectID, List<IResource> dependentResources);
-
-  /**
-   * Returns all shared resources in this session.
-   *
-   * @return a list of all shared resources (excluding projects) from this session.
-   */
-  public List<IResource> getSharedResources();
-
-  /**
-   * Returns a map with the mapping of shared resources to their project.
-   *
-   * @return project-->resource mapping
-   */
-  public Map<IProject, List<IResource>> getProjectResourcesMapping();
-
-  /**
-   * Returns the shared resources of the project in this session.
-   *
-   * @param project
-   * @return the shared resources or <code>null</code> if this project is not or fully shared.
-   */
-  public List<IResource> getSharedResources(IProject project);
+  void addSharedProject(IProject project, String projectID);
 
   /**
    * Stores a bidirectional mapping between <code>project</code> and <code>projectID</code>.

--- a/core/src/saros/session/ISarosSessionManager.java
+++ b/core/src/saros/session/ISarosSessionManager.java
@@ -1,10 +1,8 @@
 package saros.session;
 
 import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.Set;
 import saros.filesystem.IProject;
-import saros.filesystem.IResource;
 import saros.net.xmpp.JID;
 import saros.preferences.IPreferenceStore;
 
@@ -18,11 +16,11 @@ public interface ISarosSessionManager {
   public ISarosSession getSession();
 
   /**
-   * Starts a new DPP session with the local user as only participant.
+   * Starts a new Saros session with the local user as the only participant.
    *
-   * @param projectResources the local project resources which should be shared.
+   * @param projects the local projects which should be shared
    */
-  public void startSession(Map<IProject, List<IResource>> projectResources);
+  void startSession(Set<IProject> projects);
 
   // FIXME this method is error prone and only used by the IPN, find a better
   // abstraction
@@ -84,11 +82,11 @@ public interface ISarosSessionManager {
   public void invite(Collection<JID> jidsToInvite, String description);
 
   /**
-   * Adds project resources to an existing session.
+   * Adds projects to an existing session.
    *
-   * @param projectResourcesMapping
+   * @param projects the projects to add
    */
-  public void addResourcesToSession(Map<IProject, List<IResource>> projectResourcesMapping);
+  void addProjectsToSession(Set<IProject> projects);
 
   /**
    * Call this before a ISarosSession is started.

--- a/core/src/saros/session/ISessionListener.java
+++ b/core/src/saros/session/ISessionListener.java
@@ -98,9 +98,6 @@ public interface ISessionListener {
    * Is fired then a project has been made part of the session, either because the local user began
    * sharing it or because it is being shared by a remote user.
    *
-   * <p>Note that this event is also fired if a project is re-shared with a different set of shared
-   * resources (e.g. by sharing a previously unshared folder of a partially shared project).
-   *
    * <p>This method might <i>not</i> be called on the UI thread.
    *
    * @param project the project that was added

--- a/core/src/saros/session/internal/SharedProjectMapper.java
+++ b/core/src/saros/session/internal/SharedProjectMapper.java
@@ -1,8 +1,6 @@
 package saros.session.internal;
 
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -14,9 +12,8 @@ import saros.filesystem.IResource;
 import saros.session.User;
 
 /**
- * This class is responsible for mapping global project IDs to local {@linkplain IProject projects},
- * as well as storing which resources are shared from each project. On the host, it also tracks
- * which users have already received which shared projects.
+ * This class is responsible for mapping global project IDs to local {@linkplain IProject projects}.
+ * On the host, it also tracks which users have already received which shared projects.
  *
  * <p>The project IDs are used to identify shared projects across the network, even when the local
  * names of shared projects are different. The ID is determined by the project/file-host.
@@ -26,54 +23,38 @@ class SharedProjectMapper {
   private static final Logger log = Logger.getLogger(SharedProjectMapper.class);
 
   /** Mapping from project IDs to currently registered shared projects. */
-  private Map<String, IProject> idToProjectMapping = new HashMap<String, IProject>();
+  private final Map<String, IProject> idToProjectMapping = new HashMap<String, IProject>();
 
   /** Mapping from currently registered shared projects to their id's. */
-  private Map<IProject, String> projectToIDMapping = new HashMap<IProject, String>();
+  private final Map<IProject, String> projectToIDMapping = new HashMap<IProject, String>();
 
   /**
    * Map for storing which clients have which projects. Used by the host to determine who can
    * currently process an activity related to a particular project. (Non-hosts don't maintain this
    * map.)
    */
-  private Map<User, List<String>> projectsOfUsers = new HashMap<User, List<String>>();
-
-  /**
-   * Map for storing the set of resources shared for each shared project. Maps to <code>null</code>
-   * for completely shared projects.
-   */
-  private Map<IProject, Set<IResource>> partiallySharedResourceMapping =
-      new HashMap<IProject, Set<IResource>>();
-
-  /** Set containing the currently completely shared projects. */
-  private Set<IProject> completelySharedProjects = new HashSet<IProject>();
-
-  /** Set containing the currently partially shared projects. */
-  private Set<IProject> partiallySharedProjects = new HashSet<IProject>();
+  private final Map<User, List<String>> projectsOfUsers = new HashMap<User, List<String>>();
 
   /**
    * Adds a project to the set of currently shared projects.
    *
-   * <p>It is possible to "upgrade" a partially shared project to a completely shared project by
-   * just adding the same project with the same ID again that must now marked as not partially
-   * shared.
-   *
    * @param id the ID for the project
    * @param project the project to add
-   * @param isPartially <code>true</code> if the project should be treated as a partially shared
-   *     project, <code>false</code> if it should be treated as completely shared
    * @throws NullPointerException if the ID or project is <code>null</code>
    * @throws IllegalStateException if the ID is already in use or the project was already added
    */
-  public synchronized void addProject(String id, IProject project, boolean isPartially) {
-    boolean upgrade = false;
-
+  public synchronized void addProject(String id, IProject project) {
     if (id == null) throw new NullPointerException("ID is null");
 
     if (project == null) throw new NullPointerException("project is null");
 
     String currentProjectID = projectToIDMapping.get(project);
     IProject currentProject = idToProjectMapping.get(id);
+
+    if (id.equals(currentProjectID) && project.equals(currentProject)) {
+      throw new IllegalStateException(
+          "ID - project mapping (" + id + " - " + project + ") already present.");
+    }
 
     if (currentProjectID != null && !id.equals(currentProjectID)) {
       throw new IllegalStateException(
@@ -87,58 +68,18 @@ class SharedProjectMapper {
 
     if (currentProject != null && !project.equals(currentProject)) {
       throw new IllegalStateException(
-          "ID " + id + " for project " + project + " is already used by project " + currentProject);
-    }
-
-    if (isPartially && partiallySharedProjects.contains(project))
-      throw new IllegalStateException("project " + project + " is already partially shared");
-
-    if (!isPartially && completelySharedProjects.contains(project))
-      throw new IllegalStateException("project " + project + " is already completely shared");
-
-    if (isPartially && completelySharedProjects.contains(project))
-      throw new IllegalStateException(
-          "project "
+          "cannot assign project "
               + project
-              + " is already completely shared (cannot downgrade a completely shared project)");
-
-    if (!isPartially && partiallySharedProjects.contains(project)) {
-      partiallySharedProjects.remove(project);
-      upgrade = true;
-    }
-
-    if (isPartially) partiallySharedProjects.add(project);
-    else completelySharedProjects.add(project);
-
-    assert Collections.disjoint(completelySharedProjects, partiallySharedProjects);
-
-    if (upgrade) {
-      // release resources
-      partiallySharedResourceMapping.put(project, null);
-
-      log.debug(
-          "upgraded partially shared project "
-              + project
-              + " with ID "
+              + " to ID "
               + id
-              + " to a completely shared project");
-      return;
+              + " because it is already registered with project "
+              + currentProject);
     }
 
     idToProjectMapping.put(id, project);
     projectToIDMapping.put(project, id);
 
-    if (isPartially) partiallySharedResourceMapping.put(project, new HashSet<IResource>());
-    else partiallySharedResourceMapping.put(project, null);
-
-    log.debug(
-        "added project "
-            + project
-            + " with ID "
-            + id
-            + " [completely shared:"
-            + !isPartially
-            + "]");
+    log.debug("added project " + project + " with ID " + id);
   }
 
   /**
@@ -155,114 +96,10 @@ class SharedProjectMapper {
       return;
     }
 
-    if (partiallySharedProjects.contains(project)) partiallySharedProjects.remove(project);
-    else completelySharedProjects.remove(project);
-
     idToProjectMapping.remove(id);
     projectToIDMapping.remove(project);
-    partiallySharedResourceMapping.remove(project);
 
     log.debug("removed project " + project + " with ID " + id);
-  }
-
-  /**
-   * Adds the given resources to a <b>partially</b> shared project.
-   *
-   * @param project a project that was added as a partially shared project
-   * @param resources the resources to add
-   */
-  /*
-   * TODO needs proper sync. in the SarosSession class
-   *
-   * @throws IllegalStateException if the project is completely or not shared
-   * at all
-   */
-  public synchronized void addResources(
-      IProject project, Collection<? extends IResource> resources) {
-
-    if (projectToIDMapping.get(project) == null) {
-      log.warn("could not add resources to project " + project + " because it is not shared");
-      // throw new IllegalStateException(
-      // "could not add resources to project " + project
-      // + " because it is not shared");
-      return;
-    }
-
-    if (completelySharedProjects.contains(project)) {
-      log.warn("cannot add resources to completely shared project: " + project);
-      // throw new IllegalStateException(
-      // "cannot add resources to completely shared project: " + project);
-      return;
-    }
-
-    Set<IResource> partiallySharedResources = partiallySharedResourceMapping.get(project);
-
-    if (partiallySharedResources.isEmpty()) {
-      partiallySharedResources = new HashSet<IResource>(Math.max(1024, (resources.size() * 3) / 2));
-
-      partiallySharedResourceMapping.put(project, partiallySharedResources);
-    }
-
-    partiallySharedResources.addAll(resources);
-  }
-
-  /**
-   * Removes the given resources from a <b>partially</b> shared project.
-   *
-   * @param project a project that was added as a partially shared project
-   * @param resources the resources to remove
-   */
-  /*
-   * TODO needs proper sync. in the SarosSession class
-   *
-   * @throws IllegalStateException if the project is completely or not shared
-   * at all
-   */
-  public synchronized void removeResources(
-      IProject project, Collection<? extends IResource> resources) {
-
-    if (projectToIDMapping.get(project) == null) {
-      log.warn("could not remove resources from project " + project + " because it is not shared");
-      // throw new IllegalStateException(
-      // "could not remove resources from project " + project
-      // + " because it is not shared");
-      return;
-    }
-
-    if (completelySharedProjects.contains(project)) {
-      log.warn("cannot remove resources from completely shared project: " + project);
-      // throw new IllegalStateException(
-      // "cannot remove resources from completely shared project: " +
-      // project);
-      return;
-    }
-
-    Set<IResource> partiallySharedResources = partiallySharedResourceMapping.get(project);
-
-    partiallySharedResources.removeAll(resources);
-  }
-
-  /**
-   * Atomically removes and adds resources. The resources to remove will be removed first before the
-   * resources to add will be added.
-   *
-   * @param project a project that was added as a partially shared project
-   * @param resourcesToRemove the resources to remove
-   * @param resourcesToAdd the resources to add
-   */
-  /*
-   * TODO needs proper sync. in the SarosSession class
-   *
-   * @throws IllegalStateException if the project is completely or not shared
-   * at all
-   */
-  public synchronized void removeAndAddResources(
-      IProject project,
-      Collection<? extends IResource> resourcesToRemove,
-      Collection<? extends IResource> resourcesToAdd) {
-
-    removeResources(project, resourcesToRemove);
-    addResources(project, resourcesToAdd);
   }
 
   /**
@@ -301,10 +138,7 @@ class SharedProjectMapper {
 
     if (!idToProjectMapping.containsValue(project)) return false;
 
-    if (isCompletelyShared(project))
-      // TODO how should partial sharing handle this case ?
-      return !resource.isIgnored();
-    else return partiallySharedResourceMapping.get(project).contains(resource);
+    return !resource.isIgnored();
   }
 
   /**
@@ -317,78 +151,12 @@ class SharedProjectMapper {
   }
 
   /**
-   * Returns all resources from all partially shared projects.
-   *
-   * @return a newly created {@link List} with all of the partially shared projects' resources
-   */
-  public synchronized List<IResource> getPartiallySharedResources() {
-
-    int size = 0;
-
-    for (Set<IResource> resources : partiallySharedResourceMapping.values())
-      if (resources != null) size += resources.size();
-
-    List<IResource> partiallySharedResources = new ArrayList<IResource>(size);
-
-    for (Set<IResource> resources : partiallySharedResourceMapping.values())
-      if (resources != null) partiallySharedResources.addAll(resources);
-
-    return partiallySharedResources;
-  }
-
-  /**
    * Returns the current number of shared projects.
    *
    * @return number of shared projects
    */
   public synchronized int size() {
     return idToProjectMapping.size();
-  }
-
-  /**
-   * Returns a mapping for each shared project and its containing resources. The resource list is
-   * <b>always</b> <code>null</code> for completely shared projects.
-   *
-   * @return a map from project to resource list (partially shared) or <code>null</code> (completely
-   *     shared)
-   */
-  public synchronized Map<IProject, List<IResource>> getProjectResourceMapping() {
-
-    Map<IProject, List<IResource>> result = new HashMap<IProject, List<IResource>>();
-
-    for (Map.Entry<IProject, Set<IResource>> entry : partiallySharedResourceMapping.entrySet()) {
-
-      List<IResource> partiallySharedResources = null;
-
-      if (entry.getValue() != null)
-        partiallySharedResources = new ArrayList<IResource>(entry.getValue());
-
-      result.put(entry.getKey(), partiallySharedResources);
-    }
-
-    return result;
-  }
-
-  /**
-   * Checks whether a project is completely shared.
-   *
-   * @param project the project to check for
-   * @return <code>true</code> if the project is completely shared, <code>false</code> if the
-   *     project is not or partially shared
-   */
-  public synchronized boolean isCompletelyShared(IProject project) {
-    return completelySharedProjects.contains(project);
-  }
-
-  /**
-   * Checks if a project is partially shared.
-   *
-   * @param project the project to check
-   * @return <code>true</code> if the project is partially shared, <code>false</code> if the project
-   *     is not or completely shared
-   */
-  public synchronized boolean isPartiallyShared(IProject project) {
-    return partiallySharedProjects.contains(project);
   }
 
   /**

--- a/core/src/saros/ui/util/ICollaborationUtils.java
+++ b/core/src/saros/ui/util/ICollaborationUtils.java
@@ -1,7 +1,8 @@
 package saros.ui.util;
 
 import java.util.List;
-import saros.filesystem.IResource;
+import java.util.Set;
+import saros.filesystem.IProject;
 import saros.net.xmpp.JID;
 import saros.session.ISarosSession;
 
@@ -9,14 +10,14 @@ import saros.session.ISarosSession;
 public interface ICollaborationUtils {
 
   /**
-   * Starts a new session and shares the given resources with given contacts.<br>
+   * Starts a new session and shares the given projects with given contacts.<br>
    * Does nothing if a {@link ISarosSession session} is already running.
    *
-   * @param resources to share
+   * @param projects projects to share
    * @param contacts which should be invited
    * @nonBlocking
    */
-  public void startSession(List<IResource> resources, List<JID> contacts);
+  public void startSession(Set<IProject> projects, List<JID> contacts);
 
   /**
    * Leaves the currently running {@link ISarosSession}<br>
@@ -25,13 +26,13 @@ public interface ICollaborationUtils {
   public void leaveSession();
 
   /**
-   * Adds the given project resources to the session.<br>
+   * Adds the given projects to the session.<br>
    * Does nothing if no {@link ISarosSession session} is running.
    *
-   * @param resources
+   * @param projects the projects to add to the session
    * @nonBlocking
    */
-  public void addResourcesToSession(List<IResource> resources);
+  public void addProjectsToSession(Set<IProject> projects);
 
   /**
    * Adds the given contacts to the session.<br>

--- a/core/test/junit/saros/negotiation/FileListDiffTest.java
+++ b/core/test/junit/saros/negotiation/FileListDiffTest.java
@@ -35,7 +35,7 @@ public class FileListDiffTest {
     b.addPath(FILE_A);
     b.addPath(FILE_C);
 
-    FileListDiff diff = FileListDiff.diff(a, b, false);
+    FileListDiff diff = FileListDiff.diff(a, b);
 
     assertPaths(diff.getAddedFiles(), FILE_C);
     assertPaths(diff.getRemovedFiles(), FILE_B);
@@ -74,7 +74,7 @@ public class FileListDiffTest {
 
     b.addPath(FILE_C);
 
-    FileListDiff diff = FileListDiff.diff(a, b, false);
+    FileListDiff diff = FileListDiff.diff(a, b);
 
     assertPaths(diff.getAddedFiles(), FILE_C);
     assertPaths(diff.getRemovedFiles());
@@ -103,7 +103,7 @@ public class FileListDiffTest {
     b.addPath(FOLDER_C, null, true);
     b.addPath(FOLDER_D, null, true);
 
-    FileListDiff diff = FileListDiff.diff(a, b, false);
+    FileListDiff diff = FileListDiff.diff(a, b);
 
     assertPaths(diff.getAddedFiles());
     assertPaths(diff.getRemovedFiles());
@@ -132,7 +132,7 @@ public class FileListDiffTest {
     b.addPath(FOLDER_A, null, true);
     b.addPath(FOLDER_B, null, true);
 
-    FileListDiff diff = FileListDiff.diff(a, b, false);
+    FileListDiff diff = FileListDiff.diff(a, b);
 
     assertPaths(diff.getAddedFiles());
     assertPaths(diff.getRemovedFiles());
@@ -144,35 +144,6 @@ public class FileListDiffTest {
     assertPaths(diff.getRemovedFolders(), FOLDER_C, FOLDER_D);
 
     assertPaths(diff.getUnalteredFolders(), FOLDER_SRC, FOLDER_A, FOLDER_B);
-  }
-
-  @Test
-  public void testExcludeRemoved() {
-
-    FileList a = new FileList();
-
-    a.addPath(FOLDER_A, null, true);
-    a.addPath(FOLDER_B, null, true);
-    a.addPath(FOLDER_C, null, true);
-    a.addPath(FOLDER_D, null, true);
-
-    a.addPath(FILE_A, null, false);
-    a.addPath(FILE_B, null, false);
-    a.addPath(FILE_C, null, false);
-    a.addPath(FILE_D, null, false);
-
-    FileListDiff diff = FileListDiff.diff(a, new FileList(), true);
-
-    assertPaths(diff.getAddedFiles());
-    assertPaths(diff.getRemovedFiles());
-
-    assertPaths(diff.getUnalteredFiles());
-    assertPaths(diff.getAlteredFiles());
-
-    assertPaths(diff.getAddedFolders());
-    assertPaths(diff.getRemovedFolders());
-
-    assertPaths(diff.getUnalteredFolders());
   }
 
   private static void assertPaths(List<String> actual, String... expected) {

--- a/core/test/junit/saros/negotiation/FileListTest.java
+++ b/core/test/junit/saros/negotiation/FileListTest.java
@@ -59,7 +59,7 @@ public class FileListTest {
   @Test
   public void testCreateFileListForProject() throws IOException {
 
-    final FileList fileList = FileListFactory.createFileList(project, null, null, null);
+    final FileList fileList = FileListFactory.createFileList(project, null, null);
 
     final List<String> paths = fileList.getPaths();
 

--- a/core/test/junit/saros/session/SarosSessionManagerTest.java
+++ b/core/test/junit/saros/session/SarosSessionManagerTest.java
@@ -3,8 +3,7 @@ package saros.session;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicReference;
 import org.easymock.EasyMock;
 import org.junit.Before;
@@ -16,8 +15,6 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import saros.communication.connection.ConnectionHandler;
 import saros.context.IContainerContext;
-import saros.filesystem.IProject;
-import saros.filesystem.IResource;
 import saros.net.IReceiver;
 import saros.net.ITransmitter;
 import saros.preferences.IPreferenceStore;
@@ -112,22 +109,22 @@ public class SarosSessionManagerTest {
   @Test
   public void testStartStopListenerCallback() {
     manager.addSessionLifecycleListener(new StateVerifyListener());
-    manager.startSession(new HashMap<IProject, List<IResource>>());
+    manager.startSession(new HashSet<>());
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
   }
 
   @Test
   public void testMultipleStarts() {
     manager.addSessionLifecycleListener(new StateVerifyListener());
-    manager.startSession(new HashMap<IProject, List<IResource>>());
-    manager.startSession(new HashMap<IProject, List<IResource>>());
+    manager.startSession(new HashSet<>());
+    manager.startSession(new HashSet<>());
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
   }
 
   @Test
   public void testMultipleStops() {
     manager.addSessionLifecycleListener(new StateVerifyListener());
-    manager.startSession(new HashMap<IProject, List<IResource>>());
+    manager.startSession(new HashSet<>());
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
   }
@@ -135,7 +132,7 @@ public class SarosSessionManagerTest {
   @Test(expected = DummyError.class)
   public void testListenerDispatchIsNotCatchingErrors() {
     manager.addSessionLifecycleListener(new ErrorThrowingListener());
-    manager.startSession(new HashMap<IProject, List<IResource>>());
+    manager.startSession(new HashSet<>());
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
   }
 
@@ -153,7 +150,7 @@ public class SarosSessionManagerTest {
           }
         };
     manager.addSessionLifecycleListener(listener);
-    manager.startSession(new HashMap<IProject, List<IResource>>());
+    manager.startSession(new HashSet<>());
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
   }
 
@@ -167,11 +164,11 @@ public class SarosSessionManagerTest {
           public void sessionStarting(ISarosSession oldSarosSession) {
             assertTrue("startSession is executed recusive", count == 0);
             count++;
-            manager.startSession(new HashMap<IProject, List<IResource>>());
+            manager.startSession(new HashSet<>());
           }
         };
     manager.addSessionLifecycleListener(listener);
-    manager.startSession(new HashMap<IProject, List<IResource>>());
+    manager.startSession(new HashSet<>());
   }
 
   @Test(expected = IllegalStateException.class)
@@ -191,7 +188,7 @@ public class SarosSessionManagerTest {
           }
         };
     manager.addSessionLifecycleListener(listener);
-    manager.startSession(new HashMap<IProject, List<IResource>>());
+    manager.startSession(new HashSet<>());
 
     RuntimeException rte = exception.get();
 
@@ -208,14 +205,14 @@ public class SarosSessionManagerTest {
           @Override
           public void sessionEnding(ISarosSession oldSarosSession) {
             try {
-              manager.startSession(new HashMap<IProject, List<IResource>>());
+              manager.startSession(new HashSet<>());
             } catch (RuntimeException e) {
               exception.set(e);
             }
           }
         };
     manager.addSessionLifecycleListener(listener);
-    manager.startSession(new HashMap<IProject, List<IResource>>());
+    manager.startSession(new HashSet<>());
     manager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
 
     RuntimeException rte = exception.get();

--- a/core/test/junit/saros/session/internal/SharedProjectMapperTest.java
+++ b/core/test/junit/saros/session/internal/SharedProjectMapperTest.java
@@ -2,17 +2,11 @@ package saros.session.internal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import org.easymock.EasyMock;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
@@ -28,38 +22,21 @@ public class SharedProjectMapperTest {
 
   @Test(expected = NullPointerException.class)
   public void testAddNullProject() {
-    mapper.addProject("0", null, false);
+    mapper.addProject("0", null);
   }
 
   @Test(expected = NullPointerException.class)
   public void testAddProjectWithNullID() {
-    mapper.addProject(null, createProjectMock(), false);
+    mapper.addProject(null, createProjectMock());
   }
 
   @Test
   public void testAddCompletelySharedProject() {
     IProject projectMock = createProjectMock();
 
-    mapper.addProject("0", projectMock, false);
+    mapper.addProject("0", projectMock);
 
     assertTrue("project is not shared at all", mapper.isShared(projectMock));
-
-    assertFalse("project is partially shared", mapper.isPartiallyShared(projectMock));
-
-    assertTrue("project is not completely shared", mapper.isCompletelyShared(projectMock));
-  }
-
-  @Test
-  public void testAddPartiallySharedProject() {
-    IProject projectMock = createProjectMock();
-
-    mapper.addProject("0", projectMock, true);
-
-    assertTrue("project is not shared at all", mapper.isShared(projectMock));
-
-    assertFalse("project is completely shared", mapper.isCompletelyShared(projectMock));
-
-    assertTrue("project is not partially shared", mapper.isPartiallyShared(projectMock));
   }
 
   @Test(expected = IllegalStateException.class)
@@ -67,25 +44,12 @@ public class SharedProjectMapperTest {
     IProject projectMock = createProjectMock();
 
     try {
-      mapper.addProject("0", projectMock, false);
+      mapper.addProject("0", projectMock);
     } catch (RuntimeException e) {
       e.printStackTrace();
       fail(e.getMessage());
     }
-    mapper.addProject("0", projectMock, false);
-  }
-
-  @Test(expected = IllegalStateException.class)
-  public void testAddPartiallySharedProjectTwice() {
-    IProject projectMock = createProjectMock();
-
-    try {
-      mapper.addProject("0", projectMock, true);
-    } catch (RuntimeException e) {
-      e.printStackTrace();
-      fail(e.getMessage());
-    }
-    mapper.addProject("0", projectMock, true);
+    mapper.addProject("0", projectMock);
   }
 
   @Test(expected = IllegalStateException.class)
@@ -93,13 +57,13 @@ public class SharedProjectMapperTest {
     IProject projectMock = createProjectMock();
 
     try {
-      mapper.addProject("0", projectMock, true);
+      mapper.addProject("0", projectMock);
     } catch (RuntimeException e) {
       e.printStackTrace();
       fail(e.getMessage());
     }
 
-    mapper.addProject("1", projectMock, true);
+    mapper.addProject("1", projectMock);
   }
 
   @Test(expected = IllegalStateException.class)
@@ -108,136 +72,24 @@ public class SharedProjectMapperTest {
     IProject projectMockB = createProjectMock();
 
     try {
-      mapper.addProject("0", projectMockA, true);
+      mapper.addProject("0", projectMockA);
     } catch (RuntimeException e) {
       e.printStackTrace();
       fail(e.getMessage());
     }
 
-    mapper.addProject("0", projectMockB, true);
-  }
-
-  @Test
-  public void testPartiallySharedProjectUpgrade() {
-    IProject projectMock = createProjectMock();
-
-    mapper.addProject("0", projectMock, true);
-    assertTrue("project is not partially shared", mapper.isPartiallyShared(projectMock));
-
-    assertFalse("project is completely shared", mapper.isCompletelyShared(projectMock));
-
-    mapper.addProject("0", projectMock, false);
-    assertFalse("project is partially shared", mapper.isPartiallyShared(projectMock));
-
-    assertTrue("project is not completely shared", mapper.isCompletelyShared(projectMock));
-  }
-
-  @Test(expected = IllegalStateException.class)
-  public void testCompletelySharedProjectDowngrade() {
-    IProject projectMock = createProjectMock();
-
-    try {
-      mapper.addProject("0", projectMock, false);
-    } catch (RuntimeException e) {
-      e.printStackTrace();
-      fail(e.getMessage());
-    }
-
-    mapper.addProject("0", projectMock, true);
+    mapper.addProject("0", projectMockB);
   }
 
   @Test
   public void testRemoveProjects() {
     IProject projectMockA = createProjectMock();
-    IProject projectMockB = createProjectMock();
 
-    mapper.addProject("0", projectMockA, false);
-    mapper.addProject("1", projectMockB, true);
+    mapper.addProject("0", projectMockA);
 
     mapper.removeProject("0");
-    mapper.removeProject("1");
 
     assertFalse("project is still shared", mapper.isShared(projectMockA));
-    assertFalse("project is still shared", mapper.isShared(projectMockB));
-
-    assertFalse("project is still completely shared", mapper.isCompletelyShared(projectMockA));
-    assertFalse("project is still partially shared", mapper.isPartiallyShared(projectMockB));
-  }
-
-  @Test(expected = IllegalStateException.class)
-  @Ignore(
-      "logic is currently not performed - should be enabled after the SarosSession is properly synchronized")
-  public void testAddResourcesToCompletelySharedProject() {
-    IProject projectMock = createProjectMock();
-    mapper.addProject("0", projectMock, false);
-    List<IResource> emptyList = Collections.emptyList();
-    mapper.addResources(projectMock, emptyList);
-  }
-
-  @Test(expected = IllegalStateException.class)
-  @Ignore(
-      "logic is currently not performed - should be enabled after the SarosSession is properly synchronized")
-  public void testAddResourcesToNonSharedProject() {
-    IProject projectMock = createProjectMock();
-
-    List<IResource> emptyList = Collections.emptyList();
-    mapper.addResources(projectMock, emptyList);
-  }
-
-  @Test(expected = IllegalStateException.class)
-  @Ignore(
-      "logic is currently not performed - should be enabled after the SarosSession is properly synchronized")
-  public void testRemoveResourcesFromCompletelySharedProject() {
-    IProject projectMock = createProjectMock();
-
-    mapper.addProject("0", projectMock, false);
-
-    List<IResource> emptyList = Collections.emptyList();
-    mapper.removeResources(projectMock, emptyList);
-  }
-
-  @Test(expected = IllegalStateException.class)
-  @Ignore(
-      "logic is currently not performed - should be enabled after the SarosSession is properly synchronized")
-  public void testRemoveResourcesFromNonSharedProject() {
-    IProject projectMock = createProjectMock();
-
-    List<IResource> emptyList = Collections.emptyList();
-    mapper.removeResources(projectMock, emptyList);
-  }
-
-  @Test
-  public void testAddRemoveResourcesOfPartiallySharedProject() {
-
-    IProject projectMock = createProjectMock();
-
-    IResource resourceMockA = EasyMock.createNiceMock(IResource.class);
-    EasyMock.expect(resourceMockA.getProject()).andStubReturn(projectMock);
-    IResource resourceMockB = EasyMock.createNiceMock(IResource.class);
-    EasyMock.expect(resourceMockB.getProject()).andStubReturn(projectMock);
-    EasyMock.replay(resourceMockA, resourceMockB);
-
-    mapper.addProject("0", projectMock, true);
-    mapper.addResources(projectMock, Collections.singletonList(resourceMockA));
-
-    assertTrue("resource is not shared", mapper.isShared(resourceMockA));
-    assertEquals(1, mapper.getPartiallySharedResources().size());
-
-    mapper.removeResources(projectMock, Collections.singletonList(resourceMockA));
-
-    assertFalse("resource is still shared", mapper.isShared(resourceMockA));
-    assertEquals(0, mapper.getPartiallySharedResources().size());
-
-    mapper.addResources(projectMock, Collections.singletonList(resourceMockA));
-
-    mapper.removeAndAddResources(
-        projectMock,
-        Collections.singletonList(resourceMockA),
-        Collections.singletonList(resourceMockB));
-
-    assertFalse("resource is still shared", mapper.isShared(resourceMockA));
-    assertTrue("resource is not shared", mapper.isShared(resourceMockB));
-    assertEquals(1, mapper.getPartiallySharedResources().size());
   }
 
   @Test
@@ -250,7 +102,7 @@ public class SharedProjectMapperTest {
 
     EasyMock.replay(resourceMock);
 
-    mapper.addProject("0", projectMock, false);
+    mapper.addProject("0", projectMock);
 
     assertFalse("ignored resource is marked as shared", mapper.isShared(resourceMock));
 
@@ -261,55 +113,17 @@ public class SharedProjectMapperTest {
   public void testIsShared() {
 
     IProject projectMockA = createProjectMock();
-    IProject projectMockB = createProjectMock();
 
     IResource resourceMockA = EasyMock.createNiceMock(IResource.class);
     EasyMock.expect(resourceMockA.getProject()).andStubReturn(projectMockA);
 
-    IResource resourceMockB = EasyMock.createNiceMock(IResource.class);
-    EasyMock.expect(resourceMockB.getProject()).andStubReturn(projectMockB);
-
-    EasyMock.replay(resourceMockA, resourceMockB);
+    EasyMock.replay(resourceMockA);
 
     assertFalse("resource should not be marked as shared", mapper.isShared(resourceMockA));
 
-    assertFalse("resource should not be marked as shared", mapper.isShared(resourceMockB));
-
-    mapper.addProject("0", projectMockA, false);
-    mapper.addProject("1", projectMockB, true);
+    mapper.addProject("0", projectMockA);
 
     assertTrue("resource is not marked as shared", mapper.isShared(resourceMockA));
-
-    assertFalse("resource should not be marked as shared", mapper.isShared(resourceMockB));
-
-    mapper.addResources(projectMockB, Collections.singletonList(resourceMockB));
-
-    assertTrue("resource is not marked as shared", mapper.isShared(resourceMockB));
-  }
-
-  @Test
-  public void testGetProjectResourceMapping() {
-    IProject projectMockA = createProjectMock();
-    IProject projectMockB = createProjectMock();
-
-    IResource resourceMockB = EasyMock.createNiceMock(IResource.class);
-    EasyMock.expect(resourceMockB.getProject()).andStubReturn(projectMockB);
-
-    EasyMock.replay(resourceMockB);
-
-    mapper.addProject("0", projectMockA, false);
-    mapper.addProject("1", projectMockB, true);
-
-    mapper.addResources(projectMockB, Collections.singletonList(resourceMockB));
-
-    Map<IProject, List<IResource>> mapping = mapper.getProjectResourceMapping();
-
-    assertNull("completely shared projects have no resource list", mapping.get(projectMockA));
-
-    assertNotNull("partially shared projects must have a resource list", mapping.get(projectMockB));
-
-    assertEquals(
-        "resource list does not contain the shared resource", 1, mapping.get(projectMockB).size());
   }
 
   @Test
@@ -317,8 +131,8 @@ public class SharedProjectMapperTest {
     IProject projectMockA = createProjectMock();
     IProject projectMockB = createProjectMock();
 
-    mapper.addProject("0", projectMockA, false);
-    mapper.addProject("1", projectMockB, false);
+    mapper.addProject("0", projectMockA);
+    mapper.addProject("1", projectMockB);
 
     assertEquals(2, mapper.getProjects().size());
     assertEquals(2, mapper.size());
@@ -327,7 +141,7 @@ public class SharedProjectMapperTest {
   @Test
   public void testIDToProjectMapping() {
     IProject projectMock = createProjectMock();
-    mapper.addProject("0", projectMock, false);
+    mapper.addProject("0", projectMock);
     assertEquals("0", mapper.getID(projectMock));
     assertEquals(projectMock, mapper.getProject("0"));
   }

--- a/eclipse/src/saros/editor/EditorManager.java
+++ b/eclipse/src/saros/editor/EditorManager.java
@@ -986,8 +986,8 @@ public class EditorManager implements IEditorManager {
    * <ol>
    *   <li>Has an underlying <code>IResource</code> as storage.
    *   <li>Can be adapted to an <code>ITextViewer</code>.
-   *   <li>The underlying <code>IResource</code> is part of the current (partial) project sharing
-   *       (see {@link ISarosSession#isShared}).
+   *   <li>The underlying <code>IResource</code> is part of the current project sharing (see {@link
+   *       ISarosSession#isShared}).
    * </ol>
    */
   private boolean isSharedEditor(final IEditorPart editorPart) {

--- a/eclipse/src/saros/feedback/ProjectCollector.java
+++ b/eclipse/src/saros/feedback/ProjectCollector.java
@@ -1,12 +1,9 @@
 package saros.feedback;
 
 import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import saros.annotations.Component;
 import saros.filesystem.IProject;
-import saros.filesystem.IResource;
 import saros.session.ISarosSession;
 import saros.session.ISessionListener;
 
@@ -21,12 +18,8 @@ public class ProjectCollector extends AbstractStatisticCollector {
   // Keys for shared project information
   private static final String KEY_COMPLETE_SHARED_PROJECTS =
       "session.shared.project.complete.count";
-  private static final String KEY_PARTIAL_SHARED_PROJECTS = "session.shared.project.partial.count";
-  private static final String KEY_PARTIAL_SHARED_PROJECTS_FILES =
-      "session.shared.project.partial.files.count";
 
   private static class ProjectInformation {
-    public boolean isPartial;
     public int files;
   }
 
@@ -45,27 +38,6 @@ public class ProjectCollector extends AbstractStatisticCollector {
             info = new ProjectInformation();
             sharedProjects.put(projectID, info);
           }
-
-          boolean isPartial = !sarosSession.isCompletelyShared(project);
-
-          /*
-           * ignore partial shared projects that were upgraded to full shared
-           * projects so we now that the users use at least partial sharing
-           */
-          if (!info.isPartial && isPartial) info.isPartial = true;
-
-          List<IResource> sharedResources = sarosSession.getSharedResources(project);
-
-          if (sharedResources != null) {
-            for (Iterator<IResource> it = sharedResources.iterator(); it.hasNext(); ) {
-
-              IResource resource = it.next();
-
-              if (resource.getType() != IResource.FILE) it.remove();
-            }
-
-            info.files = sharedResources.size();
-          }
         }
       };
 
@@ -75,20 +47,9 @@ public class ProjectCollector extends AbstractStatisticCollector {
 
   @Override
   protected void processGatheredData() {
-    int completeSharedProjects = 0;
-    int partialSharedProjects = 0;
-    int partialSharedFiles = 0;
-
-    for (ProjectInformation info : sharedProjects.values()) {
-      if (info.isPartial) {
-        partialSharedProjects++;
-        partialSharedFiles += info.files;
-      } else completeSharedProjects++;
-    }
+    int completeSharedProjects = sharedProjects.size();
 
     data.put(KEY_COMPLETE_SHARED_PROJECTS, completeSharedProjects);
-    data.put(KEY_PARTIAL_SHARED_PROJECTS, partialSharedProjects);
-    data.put(KEY_PARTIAL_SHARED_PROJECTS_FILES, partialSharedFiles);
   }
 
   @Override

--- a/eclipse/src/saros/ui/Messages.java
+++ b/eclipse/src/saros/ui/Messages.java
@@ -77,7 +77,6 @@ public class Messages extends NLS {
   public static String CollaborationUtils_confirm_closing_text;
   public static String CollaborationUtils_confirm_leaving;
   public static String CollaborationUtils_confirm_leaving_text;
-  public static String CollaborationUtils_partial;
   public static String CollaborationUtils_insufficient_privileges;
   public static String CollaborationUtils_insufficient_privileges_text;
 
@@ -367,7 +366,6 @@ public class Messages extends NLS {
   public static String FollowThisPersonAction_stop_follow_tooltip;
 
   public static String SharedProjectDecorator_shared;
-  public static String SharedProjectDecorator_shared_partial;
 
   public static String SubscriptionManager_incoming_subscription_request_title;
   public static String SubscriptionManager_incoming_subscription_request_message;

--- a/eclipse/src/saros/ui/decorators/SharedProjectDecorator.java
+++ b/eclipse/src/saros/ui/decorators/SharedProjectDecorator.java
@@ -111,13 +111,7 @@ public final class SharedProjectDecorator implements ILightweightLabelDecorator 
     decoration.addOverlay(SharedProjectDecorator.PROJECT_DESCRIPTOR, IDecoration.TOP_LEFT);
 
     if (resource.getType() == IResource.PROJECT) {
-      boolean isCompletelyShared =
-          currentSession.isCompletelyShared(ResourceAdapterFactory.create(resource.getProject()));
-
-      decoration.addSuffix(
-          isCompletelyShared
-              ? Messages.SharedProjectDecorator_shared
-              : Messages.SharedProjectDecorator_shared_partial);
+      decoration.addSuffix(Messages.SharedProjectDecorator_shared);
     }
   }
 

--- a/eclipse/src/saros/ui/expressions/ProjectPropertyTester.java
+++ b/eclipse/src/saros/ui/expressions/ProjectPropertyTester.java
@@ -35,7 +35,7 @@ public class ProjectPropertyTester extends PropertyTester {
     if ("isInSarosSession".equals(property)) {
 
       if (resource.getType() == IResource.PROJECT) {
-        return session.isCompletelyShared(ResourceAdapterFactory.create((IProject) resource));
+        return session.isShared(ResourceAdapterFactory.create((IProject) resource));
       }
 
       return session.isShared(ResourceAdapterFactory.create(resource));

--- a/eclipse/src/saros/ui/messages.properties
+++ b/eclipse/src/saros/ui/messages.properties
@@ -83,7 +83,6 @@ CollaborationUtils_confirm_closing=Confirm Closing Session
 CollaborationUtils_confirm_closing_text=Are you sure that you want to close this Saros session? Since you are the creator of this session, it will be closed for all participants.
 CollaborationUtils_confirm_leaving=Confirm Leaving Session
 CollaborationUtils_confirm_leaving_text=Are you sure that you want to leave this Saros session?
-CollaborationUtils_partial=\ (partial)
 CollaborationUtils_insufficient_privileges=Insufficient Privileges
 CollaborationUtils_insufficient_privileges_text=You cannot add projects or files to the current session without write permission.
 
@@ -340,7 +339,7 @@ NetworkPreferencePage_upnp_device_not_found=UPnP devices not found (a device mig
 NetworkPreferencePage_upnp_devices=UPnP Devices
 NetworkPreferencePage_upnp_label_Text=To enable low-latency real-time collaboration Saros needs a direct TCP connection. Direct TCP connections\nare normally not possible if you are behind a router due to Network Address Translation (NAT).\nEnabling UPnP port mapping on your router allows Saros to communicate with the router to forward\na port without your manual intervention.
 
-ProjectSelectionWizardPage_description=Select the projects, folders or files you want to work on. You can choose projects completely or partially.
+ProjectSelectionWizardPage_description=Select the projects you want to work on.
 ProjectSelectionWizardPage_selected_no_project=Select at least one file to work on.
 ProjectSelectionWizardPage_title=Select Project
 
@@ -383,7 +382,6 @@ UserElement_read_only=(read-only)
 UserElement_host=Host 
 
 SharedProjectDecorator_shared=\ (shared)
-SharedProjectDecorator_shared_partial=\ (partial share)
 
 OpenPreferencesAction_title=Preferences
 OpenPreferencesAction_tooltip=Open Saros Preferences

--- a/eclipse/src/saros/ui/widgets/viewer/project/BaseResourceSelectionComposite.java
+++ b/eclipse/src/saros/ui/widgets/viewer/project/BaseResourceSelectionComposite.java
@@ -476,8 +476,7 @@ public abstract class BaseResourceSelectionComposite extends ViewerComposite<Che
             if (element instanceof IFile || element instanceof IFolder) {
               return !sarosSession.isShared(ResourceAdapterFactory.create((IResource) element));
             } else if (element instanceof IProject) {
-              return !(sarosSession.isCompletelyShared(
-                  ResourceAdapterFactory.create((IProject) element)));
+              return !(sarosSession.isShared(ResourceAdapterFactory.create((IProject) element)));
             }
           }
           return true;

--- a/eclipse/src/saros/ui/wizards/AddProjectToSessionWizard.java
+++ b/eclipse/src/saros/ui/wizards/AddProjectToSessionWizard.java
@@ -567,24 +567,14 @@ public class AddProjectToSessionWizard extends Wizard {
       final saros.filesystem.IProject adaptedProject =
           ResourceAdapterFactory.create(entry.getValue());
 
-      /*
-       * do not refresh already partially shared projects as this may
-       * trigger resource change events
-       */
       if (!session.isShared(adaptedProject)) project.refreshLocal(IResource.DEPTH_INFINITE, null);
 
       final FileList localFileList;
-
-      /*
-       * TODO optimize for partial shared projects a.k.a do not scan all
-       * files
-       */
 
       try {
         localFileList =
             FileListFactory.createFileList(
                 adaptedProject,
-                null,
                 checksumCache,
                 ProgressMonitorAdapterFactory.convert(
                     subMonitor.newChild(1, SubMonitor.SUPPRESS_ALL_LABELS)));
@@ -600,8 +590,7 @@ public class AddProjectToSessionWizard extends Wizard {
 
       final ProjectNegotiationData data = negotiation.getProjectNegotiationData(projectID);
 
-      final FileListDiff diff =
-          FileListDiff.diff(localFileList, data.getFileList(), data.isPartial());
+      final FileListDiff diff = FileListDiff.diff(localFileList, data.getFileList());
 
       if (!diff.getRemovedFolders().isEmpty()
           || !diff.getRemovedFiles().isEmpty()

--- a/eclipse/src/saros/util/EclipseCollaborationUtilsImpl.java
+++ b/eclipse/src/saros/util/EclipseCollaborationUtilsImpl.java
@@ -1,7 +1,8 @@
 package saros.util;
 
 import java.util.List;
-import saros.filesystem.IResource;
+import java.util.Set;
+import saros.filesystem.IProject;
 import saros.filesystem.ResourceAdapterFactory;
 import saros.net.xmpp.JID;
 import saros.ui.util.CollaborationUtils;
@@ -13,8 +14,8 @@ import saros.ui.util.ICollaborationUtils;
 public class EclipseCollaborationUtilsImpl implements ICollaborationUtils {
 
   @Override
-  public void startSession(List<IResource> resources, List<JID> contacts) {
-    CollaborationUtils.startSession(ResourceAdapterFactory.convertBack(resources), contacts);
+  public void startSession(Set<IProject> projects, List<JID> contacts) {
+    CollaborationUtils.startSession(ResourceAdapterFactory.convertBack(projects), contacts);
   }
 
   @Override
@@ -23,8 +24,8 @@ public class EclipseCollaborationUtilsImpl implements ICollaborationUtils {
   }
 
   @Override
-  public void addResourcesToSession(List<IResource> resources) {
-    CollaborationUtils.addResourcesToSession(ResourceAdapterFactory.convertBack(resources));
+  public void addProjectsToSession(Set<IProject> projects) {
+    CollaborationUtils.addResourcesToSession(ResourceAdapterFactory.convertBack(projects));
   }
 
   @Override

--- a/intellij/src/saros/core/util/IntellijCollaborationUtilsImpl.java
+++ b/intellij/src/saros/core/util/IntellijCollaborationUtilsImpl.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import saros.core.ui.util.CollaborationUtils;
+import saros.filesystem.IProject;
 import saros.filesystem.IResource;
 import saros.intellij.context.SharedIDEContext;
 import saros.intellij.filesystem.IntelliJProjectImpl;
@@ -26,10 +27,10 @@ public class IntellijCollaborationUtilsImpl implements ICollaborationUtils {
   }
 
   @Override
-  public void startSession(List<IResource> resources, List<JID> contacts) {
+  public void startSession(Set<IProject> projects, List<JID> contacts) {
     Set<Project> sharedProjects = new HashSet<>();
 
-    for (IResource resource : resources) {
+    for (IResource resource : projects) {
       sharedProjects.add(
           resource.getProject().adaptTo(IntelliJProjectImpl.class).getModule().getProject());
     }
@@ -42,7 +43,7 @@ public class IntellijCollaborationUtilsImpl implements ICollaborationUtils {
     }
     SharedIDEContext.preregisterProject(sharedProjects.toArray(new Project[1])[0]);
 
-    CollaborationUtils.startSession(resources, contacts);
+    CollaborationUtils.startSession(projects, contacts);
   }
 
   @Override
@@ -51,8 +52,8 @@ public class IntellijCollaborationUtilsImpl implements ICollaborationUtils {
   }
 
   @Override
-  public void addResourcesToSession(List<IResource> resources) {
-    CollaborationUtils.addResourcesToSession(resources);
+  public void addProjectsToSession(Set<IProject> projects) {
+    CollaborationUtils.addResourcesToSession(projects);
   }
 
   @Override

--- a/intellij/src/saros/intellij/ui/Messages.java
+++ b/intellij/src/saros/intellij/ui/Messages.java
@@ -43,7 +43,6 @@ public class Messages {
   public static String CollaborationUtils_confirm_leaving_message;
   public static String CollaborationUtils_insufficient_privileges_title;
   public static String CollaborationUtils_insufficient_privileges_message;
-  public static String CollaborationUtils_partial;
 
   public static String ConsistencyAction_progress_perform_recovery;
 

--- a/intellij/src/saros/intellij/ui/menu/ShareWithUserAction.java
+++ b/intellij/src/saros/intellij/ui/menu/ShareWithUserAction.java
@@ -65,8 +65,6 @@ public class ShareWithUserAction extends AnAction {
     IResource module;
 
     try {
-      // We allow only completely shared projects, so no need to check
-      // for partially shared ones.
       module = getModuleForVirtualFile(virtualFile, event.getProject());
 
     } catch (IllegalArgumentException e) {

--- a/intellij/src/saros/intellij/ui/menu/ShareWithUserAction.java
+++ b/intellij/src/saros/intellij/ui/menu/ShareWithUserAction.java
@@ -8,11 +8,13 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.vfs.VirtualFile;
 import java.text.MessageFormat;
-import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.apache.log4j.Logger;
 import saros.core.ui.util.CollaborationUtils;
-import saros.filesystem.IResource;
+import saros.filesystem.IProject;
 import saros.intellij.context.SharedIDEContext;
 import saros.intellij.filesystem.IntelliJProjectImpl;
 import saros.intellij.runtime.FilesystemRunner;
@@ -24,7 +26,7 @@ import saros.net.xmpp.JID;
 /**
  * An Action that starts a session when triggered.
  *
- * <p>Calls {@link CollaborationUtils#startSession(List, List)} with the selected module as
+ * <p>Calls {@link CollaborationUtils#startSession(Set, List)} with the selected module as
  * parameter.
  *
  * <p>This class assumes that the project is allowed to be shared (at the moment only completely
@@ -62,7 +64,7 @@ public class ShareWithUserAction extends AnAction {
           "Unable to start session - could not determine virtual file for highlighted resource.");
     }
 
-    IResource module;
+    IProject module;
 
     try {
       module = getModuleForVirtualFile(virtualFile, event.getProject());
@@ -77,15 +79,16 @@ public class ShareWithUserAction extends AnAction {
       return;
     }
 
-    List<IResource> resources = Arrays.asList(module);
+    Set<IProject> projects = new HashSet<>();
+    projects.add(module);
 
-    List<JID> contacts = Arrays.asList(userJID);
+    List<JID> contacts = Collections.singletonList(userJID);
 
     SharedIDEContext.preregisterProject(project);
-    CollaborationUtils.startSession(resources, contacts);
+    CollaborationUtils.startSession(projects, contacts);
   }
 
-  private IResource getModuleForVirtualFile(VirtualFile virtualFile, Project project) {
+  private IProject getModuleForVirtualFile(VirtualFile virtualFile, Project project) {
     ProjectFileIndex projectFileIndex = ProjectFileIndex.getInstance(project);
 
     Module module =

--- a/intellij/src/saros/intellij/ui/messages.properties
+++ b/intellij/src/saros/intellij/ui/messages.properties
@@ -30,7 +30,6 @@ CollaborationUtils_confirm_leaving_title=Confirm Leaving Session
 CollaborationUtils_confirm_leaving_message=Are you sure that you want to leave this Saros session?
 CollaborationUtils_insufficient_privileges_title=Insufficient Privileges
 CollaborationUtils_insufficient_privileges_message=You cannot add modules or files to the current session without write permission.
-CollaborationUtils_partial=\ (partial)
 
 ConsistencyAction_progress_perform_recovery=Performing recovery...
 

--- a/intellij/src/saros/intellij/ui/tree/ContactPopMenu.java
+++ b/intellij/src/saros/intellij/ui/tree/ContactPopMenu.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
@@ -21,7 +22,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import saros.core.ui.util.CollaborationUtils;
 import saros.filesystem.IProject;
-import saros.filesystem.IResource;
 import saros.intellij.context.SharedIDEContext;
 import saros.intellij.filesystem.IntelliJProjectImpl;
 import saros.intellij.ui.Messages;
@@ -217,11 +217,11 @@ class ContactPopMenu extends JPopupMenu {
         return;
       }
 
-      List<IResource> resources = Collections.singletonList(module);
-      List<JID> contact = Collections.singletonList(contactInfo.getJid());
+      Set<IProject> projects = Collections.singleton(module);
+      List<JID> contacts = Collections.singletonList(contactInfo.getJid());
 
       SharedIDEContext.preregisterProject(project);
-      CollaborationUtils.startSession(resources, contact);
+      CollaborationUtils.startSession(projects, contacts);
     }
   }
 }

--- a/intellij/src/saros/intellij/ui/tree/SessionTreeRootNode.java
+++ b/intellij/src/saros/intellij/ui/tree/SessionTreeRootNode.java
@@ -11,7 +11,6 @@ import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
 import saros.SarosPluginContext;
 import saros.filesystem.IProject;
-import saros.filesystem.IResource;
 import saros.intellij.ui.util.IconManager;
 import saros.intellij.ui.views.SarosMainPanelView;
 import saros.repackaged.picocontainer.annotations.Inject;
@@ -188,14 +187,7 @@ public class SessionTreeRootNode extends DefaultMutableTreeNode implements Dispo
 
   private void addProjectNode(IProject project) {
     for (DefaultMutableTreeNode nSession : sessionNodeList.values()) {
-      ISarosSession session = ((SessionInfo) nSession.getUserObject()).getSession();
-
-      ProjectInfo projInfo;
-      if (session.isCompletelyShared(project)) {
-        projInfo = new ProjectInfo(project);
-      } else {
-        projInfo = new ProjectInfo(project, session.getSharedResources(project));
-      }
+      ProjectInfo projInfo = new ProjectInfo(project);
 
       DefaultMutableTreeNode nProject = new DefaultMutableTreeNode(projInfo);
       treeModel.insertNodeInto(nProject, nSession, nSession.getChildCount());
@@ -263,16 +255,10 @@ public class SessionTreeRootNode extends DefaultMutableTreeNode implements Dispo
 
   protected class ProjectInfo extends LeafInfo {
     private final IProject project;
-    private List<IResource> resList;
 
     public ProjectInfo(IProject project) {
       super(project.getName());
       this.project = project;
-    }
-
-    public ProjectInfo(IProject project, List<IResource> resources) {
-      this(project);
-      resList = resources;
     }
 
     public IProject getProject() {
@@ -281,21 +267,8 @@ public class SessionTreeRootNode extends DefaultMutableTreeNode implements Dispo
 
     @Override
     public String toString() {
-      if (resList != null) {
-        StringBuilder sbOut = new StringBuilder();
-        sbOut.append(project.getName());
-        sbOut.append(" : ");
-        for (IResource res : resList) {
-          if (res.getType() == IResource.FILE) {
-            sbOut.append(res.getName());
-            sbOut.append("; ");
-          }
-        }
 
-        return sbOut.toString();
-      } else {
-        return project.getName();
-      }
+      return project.getName();
     }
   }
 }

--- a/intellij/src/saros/intellij/ui/wizards/AddProjectToSessionWizard.java
+++ b/intellij/src/saros/intellij/ui/wizards/AddProjectToSessionWizard.java
@@ -741,16 +741,13 @@ public class AddProjectToSessionWizard extends Wizard {
 
         final ProjectNegotiationData data = negotiation.getProjectNegotiationData(projectID);
 
-        if (data.isPartial()) throw new IllegalStateException("partial sharing is not supported");
-
         FileList localFileList =
             FileListFactory.createFileList(
                 project,
-                null,
                 checksumCache,
                 new SubProgressMonitor(monitor, 1, SubProgressMonitor.SUPPRESS_SETTASKNAME));
 
-        final FileListDiff diff = FileListDiff.diff(localFileList, data.getFileList(), false);
+        final FileListDiff diff = FileListDiff.diff(localFileList, data.getFileList());
 
         if (!diff.getRemovedFolders().isEmpty()
             || !diff.getRemovedFiles().isEmpty()

--- a/server/src/saros/server/ServerLifecycle.java
+++ b/server/src/saros/server/ServerLifecycle.java
@@ -2,7 +2,7 @@ package saros.server;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import org.apache.log4j.Logger;
 import saros.account.XMPPAccount;
@@ -11,8 +11,6 @@ import saros.communication.connection.ConnectionHandler;
 import saros.context.AbstractContextLifecycle;
 import saros.context.ContainerContext;
 import saros.context.IContextFactory;
-import saros.filesystem.IProject;
-import saros.filesystem.IResource;
 import saros.net.xmpp.JID;
 import saros.session.ISarosSessionManager;
 import saros.session.SessionEndReason;
@@ -31,9 +29,7 @@ public class ServerLifecycle extends AbstractContextLifecycle {
   @Override
   protected void initializeContext(final ContainerContext context) {
     connectToXMPPServer(context);
-    context
-        .getComponent(ISarosSessionManager.class)
-        .startSession(new HashMap<IProject, List<IResource>>());
+    context.getComponent(ISarosSessionManager.class).startSession(new HashSet<>());
   }
 
   @Override

--- a/server/src/saros/server/console/ShareCommand.java
+++ b/server/src/saros/server/console/ShareCommand.java
@@ -1,12 +1,11 @@
 package saros.server.console;
 
 import java.io.PrintStream;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Set;
 import org.apache.log4j.Logger;
 import saros.filesystem.IProject;
-import saros.filesystem.IResource;
 import saros.filesystem.IWorkspace;
 import saros.server.filesystem.ServerProjectImpl;
 import saros.session.ISarosSession;
@@ -44,16 +43,16 @@ public class ShareCommand extends ConsoleCommand {
     }
 
     try {
-      Map<IProject, List<IResource>> projects = new HashMap<>();
+      Set<IProject> projects = new HashSet<>();
       for (String path : args) {
         try {
           IProject project = new ServerProjectImpl(this.workspace, path);
-          projects.put(project, null);
+          projects.add(project);
         } catch (Exception e) {
           log.error(path + " could not be added to the session", e);
         }
       }
-      sessionManager.addResourcesToSession(projects);
+      sessionManager.addProjectsToSession(projects);
     } catch (Exception e) {
       log.error("Error sharing resources", e);
     }

--- a/stf.test/test/saros/stf/test/permissions/AllParticipantsFollowUserWithWriteAccessTest.java
+++ b/stf.test/test/saros/stf/test/permissions/AllParticipantsFollowUserWithWriteAccessTest.java
@@ -35,6 +35,9 @@ public class AllParticipantsFollowUserWithWriteAccessTest extends StfTestCase {
 
     Util.setUpSessionWithJavaProjectAndClass(
         Constants.PROJECT1, Constants.PKG1, Constants.CLS1, ALICE, BOB, CARL, DAVE);
+
+    // ensure all participants have successfully joined the session
+    Thread.sleep(5000);
   }
 
   @Before

--- a/stf/src/saros/stf/server/rmi/superbot/component/view/eclipse/impl/PackageExplorerView.java
+++ b/stf/src/saros/stf/server/rmi/superbot/component/view/eclipse/impl/PackageExplorerView.java
@@ -336,12 +336,7 @@ public final class PackageExplorerView extends StfRemoteObject implements IPacka
   }
 
   private String createProjectRegex(String projectName) {
-    return Pattern.quote(projectName)
-        + "("
-        + Pattern.quote(PROJECT_SHARED_DECORATOR)
-        + "|"
-        + Pattern.quote(PROJECT_PARTIAL_SHARED_DECORATOR)
-        + ")?+";
+    return Pattern.quote(projectName) + "(" + Pattern.quote(PROJECT_SHARED_DECORATOR) + ")?+";
   }
 
   private String[] createNodeRegex(String projectName, String... nodes) {

--- a/stf/src/saros/stf/shared/Constants.java
+++ b/stf/src/saros/stf/shared/Constants.java
@@ -36,9 +36,6 @@ public interface Constants {
 
   public static final String PROJECT_SHARED_DECORATOR = get("SharedProjectDecorator_shared");
 
-  public static final String PROJECT_PARTIAL_SHARED_DECORATOR =
-      get("SharedProjectDecorator_shared_partial");
-
   /* *********************************************
    *
    * Basic Wigets


### PR DESCRIPTION
Resolves the following issues as it completely removes the partial sharing functionality:
Resolves #256.
Resolves #44.
Resolves #36.
Resolves #31.

#### [INTERNAL] Remove partial sharing logic

Removes all logic related to partial sharing.

Simplifies the SharedProjectMapper.

Adjusts tests as necessary.

Adds a delay to STF test
AllParticipantsFollowUserWithWriteAccessTest.
followingUserOpenClassWhenFollowedUserOpenClass() to ensure that the
session is successfully started by all participants before the actual
test is run.
This adjustment was added as the test failed after the removal of the
partial sharing logic due to the method waitUntilEditorOpen running into
a timeout before the session clients could finish joining the session. I
am not sure what causes the perceived slowdown in the session joining
process leading to this issue.

#### [INTERNAL] Clean up collaboration util resource helper methods

Cleans up the usage of the collaboration util helper methods used to
start a session or add projects to a running session.