### PR TITLE
Improve charset handling

### DIFF
--- a/core/src/saros/filesystem/IFile.java
+++ b/core/src/saros/filesystem/IFile.java
@@ -23,6 +23,8 @@ package saros.filesystem;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.IllegalCharsetNameException;
 
 /**
  * This interface is under development. It currently equals its Eclipse counterpart. If not
@@ -30,6 +32,19 @@ import java.io.InputStream;
  */
 public interface IFile extends IResource {
   public String getCharset() throws IOException;
+
+  /**
+   * Sets the given character set for this file.
+   *
+   * <p>Does nothing if the passed character set is <code>null</code>.
+   *
+   * @param charset the character set to set
+   * @throws IOException if the character set could not be set
+   * @throws IllegalCharsetNameException if the given character set name is not valid
+   * @throws UnsupportedEncodingException if the given character set is not supported by the local
+   *     JVM
+   */
+  void setCharset(String charset) throws IOException;
 
   public InputStream getContents() throws IOException;
 

--- a/intellij/src/saros/intellij/filesystem/IntelliJFileImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFileImpl.java
@@ -10,6 +10,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.nio.file.FileAlreadyExistsException;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
@@ -139,6 +140,21 @@ public final class IntelliJFileImpl extends IntelliJResourceImpl implements IFil
     final VirtualFile file = project.findVirtualFile(path);
 
     return file == null ? null : file.getCharset().name();
+  }
+
+  @Override
+  public void setCharset(String charset) throws IOException {
+    if (charset == null) {
+      return;
+    }
+
+    final VirtualFile file = project.findVirtualFile(path);
+
+    if (file == null) {
+      throw new FileNotFoundException("Could not obtain virtual file for " + this);
+    }
+
+    file.setCharset(Charset.forName(charset));
   }
 
   @NotNull

--- a/server/src/saros/server/editor/Editor.java
+++ b/server/src/saros/server/editor/Editor.java
@@ -15,10 +15,17 @@ public class Editor {
   private GapBuffer content;
 
   public Editor(IFile file) throws IOException {
+    String charset = file.getCharset();
+
+    if (charset == null) {
+      throw new IllegalStateException(
+          "Tried to open an editor for a file without a valid charset mapping: " + file);
+    }
+
     this.file = file;
 
     try (InputStream input = file.getContents()) {
-      content = new GapBuffer(IOUtils.toString(input));
+      content = new GapBuffer(IOUtils.toString(input, charset));
     }
   }
 
@@ -87,6 +94,6 @@ public class Editor {
    * @throws IOException if writing the file fails
    */
   public void save() throws IOException {
-    getFile().setContents(IOUtils.toInputStream(content.toString()));
+    getFile().setContents(IOUtils.toInputStream(content.toString(), file.getCharset()));
   }
 }

--- a/server/src/saros/server/filesystem/ServerFileImpl.java
+++ b/server/src/saros/server/filesystem/ServerFileImpl.java
@@ -4,6 +4,9 @@ import static saros.filesystem.IResource.Type.FILE;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.UnsupportedCharsetException;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
@@ -31,17 +34,6 @@ public class ServerFileImpl extends ServerResourceImpl implements IFile {
     super(workspace, path);
   }
 
-  /**
-   * Sets the character encoding to use when decoding this file to text. Passing <code>null</code>
-   * means the default encoding of the surrounding container should be used (which is the default
-   * behavior).
-   *
-   * @param charset the file's character encoding
-   */
-  public void setCharset(String charset) {
-    this.charset = charset;
-  }
-
   @Override
   public Type getType() {
     return FILE;
@@ -50,6 +42,20 @@ public class ServerFileImpl extends ServerResourceImpl implements IFile {
   @Override
   public String getCharset() throws IOException {
     return charset != null ? charset : getParent().getDefaultCharset();
+  }
+
+  @Override
+  public void setCharset(String charset)
+      throws IllegalCharsetNameException, UnsupportedCharsetException {
+
+    if (charset == null) {
+      return;
+    }
+
+    // Check whether charset is valid and supported
+    Charset.forName(charset);
+
+    this.charset = charset;
   }
 
   @Override

--- a/server/test/junit/saros/server/filesystem/ServerFileImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerFileImplTest.java
@@ -63,7 +63,7 @@ public class ServerFileImplTest extends EasyMockSupport {
 
   @Test
   public void getCharsetIfExplicitlySet() throws Exception {
-    ((ServerFileImpl) file).setCharset("ISO-8859-1");
+    file.setCharset("ISO-8859-1");
     assertEquals("ISO-8859-1", file.getCharset());
   }
 


### PR DESCRIPTION
Improves the local handling of charsets for received file creation activities. Part of requirement for #912.

### Commits

<details><summary><b>[API] Add IFile.setCharset(String)</b></summary>
<br>

Introduces IFile.setCharset(String). This method can be used to set the
character set for a file. It will be required for setting the correct
character set for resources created as part of the session creation once
this logic has been introduced.

Implements the method for Saros/E, Saros/I, and Saros/S.

The IFile.setCharset(String) implementation for Saros/E was largely
copied from FileActivityConsumer.updateFileEncoding(String,IFile). In an
upcoming change, the method updateFileEncoding will subsequently be
replaced with using IFile.setCharset(String).

</details>

<details><summary><b>[REFACTOR][E] Use IFile.setCharset(String) in FileActivityConsumer</b></summary>
<br>

Replaces the logic to set the charset in FileActivityConsumer with a
call to IFile.setCharset(String). This does not actually change the
logic as the implementation of IFile.setCharset(String) for Saros/E was
modeled after the removed logic.

</details>

<details><summary><b>[FIX][I] Set charset when creating files as part of file activities</b></summary>
<br>

Adjusts SharedResourcesmanager to also set the character set for files
created for a received file activity. Uses the character set contained
in the file activity.

</details>

<details><summary><b>[FIX][S] Set charset when creating files as part of file activities</b></summary>
<br>

Adjusts the logic handling file creations and moves for received file
activities to set the encoding for the new file. The encoding contained
in the file activity is used.

</details>

<details><summary><b>[FIX][S] Use file encoding for editors</b></summary>
<br>

Adjusts the logic reading content from disk and writing content to disk
to use the file encoding. This ensures that the correct encoding it used
for the conversion from binary content to string and vice versa.

Adds a check in the editor constructor to ensure that the file for the
editor always provides a valid charset. This is not important with the
current implementation but will be useful when the logic has been
adjusted so that every file creation has to provide its own charset.

</details>