### PR TITLE
[STF] Update Version Set in STF Superbot

### DIFF
--- a/core/src/saros/versioning/VersionManager.java
+++ b/core/src/saros/versioning/VersionManager.java
@@ -19,7 +19,7 @@ public class VersionManager {
    * key with the last working version as value and add a check for it.
    */
 
-  static final String VERSION_KEY = "version";
+  public static final String VERSION_KEY = "version";
 
   private static final Logger log = Logger.getLogger(VersionManager.class);
 

--- a/stf/src/saros/stf/server/StfRemoteObject.java
+++ b/stf/src/saros/stf/server/StfRemoteObject.java
@@ -4,6 +4,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import org.osgi.service.prefs.Preferences;
 import saros.Saros;
 import saros.account.XMPPAccountStore;
+import saros.communication.InfoManager;
 import saros.context.IContainerContext;
 import saros.editor.EditorManager;
 import saros.editor.FollowModeManager;
@@ -64,6 +65,10 @@ public abstract class StfRemoteObject implements Constants {
 
   protected XMPPAccountStore getXmppAccountStore() {
     return context.getComponent(XMPPAccountStore.class);
+  }
+
+  protected InfoManager getInfoManager() {
+    return context.getComponent(InfoManager.class);
   }
 
   protected VersionManager getVersionManager() {

--- a/stf/src/saros/stf/server/rmi/superbot/internal/impl/InternalImpl.java
+++ b/stf/src/saros/stf/server/rmi/superbot/internal/impl/InternalImpl.java
@@ -107,6 +107,7 @@ public final class InternalImpl extends StfRemoteObject implements IInternal {
         originalVersion = (Version) localVersionField.get(getVersionManager());
 
       localVersionField.set(getVersionManager(), newVersion);
+      getInfoManager().setLocalInfo(VersionManager.VERSION_KEY, newVersion.toString());
 
     } catch (IllegalArgumentException e) {
       log.error("unable to change saros version, reflection failed", e);
@@ -129,6 +130,7 @@ public final class InternalImpl extends StfRemoteObject implements IInternal {
 
     try {
       localVersionField.set(getVersionManager(), originalVersion);
+      getInfoManager().setLocalInfo(VersionManager.VERSION_KEY, originalVersion.toString());
     } catch (IllegalArgumentException e) {
       log.error("unable to reset saros version, reflection failed", e);
       throw new RemoteException("unable to reset saros version, reflection failed", e);


### PR DESCRIPTION
This patch updates the STF Superbot to correctly set a different Saros
version in VersionManager. This change is needed after changes on the
VersionManager logic in previous patches.

fixes #892 