### PR TITLE
Move remaining methods from IProject to IContainer

### DIFF
--- a/core/src/saros/filesystem/IContainer.java
+++ b/core/src/saros/filesystem/IContainer.java
@@ -34,4 +34,28 @@ public interface IContainer extends IResource {
   public IResource[] members() throws IOException;
 
   public String getDefaultCharset() throws IOException;
+
+  /**
+   * Returns a handle for the file with the given relative path to this resource.
+   *
+   * @param pathString a string representation of the path relative to this resource
+   * @return a handle for the file with the given relative path to this resource
+   * @throws NullPointerException if the given string is <code>null</code>
+   * @throws IllegalArgumentException if the given string represents an absolute path
+   */
+  public IFile getFile(String pathString);
+
+  public IFile getFile(IPath path);
+
+  /**
+   * Returns a handle for the folder with the given relative path to this resource.
+   *
+   * @param pathString a string representation of the path relative to this resource
+   * @return a handle for the folder with the given relative path to this resource
+   * @throws NullPointerException if the given string is <code>null</code>
+   * @throws IllegalArgumentException if the given string represents an absolute path
+   */
+  public IFolder getFolder(String pathString);
+
+  public IFolder getFolder(IPath path);
 }

--- a/core/src/saros/filesystem/IPathFactory.java
+++ b/core/src/saros/filesystem/IPathFactory.java
@@ -29,7 +29,7 @@ package saros.filesystem;
 public interface IPathFactory {
 
   /**
-   * Converts a path to its string representation
+   * Converts a path to its string representation.
    *
    * @param path the path to convert
    * @return the string representation of the path
@@ -37,15 +37,15 @@ public interface IPathFactory {
    * @throws IllegalArgumentException if the path is not relative (e.g it presents a full path like
    *     <code>/etc/init.d/</code>)
    */
-  public String fromPath(IPath path);
+  String fromPath(IPath path);
 
   /**
-   * Converts a string to a path object
+   * Converts a string representation of a path to an <code>IPath</code> object.
    *
-   * @param name the name of the path to convert
-   * @return a path object representing the path of the given name
+   * @param pathString the string path to convert
+   * @return an <code>IPath</code> object representing the path of the given string
    * @throws NullPointerException if name is <code>null</code>
    * @throws IllegalArgumentException if the resulting path object is not a relative path
    */
-  public IPath fromString(String name);
+  IPath fromString(String pathString);
 }

--- a/core/src/saros/filesystem/IProject.java
+++ b/core/src/saros/filesystem/IProject.java
@@ -25,29 +25,4 @@ package saros.filesystem;
  * This interface is under development. It currently equals its Eclipse counterpart. If not
  * mentioned otherwise all offered methods are equivalent to their Eclipse counterpart.
  */
-public interface IProject extends IContainer {
-
-  /**
-   * Returns a handle for the file with the given relative path to this resource.
-   *
-   * @param pathString a string representation of the path relative to this resource
-   * @return a handle for the file with the given relative path to this resource
-   * @throws NullPointerException if the given string is <code>null</code>
-   * @throws IllegalArgumentException if the given string represents an absolute path
-   */
-  public IFile getFile(String pathString);
-
-  public IFile getFile(IPath path);
-
-  /**
-   * Returns a handle for the folder with the given relative path to this resource.
-   *
-   * @param pathString a string representation of the path relative to this resource
-   * @return a handle for the folder with the given relative path to this resource
-   * @throws NullPointerException if the given string is <code>null</code>
-   * @throws IllegalArgumentException if the given string represents an absolute path
-   */
-  public IFolder getFolder(String pathString);
-
-  public IFolder getFolder(IPath path);
-}
+public interface IProject extends IContainer {}

--- a/core/src/saros/filesystem/IProject.java
+++ b/core/src/saros/filesystem/IProject.java
@@ -26,11 +26,28 @@ package saros.filesystem;
  * mentioned otherwise all offered methods are equivalent to their Eclipse counterpart.
  */
 public interface IProject extends IContainer {
-  public IFile getFile(String name);
+
+  /**
+   * Returns a handle for the file with the given relative path to this resource.
+   *
+   * @param pathString a string representation of the path relative to this resource
+   * @return a handle for the file with the given relative path to this resource
+   * @throws NullPointerException if the given string is <code>null</code>
+   * @throws IllegalArgumentException if the given string represents an absolute path
+   */
+  public IFile getFile(String pathString);
 
   public IFile getFile(IPath path);
 
-  public IFolder getFolder(String name);
+  /**
+   * Returns a handle for the folder with the given relative path to this resource.
+   *
+   * @param pathString a string representation of the path relative to this resource
+   * @return a handle for the folder with the given relative path to this resource
+   * @throws NullPointerException if the given string is <code>null</code>
+   * @throws IllegalArgumentException if the given string represents an absolute path
+   */
+  public IFolder getFolder(String pathString);
 
   public IFolder getFolder(IPath path);
 }

--- a/eclipse/src/saros/filesystem/EclipseContainerImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseContainerImpl.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Path;
 
 public class EclipseContainerImpl extends EclipseResourceImpl implements IContainer {
 
@@ -31,6 +32,37 @@ public class EclipseContainerImpl extends EclipseResourceImpl implements IContai
     } catch (CoreException e) {
       throw new IOException(e);
     }
+  }
+
+  @Override
+  public IFile getFile(String pathString) {
+    return getFile(getPath(pathString));
+  }
+
+  @Override
+  public IFile getFile(IPath path) {
+    return new EclipseFileImpl(getDelegate().getFile(((EclipsePathImpl) path).getDelegate()));
+  }
+
+  @Override
+  public IFolder getFolder(String pathString) {
+    return getFolder(getPath(pathString));
+  }
+
+  @Override
+  public IFolder getFolder(IPath path) {
+    return new EclipseFolderImpl(getDelegate().getFolder(((EclipsePathImpl) path).getDelegate()));
+  }
+
+  private IPath getPath(String pathString) {
+    if (pathString == null) throw new NullPointerException("Given string is null");
+
+    Path path = new Path(pathString);
+
+    if (path.isAbsolute())
+      throw new IllegalArgumentException("Given string denotes an absolute path: " + pathString);
+
+    return ResourceAdapterFactory.create(path);
   }
 
   @Override

--- a/eclipse/src/saros/filesystem/EclipsePathFactory.java
+++ b/eclipse/src/saros/filesystem/EclipsePathFactory.java
@@ -14,13 +14,13 @@ public class EclipsePathFactory implements IPathFactory {
   }
 
   @Override
-  public IPath fromString(String name) {
-    if (name == null) throw new NullPointerException("name is null");
+  public IPath fromString(String pathString) {
+    if (pathString == null) throw new NullPointerException("Given string is null");
 
-    Path path = new Path(name);
+    Path path = new Path(pathString);
 
     if (path.isAbsolute())
-      throw new IllegalArgumentException("name denotes an absolute path: " + name);
+      throw new IllegalArgumentException("Given string denotes an absolute path: " + pathString);
 
     return ResourceAdapterFactory.create(path);
   }

--- a/eclipse/src/saros/filesystem/EclipseProjectImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseProjectImpl.java
@@ -1,5 +1,7 @@
 package saros.filesystem;
 
+import org.eclipse.core.runtime.Path;
+
 public class EclipseProjectImpl extends EclipseContainerImpl implements IProject {
 
   EclipseProjectImpl(org.eclipse.core.resources.IProject delegate) {
@@ -7,8 +9,8 @@ public class EclipseProjectImpl extends EclipseContainerImpl implements IProject
   }
 
   @Override
-  public IFile getFile(String name) {
-    return new EclipseFileImpl(getDelegate().getFile(name));
+  public IFile getFile(String pathString) {
+    return getFile(getPath(pathString));
   }
 
   @Override
@@ -17,13 +19,24 @@ public class EclipseProjectImpl extends EclipseContainerImpl implements IProject
   }
 
   @Override
-  public IFolder getFolder(String name) {
-    return new EclipseFolderImpl(getDelegate().getFolder(name));
+  public IFolder getFolder(String pathString) {
+    return getFolder(getPath(pathString));
   }
 
   @Override
   public IFolder getFolder(IPath path) {
     return new EclipseFolderImpl(getDelegate().getFolder(((EclipsePathImpl) path).getDelegate()));
+  }
+
+  private IPath getPath(String pathString) {
+    if (pathString == null) throw new NullPointerException("Given string is null");
+
+    Path path = new Path(pathString);
+
+    if (path.isAbsolute())
+      throw new IllegalArgumentException("Given string denotes an absolute path: " + pathString);
+
+    return ResourceAdapterFactory.create(path);
   }
 
   /**

--- a/eclipse/src/saros/filesystem/EclipseProjectImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseProjectImpl.java
@@ -1,42 +1,9 @@
 package saros.filesystem;
 
-import org.eclipse.core.runtime.Path;
-
 public class EclipseProjectImpl extends EclipseContainerImpl implements IProject {
 
   EclipseProjectImpl(org.eclipse.core.resources.IProject delegate) {
     super(delegate);
-  }
-
-  @Override
-  public IFile getFile(String pathString) {
-    return getFile(getPath(pathString));
-  }
-
-  @Override
-  public IFile getFile(IPath path) {
-    return new EclipseFileImpl(getDelegate().getFile(((EclipsePathImpl) path).getDelegate()));
-  }
-
-  @Override
-  public IFolder getFolder(String pathString) {
-    return getFolder(getPath(pathString));
-  }
-
-  @Override
-  public IFolder getFolder(IPath path) {
-    return new EclipseFolderImpl(getDelegate().getFolder(((EclipsePathImpl) path).getDelegate()));
-  }
-
-  private IPath getPath(String pathString) {
-    if (pathString == null) throw new NullPointerException("Given string is null");
-
-    Path path = new Path(pathString);
-
-    if (path.isAbsolute())
-      throw new IllegalArgumentException("Given string denotes an absolute path: " + pathString);
-
-    return ResourceAdapterFactory.create(path);
   }
 
   /**

--- a/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
@@ -16,6 +16,7 @@ import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import saros.filesystem.IContainer;
+import saros.filesystem.IFile;
 import saros.filesystem.IFolder;
 import saros.filesystem.IPath;
 import saros.filesystem.IProject;
@@ -76,6 +77,39 @@ public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IF
     }
 
     return result.toArray(new IResource[0]);
+  }
+
+  // TODO unify with IntelliJProjectImpl.getFile(...) and getFolder(...)
+  @NotNull
+  @Override
+  public IFile getFile(final String pathString) {
+    return getFile(IntelliJPathImpl.fromString(pathString));
+  }
+
+  @NotNull
+  @Override
+  public IFile getFile(final IPath path) {
+
+    if (path.segmentCount() == 0)
+      throw new IllegalArgumentException("cannot create file handle for an empty path");
+
+    return new IntelliJFileImpl(project, path);
+  }
+
+  @NotNull
+  @Override
+  public IFolder getFolder(final String pathString) {
+    return getFolder(IntelliJPathImpl.fromString(pathString));
+  }
+
+  @NotNull
+  @Override
+  public IFolder getFolder(final IPath path) {
+
+    if (path.segmentCount() == 0)
+      throw new IllegalArgumentException("cannot create folder handle for an empty path");
+
+    return new IntelliJFolderImpl(project, path);
   }
 
   @Nullable

--- a/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
@@ -245,8 +245,8 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
 
   @NotNull
   @Override
-  public IFile getFile(final String name) {
-    return getFile(IntelliJPathImpl.fromString(name));
+  public IFile getFile(final String pathString) {
+    return getFile(IntelliJPathImpl.fromString(pathString));
   }
 
   @NotNull
@@ -279,8 +279,8 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
 
   @NotNull
   @Override
-  public IFolder getFolder(final String name) {
-    return getFolder(IntelliJPathImpl.fromString(name));
+  public IFolder getFolder(final String pathString) {
+    return getFolder(IntelliJPathImpl.fromString(pathString));
   }
 
   @NotNull

--- a/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
@@ -243,6 +243,7 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
     return IntelliJPathImpl.fromString(getModuleContentRoot(module).getPath());
   }
 
+  // TODO unify with IntelliJFolderImpl.getFile(...) and getFolder(...)
   @NotNull
   @Override
   public IFile getFile(final String pathString) {

--- a/intellij/src/saros/intellij/project/filesystem/PathFactory.java
+++ b/intellij/src/saros/intellij/project/filesystem/PathFactory.java
@@ -18,16 +18,16 @@ public class PathFactory implements IPathFactory {
   }
 
   @Override
-  public IPath fromString(String name) {
-    if (name == null) {
+  public IPath fromString(String pathString) {
+    if (pathString == null) {
       throw new NullPointerException("Given string must not be null.");
     }
 
-    IPath path = IntelliJPathImpl.fromString(name);
+    IPath path = IntelliJPathImpl.fromString(pathString);
 
     if (path.isAbsolute()) {
       throw new IllegalArgumentException(
-          "The given string must not be represent an absolute path. " + "path: " + path);
+          "The given string must not represent an absolute path! - path: " + path);
     }
 
     return path;

--- a/server/src/saros/server/filesystem/ServerContainerImpl.java
+++ b/server/src/saros/server/filesystem/ServerContainerImpl.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import saros.filesystem.IContainer;
+import saros.filesystem.IFile;
+import saros.filesystem.IFolder;
 import saros.filesystem.IPath;
 import saros.filesystem.IResource;
 import saros.filesystem.IWorkspace;
@@ -55,6 +57,30 @@ public abstract class ServerContainerImpl extends ServerResourceImpl implements 
     }
 
     return members.toArray(new IResource[members.size()]);
+  }
+
+  @Override
+  public IFile getFile(IPath path) {
+    return new ServerFileImpl(getWorkspace(), getFullMemberPath(path));
+  }
+
+  @Override
+  public IFile getFile(String pathString) {
+    return getFile(ServerPathImpl.fromString(pathString));
+  }
+
+  @Override
+  public IFolder getFolder(IPath path) {
+    return new ServerFolderImpl(getWorkspace(), getFullMemberPath(path));
+  }
+
+  @Override
+  public IFolder getFolder(String pathString) {
+    return getFolder(ServerPathImpl.fromString(pathString));
+  }
+
+  private IPath getFullMemberPath(IPath memberPath) {
+    return getFullPath().append(memberPath);
   }
 
   @Override

--- a/server/src/saros/server/filesystem/ServerPathFactoryImpl.java
+++ b/server/src/saros/server/filesystem/ServerPathFactoryImpl.java
@@ -14,16 +14,17 @@ public class ServerPathFactoryImpl implements IPathFactory {
   }
 
   @Override
-  public IPath fromString(String name) {
+  public IPath fromString(String pathString) {
 
-    if (name == null) throw new NullPointerException("name is null");
+    if (pathString == null) throw new NullPointerException("given string is null");
 
-    return checkRelative(ServerPathImpl.fromString(name));
+    return checkRelative(ServerPathImpl.fromString(pathString));
   }
 
   private IPath checkRelative(IPath path) {
 
-    if (path.isAbsolute()) throw new IllegalArgumentException("path is absolute: " + path);
+    if (path.isAbsolute())
+      throw new IllegalArgumentException("given string represents an absolute path: " + path);
 
     return path;
   }

--- a/server/src/saros/server/filesystem/ServerProjectImpl.java
+++ b/server/src/saros/server/filesystem/ServerProjectImpl.java
@@ -4,9 +4,6 @@ import static saros.filesystem.IResource.Type.PROJECT;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import saros.filesystem.IFile;
-import saros.filesystem.IFolder;
-import saros.filesystem.IPath;
 import saros.filesystem.IProject;
 import saros.filesystem.IWorkspace;
 
@@ -34,30 +31,6 @@ public class ServerProjectImpl extends ServerContainerImpl implements IProject {
   public String getDefaultCharset() {
     // TODO: Read default character set from the project metadata files.
     return DEFAULT_CHARSET;
-  }
-
-  @Override
-  public IFile getFile(IPath path) {
-    return new ServerFileImpl(getWorkspace(), getFullMemberPath(path));
-  }
-
-  @Override
-  public IFile getFile(String pathString) {
-    return getFile(ServerPathImpl.fromString(pathString));
-  }
-
-  @Override
-  public IFolder getFolder(IPath path) {
-    return new ServerFolderImpl(getWorkspace(), getFullMemberPath(path));
-  }
-
-  @Override
-  public IFolder getFolder(String pathString) {
-    return getFolder(ServerPathImpl.fromString(pathString));
-  }
-
-  private IPath getFullMemberPath(IPath memberPath) {
-    return getFullPath().append(memberPath);
   }
 
   /**


### PR DESCRIPTION
#### [API][CORE] Adjust wording in `IPathFactory`

Adjusts the wording in `IPathFactory` to make it more clear that
`fromString(String)` takes a string representation of a path and not just
the name of a file.

#### [API][CORE] Adjust IProject.getFile(String)` and `getFolder(String)`

Adjusts the methods of `IProject.getFile(String)` and `getFolder(String)` to
simply convert the given string into an `IPath` object and pass it to
`getFile(IPath)` or `getFolder(IPath)` respectively.

This already matched the implemented functionality of IntelliJ and the
Server. For Eclipse, the old implementation called the Eclipse method
`IProject.getFile(String)`, which actually searches for a file with the
given name in the project.

Renames the parameter of the methods to "pathString" instead of "name"
to reflect the new functionality.

Adjusts the javadoc of the methods to correctly describe their actual
functionality.

#### [API] Move remaining `IProject` methods to `IContainer`

Moves the remaining `IProject` methods `getFile(...)` and `getFolder(...)`
into `IContainer`. This is done as a preparation for the migration to a
reference point based resource system where the project metaphor is
replaced by a base folder everything is described relative to.

With this change, `IProject` no longer contains any methods and only
functions as a marker interface with the current logic. The scope of the
interface might be extended later on after it was repurposed for the new
reference point model.

Simply moves the implementation to the abstract `IContainer`
implementation class for the Eclipse and Server implementation.

Copies the existing logic in `IntelliJProjectImpl` into
`IntellijFolderImpl`. This code duplication is currently necessary as
there is no real possibility for a common superclass for `IContainer`
implementations with the current implementations. This logic should be
unified once the resource model has been overhauled.