### PR TITLE
[DOC] Create CNAME file in gh-pages

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -50,10 +50,12 @@ jobs:
       # therefore we want to avoid that GitHub tries to interpret
       # the gh-pages content as Jekyll project
       # https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/
-      - name: Create .nojekyll file
+      - name: Create .nojekyll and CNAME file
         if: github.ref == 'refs/heads/master'
         run: |
           touch docs/_site/.nojekyll
+          echo "www.saros-project.org" > docs/_site/CNAME
+
       - name: Deploy 🚀
         if: github.ref == 'refs/heads/master'
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -53,8 +53,9 @@ jobs:
       - name: Create .nojekyll and CNAME file
         if: github.ref == 'refs/heads/master'
         run: |
-          touch docs/_site/.nojekyll
-          echo "www.saros-project.org" > docs/_site/CNAME
+          cd docs/_site
+          touch .nojekyll
+          mv CNAME_template CNAME
 
       - name: Deploy 🚀
         if: github.ref == 'refs/heads/master'

--- a/docs/CNAME_template
+++ b/docs/CNAME_template
@@ -1,0 +1,1 @@
+www.saros-project.org


### PR DESCRIPTION
Storing the CNAME file in the master branch
and deploying it into the gh-pages branch
led to the situation that the landing page was missing.
In order to avoid that we create the file only in the gh-pages.
