### PR TITLE
Require charset for file activity containing binary content

### DIFF
--- a/core/src/saros/activities/FileActivity.java
+++ b/core/src/saros/activities/FileActivity.java
@@ -48,7 +48,9 @@ public class FileActivity extends AbstractResourceActivity
    *     null</code> otherwise)
    * @param content content of the file denoted by the path (only valid for {@link Type#CREATED} and
    *     {@link Type#MOVED})
-   * @param encoding the encoding the content is encoded with or <code>null</code>
+   * @param encoding the encoding the content is encoded with or <code>null</code> if (and only if)
+   *     the type is {@link Type#MOVED} and the content is <code>null</code> or the type is {@link
+   *     Type#REMOVED}
    */
   public FileActivity(
       User source,
@@ -75,6 +77,11 @@ public class FileActivity extends AbstractResourceActivity
       case MOVED:
         if (oldPath == null) throw new IllegalArgumentException();
         break;
+    }
+
+    if (encoding == null && (type == Type.CREATED || (type == Type.MOVED && content != null))) {
+      throw new IllegalArgumentException(
+          "Encoding must be passed if type is created and/or binary content is passed");
     }
 
     this.type = type;

--- a/eclipse/src/saros/util/FileUtils.java
+++ b/eclipse/src/saros/util/FileUtils.java
@@ -2,6 +2,9 @@ package saros.util;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -193,5 +196,35 @@ public class FileUtils {
       IOUtils.closeQuietly(in);
     }
     return content;
+  }
+
+  /**
+   * Retrieves the character set of a local file.
+   *
+   * @param localFile the file for which to retrieve the character set
+   * @return the character set of a local file or <code>null</code> if the character set could not
+   *     be determined or the charset is not valid
+   * @see IFile#getCharset()
+   * @see Charset#forName(String)
+   */
+  public static String getLocalFileCharset(IFile localFile) {
+    String charset = null;
+
+    try {
+      charset = localFile.getCharset();
+
+      // validate charset
+      Charset.forName(charset);
+
+    } catch (CoreException e) {
+      log.warn("could not get charset of file " + localFile.getFullPath());
+
+    } catch (IllegalCharsetNameException | UnsupportedCharsetException e) {
+      log.warn("charset for " + localFile.getFullPath() + " not valid - charset name: " + charset);
+
+      return null;
+    }
+
+    return charset;
   }
 }


### PR DESCRIPTION
Introduces the requirement for all file activities containing binary content to also contain a charset to use for that content. Adjusts Saros/E to always send a charset for such activities. Part of requirement for #912.

### Commits

<details><summary><b>[INTERNAL][E] Adjust FileActivityConsumerTest to use file encoding</b></summary>
<br>

Adjusts the FileActivityConsumerTest to pass a specific file encoding
when creating a file activity. This was done in preparation of an
upcoming change requiring all file activities containing binary content
to also contain a valid encoding.

Introduces UTF-8 as the default chatset to use for the test. Explicitly
uses the charset for the string conversion instead of implicitly using
the JVM default charset.

Restructures the mocking logic to be able to mock internal calls to
IFile.setCharset(String). This is necessary as I am unable to mock the
Eclipse interface IProject which is used in the method.

When trying to mock IProject or its implementations, EasyMock runs ino
a NoClassDefFoundError for org/eclipse/core/runtime/IPluginDescriptor.
The cause of this issue seems to be that the class IPluginDescriptor has
been deprecated and is no longer included in the default Eclipse
artifacts. As a result, I was unable to either mock IProject nor create
an IProject stub implementation.  See issue #910.

</details>

<details><summary><b>[FIX][E] Always pass charset when creating file activities with content</b></summary>
<br>

Adjusts the logic instantiating new file activities to always also pass
the character set for the corresponding file when passing binary
content.

This was done in preparation of an upcoming change requiring all file
activities that contain binary content to also contain a character set
to use for that content.

</details>

<details><summary><b>[INTERNAL][CORE] Require charset for file activities with content</b></summary>
<br>

Adds a check to the FileActivity constructor to ensure that all file
activities containing binary content also contain a character set to use
for the binary content.

Adjusts the javadoc to reflect this new restriction.

</details>