### PR TITLE
Fix minor issue with resource activity filter logic

### DIFF
--- a/core/src/saros/concurrent/management/ResourceActivityFilter.java
+++ b/core/src/saros/concurrent/management/ResourceActivityFilter.java
@@ -155,6 +155,8 @@ class ResourceActivityFilter {
    * <p>Does nothing if the passed activity is not a {@link FileActivity} or does not have the type
    * {@link FileActivity.Type#REMOVED} or {@link FileActivity.Type#MOVED}.
    *
+   * <p>Ignores file move activities where the origin and destination path is the same.
+   *
    * @param activity the activity to handle
    * @see #deletedFileFilter
    * @see #handleFileCreation(IActivity)

--- a/core/src/saros/session/internal/DeletionAcknowledgmentDispatcher.java
+++ b/core/src/saros/session/internal/DeletionAcknowledgmentDispatcher.java
@@ -58,12 +58,16 @@ public class DeletionAcknowledgmentDispatcher extends AbstractActivityProducer
    * <p>Activities that contain file deletions are {@link FileActivity file activities} of the type
    * {@link Type#REMOVED} or {@link Type#MOVED}.
    *
+   * <p>Ignores file move activities where the origin and destination path is the same.
+   *
    * @param fileActivity the file activity to check and acknowledge if applicable
    */
   private void acknowledgeDeletionActivity(FileActivity fileActivity) {
     SPath deletedResource;
 
-    if (fileActivity.getType() == Type.MOVED) {
+    if (fileActivity.getType() == Type.MOVED
+        && !fileActivity.getPath().equals(fileActivity.getOldPath())) {
+
       deletedResource = fileActivity.getOldPath();
 
     } else if (fileActivity.getType() == Type.REMOVED) {

--- a/intellij/src/saros/intellij/project/SharedResourcesManager.java
+++ b/intellij/src/saros/intellij/project/SharedResourcesManager.java
@@ -239,8 +239,6 @@ public class SharedResourcesManager implements Startable {
     } finally {
       setFilesystemModificationHandlerEnabled(true);
     }
-
-    // TODO reset the vector time for the old file
   }
 
   private void handleFileDeletion(@NotNull FileActivity activity) throws IOException {
@@ -270,8 +268,6 @@ public class SharedResourcesManager implements Startable {
     }
 
     annotationManager.removeAnnotations(file);
-
-    // TODO reset the vector time for the deleted file
   }
 
   private void handleFileCreation(@NotNull FileActivity activity) throws IOException {


### PR DESCRIPTION
#### [NOP][I] Remove remaining TODOs calling for a vector time reset

Such comments are no longer necessary as the vector time reset is
already completely handled in the core.

#### [FIX][CORE] Avoid unnecessary deletion acknowledgements

Fixes the deletion acknowledgement logic for the corner case where a
file move has the same origin and destination path. Even though such
cases were already ignored by the resource filtering logic, the deletion
acknowledgement logic was still sending acknowledgements, leading to
unnecessary warnings due to unexpected deletion acknowledgements.

Amends the javadoc of the corresponding methods to mention that such
move activities are ignored.