### PR TITLE
Remove IResource.move(...) method

### DIFF
--- a/core/src/saros/filesystem/IResource.java
+++ b/core/src/saros/filesystem/IResource.java
@@ -64,9 +64,6 @@ public interface IResource {
   /** Equivalent to the Eclipse call <code>IResource#delete(updateFlags, null)</code> */
   public void delete(int updateFlags) throws IOException;
 
-  /** Equivalent to the Eclipse call <code>IResource#delete(destination, force, null)</code> */
-  public void move(IPath destination, boolean force) throws IOException;
-
   public IPath getLocation();
 
   public <T extends IResource> T adaptTo(Class<T> clazz);

--- a/eclipse/src/saros/filesystem/EclipseResourceImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseResourceImpl.java
@@ -118,17 +118,6 @@ public class EclipseResourceImpl implements IResource {
   }
 
   @Override
-  public void move(IPath destination, boolean force) throws IOException {
-    try {
-      delegate.move(((EclipsePathImpl) destination).getDelegate(), force, null);
-    } catch (CoreException e) {
-      throw new IOException(e);
-    } catch (OperationCanceledException e) {
-      throw new IOException(e);
-    }
-  }
-
-  @Override
   public IPath getLocation() {
     org.eclipse.core.runtime.IPath location = delegate.getLocation();
     return (location != null) ? new EclipsePathImpl(location) : null;

--- a/intellij/src/saros/intellij/filesystem/IntelliJFileImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFileImpl.java
@@ -120,11 +120,6 @@ public final class IntelliJFileImpl extends IntelliJResourceImpl implements IFil
         ModalityState.defaultModalityState());
   }
 
-  @Override
-  public void move(@NotNull final IPath destination, final boolean force) throws IOException {
-    throw new IOException("NYI");
-  }
-
   @NotNull
   @Override
   public IPath getLocation() {

--- a/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
@@ -174,11 +174,6 @@ public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IF
         ModalityState.defaultModalityState());
   }
 
-  @Override
-  public void move(final IPath destination, final boolean force) throws IOException {
-    throw new IOException("NYI");
-  }
-
   @NotNull
   @Override
   public IPath getLocation() {

--- a/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
@@ -241,11 +241,6 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
     throw new IOException("delete is not supported");
   }
 
-  @Override
-  public void move(final IPath destination, final boolean force) throws IOException {
-    throw new IOException("move is not supported");
-  }
-
   @NotNull
   @Override
   public IPath getLocation() {

--- a/intellij/src/saros/intellij/project/filesystem/IntelliJWorkspaceRootImpl.java
+++ b/intellij/src/saros/intellij/project/filesystem/IntelliJWorkspaceRootImpl.java
@@ -86,11 +86,6 @@ public class IntelliJWorkspaceRootImpl implements IWorkspaceRoot {
   }
 
   @Override
-  public void move(IPath destination, boolean force) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public IPath getLocation() {
     throw new UnsupportedOperationException();
   }

--- a/server/src/saros/server/filesystem/ServerContainerImpl.java
+++ b/server/src/saros/server/filesystem/ServerContainerImpl.java
@@ -33,17 +33,6 @@ public abstract class ServerContainerImpl extends ServerResourceImpl implements 
   }
 
   @Override
-  public void move(IPath destination, boolean force) throws IOException {
-    IPath destinationBase =
-        destination.isAbsolute()
-            ? getWorkspace().getLocation()
-            : getLocation().removeLastSegments(1);
-
-    IPath absoluteDestination = destinationBase.append(destination);
-    FileUtils.moveDirectory(getLocation().toFile(), absoluteDestination.toFile());
-  }
-
-  @Override
   public IResource[] members() throws IOException {
     List<IResource> members = new ArrayList<>();
 

--- a/server/src/saros/server/filesystem/ServerFileImpl.java
+++ b/server/src/saros/server/filesystem/ServerFileImpl.java
@@ -60,19 +60,6 @@ public class ServerFileImpl extends ServerResourceImpl implements IFile {
   }
 
   @Override
-  public void move(IPath destination, boolean force) throws IOException {
-    IPath destinationRoot =
-        destination.isAbsolute()
-            ? getWorkspace().getLocation()
-            : getLocation().removeLastSegments(1);
-
-    IPath absoluteDestination = destinationRoot.append(destination);
-    Path nioDestination = ((ServerPathImpl) absoluteDestination).getDelegate();
-
-    Files.move(toNioPath(), nioDestination);
-  }
-
-  @Override
   public void create(InputStream input, boolean force) throws IOException {
     Path nioPath = toNioPath();
 

--- a/server/test/junit/saros/server/filesystem/ServerContainerImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerContainerImplTest.java
@@ -4,9 +4,6 @@ import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static saros.server.filesystem.FileSystemTestUtils.absolutePath;
-import static saros.server.filesystem.FileSystemTestUtils.assertFileHasContent;
-import static saros.server.filesystem.FileSystemTestUtils.assertResourceExists;
 import static saros.server.filesystem.FileSystemTestUtils.assertResourceNotExists;
 import static saros.server.filesystem.FileSystemTestUtils.createFile;
 import static saros.server.filesystem.FileSystemTestUtils.createFolder;
@@ -43,8 +40,6 @@ public class ServerContainerImplTest extends EasyMockSupport {
   }
 
   private static final String CONTAINER_PATH = "project/folder";
-  private static final String CONTAINER_PARENT_PATH = "project";
-  private static final String OTHER_PATH = "project2/other";
 
   private IContainer container;
   private IWorkspace workspace;
@@ -89,43 +84,6 @@ public class ServerContainerImplTest extends EasyMockSupport {
   public void deleteNonExistent() throws Exception {
     assertResourceNotExists(workspace, CONTAINER_PATH);
     container.delete(IResource.NONE);
-  }
-
-  @Test
-  public void moveToAbsolutePath() throws Exception {
-    createFolder(workspace, CONTAINER_PATH);
-    createFile(workspace, CONTAINER_PATH + "/file", "content");
-    createFolder(workspace, OTHER_PATH);
-
-    container.move(absolutePath(OTHER_PATH + "/folder"), true);
-
-    assertResourceNotExists(workspace, CONTAINER_PATH);
-    assertResourceExists(workspace, OTHER_PATH + "/folder");
-    assertResourceExists(workspace, OTHER_PATH + "/folder/file");
-    assertFileHasContent(workspace, OTHER_PATH + "/folder/file", "content");
-  }
-
-  @Test
-  public void moveToRelativePath() throws Exception {
-    createFolder(workspace, CONTAINER_PATH);
-    createFile(workspace, CONTAINER_PATH + "/file", "content");
-
-    String siblingFolderPath = CONTAINER_PARENT_PATH + "/destination";
-    createFolder(workspace, siblingFolderPath);
-
-    container.move(path("destination/folder"), true);
-
-    assertResourceNotExists(workspace, CONTAINER_PATH);
-    assertResourceExists(workspace, siblingFolderPath + "/folder");
-    assertResourceExists(workspace, siblingFolderPath + "/folder/file");
-    assertFileHasContent(workspace, siblingFolderPath + "/folder/file", "content");
-  }
-
-  @Test(expected = IOException.class)
-  public void moveNonExistent() throws Exception {
-    assertResourceNotExists(workspace, CONTAINER_PATH);
-    createFolder(workspace, OTHER_PATH);
-    container.move(absolutePath(OTHER_PATH + "/folder"), true);
   }
 
   @Test

--- a/server/test/junit/saros/server/filesystem/ServerFileImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerFileImplTest.java
@@ -3,12 +3,10 @@ package saros.server.filesystem;
 import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static saros.server.filesystem.FileSystemTestUtils.absolutePath;
 import static saros.server.filesystem.FileSystemTestUtils.assertFileHasContent;
 import static saros.server.filesystem.FileSystemTestUtils.assertResourceExists;
 import static saros.server.filesystem.FileSystemTestUtils.assertResourceNotExists;
 import static saros.server.filesystem.FileSystemTestUtils.createFile;
-import static saros.server.filesystem.FileSystemTestUtils.createFolder;
 import static saros.server.filesystem.FileSystemTestUtils.createWorkspaceFolder;
 import static saros.server.filesystem.FileSystemTestUtils.path;
 
@@ -80,44 +78,6 @@ public class ServerFileImplTest extends EasyMockSupport {
   public void deleteNonExistent() throws Exception {
     assertResourceNotExists(workspace, "project/file");
     file.delete(IResource.NONE);
-  }
-
-  @Test
-  public void moveAbsolute() throws Exception {
-    createFile(workspace, "project/file", "content");
-    createFolder(workspace, "project/destination");
-
-    file.move(absolutePath("project/destination/newname"), true);
-
-    assertResourceNotExists(workspace, "project/file");
-    assertResourceExists(workspace, "project/destination/newname");
-    assertFileHasContent(workspace, "project/destination/newname", "content");
-  }
-
-  @Test
-  public void moveRelative() throws Exception {
-    createFile(workspace, "project/file", "content");
-    createFolder(workspace, "project/destination");
-
-    file.move(path("destination/newname"), true);
-
-    assertResourceNotExists(workspace, "project/file");
-    assertResourceExists(workspace, "project/destination/newname");
-    assertFileHasContent(workspace, "project/destination/newname", "content");
-  }
-
-  @Test(expected = IOException.class)
-  public void moveNonExistent() throws Exception {
-    assertResourceNotExists(workspace, "project/file");
-    createFolder(workspace, "project/destination");
-    file.move(path("project/destination/newname"), true);
-  }
-
-  @Test(expected = IOException.class)
-  public void moveToNonExistentFolder() throws Exception {
-    createFile(workspace, "project/file");
-    assertResourceNotExists(workspace, "project/desination");
-    file.move(path("project/destination/newname"), true);
   }
 
   public void create() throws Exception {

--- a/server/test/junit/saros/server/filesystem/ServerResourceImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerResourceImplTest.java
@@ -40,11 +40,6 @@ public class ServerResourceImplTest extends EasyMockSupport {
     public void delete(int updateFlags) throws IOException {
       // Do nothing
     }
-
-    @Override
-    public void move(IPath destination, boolean force) throws IOException {
-      // Do nothing
-    }
   }
 
   private IResource resource;


### PR DESCRIPTION
#### [INTERNAL][S] Replaces the usage of IResource.move(...)

Replaces the usage of IResource.move(...) with explicitly creating the
new resource and then deleting the old resource. The new implementation
returns with a warning if the old resource to move does not exist. It
does not create the new resource in such cases.

This was done to remove the last (non-test) usage of IResource.move(...)
so that the method can be removed in a subsequent PR.

#### [API] Remove IResource.move(...)

Removes the method IResource.move(...) and its implementations.
Removes all remaining usages of IResource.move(...) (only test cases).

The method was removed as it was only used by the Saros Server and is
not generally usable with the Saros resource model.

As the Server only operates on folders and the resource move
implementation is set up to handle absolute paths, it is technically
usable for the Server implementation.

But for any other IDE implementation, the method will fail for cases
where the target resource does not share the same base reference point
(currently project/module). Furthermore, the general usage of absolute
paths in the IResource logic is discouraged as the Saros resource model
always works relative to a shared base point.

In general, since the logic is only used in the IDE implementations of
Saros and not in the core, it does not seem sensible to keep it as part
of the core interface. The necessary abstractions to do so make the
logic much harder to implement/understand. Furthermore, completely
handling such move cases in the IDE logic without using the IResource
wrapper allows for much more optimized/IDE specific implementations of