### PR TITLE
[INTERNAL] Ignore encoding configuration files

### DIFF
--- a/eclipse/src/saros/filesystem/EclipseResourceImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseResourceImpl.java
@@ -107,7 +107,7 @@ public class EclipseResourceImpl implements IResource {
 
   @Override
   public boolean isIgnored() {
-    return isGitConfig() || isDerived();
+    return isGitConfig() || isEncodingConfig() || isDerived();
   }
 
   /**
@@ -131,6 +131,20 @@ public class EclipseResourceImpl implements IResource {
     return (path.startsWith(".git/")
         || path.contains("/.git/")
         || getType() == FOLDER && (path.endsWith("/.git") || path.equals(".git")));
+  }
+
+  /**
+   * Returns whether this resource is the configuration file for the project encodings.
+   *
+   * <p>Such files are ignored by Saros to avoid clashed with differing setups. The encoding
+   * management for shared resources created by a remote participant is handled by Saros itself.
+   *
+   * @return whether this resource is the configuration file for the project encodings
+   */
+  private boolean isEncodingConfig() {
+    String path = getProjectRelativePath().toPortableString();
+
+    return path.endsWith(".settings/org.eclipse.core.resources.prefs");
   }
 
   @Override

--- a/intellij/src/saros/intellij/filesystem/IntelliJResourceImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJResourceImpl.java
@@ -29,6 +29,7 @@ public abstract class IntelliJResourceImpl implements IResource {
     }
 
     return isGitConfig()
+        || isEncodingConfig()
         || isExcluded(project, virtualFile)
         || isModuleFile(module, virtualFile)
         || isProjectConfig(project, virtualFile);
@@ -45,6 +46,20 @@ public abstract class IntelliJResourceImpl implements IResource {
     return (path.startsWith(".git/")
         || path.contains("/.git/")
         || getType() == FOLDER && (path.endsWith("/.git") || path.equals(".git")));
+  }
+
+  /**
+   * Returns whether this resource is the configuration file for the project encodings.
+   *
+   * <p>Such files are ignored by Saros to avoid clashed with differing setups. The encoding
+   * management for shared resources created by a remote participant is handled by Saros itself.
+   *
+   * @return whether this resource is the configuration file for the project encodings
+   */
+  private boolean isEncodingConfig() {
+    String path = getProjectRelativePath().toPortableString();
+
+    return path.endsWith(".idea/encodings.xml");
   }
 
   /**


### PR DESCRIPTION
Amends the Saros/E and Saros/I resource implementation to ignore files
defining the encoding for shared resources. This was done to prevent
issues caused by differing base-encoding settings which could cause the
desynchronization of such files.

The encoding management of shared files that are created during the
session is completely done by Saros, meaning we are not reliant on such
configuration files.

The encoding management of files created as part of the project
negotiation has not been adjusted yet and is therefore not managed by
Saros. See issue #912.