### PR TITLE
Remove IContainer.getDefaultCharset()

### DIFF
--- a/core/src/saros/filesystem/IContainer.java
+++ b/core/src/saros/filesystem/IContainer.java
@@ -33,8 +33,6 @@ public interface IContainer extends IResource {
 
   public IResource[] members() throws IOException;
 
-  public String getDefaultCharset() throws IOException;
-
   /**
    * Returns a handle for the file with the given relative path to this resource.
    *

--- a/core/src/saros/negotiation/FileListFactory.java
+++ b/core/src/saros/negotiation/FileListFactory.java
@@ -77,8 +77,6 @@ public class FileListFactory {
 
     FileList list = new FileList();
 
-    list.addEncoding(project.getDefaultCharset());
-
     List<IFile> files = calculateMembers(list, project);
 
     IProgressMonitor monitor =

--- a/core/test/junit/saros/negotiation/FileListTest.java
+++ b/core/test/junit/saros/negotiation/FileListTest.java
@@ -34,7 +34,7 @@ import saros.misc.xstream.XStreamFactory;
 /*
  *Project Layout for test
  *
- *  foo (Project, UTF-16 encoding)
+ *  foo (Project)
  *      bar (Empty folder)
  *      info.txt (File, random content, UTF-8 encoding)
  *      foobar (Folder)
@@ -74,8 +74,7 @@ public class FileListTest {
 
     assertTrue("file list does not contain folder: foobar/foo", paths.contains("foobar/foo/"));
 
-    final Set<String> expectedEncodings =
-        new HashSet<String>(Arrays.asList("ISO-8859-1", "UTF-8", "UTF-16"));
+    final Set<String> expectedEncodings = new HashSet<String>(Arrays.asList("ISO-8859-1", "UTF-8"));
 
     assertNotNull("no checksum found for file: info.txt", fileList.getMetaData("info.txt"));
 
@@ -128,8 +127,6 @@ public class FileListTest {
     EasyMock.expect(project.getName()).andStubReturn("foo");
 
     try {
-      EasyMock.expect(project.getDefaultCharset()).andStubReturn("UTF-16");
-
       EasyMock.expect(project.members())
           .andStubReturn(new IResource[] {barFolder, infoTxtFile, foobarFolder});
     } catch (IOException e) {

--- a/eclipse/src/saros/filesystem/EclipseContainerImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseContainerImpl.java
@@ -65,15 +65,6 @@ public class EclipseContainerImpl extends EclipseResourceImpl implements IContai
     return ResourceAdapterFactory.create(path);
   }
 
-  @Override
-  public String getDefaultCharset() throws IOException {
-    try {
-      return getDelegate().getDefaultCharset();
-    } catch (CoreException e) {
-      throw new IOException(e);
-    }
-  }
-
   /**
    * Returns the original {@link org.eclipse.core.resources.IContainer IContainer} object.
    *

--- a/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import saros.filesystem.IContainer;
 import saros.filesystem.IFile;
 import saros.filesystem.IFolder;
@@ -110,13 +109,6 @@ public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IF
       throw new IllegalArgumentException("cannot create folder handle for an empty path");
 
     return new IntelliJFolderImpl(project, path);
-  }
-
-  @Nullable
-  @Override
-  public String getDefaultCharset() throws IOException {
-    // TODO retrieve encoding for the module or use the project settings
-    return getParent().getDefaultCharset();
   }
 
   /**

--- a/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
@@ -142,13 +142,6 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
     return result.toArray(new IResource[0]);
   }
 
-  @Nullable
-  @Override
-  public String getDefaultCharset() {
-    // TODO retrieve encoding for the module or use the project settings
-    return null;
-  }
-
   @Override
   public boolean exists() {
     return !module.isDisposed() && module.isLoaded();

--- a/server/src/saros/server/filesystem/ServerContainerImpl.java
+++ b/server/src/saros/server/filesystem/ServerContainerImpl.java
@@ -88,9 +88,4 @@ public abstract class ServerContainerImpl extends ServerResourceImpl implements 
     IPath childLocation = getLocation().append(path);
     return childLocation.toFile().exists();
   }
-
-  @Override
-  public String getDefaultCharset() throws IOException {
-    return getParent().getDefaultCharset();
-  }
 }

--- a/server/src/saros/server/filesystem/ServerFileImpl.java
+++ b/server/src/saros/server/filesystem/ServerFileImpl.java
@@ -22,6 +22,8 @@ public class ServerFileImpl extends ServerResourceImpl implements IFile {
 
   private static final Logger log = Logger.getLogger(ServerFileImpl.class);
 
+  private static final String DEFAULT_CHARSET = "UTF-8";
+
   private String charset;
 
   /**
@@ -40,8 +42,13 @@ public class ServerFileImpl extends ServerResourceImpl implements IFile {
   }
 
   @Override
-  public String getCharset() throws IOException {
-    return charset != null ? charset : getParent().getDefaultCharset();
+  public String getCharset() {
+    // TODO remove once #912 is resolved as this will no longer be necessary
+    if (charset == null) {
+      return DEFAULT_CHARSET;
+    }
+
+    return charset;
   }
 
   @Override

--- a/server/src/saros/server/filesystem/ServerProjectImpl.java
+++ b/server/src/saros/server/filesystem/ServerProjectImpl.java
@@ -9,9 +9,6 @@ import saros.filesystem.IWorkspace;
 
 /** Server implementation of the {@link IProject} interface. */
 public class ServerProjectImpl extends ServerContainerImpl implements IProject {
-
-  private static final String DEFAULT_CHARSET = "UTF-8";
-
   /**
    * Creates a ServerProjectImpl.
    *
@@ -25,12 +22,6 @@ public class ServerProjectImpl extends ServerContainerImpl implements IProject {
   @Override
   public Type getType() {
     return PROJECT;
-  }
-
-  @Override
-  public String getDefaultCharset() {
-    // TODO: Read default character set from the project metadata files.
-    return DEFAULT_CHARSET;
   }
 
   /**

--- a/server/test/junit/saros/server/filesystem/ServerContainerImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerContainerImplTest.java
@@ -53,7 +53,6 @@ public class ServerContainerImplTest extends EasyMockSupport {
     expect(workspace.getLocation()).andStubReturn(createWorkspaceFolder());
 
     expect(workspace.getProject("project")).andStubReturn(project);
-    expect(project.getDefaultCharset()).andStubReturn("UTF-8");
 
     replayAll();
 
@@ -130,10 +129,5 @@ public class ServerContainerImplTest extends EasyMockSupport {
     assertTrue(container.exists(path("subfolder")));
     assertTrue(container.exists(path("subfolder/file2")));
     assertFalse(container.exists(path("something/else")));
-  }
-
-  @Test
-  public void defaultCharset() throws IOException {
-    assertEquals("UTF-8", container.getDefaultCharset());
   }
 }

--- a/server/test/junit/saros/server/filesystem/ServerFileImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerFileImplTest.java
@@ -40,7 +40,6 @@ public class ServerFileImplTest extends EasyMockSupport {
     expect(workspace.getLocation()).andStubReturn(createWorkspaceFolder());
 
     expect(workspace.getProject("project")).andStubReturn(project);
-    expect(project.getDefaultCharset()).andStubReturn("UTF-8");
 
     replayAll();
     file = new ServerFileImpl(workspace, path("project/file"));
@@ -54,11 +53,6 @@ public class ServerFileImplTest extends EasyMockSupport {
   @Test
   public void getType() {
     assertEquals(IResource.Type.FILE, file.getType());
-  }
-
-  @Test
-  public void getCharsetIfDefault() throws Exception {
-    assertEquals(project.getDefaultCharset(), file.getCharset());
   }
 
   @Test

--- a/server/test/junit/saros/server/filesystem/ServerProjectImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerProjectImplTest.java
@@ -42,11 +42,6 @@ public class ServerProjectImplTest extends EasyMockSupport {
   }
 
   @Test
-  public void defaultCharsetUTF8() throws Exception {
-    assertEquals("UTF-8", project.getDefaultCharset());
-  }
-
-  @Test
   public void getFileByPath() {
     IFile file = project.getFile(path("folder/file"));
     assertEquals(path("project/folder/file"), ((ServerFileImpl) file).getFullPath());


### PR DESCRIPTION
~~Might still need to be adjusted. Currently, merging this PR would break the server as the project encoding is used as the default for file encodings. This issue would be resolved by implementing #912. Another option would be to add a default handling to the server file implementation until #912 is resolved. (As a result of the change, this would also mean that the server would have to persist the encodings or would no longer be able to add a project to the session.)~~ Added temporary workaround until #912 is resolved.

~~This PR also removes the addition of the project default encoding from the file list. This might still be useful for compatibility checks during before executing the project negotiation on the remote side. So this PR might be adjusted to just move the method `getDefaultCharset()` to `IProject`.~~
Any charset actually used in the project should be contained in the compatibility list as the charset for each file on the list is added as part of the list creation.

#### [INTERNAL] Remove usage of IContainer.getDefaultCharset()

Removes the usage of IContainer.getDefaultCharset() to prepare for its
upcoming removal.

Introduces UTF-8 as the default charset for the ServerFileImpl that is
used if no charset has been specified. This is needed until #912 is
resolved as resources created as part of the project negotiation won't
set their charset with the current logic. This workaround does not
change the current behavior of the server as this default was previously
set in the server project implementation instead and was requested by
the file implementation if no charset was available.

#### [API] Remove IContainer.getDefaultCharset()

Removes the method IContainer.getDefaultCharset() as not all containers
provide the concept of a default charset.

The method was only used in the FileListFactory to add to the list of
encodings and in the Server file implementation if the file does not
exist.

Furthermore, such a method to access the default charset for a container
should be unnecessary. When creating a file locally, the charset
assigned to the newly created resource should be used instead. When
creating files for a received file activity, the charset contained in
the activity should be used.