### PR TITLE
[FIX] #922 Ignore .git directory for Saros sessions

### DIFF
--- a/eclipse/src/saros/filesystem/EclipseResourceImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseResourceImpl.java
@@ -107,7 +107,30 @@ public class EclipseResourceImpl implements IResource {
 
   @Override
   public boolean isIgnored() {
+    return isGitConfig() || isDerived();
+  }
+
+  /**
+   * Returns whether this resource is seen as derived by the local Eclipse instance.
+   *
+   * @return whether this resource is seen as derived by the local Eclipse instance
+   * @see org.eclipse.core.resources.IResource#isDerived(int)
+   */
+  boolean isDerived() {
     return delegate.isDerived(org.eclipse.core.resources.IResource.CHECK_ANCESTORS);
+  }
+
+  /**
+   * Returns whether this resource is part of the git configuration directory.
+   *
+   * @return whether this resource is part of the git configuration directory
+   */
+  private boolean isGitConfig() {
+    String path = getProjectRelativePath().toPortableString();
+
+    return (path.startsWith(".git/")
+        || path.contains("/.git/")
+        || getType() == FOLDER && (path.endsWith("/.git") || path.equals(".git")));
   }
 
   @Override

--- a/intellij/src/saros/intellij/filesystem/IntelliJResourceImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJResourceImpl.java
@@ -1,5 +1,7 @@
 package saros.intellij.filesystem;
 
+import static saros.filesystem.IResource.Type.FOLDER;
+
 import com.intellij.ide.highlighter.ProjectFileType;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
@@ -26,9 +28,23 @@ public abstract class IntelliJResourceImpl implements IResource {
       return true;
     }
 
-    return isExcluded(project, virtualFile)
+    return isGitConfig()
+        || isExcluded(project, virtualFile)
         || isModuleFile(module, virtualFile)
         || isProjectConfig(project, virtualFile);
+  }
+
+  /**
+   * Returns whether this resource is part of the git configuration directory.
+   *
+   * @return whether this resource is part of the git configuration directory
+   */
+  private boolean isGitConfig() {
+    String path = getProjectRelativePath().toPortableString();
+
+    return (path.startsWith(".git/")
+        || path.contains("/.git/")
+        || getType() == FOLDER && (path.endsWith("/.git") || path.equals(".git")));
   }
 
   /**


### PR DESCRIPTION
Adjusts the IResource.isIgnored() implementations for Saros/E and
Saros/I to see any resource located in a '.git' directory and the
directory itself as ignored.

This is a temporary workaround to ensure that Saros does not destroy
data by overwriting the local git configuration as part of the project
negotiation.