### PR TITLE
[INTERNAL][I] Use content for file move activities

### DIFF
--- a/intellij/src/saros/intellij/project/SharedResourcesManager.java
+++ b/intellij/src/saros/intellij/project/SharedResourcesManager.java
@@ -183,6 +183,9 @@ public class SharedResourcesManager implements Startable {
    * Applies the given move FileActivity. Subsequently cleans up the EditorPool and
    * AnnotationManager for the moved file if necessary.
    *
+   * <p>Overwrites the content of the moved file with the content contained in the activity if
+   * present. Keeps the original content otherwise.
+   *
    * @param activity the move activity to execute
    * @throws IOException if the creation of the new file or the deletion of the old file fails
    */
@@ -226,7 +229,18 @@ public class SharedResourcesManager implements Startable {
 
       localEditorHandler.saveDocument(oldPath);
 
-      newFile.create(oldFile.getContents(), FORCE);
+      byte[] activityContent = activity.getContent();
+
+      InputStream contents;
+
+      if (activityContent != null) {
+        contents = new ByteArrayInputStream(activityContent);
+
+      } else {
+        contents = oldFile.getContents();
+      }
+
+      newFile.create(contents, FORCE);
 
       if (fileOpen) {
         localEditorManipulator.openEditor(newPath, false);


### PR DESCRIPTION
Checks whether the file move activity contained a content to use for the
new file. If so, uses the given content. Keeps the original content
otherwise.

This split handling is necessary as file moves are handled differently
by different IDEs. For Saros/E, the adjustments to the file as part of
the move are passed as the new content for the file. For Saros/I such
adjustments are send as additional text edit activities after the file
was moved.

With this adjustment, both handlings should be compatible with each
other.