### PR TITLE
[I] Set UTF-8 as project default

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="Encoding" useUTFGuessing="true" native2AsciiForPropertiesFiles="false" />
+  <component name="Encoding" defaultCharsetForPropertiesFiles="UTF-8">
+    <file url="PROJECT" charset="UTF-8" />
+  </component>
 </project>


### PR DESCRIPTION
Sets UTF-8 as the default project encoding for newly created file.

Sets UTF-8 as the default project encoding for property files.