### PR TITLE
Fix minor annotation manager issues

### DIFF
--- a/intellij/src/saros/intellij/editor/annotations/AnnotationQueue.java
+++ b/intellij/src/saros/intellij/editor/annotations/AnnotationQueue.java
@@ -53,7 +53,11 @@ class AnnotationQueue<E extends AbstractEditorAnnotation> extends AnnotationStor
   @Nullable
   E removeIfFull() {
     if (annotationQueue.size() == maxSize) {
-      return annotationQueue.remove();
+      E removedAnnotation = annotationQueue.remove();
+
+      super.removeAnnotation(removedAnnotation);
+
+      return removedAnnotation;
     }
 
     return null;

--- a/intellij/src/saros/intellij/editor/annotations/AnnotationRange.java
+++ b/intellij/src/saros/intellij/editor/annotations/AnnotationRange.java
@@ -55,11 +55,17 @@ class AnnotationRange {
               + end);
     }
 
-    if (rangeHighlighter != null
-        && (start != rangeHighlighter.getStartOffset() || end != rangeHighlighter.getEndOffset())) {
+    if (rangeHighlighter != null) {
+      if (!rangeHighlighter.isValid()) {
+        throw new IllegalArgumentException(
+            "The given RangeHighlighter for the range (" + start + "," + end + ") is invalid");
 
-      throw new IllegalArgumentException(
-          "The range of the RangeHighlighter does not match the given " + "start and end value");
+      } else if (start != rangeHighlighter.getStartOffset()
+          || end != rangeHighlighter.getEndOffset()) {
+
+        throw new IllegalArgumentException(
+            "The range of the given RangeHighlighter does not match the given start and end value");
+      }
     }
 
     this.start = start;


### PR DESCRIPTION
#### [FIX][I] Remove annotation from mapping when rotated out

Adjusts the call AnnotationQueue.removeIfFull() to also remove the
dequeued annotation from the actual annotation mapping.

This was not causing any issues with the annotation logic as these
annotations no longer contain valid range highlighters, meaning they
would be removed from the annotation store when the corresponding editor
is closed. But this ensures that we only store annotations as long as
necessary to avoid any other potential issues with working on disposed
annotations and avoid unnecessary memory consumption.

#### [INTERNAL][I] Ensure that highlighter is valid in annotation range CTOR