### PR TITLE
[BUILD] Always run STF on PR

### DIFF
--- a/.github/workflows/stf.yml
+++ b/.github/workflows/stf.yml
@@ -3,8 +3,11 @@ name: STF Tests
 on:
   push:
     branches:
-      - 'pr/stf/*'
       - 'master'
+      - 'test/stf/*'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   stf:


### PR DESCRIPTION
Sets the STF workflow to run for all PRs (excluding pure documentation
PRs) and on pushes on master. This now seems sensible as the STF is
relatively stable and accidental breakages still occur.

Also runs the STF for any push on a branch matching 'test/stf/*'. This
can be used to trigger STF builds for arbitrary commits without creating
PRs, allowing the GitHub workflows to be used as a remote test runner.