### PR TITLE
Replace resource type list with enum

### DIFF
--- a/core/src/saros/filesystem/FileSystem.java
+++ b/core/src/saros/filesystem/FileSystem.java
@@ -1,5 +1,8 @@
 package saros.filesystem;
 
+import static saros.filesystem.IResource.Type.FILE;
+import static saros.filesystem.IResource.Type.FOLDER;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -77,15 +80,15 @@ public class FileSystem {
 
   private static void createFolders(final IResource resource) throws IOException {
 
-    if (!(resource.getType() == IResource.FILE || resource.getType() == IResource.FOLDER)) return;
+    if (!(resource.getType() == FILE || resource.getType() == FOLDER)) return;
 
     final List<IFolder> parents = new ArrayList<IFolder>();
 
-    if (resource.getType() == IResource.FOLDER) parents.add((IFolder) resource);
+    if (resource.getType() == FOLDER) parents.add((IFolder) resource);
 
     IContainer parent = resource.getParent();
 
-    while (parent != null && parent.getType() == IResource.FOLDER) {
+    while (parent != null && parent.getType() == FOLDER) {
 
       if (parent.exists()) break;
 

--- a/core/src/saros/filesystem/IResource.java
+++ b/core/src/saros/filesystem/IResource.java
@@ -25,11 +25,13 @@ import java.io.IOException;
  */
 public interface IResource {
 
-  public static final int NONE = 0;
-  public static final int FILE = 1;
-  public static final int FOLDER = 2;
-  public static final int PROJECT = 4;
-  public static final int ROOT = 8;
+  /** The different types of resources. */
+  enum Type {
+    FILE,
+    FOLDER,
+    PROJECT,
+    ROOT
+  }
 
   public boolean exists();
 
@@ -43,7 +45,7 @@ public interface IResource {
 
   public IPath getProjectRelativePath();
 
-  public int getType();
+  public Type getType();
 
   /**
    * Returns whether the resource should be ignored. Resources should be ignored if they match any

--- a/core/src/saros/negotiation/FileListFactory.java
+++ b/core/src/saros/negotiation/FileListFactory.java
@@ -120,14 +120,14 @@ public class FileListFactory {
       if (list.contains(path)) continue;
 
       switch (resource.getType()) {
-        case IResource.FILE:
+        case FILE:
           files.add((IFile) resource);
           MetaData data = new MetaData();
           list.addPath(path, data, false);
           list.addEncoding(((IFile) resource).getCharset());
           break;
 
-        case IResource.FOLDER:
+        case FOLDER:
           stack.addAll(Arrays.asList(((IFolder) resource).members()));
           list.addPath(path, null, true);
           break;

--- a/core/src/saros/session/internal/SharedProjectMapper.java
+++ b/core/src/saros/session/internal/SharedProjectMapper.java
@@ -1,5 +1,7 @@
 package saros.session.internal;
 
+import static saros.filesystem.IResource.Type.PROJECT;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -132,7 +134,7 @@ class SharedProjectMapper {
   public synchronized boolean isShared(IResource resource) {
     if (resource == null) return false;
 
-    if (resource.getType() == IResource.PROJECT) return idToProjectMapping.containsValue(resource);
+    if (resource.getType() == PROJECT) return idToProjectMapping.containsValue(resource);
 
     IProject project = resource.getProject();
 

--- a/core/test/junit/saros/negotiation/FileListTest.java
+++ b/core/test/junit/saros/negotiation/FileListTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static saros.filesystem.IResource.Type.FILE;
+import static saros.filesystem.IResource.Type.FOLDER;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.basic.BooleanConverter;
@@ -151,7 +153,7 @@ public class FileListTest {
 
     EasyMock.expect(fileMock.isIgnored()).andStubReturn(false);
     EasyMock.expect(fileMock.exists()).andStubReturn(true);
-    EasyMock.expect(fileMock.getType()).andStubReturn(IResource.FILE);
+    EasyMock.expect(fileMock.getType()).andStubReturn(FILE);
 
     // only used for UI feedback
     EasyMock.expect(fileMock.getName()).andStubReturn("");
@@ -198,7 +200,7 @@ public class FileListTest {
 
     EasyMock.expect(folderMock.isIgnored()).andStubReturn(false);
     EasyMock.expect(folderMock.exists()).andStubReturn(true);
-    EasyMock.expect(folderMock.getType()).andStubReturn(IResource.FOLDER);
+    EasyMock.expect(folderMock.getType()).andStubReturn(FOLDER);
 
     try {
       EasyMock.expect(folderMock.members()).andStubReturn(members);

--- a/core/test/junit/saros/session/internal/SharedProjectMapperTest.java
+++ b/core/test/junit/saros/session/internal/SharedProjectMapperTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static saros.filesystem.IResource.Type.PROJECT;
 
 import org.easymock.EasyMock;
 import org.junit.Before;
@@ -153,7 +154,7 @@ public class SharedProjectMapperTest {
    */
   private IProject createProjectMock() {
     IProject projectMock = EasyMock.createNiceMock(IProject.class);
-    EasyMock.expect(projectMock.getType()).andStubReturn(IResource.PROJECT);
+    EasyMock.expect(projectMock.getType()).andStubReturn(PROJECT);
     EasyMock.replay(projectMock);
     return projectMock;
   }

--- a/eclipse/src/saros/filesystem/EclipseResourceImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseResourceImpl.java
@@ -1,5 +1,10 @@
 package saros.filesystem;
 
+import static saros.filesystem.IResource.Type.FILE;
+import static saros.filesystem.IResource.Type.FOLDER;
+import static saros.filesystem.IResource.Type.PROJECT;
+import static saros.filesystem.IResource.Type.ROOT;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -79,26 +84,25 @@ public class EclipseResourceImpl implements IResource {
   }
 
   @Override
-  public int getType() {
-    int type = delegate.getType();
+  public Type getType() {
+    int delegateType = delegate.getType();
 
-    switch (type) {
+    switch (delegateType) {
       case org.eclipse.core.resources.IResource.FILE:
-        type = IResource.FILE;
-        break;
+        return FILE;
+
       case org.eclipse.core.resources.IResource.FOLDER:
-        type = IResource.FOLDER;
-        break;
+        return FOLDER;
+
       case org.eclipse.core.resources.IResource.PROJECT:
-        type = IResource.PROJECT;
-        break;
+        return PROJECT;
+
       case org.eclipse.core.resources.IResource.ROOT:
-        type = IResource.ROOT;
-        break;
+        return ROOT;
+
       default:
-        type = 0;
+        throw new IllegalStateException("Encountered unknown resource type " + delegateType);
     }
-    return type;
   }
 
   @Override

--- a/eclipse/src/saros/filesystem/ResourceAdapterFactory.java
+++ b/eclipse/src/saros/filesystem/ResourceAdapterFactory.java
@@ -114,16 +114,20 @@ public class ResourceAdapterFactory {
     if (resource == null) return null;
 
     switch (resource.getType()) {
-      case IResource.FILE:
+      case org.eclipse.core.resources.IResource.FILE:
         return new EclipseFileImpl(resource.getAdapter(org.eclipse.core.resources.IFile.class));
-      case IResource.FOLDER:
+
+      case org.eclipse.core.resources.IResource.FOLDER:
         return new EclipseFolderImpl(resource.getAdapter(org.eclipse.core.resources.IFolder.class));
-      case IResource.PROJECT:
+
+      case org.eclipse.core.resources.IResource.PROJECT:
         return new EclipseProjectImpl(
             resource.getAdapter(org.eclipse.core.resources.IProject.class));
-      case IResource.ROOT:
+
+      case org.eclipse.core.resources.IResource.ROOT:
         return new EclipseWorkspaceRootImpl(
             resource.getAdapter(org.eclipse.core.resources.IWorkspaceRoot.class));
+
       default:
         return new EclipseResourceImpl(resource);
     }

--- a/eclipse/test/junit/saros/project/FileActivityConsumerTest.java
+++ b/eclipse/test/junit/saros/project/FileActivityConsumerTest.java
@@ -21,7 +21,6 @@ import saros.activities.FileActivity;
 import saros.activities.FileActivity.Purpose;
 import saros.activities.FileActivity.Type;
 import saros.activities.SPath;
-import saros.filesystem.IResource;
 import saros.filesystem.ResourceAdapterFactory;
 import saros.net.xmpp.JID;
 import saros.session.User;
@@ -61,7 +60,7 @@ public class FileActivityConsumerTest {
     expect(file.getContents()).andStubReturn(new ByteArrayInputStream(FILE_CONTENT));
 
     expect(file.exists()).andStubReturn(Boolean.TRUE);
-    expect(file.getType()).andStubReturn(IResource.FILE);
+    expect(file.getType()).andStubReturn(org.eclipse.core.resources.IResource.FILE);
     expect(file.getAdapter(IFile.class)).andStubReturn(file);
   }
 

--- a/intellij/src/saros/core/ui/util/CollaborationUtils.java
+++ b/intellij/src/saros/core/ui/util/CollaborationUtils.java
@@ -287,7 +287,7 @@ public class CollaborationUtils {
 
     for (IResource resource : resources) {
       switch (resource.getType()) {
-        case IResource.FILE:
+        case FILE:
           totalFileCount++;
 
           try {
@@ -298,8 +298,8 @@ public class CollaborationUtils {
             log.warn("failed to retrieve size of file " + resource, e);
           }
           break;
-        case IResource.PROJECT:
-        case IResource.FOLDER:
+        case PROJECT:
+        case FOLDER:
           try {
             IContainer container = resource.adaptTo(IContainer.class);
 

--- a/intellij/src/saros/intellij/filesystem/IntelliJFileImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFileImpl.java
@@ -1,5 +1,7 @@
 package saros.intellij.filesystem;
 
+import static saros.filesystem.IResource.Type.FILE;
+
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.util.ThrowableComputable;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -93,8 +95,8 @@ public final class IntelliJFileImpl extends IntelliJResourceImpl implements IFil
   }
 
   @Override
-  public int getType() {
-    return IResource.FILE;
+  public Type getType() {
+    return FILE;
   }
 
   @Override

--- a/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
@@ -1,5 +1,7 @@
 package saros.intellij.filesystem;
 
+import static saros.filesystem.IResource.Type.FOLDER;
+
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.roots.ModuleFileIndex;
 import com.intellij.openapi.roots.ModuleRootManager;
@@ -141,8 +143,8 @@ public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IF
   }
 
   @Override
-  public int getType() {
-    return IResource.FOLDER;
+  public Type getType() {
+    return FOLDER;
   }
 
   @Override

--- a/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
@@ -1,5 +1,7 @@
 package saros.intellij.filesystem;
 
+import static saros.filesystem.IResource.Type.PROJECT;
+
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ModuleFileIndex;
@@ -221,8 +223,8 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
   }
 
   @Override
-  public int getType() {
-    return IResource.PROJECT;
+  public Type getType() {
+    return PROJECT;
   }
 
   @Override

--- a/intellij/src/saros/intellij/project/filesystem/IntelliJWorkspaceRootImpl.java
+++ b/intellij/src/saros/intellij/project/filesystem/IntelliJWorkspaceRootImpl.java
@@ -1,5 +1,7 @@
 package saros.intellij.project.filesystem;
 
+import static saros.filesystem.IResource.Type.ROOT;
+
 import saros.filesystem.IContainer;
 import saros.filesystem.IPath;
 import saros.filesystem.IProject;
@@ -66,8 +68,8 @@ public class IntelliJWorkspaceRootImpl implements IWorkspaceRoot {
   }
 
   @Override
-  public int getType() {
-    return IResource.ROOT;
+  public Type getType() {
+    return ROOT;
   }
 
   @Override

--- a/server/src/saros/server/filesystem/ServerFileImpl.java
+++ b/server/src/saros/server/filesystem/ServerFileImpl.java
@@ -1,5 +1,7 @@
 package saros.server.filesystem;
 
+import static saros.filesystem.IResource.Type.FILE;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.AtomicMoveNotSupportedException;
@@ -41,7 +43,7 @@ public class ServerFileImpl extends ServerResourceImpl implements IFile {
   }
 
   @Override
-  public int getType() {
+  public Type getType() {
     return FILE;
   }
 

--- a/server/src/saros/server/filesystem/ServerFolderImpl.java
+++ b/server/src/saros/server/filesystem/ServerFolderImpl.java
@@ -1,12 +1,13 @@
 package saros.server.filesystem;
 
+import static saros.filesystem.IResource.Type.FOLDER;
+
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import saros.filesystem.IFolder;
 import saros.filesystem.IPath;
-import saros.filesystem.IResource;
 import saros.filesystem.IWorkspace;
 
 /** Server implementation of the {@link IFolder} interface. */
@@ -23,8 +24,8 @@ public class ServerFolderImpl extends ServerContainerImpl implements IFolder {
   }
 
   @Override
-  public int getType() {
-    return IResource.FOLDER;
+  public Type getType() {
+    return FOLDER;
   }
 
   @Override

--- a/server/src/saros/server/filesystem/ServerProjectImpl.java
+++ b/server/src/saros/server/filesystem/ServerProjectImpl.java
@@ -1,5 +1,7 @@
 package saros.server.filesystem;
 
+import static saros.filesystem.IResource.Type.PROJECT;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -26,8 +28,8 @@ public class ServerProjectImpl extends ServerContainerImpl implements IProject {
   }
 
   @Override
-  public int getType() {
-    return IResource.PROJECT;
+  public Type getType() {
+    return PROJECT;
   }
 
   @Override

--- a/server/src/saros/server/filesystem/ServerResourceImpl.java
+++ b/server/src/saros/server/filesystem/ServerResourceImpl.java
@@ -103,7 +103,7 @@ public abstract class ServerResourceImpl implements IResource {
   public final int hashCode() {
     final int prime = 31;
     int result = 1;
-    result = prime * result + getType();
+    result = prime * result + getType().hashCode();
     result = prime * result + path.hashCode();
     result = prime * result + workspace.hashCode();
     return result;

--- a/server/test/junit/saros/server/filesystem/ServerContainerImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerContainerImplTest.java
@@ -34,8 +34,8 @@ public class ServerContainerImplTest extends EasyMockSupport {
     }
 
     @Override
-    public int getType() {
-      return IResource.FOLDER;
+    public Type getType() {
+      return IResource.Type.FOLDER;
     }
   }
 
@@ -105,9 +105,9 @@ public class ServerContainerImplTest extends EasyMockSupport {
         });
 
     assertEquals(path(CONTAINER_PATH + "/file"), members[0].getFullPath());
-    assertEquals(IResource.FILE, members[0].getType());
+    assertEquals(IResource.Type.FILE, members[0].getType());
     assertEquals(path(CONTAINER_PATH + "/subfolder"), members[1].getFullPath());
-    assertEquals(IResource.FOLDER, members[1].getType());
+    assertEquals(IResource.Type.FOLDER, members[1].getType());
   }
 
   @Test(expected = IOException.class)

--- a/server/test/junit/saros/server/filesystem/ServerFileImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerFileImplTest.java
@@ -53,7 +53,7 @@ public class ServerFileImplTest extends EasyMockSupport {
 
   @Test
   public void getType() {
-    assertEquals(IResource.FILE, file.getType());
+    assertEquals(IResource.Type.FILE, file.getType());
   }
 
   @Test

--- a/server/test/junit/saros/server/filesystem/ServerProjectImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerProjectImplTest.java
@@ -42,7 +42,7 @@ public class ServerProjectImplTest extends EasyMockSupport {
 
   @Test
   public void getType() {
-    assertEquals(IResource.PROJECT, project.getType());
+    assertEquals(IResource.Type.PROJECT, project.getType());
   }
 
   @Test
@@ -60,8 +60,8 @@ public class ServerProjectImplTest extends EasyMockSupport {
     IResource file = project.findMember(path("folder/file"));
     IResource nonExistent = project.findMember(path("non/existent"));
 
-    assertEquals(IResource.FOLDER, folder.getType());
-    assertEquals(IResource.FILE, file.getType());
+    assertEquals(IResource.Type.FOLDER, folder.getType());
+    assertEquals(IResource.Type.FILE, file.getType());
     assertNull(nonExistent);
   }
 

--- a/server/test/junit/saros/server/filesystem/ServerResourceImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerResourceImplTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static saros.filesystem.IResource.Type.FILE;
 import static saros.server.filesystem.FileSystemTestUtils.createFile;
 import static saros.server.filesystem.FileSystemTestUtils.createWorkspaceFolder;
 import static saros.server.filesystem.FileSystemTestUtils.path;
@@ -32,8 +33,8 @@ public class ServerResourceImplTest extends EasyMockSupport {
     }
 
     @Override
-    public int getType() {
-      return IResource.FILE;
+    public Type getType() {
+      return FILE;
     }
 
     @Override


### PR DESCRIPTION
Replaces the list of integers specifying the different types of
resources with an enum. This makes the usage much easier and makes it
clear what to (and what not to) use the types for.

In general, it should be considered to replace the type concept as a
whole and work with instanceof checks instead.