### PR TITLE
Clean up resource interface

### DIFF
--- a/core/src/saros/filesystem/FileSystem.java
+++ b/core/src/saros/filesystem/FileSystem.java
@@ -95,6 +95,6 @@ public class FileSystem {
 
     Collections.reverse(parents);
 
-    for (final IFolder folder : parents) folder.create(false, true);
+    for (final IFolder folder : parents) folder.create();
   }
 }

--- a/core/src/saros/filesystem/IContainer.java
+++ b/core/src/saros/filesystem/IContainer.java
@@ -33,7 +33,5 @@ public interface IContainer extends IResource {
 
   public IResource[] members() throws IOException;
 
-  public IResource[] members(int memberFlags) throws IOException;
-
   public String getDefaultCharset() throws IOException;
 }

--- a/core/src/saros/filesystem/IFile.java
+++ b/core/src/saros/filesystem/IFile.java
@@ -34,9 +34,13 @@ public interface IFile extends IResource {
   public InputStream getContents() throws IOException;
 
   /**
-   * Equivalent to the Eclipse call <code>IFile#setContents(input, force, keepHistory, null)</code>
+   * Writes the content of the given input stream into the file. Any existing file content is
+   * overwritten.
+   *
+   * @param input the input stream to write into the file
+   * @throws IOException if the content could not be written to the file
    */
-  public void setContents(InputStream input, boolean force, boolean keepHistory) throws IOException;
+  public void setContents(InputStream input) throws IOException;
 
   /** Equivalent to the Eclipse call <code>IFile#create(input, force, null)</code> */
   public void create(InputStream input, boolean force) throws IOException;

--- a/core/src/saros/filesystem/IFile.java
+++ b/core/src/saros/filesystem/IFile.java
@@ -42,8 +42,13 @@ public interface IFile extends IResource {
    */
   public void setContents(InputStream input) throws IOException;
 
-  /** Equivalent to the Eclipse call <code>IFile#create(input, force, null)</code> */
-  public void create(InputStream input, boolean force) throws IOException;
+  /**
+   * Creates the this file with the given content.
+   *
+   * @throws IOException if the file already exists, could not be created, or the content of the
+   *     newly created file could not be set
+   */
+  public void create(InputStream input) throws IOException;
 
   /**
    * Returns the size of the file.

--- a/core/src/saros/filesystem/IFolder.java
+++ b/core/src/saros/filesystem/IFolder.java
@@ -29,9 +29,10 @@ import java.io.IOException;
  */
 public interface IFolder extends IContainer {
 
-  /** Equivalent to the Eclipse call <code>IFolder#create(updateFlags, local, null)</code> */
-  public void create(int updateFlags, boolean local) throws IOException;
-
-  /** Equivalent to the Eclipse call <code>IFolder#create(force, local, null)</code> */
-  public void create(boolean force, boolean local) throws IOException;
+  /**
+   * Creates the folder in the local filesystem.
+   *
+   * @throws IOException if the folder creation failed or the resource already exists
+   */
+  void create() throws IOException;
 }

--- a/core/src/saros/filesystem/IResource.java
+++ b/core/src/saros/filesystem/IResource.java
@@ -59,6 +59,13 @@ public interface IResource {
    */
   public boolean isIgnored();
 
+  /**
+   * Deletes this resource from the disk.
+   *
+   * <p>If the resource does not exist, this method does nothing.
+   *
+   * @throws IOException if the resource deletion failed
+   */
   public void delete() throws IOException;
 
   public IPath getLocation();

--- a/core/src/saros/filesystem/IResource.java
+++ b/core/src/saros/filesystem/IResource.java
@@ -30,7 +30,6 @@ public interface IResource {
   public static final int FOLDER = 2;
   public static final int PROJECT = 4;
   public static final int ROOT = 8;
-  public static final int KEEP_HISTORY = 32;
 
   public boolean exists();
 
@@ -60,8 +59,7 @@ public interface IResource {
    */
   public boolean isIgnored();
 
-  /** Equivalent to the Eclipse call <code>IResource#delete(updateFlags, null)</code> */
-  public void delete(int updateFlags) throws IOException;
+  public void delete() throws IOException;
 
   public IPath getLocation();
 

--- a/core/src/saros/filesystem/IResource.java
+++ b/core/src/saros/filesystem/IResource.java
@@ -30,7 +30,6 @@ public interface IResource {
   public static final int FOLDER = 2;
   public static final int PROJECT = 4;
   public static final int ROOT = 8;
-  public static final int FORCE = 16;
   public static final int KEEP_HISTORY = 32;
 
   public boolean exists();

--- a/core/src/saros/negotiation/AbstractIncomingProjectNegotiation.java
+++ b/core/src/saros/negotiation/AbstractIncomingProjectNegotiation.java
@@ -406,7 +406,7 @@ public abstract class AbstractIncomingProjectNegotiation extends ProjectNegotiat
 
           if (log.isTraceEnabled()) log.trace("deleting resource: " + resource);
 
-          resource.delete(IResource.KEEP_HISTORY);
+          resource.delete();
         }
       }
 

--- a/core/src/saros/negotiation/DecompressArchiveTask.java
+++ b/core/src/saros/negotiation/DecompressArchiveTask.java
@@ -109,7 +109,7 @@ public class DecompressArchiveTask implements IWorkspaceRunnable {
         in = new CancelableInputStream(inZip, monitor);
 
         try {
-          if (!decompressedFile.exists()) decompressedFile.create(in, false);
+          if (!decompressedFile.exists()) decompressedFile.create(in);
           else decompressedFile.setContents(in);
         } catch (IOException e) {
           /* if triggered by check in CancelableInputStream */

--- a/core/src/saros/negotiation/DecompressArchiveTask.java
+++ b/core/src/saros/negotiation/DecompressArchiveTask.java
@@ -110,7 +110,7 @@ public class DecompressArchiveTask implements IWorkspaceRunnable {
 
         try {
           if (!decompressedFile.exists()) decompressedFile.create(in, false);
-          else decompressedFile.setContents(in, false, true);
+          else decompressedFile.setContents(in);
         } catch (IOException e) {
           /* if triggered by check in CancelableInputStream */
           if (monitor.isCanceled()) {

--- a/core/src/saros/negotiation/stream/IncomingStreamProtocol.java
+++ b/core/src/saros/negotiation/stream/IncomingStreamProtocol.java
@@ -58,7 +58,7 @@ public class IncomingStreamProtocol extends AbstractStreamProtocol implements Au
       try (BoundedInputStream fileIn = new BoundedInputStream(in, fileSize)) {
         fileIn.setPropagateClose(false);
 
-        if (file.exists()) file.setContents(fileIn, false, true);
+        if (file.exists()) file.setContents(fileIn);
         else file.create(fileIn, false);
       }
 

--- a/core/src/saros/negotiation/stream/IncomingStreamProtocol.java
+++ b/core/src/saros/negotiation/stream/IncomingStreamProtocol.java
@@ -59,7 +59,7 @@ public class IncomingStreamProtocol extends AbstractStreamProtocol implements Au
         fileIn.setPropagateClose(false);
 
         if (file.exists()) file.setContents(fileIn);
-        else file.create(fileIn, false);
+        else file.create(fileIn);
       }
 
       if (monitor.isCanceled()) {

--- a/eclipse/src/saros/filesystem/EclipseContainerImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseContainerImpl.java
@@ -19,15 +19,10 @@ public abstract class EclipseContainerImpl extends EclipseResourceImpl implement
 
   @Override
   public IResource[] members() throws IOException {
-    return members(org.eclipse.core.resources.IResource.NONE);
-  }
-
-  @Override
-  public IResource[] members(int memberFlags) throws IOException {
     org.eclipse.core.resources.IResource[] resources;
 
     try {
-      resources = getDelegate().members(memberFlags);
+      resources = getDelegate().members();
 
       List<IResource> result = new ArrayList<IResource>(resources.length);
       ResourceAdapterFactory.convertTo(Arrays.asList(resources), result);

--- a/eclipse/src/saros/filesystem/EclipseFileImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseFileImpl.java
@@ -32,13 +32,11 @@ public class EclipseFileImpl extends EclipseResourceImpl implements IFile {
   }
 
   @Override
-  public void setContents(InputStream input, boolean force, boolean keepHistory)
-      throws IOException {
+  public void setContents(InputStream input) throws IOException {
     try {
-      getDelegate().setContents(input, force, keepHistory, null);
-    } catch (CoreException e) {
-      throw new IOException(e);
-    } catch (OperationCanceledException e) {
+      getDelegate().setContents(input, false, true, null);
+
+    } catch (CoreException | OperationCanceledException e) {
       throw new IOException(e);
     }
   }

--- a/eclipse/src/saros/filesystem/EclipseFileImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseFileImpl.java
@@ -42,12 +42,10 @@ public class EclipseFileImpl extends EclipseResourceImpl implements IFile {
   }
 
   @Override
-  public void create(InputStream input, boolean force) throws IOException {
+  public void create(InputStream input) throws IOException {
     try {
-      getDelegate().create(input, force, null);
-    } catch (CoreException e) {
-      throw new IOException(e);
-    } catch (OperationCanceledException e) {
+      getDelegate().create(input, false, null);
+    } catch (CoreException | OperationCanceledException e) {
       throw new IOException(e);
     }
   }

--- a/eclipse/src/saros/filesystem/EclipseFolderImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseFolderImpl.java
@@ -11,23 +11,10 @@ public class EclipseFolderImpl extends EclipseContainerImpl implements IFolder {
   }
 
   @Override
-  public void create(int updateFlags, boolean local) throws IOException {
+  public void create() throws IOException {
     try {
-      getDelegate().create(updateFlags, local, null);
-    } catch (CoreException e) {
-      throw new IOException(e);
-    } catch (OperationCanceledException e) {
-      throw new IOException(e);
-    }
-  }
-
-  @Override
-  public void create(boolean force, boolean local) throws IOException {
-    try {
-      getDelegate().create(force, local, null);
-    } catch (CoreException e) {
-      throw new IOException(e);
-    } catch (OperationCanceledException e) {
+      getDelegate().create(false, true, null);
+    } catch (CoreException | OperationCanceledException e) {
       throw new IOException(e);
     }
   }

--- a/eclipse/src/saros/filesystem/EclipseResourceImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseResourceImpl.java
@@ -107,12 +107,10 @@ public class EclipseResourceImpl implements IResource {
   }
 
   @Override
-  public void delete(int updateFlags) throws IOException {
+  public void delete() throws IOException {
     try {
-      delegate.delete(updateFlags, null);
-    } catch (CoreException e) {
-      throw new IOException(e);
-    } catch (OperationCanceledException e) {
+      delegate.delete(org.eclipse.core.resources.IResource.KEEP_HISTORY, null);
+    } catch (CoreException | OperationCanceledException e) {
       throw new IOException(e);
     }
   }

--- a/intellij/src/saros/core/ui/util/CollaborationUtils.java
+++ b/intellij/src/saros/core/ui/util/CollaborationUtils.java
@@ -238,7 +238,7 @@ public class CollaborationUtils {
 
         Pair<Long, Long> fileCountAndSize;
 
-        fileCountAndSize = getFileCountAndSize(Arrays.asList(project.members()), IResource.FILE);
+        fileCountAndSize = getFileCountAndSize(Arrays.asList(project.members()));
 
         result.append(
             String.format(
@@ -277,12 +277,10 @@ public class CollaborationUtils {
    *
    * @param resources collection containing the resources that file sizes and file count should be
    *     calculated
-   * @param flags additional flags on how to process the members of containers
    * @return a pair containing the file size (left element) and file count (right element) for the
    *     given resources
    */
-  private static Pair<Long, Long> getFileCountAndSize(
-      Collection<? extends IResource> resources, int flags) {
+  private static Pair<Long, Long> getFileCountAndSize(Collection<? extends IResource> resources) {
 
     long totalFileSize = 0;
     long totalFileCount = 0;
@@ -306,7 +304,7 @@ public class CollaborationUtils {
             IContainer container = resource.adaptTo(IContainer.class);
 
             Pair<Long, Long> subFileCountAndSize =
-                getFileCountAndSize(Arrays.asList(container.members(flags)), flags);
+                getFileCountAndSize(Arrays.asList(container.members()));
 
             totalFileSize += subFileCountAndSize.getLeft();
             totalFileCount += subFileCountAndSize.getRight();

--- a/intellij/src/saros/intellij/filesystem/IntelliJFileImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFileImpl.java
@@ -96,7 +96,7 @@ public final class IntelliJFileImpl extends IntelliJResourceImpl implements IFil
   }
 
   @Override
-  public void delete(final int updateFlags) throws IOException {
+  public void delete() throws IOException {
 
     FilesystemRunner.runWriteAction(
         new ThrowableComputable<Void, IOException>() {

--- a/intellij/src/saros/intellij/filesystem/IntelliJFileImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFileImpl.java
@@ -156,13 +156,10 @@ public final class IntelliJFileImpl extends IntelliJResourceImpl implements IFil
    * <p><b>Note:</b> The force flag is not supported.
    *
    * @param input new contents of the file
-   * @param force not supported
-   * @param keepHistory not supported
    * @throws IOException if the file does not exist
    */
   @Override
-  public void setContents(final InputStream input, final boolean force, final boolean keepHistory)
-      throws IOException {
+  public void setContents(final InputStream input) throws IOException {
 
     FilesystemRunner.runWriteAction(
         (ThrowableComputable<Void, IOException>)
@@ -170,11 +167,8 @@ public final class IntelliJFileImpl extends IntelliJResourceImpl implements IFil
               final VirtualFile file = project.findVirtualFile(path);
 
               if (file == null) {
-                String exceptionText = IntelliJFileImpl.this + " does not exist or is ignored";
-
-                if (force) exceptionText += ", force option is not supported";
-
-                throw new FileNotFoundException(exceptionText);
+                throw new FileNotFoundException(
+                    IntelliJFileImpl.this + " does not exist or is ignored");
               }
 
               final OutputStream out = file.getOutputStream(IntelliJFileImpl.this);
@@ -239,7 +233,7 @@ public final class IntelliJFileImpl extends IntelliJResourceImpl implements IFil
 
               parentFile.createChildData(IntelliJFileImpl.this, getName());
 
-              if (input != null) setContents(input, force, true);
+              if (input != null) setContents(input);
 
               return null;
             },

--- a/intellij/src/saros/intellij/filesystem/IntelliJFileImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFileImpl.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.FileAlreadyExistsException;
 import org.apache.commons.io.IOUtils;
+import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import saros.filesystem.IContainer;
@@ -20,6 +21,7 @@ import saros.filesystem.IResource;
 import saros.intellij.runtime.FilesystemRunner;
 
 public final class IntelliJFileImpl extends IntelliJResourceImpl implements IFile {
+  private static final Logger log = Logger.getLogger(IntelliJFileImpl.class);
 
   private static final int BUFFER_SIZE = 32 * 1024;
 
@@ -106,9 +108,11 @@ public final class IntelliJFileImpl extends IntelliJResourceImpl implements IFil
 
             final VirtualFile file = project.findVirtualFile(path);
 
-            if (file == null)
-              throw new FileNotFoundException(
-                  IntelliJFileImpl.this + " does not exist or is ignored");
+            if (file == null) {
+              log.debug("Ignoring file deletion request for " + this + " as file does not exist");
+
+              return null;
+            }
 
             if (file.isDirectory()) throw new IOException(this + " is not a file");
 

--- a/intellij/src/saros/intellij/filesystem/IntelliJFileImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFileImpl.java
@@ -200,12 +200,11 @@ public final class IntelliJFileImpl extends IntelliJResourceImpl implements IFil
    * already existing file.
    *
    * @param input contents of the new file
-   * @param force not supported
    * @throws FileAlreadyExistsException if the file already exists
    * @throws FileNotFoundException if the parent directory of this file does not exist
    */
   @Override
-  public void create(@Nullable final InputStream input, final boolean force) throws IOException {
+  public void create(@Nullable final InputStream input) throws IOException {
 
     FilesystemRunner.runWriteAction(
         (ThrowableComputable<Void, IOException>)
@@ -224,11 +223,7 @@ public final class IntelliJFileImpl extends IntelliJResourceImpl implements IFil
               final VirtualFile file = parentFile.findChild(getName());
 
               if (file != null) {
-                String exceptionText = IntelliJFileImpl.this + " already exists";
-
-                if (force) exceptionText += ", force option is not supported";
-
-                throw new FileAlreadyExistsException(exceptionText);
+                throw new FileAlreadyExistsException(IntelliJFileImpl.this + " already exists");
               }
 
               parentFile.createChildData(IntelliJFileImpl.this, getName());

--- a/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
@@ -181,25 +181,14 @@ public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IF
     return project.getLocation().append(path);
   }
 
-  @Override
-  public void create(final int updateFlags, final boolean local) throws IOException {
-    this.create((updateFlags & IResource.FORCE) != 0, local);
-  }
-
   /**
    * Creates this folder in the local filesystem.
    *
-   * <p><b>Note:</b> The force flag is not supported. It does not allow the re-creation of an
-   * already existing folder.
-   *
-   * @param force not supported
-   * @param local not supported
    * @throws FileAlreadyExistsException if the folder already exists
    * @throws FileNotFoundException if the parent directory of this folder does not exist
    */
   @Override
-  public void create(final boolean force, final boolean local) throws IOException {
-
+  public void create() throws IOException {
     FilesystemRunner.runWriteAction(
         (ThrowableComputable<Void, IOException>)
             () -> {
@@ -217,11 +206,7 @@ public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IF
               final VirtualFile file = parentFile.findChild(getName());
 
               if (file != null) {
-                String exceptionText = IntelliJFolderImpl.this + " already exists";
-
-                if (force) exceptionText += ", force option is not supported";
-
-                throw new FileAlreadyExistsException(exceptionText);
+                throw new FileAlreadyExistsException(IntelliJFolderImpl.this + " already exists");
               }
 
               parentFile.createChildDirectory(IntelliJFolderImpl.this, getName());

--- a/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import saros.filesystem.IContainer;
@@ -21,6 +22,7 @@ import saros.intellij.project.filesystem.IntelliJPathImpl;
 import saros.intellij.runtime.FilesystemRunner;
 
 public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IFolder {
+  private static final Logger log = Logger.getLogger(IntelliJFolderImpl.class);
 
   /** Relative path from the given project */
   private final IPath path;
@@ -159,9 +161,11 @@ public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IF
 
             final VirtualFile file = project.findVirtualFile(path);
 
-            if (file == null)
-              throw new FileNotFoundException(
-                  IntelliJFolderImpl.this + " does not exist or is ignored");
+            if (file == null) {
+              log.debug("Ignoring file deletion request for " + this + " as folder does not exist");
+
+              return null;
+            }
 
             if (!file.isDirectory()) throw new IOException(this + " is not a folder");
 

--- a/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
@@ -150,8 +150,7 @@ public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IF
   }
 
   @Override
-  public void delete(final int updateFlags) throws IOException {
-
+  public void delete() throws IOException {
     FilesystemRunner.runWriteAction(
         new ThrowableComputable<Void, IOException>() {
 

--- a/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
@@ -76,12 +76,6 @@ public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IF
     return result.toArray(new IResource[0]);
   }
 
-  @NotNull
-  @Override
-  public IResource[] members(final int memberFlags) throws IOException {
-    return members();
-  }
-
   @Nullable
   @Override
   public String getDefaultCharset() throws IOException {

--- a/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
@@ -237,7 +237,7 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
   }
 
   @Override
-  public void delete(final int updateFlags) throws IOException {
+  public void delete() throws IOException {
     throw new IOException("delete is not supported");
   }
 

--- a/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
@@ -140,12 +140,6 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
     return result.toArray(new IResource[0]);
   }
 
-  @NotNull
-  @Override
-  public IResource[] members(final int memberFlags) {
-    return members();
-  }
-
   @Nullable
   @Override
   public String getDefaultCharset() {

--- a/intellij/src/saros/intellij/project/SharedResourcesManager.java
+++ b/intellij/src/saros/intellij/project/SharedResourcesManager.java
@@ -35,7 +35,6 @@ public class SharedResourcesManager implements Startable {
   private static final Logger log = Logger.getLogger(SharedResourcesManager.class);
 
   private static final int DELETION_FLAGS = 0;
-  private static final boolean FORCE = false;
 
   private final ISarosSession sarosSession;
   private final EditorManager editorManager;
@@ -239,7 +238,7 @@ public class SharedResourcesManager implements Startable {
         contents = oldFile.getContents();
       }
 
-      newFile.create(contents, FORCE);
+      newFile.create(contents);
 
       if (fileOpen) {
         localEditorManipulator.openEditor(newPath, false);
@@ -307,7 +306,7 @@ public class SharedResourcesManager implements Startable {
     try {
       setFilesystemModificationHandlerEnabled(false);
 
-      file.create(contents, FORCE);
+      file.create(contents);
 
     } finally {
       setFilesystemModificationHandlerEnabled(true);

--- a/intellij/src/saros/intellij/project/SharedResourcesManager.java
+++ b/intellij/src/saros/intellij/project/SharedResourcesManager.java
@@ -36,7 +36,6 @@ public class SharedResourcesManager implements Startable {
 
   private static final int DELETION_FLAGS = 0;
   private static final boolean FORCE = false;
-  private static final boolean LOCAL = false;
 
   private final ISarosSession sarosSession;
   private final EditorManager editorManager;

--- a/intellij/src/saros/intellij/project/SharedResourcesManager.java
+++ b/intellij/src/saros/intellij/project/SharedResourcesManager.java
@@ -328,7 +328,7 @@ public class SharedResourcesManager implements Startable {
     try {
       setFilesystemModificationHandlerEnabled(false);
 
-      folder.create(FORCE, LOCAL);
+      folder.create();
 
     } finally {
       setFilesystemModificationHandlerEnabled(true);

--- a/intellij/src/saros/intellij/project/SharedResourcesManager.java
+++ b/intellij/src/saros/intellij/project/SharedResourcesManager.java
@@ -34,8 +34,6 @@ public class SharedResourcesManager implements Startable {
 
   private static final Logger log = Logger.getLogger(SharedResourcesManager.class);
 
-  private static final int DELETION_FLAGS = 0;
-
   private final ISarosSession sarosSession;
   private final EditorManager editorManager;
   private final SharedIDEContext sharedIDEContext;
@@ -252,7 +250,7 @@ public class SharedResourcesManager implements Startable {
         selectedEditorStateSnapshot.applyHeldState();
       }
 
-      oldFile.delete(DELETION_FLAGS);
+      oldFile.delete();
 
     } finally {
       setFilesystemModificationHandlerEnabled(true);
@@ -281,7 +279,7 @@ public class SharedResourcesManager implements Startable {
 
       localEditorHandler.saveDocument(path);
 
-      file.delete(DELETION_FLAGS);
+      file.delete();
 
     } finally {
       setFilesystemModificationHandlerEnabled(true);
@@ -357,7 +355,7 @@ public class SharedResourcesManager implements Startable {
     try {
       setFilesystemModificationHandlerEnabled(false);
 
-      folder.delete(DELETION_FLAGS);
+      folder.delete();
 
     } finally {
       setFilesystemModificationHandlerEnabled(true);

--- a/intellij/src/saros/intellij/project/filesystem/IntelliJWorkspaceRootImpl.java
+++ b/intellij/src/saros/intellij/project/filesystem/IntelliJWorkspaceRootImpl.java
@@ -81,7 +81,7 @@ public class IntelliJWorkspaceRootImpl implements IWorkspaceRoot {
   }
 
   @Override
-  public void delete(int updateFlags) {
+  public void delete() {
     throw new UnsupportedOperationException();
   }
 

--- a/intellij/src/saros/intellij/project/filesystem/IntelliJWorkspaceRootImpl.java
+++ b/intellij/src/saros/intellij/project/filesystem/IntelliJWorkspaceRootImpl.java
@@ -31,11 +31,6 @@ public class IntelliJWorkspaceRootImpl implements IWorkspaceRoot {
   }
 
   @Override
-  public IResource[] members(int memberFlags) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public String getDefaultCharset() {
     return null;
   }

--- a/server/src/saros/server/editor/Editor.java
+++ b/server/src/saros/server/editor/Editor.java
@@ -87,6 +87,6 @@ public class Editor {
    * @throws IOException if writing the file fails
    */
   public void save() throws IOException {
-    getFile().setContents(IOUtils.toInputStream(content.toString()), true, true);
+    getFile().setContents(IOUtils.toInputStream(content.toString()));
   }
 }

--- a/server/src/saros/server/filesystem/ServerContainerImpl.java
+++ b/server/src/saros/server/filesystem/ServerContainerImpl.java
@@ -28,7 +28,7 @@ public abstract class ServerContainerImpl extends ServerResourceImpl implements 
   }
 
   @Override
-  public void delete(int updateFlags) throws IOException {
+  public void delete() throws IOException {
     FileUtils.deleteDirectory(getLocation().toFile());
   }
 

--- a/server/src/saros/server/filesystem/ServerContainerImpl.java
+++ b/server/src/saros/server/filesystem/ServerContainerImpl.java
@@ -58,11 +58,6 @@ public abstract class ServerContainerImpl extends ServerResourceImpl implements 
   }
 
   @Override
-  public IResource[] members(int memberFlags) throws IOException {
-    return members();
-  }
-
-  @Override
   public boolean exists(IPath path) {
     IPath childLocation = getLocation().append(path);
     return childLocation.toFile().exists();

--- a/server/src/saros/server/filesystem/ServerFileImpl.java
+++ b/server/src/saros/server/filesystem/ServerFileImpl.java
@@ -60,7 +60,7 @@ public class ServerFileImpl extends ServerResourceImpl implements IFile {
   }
 
   @Override
-  public void create(InputStream input, boolean force) throws IOException {
+  public void create(InputStream input) throws IOException {
     Path nioPath = toNioPath();
 
     Files.createDirectories(nioPath.getParent());

--- a/server/src/saros/server/filesystem/ServerFileImpl.java
+++ b/server/src/saros/server/filesystem/ServerFileImpl.java
@@ -65,7 +65,7 @@ public class ServerFileImpl extends ServerResourceImpl implements IFile {
 
     Files.createDirectories(nioPath.getParent());
     Files.createFile(nioPath);
-    setContents(input, force, false);
+    setContents(input);
   }
 
   @Override
@@ -74,8 +74,7 @@ public class ServerFileImpl extends ServerResourceImpl implements IFile {
   }
 
   @Override
-  public void setContents(InputStream input, boolean force, boolean keepHistory)
-      throws IOException {
+  public void setContents(InputStream input) throws IOException {
 
     /*
      * We write the new contents to a temporary file first, then move that

--- a/server/src/saros/server/filesystem/ServerFileImpl.java
+++ b/server/src/saros/server/filesystem/ServerFileImpl.java
@@ -51,7 +51,7 @@ public class ServerFileImpl extends ServerResourceImpl implements IFile {
   }
 
   @Override
-  public void delete(int updateFlags) throws IOException {
+  public void delete() throws IOException {
     try {
       Files.delete(toNioPath());
     } catch (NoSuchFileException e) {

--- a/server/src/saros/server/filesystem/ServerFolderImpl.java
+++ b/server/src/saros/server/filesystem/ServerFolderImpl.java
@@ -28,7 +28,7 @@ public class ServerFolderImpl extends ServerContainerImpl implements IFolder {
   }
 
   @Override
-  public void create(int updateFlags, boolean local) throws IOException {
+  public void create() throws IOException {
     try {
       Files.createDirectory(toNioPath());
     } catch (FileAlreadyExistsException e) {
@@ -40,10 +40,5 @@ public class ServerFolderImpl extends ServerContainerImpl implements IFolder {
         throw e;
       }
     }
-  }
-
-  @Override
-  public void create(boolean force, boolean local) throws IOException {
-    create(IResource.NONE, local);
   }
 }

--- a/server/src/saros/server/session/FileActivityExecutor.java
+++ b/server/src/saros/server/session/FileActivityExecutor.java
@@ -7,7 +7,6 @@ import org.apache.log4j.Logger;
 import saros.activities.FileActivity;
 import saros.activities.SPath;
 import saros.filesystem.IFile;
-import saros.filesystem.IResource;
 import saros.repackaged.picocontainer.Startable;
 import saros.server.editor.ServerEditorManager;
 import saros.session.AbstractActivityConsumer;
@@ -100,7 +99,7 @@ public class FileActivityExecutor extends AbstractActivityConsumer implements St
 
     newFile.create(contents);
 
-    oldFile.delete(0);
+    oldFile.delete();
 
     // only update if all previous operations are successful
     editorManager.updateMapping(oldPath, newPath);
@@ -110,6 +109,6 @@ public class FileActivityExecutor extends AbstractActivityConsumer implements St
     SPath path = activity.getPath();
     IFile file = path.getFile();
     editorManager.closeEditor(path);
-    file.delete(IResource.NONE);
+    file.delete();
   }
 }

--- a/server/src/saros/server/session/FileActivityExecutor.java
+++ b/server/src/saros/server/session/FileActivityExecutor.java
@@ -67,7 +67,7 @@ public class FileActivityExecutor extends AbstractActivityConsumer implements St
 
   private void executeFileCreation(FileActivity activity) throws IOException {
     IFile file = activity.getPath().getFile();
-    file.create(new ByteArrayInputStream(activity.getContent()), true);
+    file.create(new ByteArrayInputStream(activity.getContent()));
   }
 
   private void executeFileMove(FileActivity activity) throws IOException {
@@ -98,7 +98,7 @@ public class FileActivityExecutor extends AbstractActivityConsumer implements St
       contents = oldFile.getContents();
     }
 
-    newFile.create(contents, false);
+    newFile.create(contents);
 
     oldFile.delete(0);
 

--- a/server/src/saros/server/session/FolderActivityExecutor.java
+++ b/server/src/saros/server/session/FolderActivityExecutor.java
@@ -6,7 +6,6 @@ import saros.activities.FolderCreatedActivity;
 import saros.activities.FolderDeletedActivity;
 import saros.activities.SPath;
 import saros.filesystem.IFolder;
-import saros.filesystem.IResource;
 import saros.repackaged.picocontainer.Startable;
 import saros.server.editor.ServerEditorManager;
 import saros.session.AbstractActivityConsumer;
@@ -70,7 +69,7 @@ public class FolderActivityExecutor extends AbstractActivityConsumer implements 
 
     SPath path = activity.getPath();
     IFolder folder = path.getFolder();
-    folder.delete(IResource.NONE);
+    folder.delete();
     editorManager.closeEditorsInFolder(path);
   }
 }

--- a/server/src/saros/server/session/FolderActivityExecutor.java
+++ b/server/src/saros/server/session/FolderActivityExecutor.java
@@ -63,7 +63,7 @@ public class FolderActivityExecutor extends AbstractActivityConsumer implements 
   private void executeFolderCreation(FolderCreatedActivity activity) throws IOException {
 
     IFolder folder = activity.getPath().getFolder();
-    folder.create(IResource.NONE, true);
+    folder.create();
   }
 
   private void executeFolderRemoval(FolderDeletedActivity activity) throws IOException {

--- a/server/test/junit/saros/server/filesystem/ServerContainerImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerContainerImplTest.java
@@ -68,7 +68,7 @@ public class ServerContainerImplTest extends EasyMockSupport {
   @Test
   public void delete() throws Exception {
     createFolder(workspace, CONTAINER_PATH);
-    container.delete(IResource.NONE);
+    container.delete();
     assertResourceNotExists(workspace, CONTAINER_PATH);
   }
 
@@ -76,14 +76,14 @@ public class ServerContainerImplTest extends EasyMockSupport {
   public void deleteNonEmpty() throws Exception {
     createFolder(workspace, CONTAINER_PATH);
     createFile(workspace, CONTAINER_PATH + "/file");
-    container.delete(IResource.NONE);
+    container.delete();
     assertResourceNotExists(workspace, CONTAINER_PATH);
   }
 
   @Test(expected = None.class)
   public void deleteNonExistent() throws Exception {
     assertResourceNotExists(workspace, CONTAINER_PATH);
-    container.delete(IResource.NONE);
+    container.delete();
   }
 
   @Test

--- a/server/test/junit/saros/server/filesystem/ServerFileImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerFileImplTest.java
@@ -118,7 +118,7 @@ public class ServerFileImplTest extends EasyMockSupport {
     createFile(workspace, "project/file", "old content");
 
     StringReader reader = new StringReader("new content");
-    file.setContents(new ReaderInputStream(reader), true, true);
+    file.setContents(new ReaderInputStream(reader));
 
     assertFileHasContent(workspace, "project/file", "new content");
   }
@@ -128,7 +128,7 @@ public class ServerFileImplTest extends EasyMockSupport {
     assertResourceNotExists(workspace, "project/file");
 
     StringReader reader = new StringReader("new content");
-    file.setContents(new ReaderInputStream(reader), true, true);
+    file.setContents(new ReaderInputStream(reader));
 
     assertFileHasContent(workspace, "project/file", "new content");
   }
@@ -136,7 +136,7 @@ public class ServerFileImplTest extends EasyMockSupport {
   @Test
   public void setContentsToNull() throws Exception {
     createFile(workspace, "project/file", "old content");
-    file.setContents(null, true, true);
+    file.setContents(null);
     assertFileHasContent(workspace, "project/file", "");
   }
 

--- a/server/test/junit/saros/server/filesystem/ServerFileImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerFileImplTest.java
@@ -70,14 +70,14 @@ public class ServerFileImplTest extends EasyMockSupport {
   @Test
   public void delete() throws Exception {
     createFile(workspace, "project/file");
-    file.delete(IResource.NONE);
+    file.delete();
     assertResourceNotExists(workspace, "project/file");
   }
 
   @Test(expected = None.class)
   public void deleteNonExistent() throws Exception {
     assertResourceNotExists(workspace, "project/file");
-    file.delete(IResource.NONE);
+    file.delete();
   }
 
   public void create() throws Exception {

--- a/server/test/junit/saros/server/filesystem/ServerFileImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerFileImplTest.java
@@ -84,7 +84,7 @@ public class ServerFileImplTest extends EasyMockSupport {
     assertResourceNotExists(workspace, "project/file");
 
     StringReader reader = new StringReader("content");
-    file.create(new ReaderInputStream(reader), true);
+    file.create(new ReaderInputStream(reader));
 
     assertResourceExists(workspace, "project/file");
     assertFileHasContent(workspace, "project/file", "content");
@@ -95,7 +95,7 @@ public class ServerFileImplTest extends EasyMockSupport {
     createFile(workspace, "project/file");
 
     StringReader reader = new StringReader("content");
-    file.create(new ReaderInputStream(reader), true);
+    file.create(new ReaderInputStream(reader));
   }
 
   @Test

--- a/server/test/junit/saros/server/filesystem/ServerFolderImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerFolderImplTest.java
@@ -17,7 +17,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.Test.None;
 import saros.filesystem.IFolder;
-import saros.filesystem.IResource;
 import saros.filesystem.IWorkspace;
 
 public class ServerFolderImplTest extends EasyMockSupport {
@@ -46,7 +45,7 @@ public class ServerFolderImplTest extends EasyMockSupport {
   @Test
   public void create() throws Exception {
     createFolder(workspace, FOLDER_PARENT_PATH);
-    folder.create(IResource.NONE, true);
+    folder.create();
     assertResourceExists(workspace, FOLDER_PATH);
     assertIsFolder(workspace, FOLDER_PATH);
   }
@@ -54,18 +53,18 @@ public class ServerFolderImplTest extends EasyMockSupport {
   @Test(expected = None.class)
   public void createIfFolderExistsAtPath() throws Exception {
     createFolder(workspace, FOLDER_PATH);
-    folder.create(IResource.NONE, true);
+    folder.create();
   }
 
   @Test(expected = IOException.class)
   public void createIfFileExistsAtPath() throws Exception {
     createFile(workspace, FOLDER_PATH);
-    folder.create(IResource.NONE, true);
+    folder.create();
   }
 
   @Test(expected = IOException.class)
   public void createAtNonExistentParent() throws Exception {
     assertResourceNotExists(workspace, FOLDER_PARENT_PATH);
-    folder.create(IResource.NONE, true);
+    folder.create();
   }
 }

--- a/server/test/junit/saros/server/filesystem/ServerResourceImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerResourceImplTest.java
@@ -37,7 +37,7 @@ public class ServerResourceImplTest extends EasyMockSupport {
     }
 
     @Override
-    public void delete(int updateFlags) throws IOException {
+    public void delete() throws IOException {
       // Do nothing
     }
   }

--- a/server/test/junit/saros/server/filesystem/ServerWorkspaceImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerWorkspaceImplTest.java
@@ -16,7 +16,6 @@ import org.junit.Test;
 import saros.exceptions.OperationCanceledException;
 import saros.filesystem.IPath;
 import saros.filesystem.IProject;
-import saros.filesystem.IResource;
 import saros.filesystem.IWorkspace;
 import saros.filesystem.IWorkspaceRunnable;
 import saros.monitoring.IProgressMonitor;
@@ -59,7 +58,7 @@ public class ServerWorkspaceImplTest extends EasyMockSupport {
           public void run(IProgressMonitor monitor) throws IOException, OperationCanceledException {
 
             assertNotNull(monitor);
-            workspace.getProject("project").delete(IResource.NONE);
+            workspace.getProject("project").delete();
           }
         });
 


### PR DESCRIPTION
As a starting point for working on refactoring the file system implementation and migrating it to a reference point based model, I decided to clean up the existing interfaces first. This gives me the opportunity to get a better overview of the current interfaces and implementations. Furthermore, the simplified interfaces will make it easier to introduce the new resource logic down the line.

I would recommend reviewing this PR commit by commit as each commit contains changes regarding a separate topic. All commits should be relatively easy to understand as this PR mainly consists of basic refactorings.

### Commits

<details><summary><b>[INTERNAL] Unify IFolder.create(...) methods</b></summary>
<br>

Removes the previous implementations of IFolder.create(...) and replaces
them by a single method create() taking no arguments. The arguments of
the previous methods were never actually used and Eclipse-specific in
their nature.

The default values for the Eclipse implementation are now "force=false"
and "local=true" as these were the only parameters used in Saros/E or
the Saros core.

</details>

<details><summary><b>[INTERNAL] Remove additional arguments from IFile.setContents(...)</b></summary>
<br>

Remove additional arguments "force" and "keepHistory" as they are
specific to the Eclipse API and had constant values where actually used.
"force" was always set to false and "keepHistory" was always set to true
for the Eclipse implementation. All other implementations simply ignored
the arguments.

The default values for the Eclipse implementation were set to
"force=false" and "keepHistory=true" as these were the only values used
in Saros/E or the Saros core.

</details>

<details><summary><b>[INTERNAL] Remove "force" argument from IFile.create(...)</b></summary>
<br>

Removes the "force" argument from IFile.create(...) as it was only
correctly implemented for Eclipse and always false in such cases.

The default value used for the Eclipse implementation was "force=false"
as this was the only value used in Saros/E or the Saros core.

</details>

<details><summary><b>[INTERNAL] Remove "updateFlags" argument from IResource.delete(...)</b></summary>
<br>

Removes the argument "updateFlags" from IResource.delete(...) as this is
an Eclipse specific feature that is not supported by the other IDE
implementations.

Set the default value to "IResource.KEEP_HISTORY" for the Eclipse
implementation as this was the only valid flag that was used by Saros/E
or the Saros core.

Does not add a new javadoc for the method as the handling of
non-existent resources that are supposed to be deleted is not
consistent. Will be done in an upcoming commit.

</details>

<details><summary><b>[INTERNAL] Set new behavior for IResource.delete()</b></summary>
<br>

Adds the javadoc for IResource.delete(). The newly specified behavior is
that the call does not fail if the resource does not exist to begin
with.

Adjusts the IntelliJ IResource implementations to match the new
behavior.

</details>

<details><summary><b>[INTERNAL][I] Remove last usage of IContainer.members(int)</b></summary>
<br>

Removes the usage of IContainer.member(int) in CollaborationUtils and
replaces it with IContainer.members(). The flag was used incorrectly
anyways, probably due to an error while copying the Saros/E
implementation when first starting to work on Saros/I.

</details>

<details><summary><b>[API] Remove IContainer.members(int)</b></summary>
<br>

Removes IContainer.members(int) as it was no longer being used.
Furthermore, the passed integer flag was specific to the Eclipse API the
interface is modeled after and therefore not applicable to other IDE
implementations.

</details>