### PR TITLE
Remove IProject.findMember(IPath)

### DIFF
--- a/core/src/saros/filesystem/IProject.java
+++ b/core/src/saros/filesystem/IProject.java
@@ -26,9 +26,6 @@ package saros.filesystem;
  * mentioned otherwise all offered methods are equivalent to their Eclipse counterpart.
  */
 public interface IProject extends IContainer {
-
-  public IResource findMember(IPath path);
-
   public IFile getFile(String name);
 
   public IFile getFile(IPath path);

--- a/eclipse/src/saros/filesystem/EclipseProjectImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseProjectImpl.java
@@ -7,16 +7,6 @@ public class EclipseProjectImpl extends EclipseContainerImpl implements IProject
   }
 
   @Override
-  public IResource findMember(IPath path) {
-    org.eclipse.core.resources.IResource resource =
-        getDelegate().findMember(((EclipsePathImpl) path).getDelegate());
-
-    if (resource == null) return null;
-
-    return ResourceAdapterFactory.create(resource);
-  }
-
-  @Override
   public IFile getFile(String name) {
     return new EclipseFileImpl(getDelegate().getFile(name));
   }

--- a/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
@@ -243,18 +243,6 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
     return IntelliJPathImpl.fromString(getModuleContentRoot(module).getPath());
   }
 
-  @Nullable
-  @Override
-  public IResource findMember(final IPath path) {
-    final VirtualFile file = findVirtualFile(path);
-
-    if (file == null) return null;
-
-    return file.isDirectory()
-        ? new IntelliJFolderImpl(this, path)
-        : new IntelliJFileImpl(this, path);
-  }
-
   @NotNull
   @Override
   public IFile getFile(final String name) {

--- a/server/src/saros/server/filesystem/ServerProjectImpl.java
+++ b/server/src/saros/server/filesystem/ServerProjectImpl.java
@@ -2,14 +2,12 @@ package saros.server.filesystem;
 
 import static saros.filesystem.IResource.Type.PROJECT;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import saros.filesystem.IFile;
 import saros.filesystem.IFolder;
 import saros.filesystem.IPath;
 import saros.filesystem.IProject;
-import saros.filesystem.IResource;
 import saros.filesystem.IWorkspace;
 
 /** Server implementation of the {@link IProject} interface. */
@@ -36,24 +34,6 @@ public class ServerProjectImpl extends ServerContainerImpl implements IProject {
   public String getDefaultCharset() {
     // TODO: Read default character set from the project metadata files.
     return DEFAULT_CHARSET;
-  }
-
-  @Override
-  public IResource findMember(IPath path) {
-    if (path.segmentCount() == 0) {
-      return this;
-    }
-
-    IPath memberLocation = getLocation().append(path);
-    File memberFile = memberLocation.toFile();
-
-    if (memberFile.isFile()) {
-      return new ServerFileImpl(getWorkspace(), getFullMemberPath(path));
-    } else if (memberFile.isDirectory()) {
-      return new ServerFolderImpl(getWorkspace(), getFullMemberPath(path));
-    } else {
-      return null;
-    }
   }
 
   @Override

--- a/server/test/junit/saros/server/filesystem/ServerProjectImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerProjectImplTest.java
@@ -2,10 +2,6 @@ package saros.server.filesystem;
 
 import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static saros.server.filesystem.FileSystemTestUtils.createFile;
-import static saros.server.filesystem.FileSystemTestUtils.createFolder;
 import static saros.server.filesystem.FileSystemTestUtils.createWorkspaceFolder;
 import static saros.server.filesystem.FileSystemTestUtils.path;
 
@@ -48,26 +44,6 @@ public class ServerProjectImplTest extends EasyMockSupport {
   @Test
   public void defaultCharsetUTF8() throws Exception {
     assertEquals("UTF-8", project.getDefaultCharset());
-  }
-
-  @Test
-  public void findMember() throws Exception {
-    createFolder(workspace, "project");
-    createFolder(workspace, "project/folder");
-    createFile(workspace, "project/folder/file");
-
-    IResource folder = project.findMember(path("folder"));
-    IResource file = project.findMember(path("folder/file"));
-    IResource nonExistent = project.findMember(path("non/existent"));
-
-    assertEquals(IResource.Type.FOLDER, folder.getType());
-    assertEquals(IResource.Type.FILE, file.getType());
-    assertNull(nonExistent);
-  }
-
-  @Test
-  public void findMemberAtEmptyPath() throws Exception {
-    assertSame(project, project.findMember(path("")));
   }
 
   @Test


### PR DESCRIPTION
Removes the method `IProject.findMember(IPath)` and its implementations as
it was no longer being used (except in its own test cases). The last
usage was removed with the removal of `SPath`.

Furthermore, the removal of this class cleans up the concept of our
general resource interface handling as the method was the only one that
did not treat the local resources as handles, only returning them if
they were actually present in the local filesystem.