### PR TITLE
Add connection failure callback handler

### DIFF
--- a/core/src/saros/communication/connection/ConnectionHandler.java
+++ b/core/src/saros/communication/connection/ConnectionHandler.java
@@ -227,8 +227,7 @@ public class ConnectionHandler {
       }
 
       if (callbackTmp != null && !failSilently) {
-        callbackTmp.connectingFailed(e);
-        return;
+        callbackTmp.connectingFailed(account, e);
       }
     }
   }

--- a/core/src/saros/communication/connection/IConnectingFailureCallback.java
+++ b/core/src/saros/communication/connection/IConnectingFailureCallback.java
@@ -1,13 +1,15 @@
 package saros.communication.connection;
 
+import saros.account.XMPPAccount;
+
 /** Simple callback interface which is being notified in case of connecting error. */
 public interface IConnectingFailureCallback {
 
   /**
    * Gets called when it was not possible to successfully connect the requested service.
    *
-   * @param exception the exception that occurred during the connection attempt or <code>null</code>
-   *     if it could not be made because of missing data
+   * @param account the XMPP used for the connection attempt
+   * @param exception the exception that occurred during the connection attempt
    */
-  public void connectingFailed(Exception exception);
+  void connectingFailed(XMPPAccount account, Exception exception);
 }

--- a/eclipse/src/saros/ui/eventhandler/ConnectingFailureHandler.java
+++ b/eclipse/src/saros/ui/eventhandler/ConnectingFailureHandler.java
@@ -31,10 +31,10 @@ public class ConnectingFailureHandler implements IConnectingFailureCallback {
 
   @Override
   public void connectingFailed(final XMPPAccount account, final Exception exception) {
-    SWTUtils.runSafeSWTAsync(log, () -> handleConnectionFailed(exception));
+    SWTUtils.runSafeSWTAsync(log, () -> handleConnectionFailed(account, exception));
   }
 
-  private void handleConnectionFailed(Exception exception) {
+  private void handleConnectionFailed(XMPPAccount account, Exception exception) {
 
     try {
 
@@ -52,28 +52,16 @@ public class ConnectingFailureHandler implements IConnectingFailureCallback {
         return;
       }
 
-      final XMPPAccount accountUsedForConnecting =
-          XMPPConnectionSupport.getInstance().getCurrentXMPPAccount();
-
-      // should not happen
-      if (accountUsedForConnecting == null) {
-        log.warn(
-            "could not found the account that was used for establishing the connection - "
-                + "this can happen if connections are not established through class: "
-                + XMPPConnectionSupport.class.getSimpleName());
-        return;
-      }
-
-      final String errorMessesage = generateHumanReadableErrorMessage((XMPPException) exception);
+      final String errorMessage = generateHumanReadableErrorMessage((XMPPException) exception);
 
       final boolean editAccountAndConnectAgain =
-          MessageDialog.openQuestion(SWTUtils.getShell(), "Connecting Error", errorMessesage);
+          MessageDialog.openQuestion(SWTUtils.getShell(), "Connecting Error", errorMessage);
 
       if (!editAccountAndConnectAgain) return;
 
-      if (WizardUtils.openEditXMPPAccountWizard(accountUsedForConnecting) == null) return;
+      if (WizardUtils.openEditXMPPAccountWizard(account) == null) return;
 
-      XMPPConnectionSupport.getInstance().connect(accountUsedForConnecting, false);
+      XMPPConnectionSupport.getInstance().connect(account, false);
 
     } finally {
       isHandling = false;

--- a/eclipse/src/saros/ui/eventhandler/ConnectingFailureHandler.java
+++ b/eclipse/src/saros/ui/eventhandler/ConnectingFailureHandler.java
@@ -30,7 +30,7 @@ public class ConnectingFailureHandler implements IConnectingFailureCallback {
   }
 
   @Override
-  public void connectingFailed(final Exception exception) {
+  public void connectingFailed(final XMPPAccount account, final Exception exception) {
     SWTUtils.runSafeSWTAsync(log, () -> handleConnectionFailed(exception));
   }
 

--- a/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
+++ b/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
@@ -23,6 +23,7 @@ import saros.intellij.project.filesystem.IntelliJWorkspaceImpl;
 import saros.intellij.project.filesystem.IntelliJWorkspaceRootImpl;
 import saros.intellij.project.filesystem.PathFactory;
 import saros.intellij.runtime.IntellijUISynchronizer;
+import saros.intellij.ui.eventhandler.ConnectingFailureHandler;
 import saros.intellij.ui.eventhandler.SessionStatusChangeHandler;
 import saros.intellij.ui.util.UIProjectUtils;
 import saros.monitoring.remote.IRemoteProgressIndicatorFactory;
@@ -53,15 +54,18 @@ public class SarosIntellijContextFactory extends AbstractContextFactory {
 
       // UI handlers
       Component.create(NegotiationHandler.class),
-      Component.create(UserStatusChangeHandler.class),
       Component.create(XMPPAuthorizationHandler.class),
-      Component.create(SessionStatusChangeHandler.class),
       Component.create(IChecksumCache.class, NullChecksumCache.class),
       Component.create(UISynchronizer.class, IntellijUISynchronizer.class),
       Component.create(IPreferenceStore.class, PropertiesComponentAdapter.class),
       Component.create(Preferences.class, IntelliJPreferences.class),
       Component.create(
           IRemoteProgressIndicatorFactory.class, IntelliJRemoteProgressIndicatorFactoryImpl.class),
+
+      // UI event handlers relaying information to the user
+      Component.create(ConnectingFailureHandler.class),
+      Component.create(UserStatusChangeHandler.class),
+      Component.create(SessionStatusChangeHandler.class),
 
       // UI Utility
       Component.create(UIProjectUtils.class),

--- a/intellij/src/saros/intellij/ui/Messages.java
+++ b/intellij/src/saros/intellij/ui/Messages.java
@@ -217,5 +217,9 @@ public class Messages {
   public static String ModuleConfigurationInitializer_override_module_config_title;
   public static String ModuleConfigurationInitializer_override_module_config_message;
 
+  public static String ConnectingFailureHandler_title;
+  public static String ConnectingFailureHandler_unknown_error_message;
+  public static String ConnectingFailureHandler_invalid_username_password_message;
+
   private Messages() {}
 }

--- a/intellij/src/saros/intellij/ui/eventhandler/ConnectingFailureHandler.java
+++ b/intellij/src/saros/intellij/ui/eventhandler/ConnectingFailureHandler.java
@@ -1,0 +1,109 @@
+package saros.intellij.ui.eventhandler;
+
+import java.text.MessageFormat;
+import org.jivesoftware.smack.XMPPException;
+import org.jivesoftware.smack.packet.XMPPError;
+import saros.account.XMPPAccount;
+import saros.communication.connection.ConnectionHandler;
+import saros.communication.connection.IConnectingFailureCallback;
+import saros.intellij.ui.Messages;
+import saros.intellij.ui.util.NotificationPanel;
+
+/** Callback handler informing the user of a failed XMPP connection attempt. */
+public class ConnectingFailureHandler {
+
+  @SuppressWarnings("FieldCanBeLocal")
+  private final IConnectingFailureCallback connectingFailureCallback = this::handleConnectionFailed;
+
+  public ConnectingFailureHandler(ConnectionHandler connectionHandler) {
+    connectionHandler.setCallback(connectingFailureCallback);
+  }
+
+  private void handleConnectionFailed(XMPPAccount account, Exception exception) {
+    if (!(exception instanceof XMPPException)) {
+      NotificationPanel.showError(
+          MessageFormat.format(
+              Messages.ConnectingFailureHandler_unknown_error_message,
+              account,
+              exception.getMessage()),
+          Messages.ConnectingFailureHandler_title);
+
+      return;
+    }
+
+    final String errorMessage =
+        generateHumanReadableErrorMessage(account, (XMPPException) exception);
+
+    // TODO offer user possibility of adjusting settings and re-connect
+    NotificationPanel.showError(errorMessage, Messages.ConnectingFailureHandler_title);
+  }
+
+  // TODO unify XMPP-protocol specific error message generation in core
+  // TODO adjust once settings are implemented
+  // largely copied from eclipse/src/saros/ui/eventhandler/ConnectingFailureHandler.java
+  private String generateHumanReadableErrorMessage(
+      XMPPAccount account, XMPPException xmppException) {
+
+    // as of Smack 3.3.1 this is always null for connection attempts
+    // Throwable cause = e.getWrappedThrowable();
+
+    XMPPError error = xmppException.getXMPPError();
+
+    if (error != null && error.getCode() == 504)
+      return "The XMPP server "
+          + account.getDomain()
+          + " could not be found. Make sure that you are connected to the internet and that you entered the domain part of your JID correctly.\n\n"
+          // TODO re-add when settings are implemented
+          /*+ "In case of DNS or SRV problems please try to manually configure the server address and port under the advanced settings for this account or update the hosts file of your OS.\n\n"*/
+          + "Detailed error:\nSMACK: "
+          + error
+          + "\n" //$NON-NLS-1$ //$NON-NLS-2$
+          + xmppException.getMessage();
+    else if (error != null && error.getCode() == 502)
+      return "Could not connect to the XMPP server "
+          + account.getDomain()
+          + (account.getPort() != 0 ? (":" + account.getPort()) : "")
+          + ". Make sure that a XMPP service is running on the given domain / IP address and port.\n\n"
+          // TODO re-add when settings are implemented
+          /*+ "In case of DNS or SRV problems please try to manually configure the server address and port under the advanced settings for this account or update the hosts file of your OS.\n\n"*/
+          + "Detailed error:\nSMACK: "
+          + error
+          + "\n" //$NON-NLS-1$ //$NON-NLS-2$
+          + xmppException.getMessage();
+
+    String message = null;
+
+    String errorMessage = xmppException.getMessage();
+
+    if (errorMessage != null) {
+      if (errorMessage
+              .toLowerCase()
+              .contains("invalid-authzid") // jabber.org got it wrong ... //$NON-NLS-1$
+          || errorMessage.toLowerCase().contains("not-authorized") // SASL //$NON-NLS-1$
+          || errorMessage.toLowerCase().contains("403") // non SASL //$NON-NLS-1$
+          || errorMessage.toLowerCase().contains("401")) { // non SASL //$NON-NLS-1$
+
+        message =
+            MessageFormat.format(
+                Messages.ConnectingFailureHandler_invalid_username_password_message,
+                account.getUsername(),
+                account.getDomain());
+
+      } else if (errorMessage.toLowerCase().contains("503")) { // $NON-NLS-1$
+        message =
+            "The XMPP server only allows authentication via SASL.\n"
+                // TODO replace when settings are implemented
+                /*+ "Please enable SASL for the current account in the account options and try again.";*/
+                + "This is currently not supported by the Saros/I client.";
+      }
+    }
+
+    if (message == null) {
+      message =
+          MessageFormat.format(
+              Messages.ConnectingFailureHandler_unknown_error_message, account, xmppException);
+    }
+
+    return message;
+  }
+}

--- a/intellij/src/saros/intellij/ui/messages.properties
+++ b/intellij/src/saros/intellij/ui/messages.properties
@@ -202,3 +202,7 @@ ColorPreferences_user_example_text_selection=This is what <sel{0}>a selection an
 
 ModuleConfigurationInitializer_override_module_config_title=Override local module configuration?
 ModuleConfigurationInitializer_override_module_config_message=The received module configuration does not match the one of the chosen local module.\nShould the local configuration be replaced with the received one?
+
+ConnectingFailureHandler_title=Connection to XMPP server failed
+ConnectingFailureHandler_unknown_error_message=Could not connect to XMPP account [{0}] due to an unexpected error:\n{1}
+ConnectingFailureHandler_invalid_username_password_message=Invalid username or password for account {0}@{1}.


### PR DESCRIPTION
#### [INTERNAL][CORE] Add XMPP account to connection failure callback

Adds the XMPP account used for the connection attempt to the failure
callback method. This makes it easier to pass this information to the
failure handlers.

#### [INTERNAL][E] Use XMPP account passed by failure handler

Adjusts ConnectionFailureHandler to use the XMPP account passed by
IConnectingFailureCallback.connectingFailed(...).

Removes a null-check for the account that is now no longer necessary as
the connection logic calling the callback would have run into a NPE
beforehand.

Fixed a minor type in a variable name.

#### [UI][I] Add connection failure callback handler

Adds a callback handler informing the user of a failed XMPP connection
attempt.

The previous handling just failed silently, leading to unnecessary
confusion.

The message handling was largely copied from the Saros/E counterpart to
this handler as it deals with specific network failure outcome messages.

Addresses usability issue brought up in #891.