### PR TITLE
[DOC] fix #935

### DIFF
--- a/docs/_includes/ide-tabs.html
+++ b/docs/_includes/ide-tabs.html
@@ -3,7 +3,7 @@
 
     <ul class="nav nav-tabs">
         <li class="nav-item">
-            <a class="nav-tab-link nav-link p-1 eclipse active-tab" onclick="selectTabs( 'eclipse' );" id="eclipse-tab" data-toggle="tab" href="#">
+            <a class="nav-tab-link nav-link p-1 eclipse active" onclick="selectTabs( 'eclipse' );" id="eclipse-tab" data-toggle="tab" href="#">
                 <img alt="Eclipse logo" src="{{ '/assets/images/logo/eclipse-logo.svg' | relative_url }}" height="30" /> Eclipse
             </a>
         </li>
@@ -15,7 +15,7 @@
     </ul>
 
     <div class="tab-content border rounded-bottom border-top-0">
-        <div class="tab-pane fade px-2 pt-2 mt-0 mb-2 eclipse active-tab show" role="tabpanel">
+        <div class="tab-pane fade px-2 pt-2 mt-0 mb-2 eclipse active show" role="tabpanel">
             {{ include.eclipse | markdownify }}
         </div>
 

--- a/docs/_sass/ide-tabs.scss
+++ b/docs/_sass/ide-tabs.scss
@@ -1,3 +1,0 @@
-.active-tab {
-    @extend .active;
-}

--- a/docs/assets/js/ide-tabs.js
+++ b/docs/assets/js/ide-tabs.js
@@ -10,20 +10,20 @@ function selectTabs(classToActivate, updateUrl = true) {
     var panesToDeactivate = document.getElementsByClassName('tab-pane');
 
     for (const e of panesToDeactivate) {
-        e.classList.remove('active-tab');
+        e.classList.remove('active');
         e.classList.remove('show');
     }
 
     var tabsToDeactivate = document.getElementsByClassName('nav-tab-link');
 
     for (const t of tabsToDeactivate) {
-        t.classList.remove('active-tab');
+        t.classList.remove('active');
     }
 
     var elementsToActivate = document.getElementsByClassName(normalizedClassToActivate)
 
     for (const e of elementsToActivate) {
-        e.classList.add('active-tab');
+        e.classList.add('active');
         if (e.nodeName === "DIV")
             e.classList.add('show');
     }

--- a/docs/assets/main.scss
+++ b/docs/assets/main.scss
@@ -11,5 +11,4 @@
 @import "sidebar";
 @import "navbar";
 @import "footer";
-@import "ide-tabs";
 @import "code-highlight";


### PR DESCRIPTION
Extending the general .active
leads to inheriting the dark background.
It would be necessary to @extend .tab-content > .active.
However, the whole introduction of .active-tab was
a workaround for using the scrollspy (which is currently
not used). Therefore the default .active class is used.