### PR TITLE
Clean up file list factory

### DIFF
--- a/core/src/saros/negotiation/FileListFactory.java
+++ b/core/src/saros/negotiation/FileListFactory.java
@@ -29,21 +29,8 @@ public class FileListFactory {
 
   private static final Logger log = Logger.getLogger(FileListFactory.class);
 
-  private IChecksumCache checksumCache;
-  private IProgressMonitor monitor;
-
-  private FileListFactory(IChecksumCache checksumCache, IProgressMonitor monitor) {
-    this.checksumCache = checksumCache;
-    this.monitor = monitor;
-
-    if (this.monitor == null) this.monitor = new NullProgressMonitor();
-  }
-
-  public static FileList createFileList(
-      IProject project, IChecksumCache checksumCache, IProgressMonitor monitor) throws IOException {
-
-    FileListFactory fact = new FileListFactory(checksumCache, monitor);
-    return fact.build(project);
+  private FileListFactory() {
+    // NOP
   }
 
   /**
@@ -68,18 +55,28 @@ public class FileListFactory {
     return new FileList();
   }
 
-  private FileList build(IProject project) throws IOException {
+  public static FileList createFileList(
+      final IProject project, final IChecksumCache checksumCache, final IProgressMonitor monitor)
+      throws IOException {
 
     FileList list = new FileList();
 
     list.addEncoding(project.getDefaultCharset());
 
-    addMembersToList(list, Arrays.asList(project.members()));
+    addMembersToList(
+        list,
+        Arrays.asList(project.members()),
+        checksumCache,
+        monitor != null ? monitor : new NullProgressMonitor());
 
     return list;
   }
 
-  private void addMembersToList(final FileList list, final List<IResource> resources)
+  private static void addMembersToList(
+      final FileList list,
+      final List<IResource> resources,
+      final IChecksumCache checksumCache,
+      final IProgressMonitor monitor)
       throws IOException {
 
     if (resources.size() == 0) return;

--- a/core/src/saros/negotiation/FileListFactory.java
+++ b/core/src/saros/negotiation/FileListFactory.java
@@ -106,11 +106,9 @@ public class FileListFactory {
 
     if (resources.size() == 0) return Collections.emptyList();
 
-    Deque<IResource> stack = new LinkedList<IResource>();
+    Deque<IResource> stack = new LinkedList<>(resources);
 
-    stack.addAll(resources);
-
-    List<IFile> files = new LinkedList<IFile>();
+    List<IFile> files = new LinkedList<>();
 
     while (!stack.isEmpty()) {
       IResource resource = stack.pop();
@@ -121,18 +119,17 @@ public class FileListFactory {
 
       if (list.contains(path)) continue;
 
-      MetaData data = null;
-
       switch (resource.getType()) {
         case IResource.FILE:
           files.add((IFile) resource);
-          data = new MetaData();
+          MetaData data = new MetaData();
           list.addPath(path, data, false);
           list.addEncoding(((IFile) resource).getCharset());
           break;
+
         case IResource.FOLDER:
           stack.addAll(Arrays.asList(((IFolder) resource).members()));
-          list.addPath(path, data, true);
+          list.addPath(path, null, true);
           break;
       }
     }


### PR DESCRIPTION
#### [REFACTOR][CORE] Make FileListFactory completely static

Removes the internal handling relying on FileListFactory objects, making
the class completely static. This was done to make it easier to inject
external dependencies from the plugin context. Furthermore, it makes the
class easier to understand.

#### [REFACTOR][CORE] Split FileListFactory.addMembersToList(...)

Splits the method FileListFactory.addMembersToList(...) into a method
calculating the file list and a separate method calculating the
checksums for all contained files.

Adds javadoc for the new methods.

#### [REFACTOR][CORE] Fix minor issues in FileListFactory

Removes unnecessary explicit type arguments.

Uses the list constructor accepting a collection instead of adding the
initial content separately.

Refactors the handling of metadata for files and folders to make it more
apparent that the metadata for folders is always null.