### PR TITLE
[FIX][I] Save all documents on session start

### DIFF
--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -795,17 +795,6 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
     editorListenerDispatch.remove(listener);
   }
 
-  /**
-   * Saves the document for the given file, thereby flushing its contents to disk.
-   *
-   * @param file the file for the document to save
-   * @see Document
-   * @see LocalEditorHandler#saveDocument(IFile)
-   */
-  private void saveDocument(IFile file) {
-    localEditorHandler.saveDocument(file);
-  }
-
   public void removeAllEditorsForFile(IFile file) {
     editorPool.removeEditor(file);
   }
@@ -1096,21 +1085,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
   @Override
   public void saveEditors(final IProject project) {
-    executeInUIThreadSynchronous(
-        () -> {
-          Set<IFile> editorFiles = new HashSet<>(editorPool.getFiles());
-
-          if (userEditorStateManager != null) {
-            editorFiles.addAll(userEditorStateManager.getOpenEditors());
-          }
-
-          for (IFile editorFile : editorFiles) {
-            if (project == null || project.equals(editorFile.getProject())) {
-
-              saveDocument(editorFile);
-            }
-          }
-        });
+    DocumentAPI.saveAllDocuments();
   }
 
   @Override


### PR DESCRIPTION
Adjusts the logic to save all files for a given IProject to simply save
all modified documents.

This adjustment is necessary as the previous implementation relied on
there being an open editor for modified documents. In IntelliJ, however,
documents are not automatically saved on closing the editor, meaning
there can be unsaved documents without an open editor. As a result, the
session negotiation could sometimes work on outdated file states,
leading to the wrong initial state on the receiving side.

Simply saving all documents is the lazy approach implementing this. It
would also have been possible to go through all unsaved documents and
check whether they belong to the given project. This is not necessary in
my opinion as there shouldn't be that many unsaved documents around,
especially since, with the default settings, IntelliJ saves each
document as soon as its editor looses focus.