### PR TITLE
Fix local project negotiation cancel

### DIFF
--- a/intellij/src/saros/intellij/ui/wizards/AddProjectToSessionWizard.java
+++ b/intellij/src/saros/intellij/ui/wizards/AddProjectToSessionWizard.java
@@ -54,6 +54,7 @@ import saros.negotiation.FileList;
 import saros.negotiation.FileListDiff;
 import saros.negotiation.FileListFactory;
 import saros.negotiation.NegotiationTools;
+import saros.negotiation.NegotiationTools.CancelLocation;
 import saros.negotiation.ProjectNegotiation;
 import saros.negotiation.ProjectNegotiationData;
 import saros.net.xmpp.JID;
@@ -507,12 +508,13 @@ public class AddProjectToSessionWizard extends Wizard {
         }
       };
 
+  @SuppressWarnings("FieldCanBeLocal")
   private final CancelListener cancelListener =
       new CancelListener() {
 
         @Override
-        public void canceled(final NegotiationTools.CancelLocation location, final String message) {
-          cancelWizard(peer, message, location);
+        public void canceled(final CancelLocation location, final String message) {
+          if (location != CancelLocation.LOCAL) cancelWizard(peer, message, location);
         }
       };
 
@@ -570,7 +572,7 @@ public class AddProjectToSessionWizard extends Wizard {
   public void cancelWizard(
       final JID peer, final String errorMsg, NegotiationTools.CancelLocation type) {
     final String message =
-        "Wizard canceled "
+        "Project negotiation canceled "
             + (type.equals(NegotiationTools.CancelLocation.LOCAL)
                 ? "locally "
                 : "remotely by " + peer);

--- a/intellij/src/saros/intellij/ui/wizards/JoinSessionWizard.java
+++ b/intellij/src/saros/intellij/ui/wizards/JoinSessionWizard.java
@@ -14,6 +14,7 @@ import saros.intellij.ui.wizards.pages.InfoPage;
 import saros.intellij.ui.wizards.pages.PageActionListener;
 import saros.monitoring.IProgressMonitor;
 import saros.monitoring.NullProgressMonitor;
+import saros.negotiation.CancelListener;
 import saros.negotiation.IncomingSessionNegotiation;
 import saros.negotiation.NegotiationTools.CancelLocation;
 import saros.net.xmpp.JID;
@@ -30,6 +31,7 @@ public class JoinSessionWizard extends Wizard {
   private static final Logger log = Logger.getLogger(JoinSessionWizard.class);
 
   private final IncomingSessionNegotiation negotiation;
+  private final JID peer;
 
   private final PageActionListener actionListener =
       new PageActionListener() {
@@ -49,6 +51,19 @@ public class JoinSessionWizard extends Wizard {
         }
       };
 
+  @SuppressWarnings("FieldCanBeLocal")
+  private final CancelListener cancelListener =
+      new CancelListener() {
+
+        @Override
+        public void canceled(final CancelLocation location, final String message) {
+          if (location != CancelLocation.LOCAL) {
+            showCancelMessage(peer, message, location);
+            close();
+          }
+        }
+      };
+
   /**
    * Instantiates the wizard and its pages.
    *
@@ -65,6 +80,9 @@ public class JoinSessionWizard extends Wizard {
             Messages.ShowDescriptionPage_title2, Messages.ShowDescriptionPage_description));
 
     this.negotiation = negotiation;
+    this.peer = negotiation.getPeer();
+
+    negotiation.addCancelListener(cancelListener);
 
     InfoPage infoPage = createInfoPage(negotiation);
 


### PR DESCRIPTION
#### [FIX][I] #923 Fix local project negotiation cancellation

Adjusts the cancellation listener in AddProjectToSessionWizard to only
close the dialog if the cancellation was caused by the remote side.

I am not really sure why the issue #923 occurred, but it seems to be a
race condition caused by CancelListener disposing the dialog at an
inconvenient moment.

The issue was introduced in ccf4111 by
removing the UIUtil.invokeLaterIfNeeded(...) block around the close()
call in cancelWizard(...).

This problem is now avoided by checking whether the cancellation was
caused locally as such cases are already handled by other logic.

Fixes #923.

#### [FIX][I] Close session negotiation wizard on remote cancel

Adjusts the JoinSessionWizard to automatically inform the user and close
when the session negotiation was aborted by the remote peer.