### PR TITLE
Bump minimal version support to 2019.2.3 and address deprecations

### DIFF
--- a/intellij/build.gradle
+++ b/intellij/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'saros.gradle.intellij.plugin'
 sarosIntellij {
   sandboxBaseDir = intellijSandboxDir as File
   localIntellijHome = intellijHome as File
-  intellijVersion = 'IC-2019.3'
+  intellijVersion = 'IC-2019.3.4'
 }
 
 intellij {

--- a/intellij/resources/META-INF/plugin.xml
+++ b/intellij/resources/META-INF/plugin.xml
@@ -30,7 +30,7 @@
     </vendor>
 
     <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="182.5107.16"/>
+    <idea-version since-build="192.6817.14"/>
 
     <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html on how to target different products -->
     <!-- ATTENTION: the following "depends" tags are automatically uncommented by nightly-rel.yml. Make sure that changes do not break the logic. -->

--- a/intellij/src/saros/intellij/eventhandler/ProjectEventHandlersFactory.java
+++ b/intellij/src/saros/intellij/eventhandler/ProjectEventHandlersFactory.java
@@ -84,7 +84,7 @@ public class ProjectEventHandlersFactory {
     /*
      * editor selection change handlers
      */
-    projectEventHandlers.add(new LocalTextSelectionChangeHandler(editorManager));
+    projectEventHandlers.add(new LocalTextSelectionChangeHandler(project, editorManager));
 
     /*
      * editor viewport change handlers

--- a/intellij/src/saros/intellij/eventhandler/editor/document/AbstractLocalDocumentModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/document/AbstractLocalDocumentModificationHandler.java
@@ -80,7 +80,9 @@ public abstract class AbstractLocalDocumentModificationHandler implements IProje
     if (!this.enabled && enabled) {
       log.debug("Started listening for document events");
 
-      EditorFactory.getInstance().getEventMulticaster().addDocumentListener(documentListener);
+      EditorFactory.getInstance()
+          .getEventMulticaster()
+          .addDocumentListener(documentListener, project);
 
       this.enabled = true;
 

--- a/intellij/src/saros/intellij/eventhandler/editor/document/LocalClosedEditorModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/document/LocalClosedEditorModificationHandler.java
@@ -23,7 +23,7 @@ public class LocalClosedEditorModificationHandler extends AbstractLocalDocumentM
   private final DocumentListener documentListener =
       new DocumentListener() {
         @Override
-        public void documentChanged(DocumentEvent event) {
+        public void documentChanged(@NotNull DocumentEvent event) {
           cleanUpAnnotations(event);
         }
       };

--- a/intellij/src/saros/intellij/eventhandler/editor/document/LocalDocumentModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/document/LocalDocumentModificationHandler.java
@@ -20,7 +20,7 @@ public class LocalDocumentModificationHandler extends AbstractLocalDocumentModif
   private final DocumentListener documentListener =
       new DocumentListener() {
         @Override
-        public void documentChanged(DocumentEvent event) {
+        public void documentChanged(@NotNull DocumentEvent event) {
           generateTextEditActivity(event);
         }
       };

--- a/intellij/src/saros/intellij/eventhandler/editor/selection/LocalTextSelectionChangeHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/selection/LocalTextSelectionChangeHandler.java
@@ -3,6 +3,7 @@ package saros.intellij.eventhandler.editor.selection;
 import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.editor.event.SelectionEvent;
 import com.intellij.openapi.editor.event.SelectionListener;
+import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 import saros.filesystem.IFile;
 import saros.intellij.editor.EditorManager;
@@ -11,6 +12,7 @@ import saros.intellij.eventhandler.IProjectEventHandler;
 /** Dispatches activities for selection changes. */
 public class LocalTextSelectionChangeHandler implements IProjectEventHandler {
 
+  private final Project project;
   private final EditorManager editorManager;
 
   private final SelectionListener selectionListener =
@@ -31,7 +33,8 @@ public class LocalTextSelectionChangeHandler implements IProjectEventHandler {
    *
    * @param editorManager the EditorManager instance
    */
-  public LocalTextSelectionChangeHandler(EditorManager editorManager) {
+  public LocalTextSelectionChangeHandler(Project project, EditorManager editorManager) {
+    this.project = project;
     this.editorManager = editorManager;
 
     this.enabled = false;
@@ -88,7 +91,9 @@ public class LocalTextSelectionChangeHandler implements IProjectEventHandler {
       this.enabled = false;
 
     } else if (!this.enabled && enabled) {
-      EditorFactory.getInstance().getEventMulticaster().addSelectionListener(selectionListener);
+      EditorFactory.getInstance()
+          .getEventMulticaster()
+          .addSelectionListener(selectionListener, project);
 
       this.enabled = true;
     }

--- a/intellij/src/saros/intellij/eventhandler/editor/viewport/LocalViewPortChangeHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/viewport/LocalViewPortChangeHandler.java
@@ -130,6 +130,7 @@ public class LocalViewPortChangeHandler implements IProjectEventHandler {
       this.enabled = false;
 
     } else if (!this.enabled && enabled) {
+      // TODO add project as disposable parent once compatibility is set to above 2019.3
       EditorFactory.getInstance().getEventMulticaster().addVisibleAreaListener(visibleAreaListener);
 
       this.enabled = true;

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -898,7 +898,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
         String oldName = (String) oldValue;
         String newName = (String) newValue;
 
-        // TODO consider using FilePropertyEvent#isRename() once compatibility is dropped to 2019.2
+        // TODO consider using FilePropertyEvent#isRename() once it is no longer marked experimental
         if (oldName.equals(newName)) {
           log.debug(
               "Dropping file property event for "

--- a/intellij/src/saros/intellij/negotiation/ModuleConfigurationInitializer.java
+++ b/intellij/src/saros/intellij/negotiation/ModuleConfigurationInitializer.java
@@ -123,7 +123,7 @@ public class ModuleConfigurationInitializer implements Startable {
 
     ContentEntry contentEntry = contentEntries[0];
 
-    if (!configurationDiffers(module, contentEntry, moduleConfiguration.getRootPaths())) {
+    if (!configurationDiffers(contentEntry, moduleConfiguration.getRootPaths())) {
       return;
     }
 
@@ -146,7 +146,6 @@ public class ModuleConfigurationInitializer implements Startable {
   /**
    * Returns whether the content entry source root configuration matches the passed configuration.
    *
-   * @param module the module the content entry belongs to
    * @param contentEntry the content entry to check
    * @param rootPaths the root paths received from the host
    * @return <code>true</code> if the root paths of the passed content entry match the paths
@@ -154,20 +153,15 @@ public class ModuleConfigurationInitializer implements Startable {
    *     configuration could not be read
    */
   private boolean configurationDiffers(
-      @NotNull Module module,
       @NotNull ContentEntry contentEntry,
       @NotNull Map<JpsModuleSourceRootType<? extends JpsElement>, String[]> rootPaths) {
 
     VirtualFile contentEntryFile = contentEntry.getFile();
 
     if (contentEntryFile == null) {
-      /*
-       * TODO drop module parameter and use content entry module root model instead when
-       *  backwards compatibility is dropped to 2019.2 or later
-       */
       log.error(
           "Encountered content root without a valid local representation for shared module \""
-              + module
+              + contentEntry.getRootModel().getModule()
               + "\". Can not provide source configuration.");
 
       return false;
@@ -290,7 +284,7 @@ public class ModuleConfigurationInitializer implements Startable {
 
     moduleConfiguration
         .getRootPaths()
-        .forEach((type, paths) -> addRoot(module, contentEntry, contentEntryFile, type, paths));
+        .forEach((type, paths) -> addRoot(contentEntry, contentEntryFile, type, paths));
   }
 
   /**
@@ -301,7 +295,6 @@ public class ModuleConfigurationInitializer implements Startable {
    * <p>Does nothing if the string representing the relative source root paths is <code>null
    * </code>.
    *
-   * @param module the module to add source root entry for
    * @param contentEntry the content entry to add the roots to
    * @param contentEntryFile the virtual file representing the content root
    * @param rootType the type of source root to add the paths as
@@ -309,7 +302,6 @@ public class ModuleConfigurationInitializer implements Startable {
    * @param <T> the type of the source root
    */
   private <T extends JpsElement> void addRoot(
-      @NotNull Module module,
       @NotNull ContentEntry contentEntry,
       @NotNull VirtualFile contentEntryFile,
       @NotNull JpsModuleSourceRootType<T> rootType,
@@ -326,13 +318,9 @@ public class ModuleConfigurationInitializer implements Startable {
         contentEntry.addSourceFolder(sourceRoot, rootType);
 
       } else {
-        /*
-         * TODO drop module parameter and use content entry module root model instead when
-         *  backwards compatibility is dropped to 2019.2 or later
-         */
         log.debug(
             "Skipping source root addition for module "
-                + module
+                + contentEntry.getRootModel().getModule()
                 + " as path resolution failed - type: "
                 + rootType
                 + ", relative path: "

--- a/intellij/src/saros/intellij/ui/wizards/pages/moduleselection/ModuleTab.java
+++ b/intellij/src/saros/intellij/ui/wizards/pages/moduleselection/ModuleTab.java
@@ -10,7 +10,7 @@ import com.intellij.openapi.ui.ComboBox;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.JBColor;
-import com.intellij.ui.ListCellRendererWrapper;
+import com.intellij.ui.SimpleListCellRenderer;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBRadioButton;
 import com.intellij.ui.components.JBTextField;
@@ -701,15 +701,11 @@ class ModuleTab {
 
     gbc.gridwidth = 1;
 
-    /*
-     * TODO replace with SimpleListCellRenderer once it is released and our the backwards
-     *  compatibility allows it
-     */
     projectComboBox.setRenderer(
-        new ListCellRendererWrapper<Project>() {
+        new SimpleListCellRenderer<Project>() {
           @Override
           public void customize(
-              JList list, Project value, int index, boolean selected, boolean hasFocus) {
+              @NotNull JList list, Project value, int index, boolean selected, boolean hasFocus) {
 
             if (value != null) {
               setText(value.getName());
@@ -786,15 +782,11 @@ class ModuleTab {
 
     moduleTabPanel.add(localModuleLabel, gbc);
 
-    /*
-     * TODO replace with SimpleListCellRenderer once it is released and our the backwards
-     *  compatibility allows it
-     */
     existingModuleComboBox.setRenderer(
-        new ListCellRendererWrapper<Module>() {
+        new SimpleListCellRenderer<Module>() {
           @Override
           public void customize(
-              JList list, Module value, int index, boolean selected, boolean hasFocus) {
+              @NotNull JList list, Module value, int index, boolean selected, boolean hasFocus) {
 
             if (value != null) {
               setText(value.getName());

--- a/intellij/test/junit/saros/intellij/eventhandler/editor/document/LocalDocumentModificationHandlerTest.java
+++ b/intellij/test/junit/saros/intellij/eventhandler/editor/document/LocalDocumentModificationHandlerTest.java
@@ -7,9 +7,12 @@ import static org.powermock.api.easymock.PowerMock.replay;
 
 import com.intellij.mock.MockEditorEventMulticaster;
 import com.intellij.mock.MockEditorFactory;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.editor.event.DocumentListener;
 import com.intellij.openapi.editor.event.EditorEventMulticaster;
+import com.intellij.openapi.project.Project;
+import org.easymock.EasyMock;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,7 +22,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import saros.intellij.editor.EditorManager;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({EditorFactory.class})
+@PrepareForTest({EditorFactory.class, Project.class})
 public class LocalDocumentModificationHandlerTest {
 
   private LocalDocumentModificationHandler localDocumentModificationHandler;
@@ -27,9 +30,12 @@ public class LocalDocumentModificationHandlerTest {
 
   @Before
   public void before() {
+    Project project = EasyMock.createNiceMock(Project.class);
+    EasyMock.replay(project);
+
     mockEditorFactory();
     localDocumentModificationHandler =
-        new LocalDocumentModificationHandler(null, dummyEditorManager(), null);
+        new LocalDocumentModificationHandler(project, dummyEditorManager(), null);
     listening = false;
   }
 
@@ -65,7 +71,8 @@ public class LocalDocumentModificationHandlerTest {
         new MockEditorEventMulticaster() {
 
           @Override
-          public void addDocumentListener(@NotNull DocumentListener listener) {
+          public void addDocumentListener(
+              @NotNull DocumentListener listener, @NotNull Disposable parentDisposable) {
             listening = true;
           }
 


### PR DESCRIPTION
#### [BUILD][I] Build against IntelliJ Idea 2019.3.4

Sets the build target to IntelliJ Idea 2019.3.4.

Smoketest did not reveal any compatibility issues.
List of incompatible changes does not suggest any changes concerning
logic used by Saros/I.

I did not set the build target to 2020.1 as the update seems to have
introduced some changes to the filesystem handlers, the effects of which
have to be investigated further.

In particular, VirtualFileListener.beforeContentsChange(...) is now
often triggered without being caused by a save or a refresh. Such cases
are currently ignored by Saros but could be important events that we are
interested in.

#### [I] Increase oldest supported IntelliJ version to 2019.2.3

Sets the new oldest supported IntelliJ IDEA version to 2019.2.3
(build 192.6817.14). This was done in order to not fall too far behind
the current release.

2019.2.3 was chosen as it is the earliest 2019.2.X release that is
still available on the IntelliJ IDEA download page.

Dropping older releases enables us to replace logic that has since been
deprecated, ensuring compatibility with future releases.

#### [FIX][I] Address deprecations resolvable with minimal version 2019.2

Addresses deprecation issues that can now be resolved after the
backwards compatibility was bumped up to 2019.2.

Replaces the usage of ListCellRendererWrapper with
SimpleListCellRenderer in ModuleTab.

Adds parent disposable objects for document and selection listener
registration calls.

Adjusts LocalDocumentModificationHandlerTest to work with new
registration method.

The same should be done for viewport listener
registration calls once the backwards compatibility has been bumped up
to at least 2019.3. Adds corresponding comment to the call.

Adds a missing NotNull annotation to the listener implementations in
LocalClosedEditorModificationHandler and
LocalDocumentModificationHandler.

Uses the module object contained in the content entry root model for
logging in ModuleConfigurationInitializer.

Adjusts the comment regarding VirtualFilePropertyEvent.isRename() to
defer the adjustment until the method is no longer marked as
experimental. Using experimental API methods should be avoided as their
removal/adjustment is not listed in the list of
changes/incompatibilities, meaning their usage can more easily lead to
breakage with IntelliJ version updated.