### PR TITLE
Add annotation mananger tests

### DIFF
--- a/intellij/src/saros/intellij/editor/annotations/AnnotationManager.java
+++ b/intellij/src/saros/intellij/editor/annotations/AnnotationManager.java
@@ -33,7 +33,7 @@ public class AnnotationManager implements Disposable {
     CONTRIBUTION_ANNOTATION
   }
 
-  private static final int MAX_CONTRIBUTION_ANNOTATIONS =
+  public static final int MAX_CONTRIBUTION_ANNOTATIONS =
       Integer.getInteger("saros.intellij.MAX_CONTRIBUTION_ANNOTATIONS", 50);
 
   private final AnnotationStore<SelectionAnnotation> selectionAnnotationStore;

--- a/intellij/src/saros/intellij/editor/annotations/AnnotationManager.java
+++ b/intellij/src/saros/intellij/editor/annotations/AnnotationManager.java
@@ -109,7 +109,7 @@ public class AnnotationManager implements Disposable {
     List<SelectionAnnotation> currentSelectionAnnotation =
         selectionAnnotationStore.removeAnnotations(user, file);
 
-    currentSelectionAnnotation.forEach(this::removeRangeHighlighter);
+    currentSelectionAnnotation.forEach(AnnotationManager::removeRangeHighlighter);
   }
 
   /**
@@ -569,9 +569,13 @@ public class AnnotationManager implements Disposable {
    */
   public void removeAnnotations(@NotNull User user) {
 
-    selectionAnnotationStore.removeAnnotations(user).forEach(this::removeRangeHighlighter);
+    selectionAnnotationStore
+        .removeAnnotations(user)
+        .forEach(AnnotationManager::removeRangeHighlighter);
 
-    contributionAnnotationQueue.removeAnnotations(user).forEach(this::removeRangeHighlighter);
+    contributionAnnotationQueue
+        .removeAnnotations(user)
+        .forEach(AnnotationManager::removeRangeHighlighter);
   }
 
   /**
@@ -603,9 +607,13 @@ public class AnnotationManager implements Disposable {
    * annotation stores.
    */
   private void removeAllAnnotations() {
-    selectionAnnotationStore.removeAllAnnotations().forEach(this::removeRangeHighlighter);
+    selectionAnnotationStore
+        .removeAllAnnotations()
+        .forEach(AnnotationManager::removeRangeHighlighter);
 
-    contributionAnnotationQueue.removeAllAnnotations().forEach(this::removeRangeHighlighter);
+    contributionAnnotationQueue
+        .removeAllAnnotations()
+        .forEach(AnnotationManager::removeRangeHighlighter);
   }
 
   /**
@@ -710,7 +718,7 @@ public class AnnotationManager implements Disposable {
    *     position is located after the document end
    */
   @Nullable
-  private RangeHighlighter addRangeHighlighter(
+  private static RangeHighlighter addRangeHighlighter(
       @NotNull User user,
       int start,
       int end,
@@ -778,7 +786,7 @@ public class AnnotationManager implements Disposable {
    *
    * @param annotation the annotation whose highlighters to remove
    */
-  private void removeRangeHighlighter(@NotNull AbstractEditorAnnotation annotation) {
+  private static void removeRangeHighlighter(@NotNull AbstractEditorAnnotation annotation) {
 
     Editor editor = annotation.getEditor();
 

--- a/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
+++ b/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
@@ -107,7 +107,9 @@ public class AnnotationManagerTest {
     int end = 52;
     List<Pair<Integer, Integer>> expectedRange = createSelectionRange(start, end);
 
+    prepareMockAddRangeHighlighters();
     mockAddRangeHighlighters(expectedRange, AnnotationType.SELECTION_ANNOTATION);
+    replayMockAddRangeHighlighters();
 
     assertTrue(selectionAnnotationStore.getAnnotations().isEmpty());
 
@@ -328,7 +330,9 @@ public class AnnotationManagerTest {
 
     List<Pair<Integer, Integer>> expectedRanges = createContributionRanges(start, end);
 
+    prepareMockAddRangeHighlighters();
     mockAddRangeHighlighters(expectedRanges, AnnotationType.CONTRIBUTION_ANNOTATION);
+    replayMockAddRangeHighlighters();
 
     assertTrue(contributionAnnotationQueue.getAnnotations().isEmpty());
 
@@ -1508,15 +1512,26 @@ public class AnnotationManagerTest {
   }
 
   /**
+   * Must be called before the first call to {@link #mockAddRangeHighlighters(List,
+   * AnnotationType)}.
+   */
+  private void prepareMockAddRangeHighlighters() {
+    PowerMock.mockStaticPartial(AnnotationManager.class, "addRangeHighlighter");
+  }
+
+  /**
    * Mocks the method creating the actual range highlighters in the editor for the list of given
    * ranges.
+   *
+   * <p>{@link #prepareMockAddRangeHighlighters()} must be called before the first call to this
+   * methods and {@link #replayMockAddRangeHighlighters()} must be called after the last call to
+   * this method to replay the added mocking logic.
    *
    * @param ranges the ranges to mock
    * @throws Exception see {@link PowerMock#expectPrivate(Object, Method, Object...)}
    */
   private void mockAddRangeHighlighters(
       List<Pair<Integer, Integer>> ranges, AnnotationType annotationType) throws Exception {
-    PowerMock.mockStaticPartial(AnnotationManager.class, "addRangeHighlighter");
 
     for (Pair<Integer, Integer> range : ranges) {
       int rangeStart = range.getLeft();
@@ -1535,7 +1550,12 @@ public class AnnotationManagerTest {
               file)
           .andStubReturn(rangeHighlighter);
     }
+  }
 
+  /**
+   * Must be called after the last call to {@link #mockAddRangeHighlighters(List, AnnotationType)}.
+   */
+  private void replayMockAddRangeHighlighters() {
     PowerMock.replay(AnnotationManager.class);
   }
 

--- a/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
+++ b/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
@@ -249,6 +249,52 @@ public class AnnotationManagerTest {
     assertEquals(0, selectionAnnotations.size());
   }
 
+  /**
+   * Tests that removing selection annotations for a specific file user combination removes all
+   * corresponding annotations and does not remove any annotations for a different file or user.
+   */
+  @Test
+  public void testRemoveSelectionAnnotation() {
+    /* setup */
+    User user1 = user;
+    IFile file1 = file;
+    User user2 = EasyMock.createNiceMock(User.class);
+    IFile file2 = EasyMock.createNiceMock(IFile.class);
+
+    int start1 = 0;
+    int end1 = 20;
+    int start2 = 53;
+    int end2 = 56;
+    List<Pair<Integer, Integer>> expectedRange2 = createSelectionRange(start2, end2);
+
+    annotationManager.addSelectionAnnotation(user1, file1, start1, end1, null);
+    annotationManager.addSelectionAnnotation(user2, file2, start2, end2, null);
+
+    assertEquals(2, selectionAnnotationStore.getAnnotations().size());
+
+    /* call to test */
+    annotationManager.removeSelectionAnnotation(user1, file1);
+
+    /* check assertions */
+    List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+    assertEquals(0, selectionAnnotationStore.getAnnotations(file1).size());
+    assertEquals(1, selectionAnnotationStore.getAnnotations(file2).size());
+
+    SelectionAnnotation selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user2, file2, expectedRange2, null);
+
+    /* call to test */
+    annotationManager.removeSelectionAnnotation(user2, file2);
+
+    /* check assertions */
+    selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(0, selectionAnnotations.size());
+
+    assertEquals(0, selectionAnnotationStore.getAnnotations(file1).size());
+    assertEquals(0, selectionAnnotationStore.getAnnotations(file2).size());
+  }
+
   /** Test adding contribution annotations without an editor. */
   @Test
   public void testAddContributionAnnotationNoEditor() {

--- a/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
+++ b/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
@@ -823,6 +823,572 @@ public class AnnotationManagerTest {
   }
 
   /**
+   * Tests moving annotations without an editor in reaction to text being removed from the file
+   * after the annotation. The annotation position should not change.
+   */
+  @Test
+  public void testMoveAnnotationsAfterDeletionNoEditorAfterAnnotation() {
+    /* setup */
+    int start = 40;
+    int end = 50;
+    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
+    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
+
+    SelectionAnnotation selectionAnnotation =
+        new SelectionAnnotation(
+            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    selectionAnnotationStore.addAnnotation(selectionAnnotation);
+
+    ContributionAnnotation contributionAnnotation =
+        new ContributionAnnotation(
+            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+    contributionAnnotationQueue.addAnnotation(contributionAnnotation);
+
+    /* call to test */
+    annotationManager.moveAnnotationsAfterDeletion(file, 50, 55);
+
+    /* check assertions */
+    List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, null);
+
+    List<ContributionAnnotation> contributionAnnotations =
+        contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(contributionAnnotation, user, file, expectedContributionRanges, null);
+  }
+
+  /**
+   * Tests moving annotations without an editor in reaction to text being removed from the file
+   * before the annotation. The annotation position should be shifted left by the deletion length.
+   */
+  @Test
+  public void testMoveAnnotationsAfterDeletionNoEditorBeforeAnnotation() {
+    /* setup */
+    int start = 40;
+    int end = 50;
+    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
+    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
+
+    SelectionAnnotation selectionAnnotation =
+        new SelectionAnnotation(
+            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    selectionAnnotationStore.addAnnotation(selectionAnnotation);
+
+    ContributionAnnotation contributionAnnotation =
+        new ContributionAnnotation(
+            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+    contributionAnnotationQueue.addAnnotation(contributionAnnotation);
+
+    int deletionStart = 2;
+    int deletionEnd = 15;
+    int deletionOffset = deletionEnd - deletionStart;
+
+    /* call to test */
+    annotationManager.moveAnnotationsAfterDeletion(file, deletionStart, deletionEnd);
+
+    /* check assertions */
+    start -= deletionOffset;
+    end -= deletionOffset;
+    expectedSelectionRanges = createSelectionRange(start, end);
+    expectedContributionRanges = createContributionRanges(start, end);
+
+    List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, null);
+
+    List<ContributionAnnotation> contributionAnnotations =
+        contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(contributionAnnotation, user, file, expectedContributionRanges, null);
+  }
+
+  /**
+   * Tests moving annotations without an editor in reaction to text being removed from the file
+   * overlapping with the start of the the annotation. The annotation position should be shifted
+   * left to the deletion start and the range should be shortened by the overlap.
+   */
+  @Test
+  public void testMoveAnnotationsAfterDeletionNoEditorLeadingOverlap() {
+    /* setup */
+    int start = 40;
+    int end = 50;
+    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
+    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
+
+    SelectionAnnotation selectionAnnotation =
+        new SelectionAnnotation(
+            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    selectionAnnotationStore.addAnnotation(selectionAnnotation);
+
+    ContributionAnnotation contributionAnnotation =
+        new ContributionAnnotation(
+            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+    contributionAnnotationQueue.addAnnotation(contributionAnnotation);
+
+    int deletionStart = 33;
+    int deletionEnd = 42;
+    int deletionOffset = deletionEnd - deletionStart;
+
+    /* call to test */
+    annotationManager.moveAnnotationsAfterDeletion(file, deletionStart, deletionEnd);
+
+    /* check assertions */
+    start = deletionStart;
+    end -= deletionOffset;
+    expectedSelectionRanges = createSelectionRange(start, end);
+    expectedContributionRanges = createContributionRanges(start, end);
+
+    List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, null);
+
+    List<ContributionAnnotation> contributionAnnotations =
+        contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(contributionAnnotation, user, file, expectedContributionRanges, null);
+  }
+
+  /**
+   * Tests moving annotations without an editor in reaction to text being removed from the file in
+   * the annotation range. The annotation range should be shortened by the deletion length.
+   */
+  @Test
+  public void testMoveAnnotationsAfterDeletionNoEditorInAnnotation() {
+    /* setup */
+    int start = 40;
+    int end = 50;
+    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
+    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
+
+    SelectionAnnotation selectionAnnotation =
+        new SelectionAnnotation(
+            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    selectionAnnotationStore.addAnnotation(selectionAnnotation);
+
+    ContributionAnnotation contributionAnnotation =
+        new ContributionAnnotation(
+            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+    contributionAnnotationQueue.addAnnotation(contributionAnnotation);
+
+    int deletionStart = 45;
+    int deletionEnd = 49;
+    int deletionOffset = deletionEnd - deletionStart;
+
+    /* call to test */
+    annotationManager.moveAnnotationsAfterDeletion(file, deletionStart, deletionEnd);
+
+    /* check assertions */
+    end -= deletionOffset;
+    expectedSelectionRanges = createSelectionRange(start, end);
+    expectedContributionRanges = createContributionRanges(start, end);
+
+    List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, null);
+
+    List<ContributionAnnotation> contributionAnnotations =
+        contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(contributionAnnotation, user, file, expectedContributionRanges, null);
+  }
+
+  /**
+   * Tests moving annotations without an editor in reaction to text being removed from the file
+   * overlapping with the end of the annotation. The annotation range should be shortened to match
+   * the deletion start.
+   */
+  @Test
+  public void testMoveAnnotationsAfterDeletionNoEditorTrailingOverlap() {
+    /* setup */
+    int start = 40;
+    int end = 50;
+    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
+    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
+
+    SelectionAnnotation selectionAnnotation =
+        new SelectionAnnotation(
+            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    selectionAnnotationStore.addAnnotation(selectionAnnotation);
+
+    ContributionAnnotation contributionAnnotation =
+        new ContributionAnnotation(
+            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+    contributionAnnotationQueue.addAnnotation(contributionAnnotation);
+
+    int deletionStart = 48;
+    int deletionEnd = 63;
+
+    /* call to test */
+    annotationManager.moveAnnotationsAfterDeletion(file, deletionStart, deletionEnd);
+
+    /* check assertions */
+    end = deletionStart;
+    expectedSelectionRanges = createSelectionRange(start, end);
+    expectedContributionRanges = createContributionRanges(start, end);
+
+    List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, null);
+
+    List<ContributionAnnotation> contributionAnnotations =
+        contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(contributionAnnotation, user, file, expectedContributionRanges, null);
+  }
+
+  /**
+   * Tests moving annotations without an editor in reaction to text being removed from the file
+   * covering the annotation. The annotation should be removed from the annotation store.
+   */
+  @Test
+  public void testMoveAnnotationsAfterDeletionNoEditorCoveringAnnotation() {
+    /* setup */
+    int start = 40;
+    int end = 50;
+    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
+    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
+
+    SelectionAnnotation selectionAnnotation =
+        new SelectionAnnotation(
+            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    selectionAnnotationStore.addAnnotation(selectionAnnotation);
+
+    ContributionAnnotation contributionAnnotation =
+        new ContributionAnnotation(
+            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+    contributionAnnotationQueue.addAnnotation(contributionAnnotation);
+
+    int deletionStart = 30;
+    int deletionEnd = 60;
+
+    /* call to test */
+    annotationManager.moveAnnotationsAfterDeletion(file, deletionStart, deletionEnd);
+
+    /* check assertions */
+    List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(0, selectionAnnotations.size());
+
+    List<ContributionAnnotation> contributionAnnotations =
+        contributionAnnotationQueue.getAnnotations();
+    assertEquals(0, contributionAnnotations.size());
+  }
+
+  /**
+   * Tests moving annotations with an editor in reaction to text being removed from the file. The
+   * annotation position should not change in any case.
+   */
+  @Test
+  public void testMoveAnnotationsAfterDeletionEditor() {
+    /* setup */
+    int start = 40;
+    int end = 50;
+    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
+    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
+
+    SelectionAnnotation selectionAnnotation =
+        new SelectionAnnotation(
+            user, file, editor, createAnnotationRanges(expectedSelectionRanges, true));
+    selectionAnnotationStore.addAnnotation(selectionAnnotation);
+
+    ContributionAnnotation contributionAnnotation =
+        new ContributionAnnotation(
+            user, file, editor, createAnnotationRanges(expectedContributionRanges, true));
+    contributionAnnotationQueue.addAnnotation(contributionAnnotation);
+
+    int deletionStartBefore = 50;
+    int deletionEndBefore = 55;
+
+    /* call to test */
+    annotationManager.moveAnnotationsAfterDeletion(file, deletionStartBefore, deletionEndBefore);
+
+    /* check assertions */
+    List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, editor);
+
+    List<ContributionAnnotation> contributionAnnotations =
+        contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(
+        contributionAnnotation, user, file, expectedContributionRanges, editor);
+
+    /* setup*/
+    deletionStartBefore = 33;
+    int deletionEndIn = 45;
+
+    /* call to test */
+    annotationManager.moveAnnotationsAfterDeletion(file, deletionStartBefore, deletionEndIn);
+
+    /* check assertions */
+    selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, editor);
+
+    contributionAnnotations = contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(
+        contributionAnnotation, user, file, expectedContributionRanges, editor);
+
+    /* setup*/
+    int deletionStartIn = 45;
+    deletionEndIn = 49;
+
+    /* call to test */
+    annotationManager.moveAnnotationsAfterDeletion(file, deletionStartIn, deletionEndIn);
+
+    /* check assertions */
+    selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, editor);
+
+    contributionAnnotations = contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(
+        contributionAnnotation, user, file, expectedContributionRanges, editor);
+
+    /* setup*/
+    deletionStartIn = 48;
+    int deletionEndAfter = 63;
+
+    /* call to test */
+    annotationManager.moveAnnotationsAfterDeletion(file, deletionStartIn, deletionEndAfter);
+
+    /* check assertions */
+    selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, editor);
+
+    contributionAnnotations = contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(
+        contributionAnnotation, user, file, expectedContributionRanges, editor);
+
+    /* setup*/
+    int deletionStartAfter = 50;
+    deletionEndAfter = 55;
+
+    /* call to test */
+    annotationManager.moveAnnotationsAfterDeletion(file, deletionStartAfter, deletionEndAfter);
+
+    /* check assertions */
+    selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, editor);
+
+    contributionAnnotations = contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(
+        contributionAnnotation, user, file, expectedContributionRanges, editor);
+
+    /* setup*/
+    deletionStartBefore = 30;
+    deletionEndAfter = 60;
+
+    /* call to test */
+    annotationManager.moveAnnotationsAfterDeletion(file, deletionStartBefore, deletionEndAfter);
+
+    /* check assertions */
+    selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, editor);
+
+    contributionAnnotations = contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(
+        contributionAnnotation, user, file, expectedContributionRanges, editor);
+  }
+
+  /**
+   * Tests moving annotations without an editor in reaction to text being removed from a different
+   * file. The annotation position should not change in any case.
+   */
+  @Test
+  public void testMoveAnnotationsAfterDeletionDifferentFile() {
+    /* setup */
+    IFile file2 = EasyMock.createNiceMock(IFile.class);
+
+    int start = 40;
+    int end = 50;
+    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
+    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
+
+    SelectionAnnotation selectionAnnotation =
+        new SelectionAnnotation(
+            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    selectionAnnotationStore.addAnnotation(selectionAnnotation);
+
+    ContributionAnnotation contributionAnnotation =
+        new ContributionAnnotation(
+            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+    contributionAnnotationQueue.addAnnotation(contributionAnnotation);
+
+    int deletionStartBefore = 50;
+    int deletionEndBefore = 55;
+
+    /* call to test */
+    annotationManager.moveAnnotationsAfterDeletion(file2, deletionStartBefore, deletionEndBefore);
+
+    /* check assertions */
+    List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, null);
+
+    List<ContributionAnnotation> contributionAnnotations =
+        contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(contributionAnnotation, user, file, expectedContributionRanges, null);
+
+    /* setup*/
+    deletionStartBefore = 33;
+    int deletionEndIn = 45;
+
+    /* call to test */
+    annotationManager.moveAnnotationsAfterDeletion(file2, deletionStartBefore, deletionEndIn);
+
+    /* check assertions */
+    selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, null);
+
+    contributionAnnotations = contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(contributionAnnotation, user, file, expectedContributionRanges, null);
+
+    /* setup*/
+    int deletionStartIn = 45;
+    deletionEndIn = 49;
+
+    /* call to test */
+    annotationManager.moveAnnotationsAfterDeletion(file2, deletionStartIn, deletionEndIn);
+
+    /* check assertions */
+    selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, null);
+
+    contributionAnnotations = contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(contributionAnnotation, user, file, expectedContributionRanges, null);
+
+    /* setup*/
+    deletionStartIn = 48;
+    int deletionEndAfter = 63;
+
+    /* call to test */
+    annotationManager.moveAnnotationsAfterDeletion(file2, deletionStartIn, deletionEndAfter);
+
+    /* check assertions */
+    selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, null);
+
+    contributionAnnotations = contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(contributionAnnotation, user, file, expectedContributionRanges, null);
+
+    /* setup*/
+    int deletionStartAfter = 50;
+    deletionEndAfter = 55;
+
+    /* call to test */
+    annotationManager.moveAnnotationsAfterDeletion(file2, deletionStartAfter, deletionEndAfter);
+
+    /* check assertions */
+    selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, null);
+
+    contributionAnnotations = contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(contributionAnnotation, user, file, expectedContributionRanges, null);
+
+    /* setup*/
+    deletionStartBefore = 30;
+    deletionEndAfter = 60;
+
+    /* call to test */
+    annotationManager.moveAnnotationsAfterDeletion(file2, deletionStartBefore, deletionEndAfter);
+
+    /* check assertions */
+    selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, null);
+
+    contributionAnnotations = contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(contributionAnnotation, user, file, expectedContributionRanges, null);
+  }
+
+  /**
    * Creates a list containing a single entry for the given range.
    *
    * @param rangeStart the start of the range

--- a/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
+++ b/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
@@ -1750,7 +1750,7 @@ public class AnnotationManagerTest {
     annotationManager.reloadAnnotations();
 
     /* check assertions */
-    PowerMock.verify(AnnotationManager.class);
+    verifyRemovalCall();
 
     /* check assertions */
     List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
@@ -1796,7 +1796,7 @@ public class AnnotationManagerTest {
     annotationManager.removeAnnotations(user);
 
     /* check assertions */
-    PowerMock.verify(AnnotationManager.class);
+    verifyRemovalCall();
 
     List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
     assertEquals(0, selectionAnnotations.size());
@@ -1876,7 +1876,7 @@ public class AnnotationManagerTest {
     annotationManager.removeAnnotations(file);
 
     /* check assertions */
-    PowerMock.verify(AnnotationManager.class);
+    verifyRemovalCall();
 
     List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
     assertEquals(0, selectionAnnotations.size());
@@ -1995,7 +1995,7 @@ public class AnnotationManagerTest {
     annotationManager.dispose();
 
     /* check assertions */
-    PowerMock.verify(AnnotationManager.class);
+    verifyRemovalCall();
 
     List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
     assertEquals(0, selectionAnnotations.size());
@@ -2276,6 +2276,14 @@ public class AnnotationManagerTest {
    */
   private void replayMockAddRemoveRangeHighlighters() {
     PowerMock.replay(AnnotationManager.class);
+  }
+
+  /**
+   * Verifies that all added range highlighter removal mocks where called at least once. This can be
+   * used to check whether the local representation of removed annotations was also removed.
+   */
+  private void verifyRemovalCall() {
+    PowerMock.verify(AnnotationManager.class);
   }
 
   private RangeHighlighter mockRangeHighlighter(int rangeStart, int rangeEnd) {

--- a/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
+++ b/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
@@ -1,15 +1,28 @@
 package saros.intellij.editor.annotations;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static saros.intellij.editor.annotations.AnnotationManager.MAX_CONTRIBUTION_ANNOTATIONS;
 
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.markup.RangeHighlighter;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.easymock.EasyMock;
 import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import saros.filesystem.IFile;
+import saros.intellij.editor.annotations.AnnotationManager.AnnotationType;
 import saros.session.User;
 
 /**
@@ -61,5 +74,330 @@ public class AnnotationManagerTest {
     file = EasyMock.createNiceMock(IFile.class);
     user = EasyMock.createNiceMock(User.class);
     editor = EasyMock.createNiceMock(Editor.class);
+  }
+
+  /** Test adding contribution annotations without an editor. */
+  @Test
+  public void testAddContributionAnnotationNoEditor() {
+    /* setup */
+    int start = 10;
+    int end = 20;
+
+    List<Pair<Integer, Integer>> expectedRanges = createContributionRanges(start, end);
+
+    assertTrue(contributionAnnotationQueue.getAnnotations().isEmpty());
+
+    /* call to test */
+    annotationManager.addContributionAnnotation(user, file, start, end, null);
+
+    /* check assertions */
+    List<ContributionAnnotation> contributionAnnotations =
+        contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    ContributionAnnotation contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(contributionAnnotation, user, file, expectedRanges, null);
+  }
+
+  /** Test adding contribution annotations with an editor. */
+  @Test
+  public void testAddContributionAnnotationEditor() throws Exception {
+    /* setup */
+    int start = 0;
+    int end = 21;
+
+    List<Pair<Integer, Integer>> expectedRanges = createContributionRanges(start, end);
+
+    mockAddRangeHighlighters(expectedRanges);
+
+    assertTrue(contributionAnnotationQueue.getAnnotations().isEmpty());
+
+    /* call to test */
+    annotationManager.addContributionAnnotation(user, file, start, end, editor);
+
+    /* check assertions */
+    List<ContributionAnnotation> contributionAnnotations =
+        contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    ContributionAnnotation contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(contributionAnnotation, user, file, expectedRanges, editor);
+  }
+
+  /**
+   * Test adding contribution annotations with a zero-width range. Such calls should not lead to an
+   * annotation being added.
+   */
+  @Test
+  public void testAddContributionAnnotationNoRange() {
+    /* setup */
+    int start = 10;
+    int end = 10;
+
+    assertTrue(contributionAnnotationQueue.getAnnotations().isEmpty());
+
+    /* call to test */
+    annotationManager.addContributionAnnotation(user, file, start, end, null);
+
+    /* check assertions */
+    List<ContributionAnnotation> contributionAnnotations =
+        contributionAnnotationQueue.getAnnotations();
+    assertEquals(0, contributionAnnotations.size());
+  }
+
+  /**
+   * Tests the contribution annotation queue mechanism to rotate out old entries when new ones are
+   * added and the store already holds {@link AnnotationManager#MAX_CONTRIBUTION_ANNOTATIONS}
+   * annotations. This maximum is for the whole store and not per file.
+   */
+  @Test
+  public void testContributionAnnotationQueueRotation() {
+    User user2 = EasyMock.createNiceMock(User.class);
+    IFile file2 = EasyMock.createNiceMock(IFile.class);
+
+    List<ContributionAnnotation> previousAnnotations = new ArrayList<>();
+    List<List<Pair<Integer, Integer>>> expectedRanges = new ArrayList<>();
+    List<IFile> expectedFiles = new ArrayList<>();
+    List<User> expectedUsers = new ArrayList<>();
+
+    for (int i = 0; i < MAX_CONTRIBUTION_ANNOTATIONS; i++) {
+      /* setup */
+      int start = i + 1;
+      int end = i + 30;
+      List<Pair<Integer, Integer>> expectedRange = createContributionRanges(start, end);
+
+      User usedUser;
+      IFile usedFile;
+      if (i % 2 == 0) {
+        usedUser = user;
+        usedFile = file;
+      } else {
+        usedUser = user2;
+        usedFile = file2;
+      }
+
+      expectedRanges.add(expectedRange);
+      expectedFiles.add(usedFile);
+      expectedUsers.add(usedUser);
+
+      /* call to test */
+      annotationManager.addContributionAnnotation(usedUser, usedFile, start, end, null);
+
+      /* check assertions */
+      List<ContributionAnnotation> currentAnnotations =
+          contributionAnnotationQueue.getAnnotations();
+      assertTrue(currentAnnotations.containsAll(previousAnnotations));
+      assertEquals(i + 1, currentAnnotations.size());
+
+      currentAnnotations.removeAll(previousAnnotations);
+      assertEquals(1, currentAnnotations.size());
+
+      ContributionAnnotation addedAnnotation = currentAnnotations.get(0);
+      assertAnnotationIntegrity(addedAnnotation, usedUser, usedFile, expectedRange, null);
+
+      previousAnnotations.add(addedAnnotation);
+    }
+
+    /* check integrity of full list */
+    List<ContributionAnnotation> annotations = contributionAnnotationQueue.getAnnotations();
+    assertEquals(MAX_CONTRIBUTION_ANNOTATIONS, annotations.size());
+    assertTrue(previousAnnotations.containsAll(annotations));
+    assertTrue(annotations.containsAll(previousAnnotations));
+
+    for (int i = 0; i < previousAnnotations.size(); i++) {
+      assertAnnotationIntegrity(
+          previousAnnotations.get(i),
+          expectedUsers.get(i),
+          expectedFiles.get(i),
+          expectedRanges.get(i),
+          null);
+    }
+
+    for (int i = MAX_CONTRIBUTION_ANNOTATIONS; i <= 2 * MAX_CONTRIBUTION_ANNOTATIONS; i++) {
+      /* setup */
+      int start = i + 1;
+      int end = i + 30;
+
+      User usedUser;
+      IFile usedFile;
+      if (i % 2 == 0) {
+        usedUser = user;
+        usedFile = file;
+      } else {
+        usedUser = user2;
+        usedFile = file2;
+      }
+
+      expectedUsers.add(usedUser);
+      expectedFiles.add(usedFile);
+      expectedRanges.add(createContributionRanges(start, end));
+
+      /* call to test */
+      annotationManager.addContributionAnnotation(usedUser, usedFile, start, end, null);
+
+      /* check assertions */
+      List<ContributionAnnotation> currentAnnotations =
+          contributionAnnotationQueue.getAnnotations();
+      assertEquals(MAX_CONTRIBUTION_ANNOTATIONS, currentAnnotations.size());
+
+      ContributionAnnotation rotatedOutAnnotation = previousAnnotations.remove(0);
+      User rotatedOutExpectedUser = expectedUsers.remove(0);
+      IFile rotatedOutExpectedFile = expectedFiles.remove(0);
+      List<Pair<Integer, Integer>> rotatedOutExpectedRanges = expectedRanges.remove(0);
+
+      assertAnnotationIntegrity(
+          rotatedOutAnnotation,
+          rotatedOutExpectedUser,
+          rotatedOutExpectedFile,
+          rotatedOutExpectedRanges,
+          null);
+
+      assertTrue(currentAnnotations.containsAll(previousAnnotations));
+      assertFalse(currentAnnotations.contains(rotatedOutAnnotation));
+
+      currentAnnotations.removeAll(previousAnnotations);
+      assertEquals(1, currentAnnotations.size());
+
+      previousAnnotations.add(currentAnnotations.get(0));
+    }
+
+    /* check integrity of full replaced list */
+    annotations = contributionAnnotationQueue.getAnnotations();
+    assertEquals(MAX_CONTRIBUTION_ANNOTATIONS, annotations.size());
+    assertTrue(previousAnnotations.containsAll(annotations));
+    assertTrue(annotations.containsAll(previousAnnotations));
+
+    for (int i = 0; i < previousAnnotations.size(); i++) {
+      assertAnnotationIntegrity(
+          previousAnnotations.get(i),
+          expectedUsers.get(i),
+          expectedFiles.get(i),
+          expectedRanges.get(i),
+          null);
+    }
+  }
+
+  /**
+   * Creates a list of ranges of size 1 covering the given range.
+   *
+   * @param rangeStart the start of the range
+   * @param rangeEnd the end of the range
+   * @return a list of ranges of size 1 covering the given range
+   */
+  private List<Pair<Integer, Integer>> createContributionRanges(int rangeStart, int rangeEnd) {
+    List<Pair<Integer, Integer>> expectedRanges = new ArrayList<>(rangeEnd - rangeStart);
+
+    for (int i = rangeStart; i < rangeEnd; i++) {
+      expectedRanges.add(new ImmutablePair<>(i, i + 1));
+    }
+
+    return expectedRanges;
+  }
+
+  /**
+   * Asserts the annotation integrity.
+   *
+   * <p>Asserts that
+   *
+   * <ul>
+   *   <li>the annotation holds the given file object
+   *   <li>the annotation holds the given user object
+   *   <li>the annotation contains exactly the expected ranges
+   *   <li>if <code>expectedEditor!=null</code>
+   *       <ul>
+   *         <li>the annotations contains
+   *         <li>each annotation range contains a range highlighter
+   *         <li>the position of each range highlighter matches its annotation range
+   *       </ul>
+   *   <li>if <code>expectedEditor!=null</code>
+   *       <ul>
+   *         <li>the annotation does not contain
+   *         <li>each annotation range does not contain a range highlighter
+   *       </ul>
+   * </ul>
+   *
+   * @param annotation the annotation to check
+   * @param expectedUser the user to whom the annotation should belong
+   * @param expectedFile the file to which the annotation should belong
+   * @param expectedRanges the ranges that should be contained in the annotation
+   * @param expectedEditor the editor that should be contained in the annotation
+   */
+  private void assertAnnotationIntegrity(
+      AbstractEditorAnnotation annotation,
+      User expectedUser,
+      IFile expectedFile,
+      List<Pair<Integer, Integer>> expectedRanges,
+      Editor expectedEditor) {
+
+    assertEquals(expectedUser, annotation.getUser());
+    assertEquals(expectedFile, annotation.getFile());
+
+    Editor editor = annotation.getEditor();
+    if (expectedEditor != null) {
+      assertEquals(expectedEditor, editor);
+
+    } else {
+      assertNull(editor);
+    }
+
+    List<AnnotationRange> annotationRanges = annotation.getAnnotationRanges();
+    assertEquals(expectedRanges.size(), annotationRanges.size());
+
+    List<Pair<Integer, Integer>> foundRanges = new ArrayList<>();
+
+    for (AnnotationRange annotationRange : annotationRanges) {
+      int rangeStart = annotationRange.getStart();
+      int rangeEnd = annotationRange.getEnd();
+      Pair<Integer, Integer> range = new ImmutablePair<>(rangeStart, rangeEnd);
+
+      foundRanges.add(range);
+
+      RangeHighlighter rangeHighlighter = annotationRange.getRangeHighlighter();
+      if (expectedEditor != null) {
+        assertNotNull(rangeHighlighter);
+        assertEquals(rangeStart, rangeHighlighter.getStartOffset());
+        assertEquals(rangeEnd, rangeHighlighter.getEndOffset());
+      } else {
+        assertNull(rangeHighlighter);
+      }
+    }
+
+    assertEquals(expectedRanges, foundRanges);
+  }
+
+  /**
+   * Mocks the method creating the actual range highlighters in the editor for the list of given
+   * ranges.
+   *
+   * @param ranges the ranges to mock
+   * @throws Exception see {@link PowerMock#expectPrivate(Object, Method, Object...)}
+   */
+  private void mockAddRangeHighlighters(List<Pair<Integer, Integer>> ranges) throws Exception {
+    PowerMock.mockStaticPartial(AnnotationManager.class, "addRangeHighlighter");
+
+    for (Pair<Integer, Integer> range : ranges) {
+      int rangeStart = range.getLeft();
+      int rangeEnd = range.getRight();
+
+      RangeHighlighter rangeHighlighter = EasyMock.createNiceMock(RangeHighlighter.class);
+
+      EasyMock.expect(rangeHighlighter.getStartOffset()).andStubReturn(rangeStart);
+      EasyMock.expect(rangeHighlighter.getEndOffset()).andStubReturn(rangeEnd);
+
+      EasyMock.replay(rangeHighlighter);
+
+      PowerMock.expectPrivate(
+              annotationManager,
+              "addRangeHighlighter",
+              user,
+              rangeStart,
+              rangeEnd,
+              editor,
+              AnnotationType.CONTRIBUTION_ANNOTATION,
+              file)
+          .andStubReturn(rangeHighlighter);
+    }
+
+    PowerMock.replay(AnnotationManager.class);
   }
 }

--- a/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
+++ b/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
@@ -1848,6 +1848,86 @@ public class AnnotationManagerTest {
     assertAnnotationIntegrity(contributionAnnotation, user, file, expectedContributionRanges, null);
   }
 
+  /** Tests removing all annotations for a specific file. */
+  @Test
+  public void testRemoveAnnotationsForFile() throws Exception {
+    /* setup */
+    int start = 94;
+    int end = 112;
+    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
+    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
+
+    SelectionAnnotation selectionAnnotation =
+        new SelectionAnnotation(
+            user, file, editor, createAnnotationRanges(expectedSelectionRanges, true));
+    selectionAnnotationStore.addAnnotation(selectionAnnotation);
+
+    ContributionAnnotation contributionAnnotation =
+        new ContributionAnnotation(
+            user, file, editor, createAnnotationRanges(expectedContributionRanges, true));
+    contributionAnnotationQueue.addAnnotation(contributionAnnotation);
+
+    prepareMockAddRemoveRangeHighlighters();
+    mockRemoveRangeHighlighters(selectionAnnotation);
+    mockRemoveRangeHighlighters(contributionAnnotation);
+    replayMockAddRemoveRangeHighlighters();
+
+    /* calls to test */
+    annotationManager.removeAnnotations(file);
+
+    /* check assertions */
+    PowerMock.verify(AnnotationManager.class);
+
+    List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(0, selectionAnnotations.size());
+
+    List<ContributionAnnotation> contributionAnnotations =
+        contributionAnnotationQueue.getAnnotations();
+    assertEquals(0, contributionAnnotations.size());
+  }
+
+  /**
+   * Tests removing all annotations for a different file. All annotations should still be present
+   * after the call.
+   */
+  @Test
+  public void testRemoveAnnotationsForDifferentFile() {
+    /* setup */
+    IFile file2 = EasyMock.createNiceMock(IFile.class);
+
+    int start = 94;
+    int end = 112;
+    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
+    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
+
+    SelectionAnnotation selectionAnnotation =
+        new SelectionAnnotation(
+            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    selectionAnnotationStore.addAnnotation(selectionAnnotation);
+
+    ContributionAnnotation contributionAnnotation =
+        new ContributionAnnotation(
+            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+    contributionAnnotationQueue.addAnnotation(contributionAnnotation);
+
+    /* calls to test */
+    annotationManager.removeAnnotations(file2);
+
+    /* check assertions */
+    List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, null);
+
+    List<ContributionAnnotation> contributionAnnotations =
+        contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(contributionAnnotation, user, file, expectedContributionRanges, null);
+  }
+
   /**
    * Creates a list containing a single entry for the given range.
    *

--- a/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
+++ b/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
@@ -1630,6 +1630,90 @@ public class AnnotationManagerTest {
   }
 
   /**
+   * Test removing the local representation of all annotations for a file. After the call, no
+   * annotation for the file should contain an editor or a range highlighter in any one of its
+   * annotation ranges.
+   */
+  @Test
+  public void testRemoveLocalRepresentation() {
+    /* setup */
+    int start = 40;
+    int end = 50;
+    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
+    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
+
+    SelectionAnnotation selectionAnnotation =
+        new SelectionAnnotation(
+            user, file, editor, createAnnotationRanges(expectedSelectionRanges, true));
+    selectionAnnotationStore.addAnnotation(selectionAnnotation);
+
+    ContributionAnnotation contributionAnnotation =
+        new ContributionAnnotation(
+            user, file, editor, createAnnotationRanges(expectedContributionRanges, true));
+    contributionAnnotationQueue.addAnnotation(contributionAnnotation);
+
+    /* call to test */
+    annotationManager.removeLocalRepresentation(file);
+
+    /* check assertions */
+    List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, null);
+
+    List<ContributionAnnotation> contributionAnnotations =
+        contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(contributionAnnotation, user, file, expectedContributionRanges, null);
+  }
+
+  /**
+   * Test removing the local representation of all annotations for a different file. No annotations
+   * should be changed.
+   */
+  @Test
+  public void testRemoveLocalRepresentationDifferentFile() {
+    /* setup */
+    IFile file2 = EasyMock.createNiceMock(IFile.class);
+
+    int start = 40;
+    int end = 50;
+    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
+    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
+
+    SelectionAnnotation selectionAnnotation =
+        new SelectionAnnotation(
+            user, file, editor, createAnnotationRanges(expectedSelectionRanges, true));
+    selectionAnnotationStore.addAnnotation(selectionAnnotation);
+
+    ContributionAnnotation contributionAnnotation =
+        new ContributionAnnotation(
+            user, file, editor, createAnnotationRanges(expectedContributionRanges, true));
+    contributionAnnotationQueue.addAnnotation(contributionAnnotation);
+
+    /* call to test */
+    annotationManager.removeLocalRepresentation(file2);
+
+    /* check assertions */
+    List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, editor);
+
+    List<ContributionAnnotation> contributionAnnotations =
+        contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(
+        contributionAnnotation, user, file, expectedContributionRanges, editor);
+  }
+
+  /**
    * Creates a list containing a single entry for the given range.
    *
    * @param rangeStart the start of the range

--- a/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
+++ b/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
@@ -1928,6 +1928,83 @@ public class AnnotationManagerTest {
     assertAnnotationIntegrity(contributionAnnotation, user, file, expectedContributionRanges, null);
   }
 
+  /** Tests removing all annotations as part of the annotation manager disposal. */
+  @Test
+  public void testRemoveAllAnnotations() throws Exception {
+    /* setup */
+    User user2 = EasyMock.createNiceMock(User.class);
+    IFile file2 = EasyMock.createNiceMock(IFile.class);
+
+    int start = 94;
+    int end = 112;
+    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
+    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
+
+    SelectionAnnotation selectionAnnotation1 =
+        new SelectionAnnotation(
+            user, file, editor, createAnnotationRanges(expectedSelectionRanges, true));
+    selectionAnnotationStore.addAnnotation(selectionAnnotation1);
+
+    ContributionAnnotation contributionAnnotation1 =
+        new ContributionAnnotation(
+            user, file, editor, createAnnotationRanges(expectedContributionRanges, true));
+    contributionAnnotationQueue.addAnnotation(contributionAnnotation1);
+
+    SelectionAnnotation selectionAnnotation2 =
+        new SelectionAnnotation(
+            user2, file, editor, createAnnotationRanges(expectedSelectionRanges, true));
+    selectionAnnotationStore.addAnnotation(selectionAnnotation2);
+
+    ContributionAnnotation contributionAnnotation2 =
+        new ContributionAnnotation(
+            user2, file, editor, createAnnotationRanges(expectedContributionRanges, true));
+    contributionAnnotationQueue.addAnnotation(contributionAnnotation2);
+
+    SelectionAnnotation selectionAnnotation3 =
+        new SelectionAnnotation(
+            user, file2, editor, createAnnotationRanges(expectedSelectionRanges, true));
+    selectionAnnotationStore.addAnnotation(selectionAnnotation3);
+
+    ContributionAnnotation contributionAnnotation3 =
+        new ContributionAnnotation(
+            user, file2, editor, createAnnotationRanges(expectedContributionRanges, true));
+    contributionAnnotationQueue.addAnnotation(contributionAnnotation3);
+
+    SelectionAnnotation selectionAnnotation4 =
+        new SelectionAnnotation(
+            user2, file2, editor, createAnnotationRanges(expectedSelectionRanges, true));
+    selectionAnnotationStore.addAnnotation(selectionAnnotation4);
+
+    ContributionAnnotation contributionAnnotation4 =
+        new ContributionAnnotation(
+            user2, file2, editor, createAnnotationRanges(expectedContributionRanges, true));
+    contributionAnnotationQueue.addAnnotation(contributionAnnotation4);
+
+    prepareMockAddRemoveRangeHighlighters();
+    mockRemoveRangeHighlighters(selectionAnnotation1);
+    mockRemoveRangeHighlighters(contributionAnnotation1);
+    mockRemoveRangeHighlighters(selectionAnnotation2);
+    mockRemoveRangeHighlighters(contributionAnnotation2);
+    mockRemoveRangeHighlighters(selectionAnnotation3);
+    mockRemoveRangeHighlighters(contributionAnnotation3);
+    mockRemoveRangeHighlighters(selectionAnnotation4);
+    mockRemoveRangeHighlighters(contributionAnnotation4);
+    replayMockAddRemoveRangeHighlighters();
+
+    /* calls to test */
+    annotationManager.dispose();
+
+    /* check assertions */
+    PowerMock.verify(AnnotationManager.class);
+
+    List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(0, selectionAnnotations.size());
+
+    List<ContributionAnnotation> contributionAnnotations =
+        contributionAnnotationQueue.getAnnotations();
+    assertEquals(0, contributionAnnotations.size());
+  }
+
   /**
    * Creates a list containing a single entry for the given range.
    *

--- a/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
+++ b/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
@@ -1,0 +1,65 @@
+package saros.intellij.editor.annotations;
+
+import static saros.intellij.editor.annotations.AnnotationManager.MAX_CONTRIBUTION_ANNOTATIONS;
+
+import com.intellij.openapi.editor.Editor;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import saros.filesystem.IFile;
+import saros.session.User;
+
+/**
+ * Tests the methods of {@link AnnotationManager}.
+ *
+ * <p>To reduce the mocking logic and make the tests easier to understand, all tests for methods
+ * that do not care about whether the annotation has a local representation (editor & range
+ * highlighters) or not work on annotations without a local representation.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({AnnotationManager.class, AnnotationStore.class, AnnotationQueue.class})
+public class AnnotationManagerTest {
+
+  /** Selection annotation store held in the annotation manager. */
+  private AnnotationStore<SelectionAnnotation> selectionAnnotationStore;
+  /** Contribution annotation store held in the annotation manager. */
+  private AnnotationQueue<ContributionAnnotation> contributionAnnotationQueue;
+
+  /**
+   * Annotation manager used for testing. Works on {@link #selectionAnnotationStore} and {@link
+   * #contributionAnnotationQueue}.
+   */
+  private AnnotationManager annotationManager;
+
+  /** Mocked file to use when creating annotations. */
+  private IFile file;
+  /** Mocked user to use when creating annotations. */
+  private User user;
+  /** Mocked editor to use when creating annotations. */
+  private Editor editor;
+
+  @Before
+  public void setUp() throws Exception {
+    selectionAnnotationStore = new AnnotationStore<>();
+    contributionAnnotationQueue = new AnnotationQueue<>(MAX_CONTRIBUTION_ANNOTATIONS);
+
+    /*
+     * Mock annotation store CTOR calls to return an object we hold a reference to.
+     * This is necessary to access the inner state of the annotation manager for testing.
+     */
+    PowerMock.expectNew(AnnotationStore.class).andReturn(selectionAnnotationStore);
+    PowerMock.expectNew(AnnotationQueue.class, MAX_CONTRIBUTION_ANNOTATIONS)
+        .andReturn(contributionAnnotationQueue);
+
+    PowerMock.replayAll();
+
+    annotationManager = new AnnotationManager();
+
+    file = EasyMock.createNiceMock(IFile.class);
+    user = EasyMock.createNiceMock(User.class);
+    editor = EasyMock.createNiceMock(Editor.class);
+  }
+}

--- a/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
+++ b/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
@@ -2005,6 +2005,89 @@ public class AnnotationManagerTest {
     assertEquals(0, contributionAnnotations.size());
   }
 
+  /** Test updating the file mapping for annotations. */
+  @Test
+  public void testUpdateAnnotationPath() {
+    /* setup */
+    IFile file2 = EasyMock.createNiceMock(IFile.class);
+
+    int start = 94;
+    int end = 112;
+    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
+    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
+
+    SelectionAnnotation selectionAnnotation =
+        new SelectionAnnotation(
+            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    selectionAnnotationStore.addAnnotation(selectionAnnotation);
+
+    ContributionAnnotation contributionAnnotation =
+        new ContributionAnnotation(
+            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+    contributionAnnotationQueue.addAnnotation(contributionAnnotation);
+
+    /* call to test */
+    annotationManager.updateAnnotationPath(file, file2);
+
+    /* check assertions */
+    List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file2, expectedSelectionRanges, null);
+
+    List<ContributionAnnotation> contributionAnnotations =
+        contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(
+        contributionAnnotation, user, file2, expectedContributionRanges, null);
+  }
+
+  /**
+   * Test updating the file mapping for a different file. All annotations should still be unchanged
+   * after the call.
+   */
+  @Test
+  public void testUpdateAnnotationPathDifferentFile() {
+    /* setup */
+    IFile file2 = EasyMock.createNiceMock(IFile.class);
+    IFile file3 = EasyMock.createNiceMock(IFile.class);
+
+    int start = 94;
+    int end = 112;
+    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
+    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
+
+    SelectionAnnotation selectionAnnotation =
+        new SelectionAnnotation(
+            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    selectionAnnotationStore.addAnnotation(selectionAnnotation);
+
+    ContributionAnnotation contributionAnnotation =
+        new ContributionAnnotation(
+            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+    contributionAnnotationQueue.addAnnotation(contributionAnnotation);
+
+    /* call to test */
+    annotationManager.updateAnnotationPath(file2, file3);
+
+    /* check assertions */
+    List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
+    assertEquals(1, selectionAnnotations.size());
+
+    selectionAnnotation = selectionAnnotations.get(0);
+    assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, null);
+
+    List<ContributionAnnotation> contributionAnnotations =
+        contributionAnnotationQueue.getAnnotations();
+    assertEquals(1, contributionAnnotations.size());
+
+    contributionAnnotation = contributionAnnotations.get(0);
+    assertAnnotationIntegrity(contributionAnnotation, user, file, expectedContributionRanges, null);
+  }
+
   /**
    * Creates a list containing a single entry for the given range.
    *

--- a/intellij/test/junit/saros/intellij/editor/annotations/TestSuite.java
+++ b/intellij/test/junit/saros/intellij/editor/annotations/TestSuite.java
@@ -1,0 +1,11 @@
+package saros.intellij.editor.annotations;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({AnnotationManagerTest.class})
+public class TestSuite {
+  // the class remains completely empty,
+  // being used only as a holder for the above annotations
+}


### PR DESCRIPTION
This PR adds test for all (public) methods in `AnnotationManager`. These test were added to cover the current (correct) behavior of the annotation manager to help with the refactoring #961 moving the functionality into the annotation objects to accommodate for caret annotations being part of the selection annotations.

To prepare for the testing logic, the methods in `AnnotationManager` to add and remove annotation ranges were also made static to make them easier to mock.

#### Reviewing This PR

In general, I am not sure whether it is worth it investing a lot of time into reviewing the addition of a whole lot of test cases for the current behavior.

If you decide to have a closer look at the PR, I would suggest reviewing these changes commit-wise to make this at least somewhat reviewable. In general, the commits should only add tests and not modify already added tests. Furthermore, I would suggest not caring that much about the little stuff (like code layout/style) as the test cases will also go through a lot of adjustments as part of the refactoring.