### PR TITLE
[STF] Retry stf tests

### DIFF
--- a/stf.test/build.gradle
+++ b/stf.test/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'org.gradle.test-retry' version '1.1.5'
+}
+
 sarosEclipse {
   manifest = file('META-INF/MANIFEST.MF')
   excludeManifestDependencies = ['org.junit', 'saros.eclipse', 'saros.core']
@@ -59,6 +63,12 @@ task stfTest (type: StfTest, dependsOn: [':saros.eclipse:build']) {
 
     useJUnit {
         excludeCategories 'saros.stf.test.categories.FlakyTests'
+    }
+
+    retry {
+        failOnPassedAfterRetry = false
+        maxFailures = 10
+        maxRetries = 3
     }
 }
 


### PR DESCRIPTION
Use the gradle retry plugin for running the stf tests.
The current configuration lead to the behavior that:
* The test run fails if >= 10 tests failed in the first attempt (no retries, because
we assume that there is a real problem if so many tests are failing) 
* Tests that failed are repeated up to 3 times