### PR TITLE
Move annotation update logic into annotation objects

### DIFF
--- a/intellij/src/saros/intellij/editor/annotations/AbstractEditorAnnotation.java
+++ b/intellij/src/saros/intellij/editor/annotations/AbstractEditorAnnotation.java
@@ -116,6 +116,14 @@ abstract class AbstractEditorAnnotation {
   }
 
   /**
+   * Adds the given editor to this annotations. Creates and adds the RangeHighlighters for all
+   * contained annotation ranges.
+   *
+   * @param editor the editor to create RangeHighlighters in
+   */
+  abstract void addLocalRepresentation(@NotNull Editor editor);
+
+  /**
    * Removes the <code>Editor</code> and <code>RangeHighlighter</code> from the annotation.
    *
    * <p><b>NOTE:</b> This does not remove the annotation from the editor. This has to be done

--- a/intellij/src/saros/intellij/editor/annotations/AbstractEditorAnnotation.java
+++ b/intellij/src/saros/intellij/editor/annotations/AbstractEditorAnnotation.java
@@ -99,6 +99,40 @@ abstract class AbstractEditorAnnotation {
   }
 
   /**
+   * Checks whether the given start and end offset form a valid range.
+   *
+   * <p>The following conditions must hold true:
+   *
+   * <ul>
+   *   <li><code>start &ge; 0</code>
+   *   <li><code>end &ge; 0</code>
+   *   <li><code>start &le; end</code>
+   * </ul>
+   *
+   * @param start the start position
+   * @param end the end position
+   * @throws IllegalStateException if <code>start &lt; 0</code>, <code>end &lt; 0</code>, or <code>
+   *     start &gt; end</code>
+   */
+  static void checkRange(int start, int end) {
+    if (start < 0 || end < 0) {
+      throw new IllegalArgumentException(
+          "The start and end of the given range must not be a negative value. start: "
+              + start
+              + ", end: "
+              + end);
+    }
+
+    if (start > end) {
+      throw new IllegalArgumentException(
+          "The start of the given range must not be after the end of the range. start: "
+              + start
+              + ", end: "
+              + end);
+    }
+  }
+
+  /**
    * Adds the given <code>Editor</code> to the annotation.
    *
    * <p>This method should be used when adding the local representation of the annotation when an
@@ -257,6 +291,8 @@ abstract class AbstractEditorAnnotation {
       return;
     }
 
+    checkRange(additionStart, additionEnd);
+
     int offset = additionEnd - additionStart;
 
     for (AnnotationRange annotationRange : annotationRanges) {
@@ -302,6 +338,8 @@ abstract class AbstractEditorAnnotation {
     if (editor != null) {
       return false;
     }
+
+    checkRange(deletionStart, deletionEnd);
 
     int offset = deletionEnd - deletionStart;
 

--- a/intellij/src/saros/intellij/editor/annotations/AnnotationManager.java
+++ b/intellij/src/saros/intellij/editor/annotations/AnnotationManager.java
@@ -599,6 +599,7 @@ public class AnnotationManager implements Disposable {
    * @return a RangeHighlighter with the given parameters or <code>null</code> if the given end
    *     position is located after the document end
    */
+  @Deprecated
   @Nullable
   private static RangeHighlighter addRangeHighlighter(
       @NotNull User user,
@@ -668,6 +669,7 @@ public class AnnotationManager implements Disposable {
    *
    * @param annotation the annotation whose highlighters to remove
    */
+  @Deprecated
   private static void removeRangeHighlighter(@NotNull AbstractEditorAnnotation annotation) {
 
     Editor editor = annotation.getEditor();

--- a/intellij/src/saros/intellij/editor/annotations/AnnotationManager.java
+++ b/intellij/src/saros/intellij/editor/annotations/AnnotationManager.java
@@ -408,7 +408,7 @@ public class AnnotationManager implements Disposable {
    * @param oldFile the old file of the annotations
    * @param newFile the new file of the annotations
    */
-  public void updateAnnotationPath(@NotNull IFile oldFile, @NotNull IFile newFile) {
+  public void updateAnnotationFile(@NotNull IFile oldFile, @NotNull IFile newFile) {
     for (SelectionAnnotation annotation : selectionAnnotationStore.getAnnotations(oldFile)) {
       annotation.updateFile(newFile);
     }

--- a/intellij/src/saros/intellij/editor/annotations/AnnotationManager.java
+++ b/intellij/src/saros/intellij/editor/annotations/AnnotationManager.java
@@ -53,8 +53,6 @@ public class AnnotationManager implements Disposable {
 
     removeSelectionAnnotation(user, file);
 
-    checkRange(start, end);
-
     if (start == end) {
       return;
     }
@@ -114,8 +112,6 @@ public class AnnotationManager implements Disposable {
   public void addContributionAnnotation(
       @NotNull User user, @NotNull IFile file, int start, int end, @Nullable Editor editor) {
 
-    checkRange(start, end);
-
     if (start == end) {
       return;
     }
@@ -172,8 +168,6 @@ public class AnnotationManager implements Disposable {
       return;
     }
 
-    checkRange(additionStart, additionEnd);
-
     for (SelectionAnnotation annotation : selectionAnnotationStore.getAnnotations(file)) {
       annotation.moveAfterAddition(additionStart, additionEnd);
     }
@@ -207,8 +201,6 @@ public class AnnotationManager implements Disposable {
     if (deletionStart == deletionEnd) {
       return;
     }
-
-    checkRange(deletionStart, deletionEnd);
 
     for (SelectionAnnotation annotation : selectionAnnotationStore.getAnnotations(file)) {
       boolean isInvalid = annotation.moveAfterDeletion(deletionStart, deletionEnd);
@@ -426,41 +418,5 @@ public class AnnotationManager implements Disposable {
       annotation.updateFile(newFile);
     }
     contributionAnnotationQueue.updateAnnotationPath(oldFile, newFile);
-  }
-
-  /**
-   * Checks whether the given start and end point form a valid range.
-   *
-   * <p>The following conditions must hold true:
-   *
-   * <ul>
-   *   <li>start >= 0
-   *   <li>end >= 0
-   *   <li>start <= end
-   * </ul>
-   *
-   * Throws an <code>IllegalArgumentException</code> otherwise.
-   *
-   * @param start the start position
-   * @param end the end position
-   */
-  private void checkRange(int start, int end) {
-    if (start < 0 || end < 0) {
-      throw new IllegalArgumentException(
-          "The start and end of the annotation must not be negative "
-              + "values. start: "
-              + start
-              + ", end: "
-              + end);
-    }
-
-    if (start > end) {
-      throw new IllegalArgumentException(
-          "The start of the annotation must not be after the end of the "
-              + "annotation. start: "
-              + start
-              + ", end: "
-              + end);
-    }
   }
 }

--- a/intellij/src/saros/intellij/editor/annotations/AnnotationManager.java
+++ b/intellij/src/saros/intellij/editor/annotations/AnnotationManager.java
@@ -94,8 +94,7 @@ public class AnnotationManager implements Disposable {
         selectionAnnotationStore.removeAnnotations(user, file);
 
     for (SelectionAnnotation annotation : currentSelectionAnnotation) {
-      AbstractEditorAnnotation.removeRangeHighlighter(
-          annotation.getEditor(), annotation.getAnnotationRanges());
+      annotation.removeLocalRepresentation();
     }
   }
 
@@ -147,8 +146,7 @@ public class AnnotationManager implements Disposable {
     ContributionAnnotation dequeuedAnnotation = contributionAnnotationQueue.removeIfFull();
 
     if (dequeuedAnnotation != null) {
-      AbstractEditorAnnotation.removeRangeHighlighter(
-          dequeuedAnnotation.getEditor(), dequeuedAnnotation.getAnnotationRanges());
+      dequeuedAnnotation.removeLocalRepresentation();
     }
 
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
@@ -348,7 +346,6 @@ public class AnnotationManager implements Disposable {
    * @param annotationStore the annotation store whose annotations to reload
    * @param <E> the annotation type
    * @see AbstractEditorAnnotation#updateBoundaries()
-   * @see AbstractEditorAnnotation#removeRangeHighlighter(Editor, List)
    * @see AbstractEditorAnnotation#removeLocalRepresentation()
    * @see AbstractEditorAnnotation#addLocalRepresentation(Editor)
    */
@@ -363,9 +360,6 @@ public class AnnotationManager implements Disposable {
       }
 
       annotation.updateBoundaries();
-
-      AbstractEditorAnnotation.removeRangeHighlighter(
-          annotation.getEditor(), annotation.getAnnotationRanges());
 
       annotation.removeLocalRepresentation();
 
@@ -385,13 +379,11 @@ public class AnnotationManager implements Disposable {
   public void removeAnnotations(@NotNull User user) {
 
     for (SelectionAnnotation annotation : selectionAnnotationStore.removeAnnotations(user)) {
-      AbstractEditorAnnotation.removeRangeHighlighter(
-          annotation.getEditor(), annotation.getAnnotationRanges());
+      annotation.removeLocalRepresentation();
     }
 
     for (ContributionAnnotation annotation : contributionAnnotationQueue.removeAnnotations(user)) {
-      AbstractEditorAnnotation.removeRangeHighlighter(
-          annotation.getEditor(), annotation.getAnnotationRanges());
+      annotation.removeLocalRepresentation();
     }
   }
 
@@ -407,8 +399,7 @@ public class AnnotationManager implements Disposable {
 
     for (SelectionAnnotation selectionAnnotation : selectionAnnotationStore.getAnnotations(file)) {
 
-      AbstractEditorAnnotation.removeRangeHighlighter(
-          selectionAnnotation.getEditor(), selectionAnnotation.getAnnotationRanges());
+      selectionAnnotation.removeLocalRepresentation();
 
       selectionAnnotationStore.removeAnnotation(selectionAnnotation);
     }
@@ -416,8 +407,7 @@ public class AnnotationManager implements Disposable {
     for (ContributionAnnotation contributionAnnotation :
         contributionAnnotationQueue.getAnnotations(file)) {
 
-      AbstractEditorAnnotation.removeRangeHighlighter(
-          contributionAnnotation.getEditor(), contributionAnnotation.getAnnotationRanges());
+      contributionAnnotation.removeLocalRepresentation();
 
       contributionAnnotationQueue.removeAnnotation(contributionAnnotation);
     }
@@ -429,13 +419,11 @@ public class AnnotationManager implements Disposable {
    */
   private void removeAllAnnotations() {
     for (SelectionAnnotation annotation : selectionAnnotationStore.removeAllAnnotations()) {
-      AbstractEditorAnnotation.removeRangeHighlighter(
-          annotation.getEditor(), annotation.getAnnotationRanges());
+      annotation.removeLocalRepresentation();
     }
 
     for (ContributionAnnotation annotation : contributionAnnotationQueue.removeAllAnnotations()) {
-      AbstractEditorAnnotation.removeRangeHighlighter(
-          annotation.getEditor(), annotation.getAnnotationRanges());
+      annotation.removeLocalRepresentation();
     }
   }
 

--- a/intellij/src/saros/intellij/editor/annotations/AnnotationManager.java
+++ b/intellij/src/saros/intellij/editor/annotations/AnnotationManager.java
@@ -3,7 +3,6 @@ package saros.intellij.editor.annotations;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.markup.RangeHighlighter;
 import com.intellij.openapi.editor.markup.TextAttributes;
-import java.util.Collections;
 import java.util.List;
 import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -62,26 +61,26 @@ public class AnnotationManager implements Disposable {
       return;
     }
 
-    AnnotationRange annotationRange;
+    SelectionAnnotation selectionAnnotation;
 
-    if (editor != null) {
-      TextAttributes textAttributes = SelectionAnnotation.getSelectionTextAttributes(editor, user);
+    try {
+      selectionAnnotation = new SelectionAnnotation(user, file, start, end, editor);
 
-      RangeHighlighter rangeHighlighter =
-          AbstractEditorAnnotation.addRangeHighlighter(start, end, editor, textAttributes, file);
+    } catch (IllegalStateException e) {
+      log.warn(
+          "Failed to add contribution annotation for file "
+              + file
+              + " and user "
+              + user
+              + " at position("
+              + start
+              + ","
+              + end
+              + ").",
+          e);
 
-      if (rangeHighlighter == null) {
-        return;
-      }
-
-      annotationRange = new AnnotationRange(start, end, rangeHighlighter);
-
-    } else {
-      annotationRange = new AnnotationRange(start, end);
+      return;
     }
-
-    SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(user, file, editor, Collections.singletonList(annotationRange));
 
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
   }

--- a/intellij/src/saros/intellij/editor/annotations/AnnotationManager.java
+++ b/intellij/src/saros/intellij/editor/annotations/AnnotationManager.java
@@ -194,71 +194,25 @@ public class AnnotationManager implements Disposable {
    * a currently closed file.
    *
    * @param file the file text was added to
-   * @param start the start position of added text
-   * @param end the end position of the added text
+   * @param additionStart the start position of added text
+   * @param additionEnd the end position of the added text
    */
-  public void moveAnnotationsAfterAddition(@NotNull IFile file, int start, int end) {
+  public void moveAnnotationsAfterAddition(
+      @NotNull IFile file, int additionStart, int additionEnd) {
 
-    if (start == end) {
+    if (additionStart == additionEnd) {
       return;
     }
 
-    checkRange(start, end);
+    checkRange(additionStart, additionEnd);
 
-    moveAnnotationsAfterAddition(selectionAnnotationStore.getAnnotations(file), start, end);
-    moveAnnotationsAfterAddition(contributionAnnotationQueue.getAnnotations(file), start, end);
-  }
+    for (SelectionAnnotation annotation : selectionAnnotationStore.getAnnotations(file)) {
+      annotation.moveAfterAddition(additionStart, additionEnd);
+    }
 
-  /**
-   * If there are not range highlighters or editors present: Moves the given annotations back by the
-   * length of the addition if they are located behind the added text. Elongates the annotations by
-   * the length of the addition if they overlap with the added text.
-   *
-   * <p>Does nothing if the annotation has a local representation (an editor or range highlighters).
-   *
-   * @param annotations the annotations to move
-   * @param additionStart the star position of the added text
-   * @param additionEnd the end position of the added text
-   * @param <E> the annotation type
-   * @see #moveAnnotationsAfterAddition(IFile, int, int)
-   */
-  private <E extends AbstractEditorAnnotation> void moveAnnotationsAfterAddition(
-      @NotNull List<E> annotations, int additionStart, int additionEnd) {
-
-    int offset = additionEnd - additionStart;
-
-    annotations.forEach(
-        annotation -> {
-          if (annotation.getEditor() != null) {
-            return;
-          }
-
-          annotation
-              .getAnnotationRanges()
-              .forEach(
-                  annotationRange -> {
-                    int currentStart = annotationRange.getStart();
-                    int currentEnd = annotationRange.getEnd();
-
-                    if (annotationRange.getRangeHighlighter() != null
-                        || currentEnd <= additionStart) {
-
-                      return;
-                    }
-
-                    AnnotationRange newAnnotationRange;
-
-                    if (currentStart >= additionStart) {
-                      newAnnotationRange =
-                          new AnnotationRange(currentStart + offset, currentEnd + offset);
-
-                    } else {
-                      newAnnotationRange = new AnnotationRange(currentStart, currentEnd + offset);
-                    }
-
-                    annotation.replaceAnnotationRange(annotationRange, newAnnotationRange);
-                  });
-        });
+    for (ContributionAnnotation annotation : contributionAnnotationQueue.getAnnotations(file)) {
+      annotation.moveAfterAddition(additionStart, additionEnd);
+    }
   }
 
   /**

--- a/intellij/src/saros/intellij/editor/annotations/ContributionAnnotation.java
+++ b/intellij/src/saros/intellij/editor/annotations/ContributionAnnotation.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.editor.markup.RangeHighlighter;
 import com.intellij.openapi.editor.markup.TextAttributes;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import saros.filesystem.IFile;
@@ -24,6 +25,7 @@ import saros.session.User;
  * the creator of the contribution annotation.
  */
 class ContributionAnnotation extends AbstractEditorAnnotation {
+  private static Logger log = Logger.getLogger(ContributionAnnotation.class);
 
   /**
    * Creates a contribution annotation with the given arguments.
@@ -95,6 +97,34 @@ class ContributionAnnotation extends AbstractEditorAnnotation {
     }
 
     return annotationRanges;
+  }
+
+  // TODO check whether local representation already added; see #958
+  @Override
+  void addLocalRepresentation(@NotNull Editor editor) {
+    User user = getUser();
+
+    TextAttributes textAttributes = getContributionTextAttributes(editor, user);
+
+    addEditor(editor);
+
+    IFile file = getFile();
+
+    for (AnnotationRange annotationRange : getAnnotationRanges()) {
+      int start = annotationRange.getStart();
+      int end = annotationRange.getEnd();
+
+      RangeHighlighter rangeHighlighter =
+          AbstractEditorAnnotation.addRangeHighlighter(start, end, editor, textAttributes, file);
+
+      if (rangeHighlighter != null) {
+        annotationRange.addRangeHighlighter(rangeHighlighter);
+
+      } else {
+        log.warn(
+            "Could not create range highlighter for range " + annotationRange + " for " + this);
+      }
+    }
   }
 
   /**

--- a/intellij/src/saros/intellij/editor/annotations/ContributionAnnotation.java
+++ b/intellij/src/saros/intellij/editor/annotations/ContributionAnnotation.java
@@ -70,9 +70,8 @@ class ContributionAnnotation extends AbstractEditorAnnotation {
       contributionTextAttributes = null;
     }
 
-    for (int i = 0; i < end - start; i++) {
-      int currentStart = start + i;
-      int currentEnd = start + i + 1;
+    for (int currentStart = start; currentStart < end; currentStart++) {
+      int currentEnd = currentStart + 1;
 
       AnnotationRange annotationRange;
       if (editor != null) {

--- a/intellij/src/saros/intellij/editor/annotations/ContributionAnnotation.java
+++ b/intellij/src/saros/intellij/editor/annotations/ContributionAnnotation.java
@@ -1,10 +1,14 @@
 package saros.intellij.editor.annotations;
 
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.colors.TextAttributesKey;
+import com.intellij.openapi.editor.markup.TextAttributes;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import saros.filesystem.IFile;
+import saros.intellij.editor.colorstorage.ColorManager;
+import saros.intellij.editor.colorstorage.ColorManager.ColorKeys;
 import saros.session.User;
 
 /**
@@ -51,5 +55,25 @@ class ContributionAnnotation extends AbstractEditorAnnotation {
                     + length);
           }
         });
+  }
+
+  /**
+   * Returns the text attributes used for contribution annotation range highlighters.
+   *
+   * @param editor the editor to which the annotation belongs
+   * @param user the user to whom the annotation belongs
+   * @return the text attributes used for contribution annotation range highlighters
+   */
+  // TODO make private once migration is complete
+  static TextAttributes getContributionTextAttributes(@NotNull Editor editor, @NotNull User user) {
+
+    // Retrieve color keys based on the color ID selected by this user. This will automatically
+    // fall back to default colors, if no colors for the given ID are available.
+    ColorKeys colorKeys = ColorManager.getColorKeys(user.getColorID());
+
+    TextAttributesKey highlightColorKey = colorKeys.getContributionColorKey();
+
+    // Resolve the correct text attributes based on the currently configured IDE scheme.
+    return editor.getColorsScheme().getAttributes(highlightColorKey);
   }
 }

--- a/intellij/src/saros/intellij/editor/annotations/ContributionAnnotation.java
+++ b/intellij/src/saros/intellij/editor/annotations/ContributionAnnotation.java
@@ -58,6 +58,9 @@ class ContributionAnnotation extends AbstractEditorAnnotation {
    */
   private static List<AnnotationRange> prepareAnnotationRanges(
       int start, int end, @Nullable Editor editor, @NotNull User user, @NotNull IFile file) {
+
+    checkRange(start, end);
+
     List<AnnotationRange> annotationRanges = new ArrayList<>();
 
     TextAttributes contributionTextAttributes;

--- a/intellij/src/saros/intellij/editor/annotations/ContributionAnnotation.java
+++ b/intellij/src/saros/intellij/editor/annotations/ContributionAnnotation.java
@@ -134,8 +134,8 @@ class ContributionAnnotation extends AbstractEditorAnnotation {
    * @param user the user to whom the annotation belongs
    * @return the text attributes used for contribution annotation range highlighters
    */
-  // TODO make private once migration is complete
-  static TextAttributes getContributionTextAttributes(@NotNull Editor editor, @NotNull User user) {
+  private static TextAttributes getContributionTextAttributes(
+      @NotNull Editor editor, @NotNull User user) {
 
     // Retrieve color keys based on the color ID selected by this user. This will automatically
     // fall back to default colors, if no colors for the given ID are available.

--- a/intellij/src/saros/intellij/editor/annotations/SelectionAnnotation.java
+++ b/intellij/src/saros/intellij/editor/annotations/SelectionAnnotation.java
@@ -43,6 +43,8 @@ class SelectionAnnotation extends AbstractEditorAnnotation {
   private static List<AnnotationRange> prepareAnnotationRange(
       @NotNull User user, @NotNull IFile file, int start, int end, @Nullable Editor editor) {
 
+    checkRange(start, end);
+
     AnnotationRange annotationRange;
 
     if (editor != null) {

--- a/intellij/src/saros/intellij/editor/annotations/SelectionAnnotation.java
+++ b/intellij/src/saros/intellij/editor/annotations/SelectionAnnotation.java
@@ -116,8 +116,8 @@ class SelectionAnnotation extends AbstractEditorAnnotation {
    * @param user the user to whom the annotation belongs
    * @return the text attributes used for selection annotation range highlighters
    */
-  // TODO make private once migration is complete
-  static TextAttributes getSelectionTextAttributes(@NotNull Editor editor, @NotNull User user) {
+  private static TextAttributes getSelectionTextAttributes(
+      @NotNull Editor editor, @NotNull User user) {
 
     // Retrieve color keys based on the color ID selected by this user. This will automatically
     // fall back to default colors, if no colors for the given ID are available.

--- a/intellij/src/saros/intellij/editor/annotations/SelectionAnnotation.java
+++ b/intellij/src/saros/intellij/editor/annotations/SelectionAnnotation.java
@@ -1,10 +1,14 @@
 package saros.intellij.editor.annotations;
 
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.colors.TextAttributesKey;
+import com.intellij.openapi.editor.markup.TextAttributes;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import saros.filesystem.IFile;
+import saros.intellij.editor.colorstorage.ColorManager;
+import saros.intellij.editor.colorstorage.ColorManager.ColorKeys;
 import saros.session.User;
 
 /**
@@ -36,5 +40,25 @@ class SelectionAnnotation extends AbstractEditorAnnotation {
       throw new IllegalArgumentException(
           "A selection annotation must have exactly one " + "AnnotationRange.");
     }
+  }
+
+  /**
+   * Returns the text attributes used for selection annotation range highlighters.
+   *
+   * @param editor the editor to which the annotation belongs
+   * @param user the user to whom the annotation belongs
+   * @return the text attributes used for selection annotation range highlighters
+   */
+  // TODO make private once migration is complete
+  static TextAttributes getSelectionTextAttributes(@NotNull Editor editor, @NotNull User user) {
+
+    // Retrieve color keys based on the color ID selected by this user. This will automatically
+    // fall back to default colors, if no colors for the given ID are available.
+    ColorKeys colorKeys = ColorManager.getColorKeys(user.getColorID());
+
+    TextAttributesKey highlightColorKey = colorKeys.getSelectionColorKey();
+
+    // Resolve the correct text attributes based on the currently configured IDE scheme.
+    return editor.getColorsScheme().getAttributes(highlightColorKey);
   }
 }

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -1075,7 +1075,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
   private void updateMovedFileState(@NotNull IFile oldFile, @NotNull IFile newFile) {
     editorManager.replaceAllEditorsForFile(oldFile, newFile);
 
-    annotationManager.updateAnnotationPath(oldFile, newFile);
+    annotationManager.updateAnnotationFile(oldFile, newFile);
   }
 
   /**

--- a/intellij/src/saros/intellij/project/SharedResourcesManager.java
+++ b/intellij/src/saros/intellij/project/SharedResourcesManager.java
@@ -220,7 +220,7 @@ public class SharedResourcesManager implements Startable {
 
     cleanUpBackgroundEditorPool(oldFile);
 
-    annotationManager.updateAnnotationPath(oldFile, newFile);
+    annotationManager.updateAnnotationFile(oldFile, newFile);
 
     try {
       setFilesystemModificationHandlerEnabled(false);

--- a/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
+++ b/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
@@ -607,16 +607,19 @@ public class AnnotationManagerTest {
   @Test
   public void testContributionAnnotationQueueRotationEditor() throws Exception {
     /* setup */
-    List<Pair<Integer, Integer>> expectedRanges = createContributionRanges(100, 200);
+    int start = 100;
+    int end = 200;
+    List<Pair<Integer, Integer>> expectedRanges = createContributionRanges(start, end);
+
+    prepareMockAddRemoveRangeHighlighters();
+    mockAddContributionRangeHighlighters(expectedRanges);
+    replayMockAddRemoveRangeHighlighters();
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, editor, createAnnotationRanges(expectedRanges, true));
+        new ContributionAnnotation(user, file, start, end, editor);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
-    ContributionAnnotation filler =
-        new ContributionAnnotation(
-            user, file, null, createAnnotationRanges(createContributionRanges(0, 1), false));
+    ContributionAnnotation filler = new ContributionAnnotation(user, file, 0, 1, null);
 
     for (int i = 0; i < MAX_CONTRIBUTION_ANNOTATIONS - 1; i++) {
       contributionAnnotationQueue.addAnnotation(filler);
@@ -658,8 +661,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+        new ContributionAnnotation(user, file, start, end, null);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     /* call to test */
@@ -690,7 +692,6 @@ public class AnnotationManagerTest {
     int start = 40;
     int end = 50;
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
-    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     SelectionAnnotation selectionAnnotation =
         new SelectionAnnotation(
@@ -698,8 +699,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+        new ContributionAnnotation(user, file, start, end, null);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     int additionStart = 2;
@@ -713,7 +713,7 @@ public class AnnotationManagerTest {
     start += additionOffset;
     end += additionOffset;
     expectedSelectionRanges = createSelectionRange(start, end);
-    expectedContributionRanges = createContributionRanges(start, end);
+    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
     assertEquals(1, selectionAnnotations.size());
@@ -742,7 +742,6 @@ public class AnnotationManagerTest {
     int start = 40;
     int end = 50;
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
-    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     SelectionAnnotation selectionAnnotation =
         new SelectionAnnotation(
@@ -750,8 +749,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+        new ContributionAnnotation(user, file, start, end, null);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     int additionStart = 45;
@@ -775,7 +773,7 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> rangesSecondHalve =
         createContributionRanges(newContributionStarSecondHalve, newContributionEndSecondHalve);
 
-    expectedContributionRanges = new ArrayList<>();
+    List<Pair<Integer, Integer>> expectedContributionRanges = new ArrayList<>();
     expectedContributionRanges.addAll(rangesFirstHalve);
     expectedContributionRanges.addAll(rangesSecondHalve);
 
@@ -798,12 +796,16 @@ public class AnnotationManagerTest {
    * or after the annotation. The annotation position should not be adjusted in any case.
    */
   @Test
-  public void testMoveAnnotationsAfterAdditionEditor() {
+  public void testMoveAnnotationsAfterAdditionEditor() throws Exception {
     /* setup */
     int start = 40;
     int end = 50;
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
+
+    prepareMockAddRemoveRangeHighlighters();
+    mockAddContributionRangeHighlighters(expectedContributionRanges);
+    replayMockAddRemoveRangeHighlighters();
 
     SelectionAnnotation selectionAnnotation =
         new SelectionAnnotation(
@@ -811,8 +813,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, editor, createAnnotationRanges(expectedContributionRanges, true));
+        new ContributionAnnotation(user, file, start, end, editor);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     int additionStartBefore = 50;
@@ -900,8 +901,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+        new ContributionAnnotation(user, file, start, end, null);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     int additionStartBefore = 50;
@@ -983,8 +983,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+        new ContributionAnnotation(user, file, start, end, null);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     /* call to test */
@@ -1015,7 +1014,6 @@ public class AnnotationManagerTest {
     int start = 40;
     int end = 50;
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
-    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     SelectionAnnotation selectionAnnotation =
         new SelectionAnnotation(
@@ -1023,8 +1021,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+        new ContributionAnnotation(user, file, start, end, null);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     int deletionStart = 2;
@@ -1038,7 +1035,7 @@ public class AnnotationManagerTest {
     start -= deletionOffset;
     end -= deletionOffset;
     expectedSelectionRanges = createSelectionRange(start, end);
-    expectedContributionRanges = createContributionRanges(start, end);
+    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
     assertEquals(1, selectionAnnotations.size());
@@ -1065,7 +1062,6 @@ public class AnnotationManagerTest {
     int start = 40;
     int end = 50;
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
-    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     SelectionAnnotation selectionAnnotation =
         new SelectionAnnotation(
@@ -1073,8 +1069,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+        new ContributionAnnotation(user, file, start, end, null);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     int deletionStart = 33;
@@ -1088,7 +1083,7 @@ public class AnnotationManagerTest {
     start = deletionStart;
     end -= deletionOffset;
     expectedSelectionRanges = createSelectionRange(start, end);
-    expectedContributionRanges = createContributionRanges(start, end);
+    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
     assertEquals(1, selectionAnnotations.size());
@@ -1114,7 +1109,6 @@ public class AnnotationManagerTest {
     int start = 40;
     int end = 50;
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
-    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     SelectionAnnotation selectionAnnotation =
         new SelectionAnnotation(
@@ -1122,8 +1116,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+        new ContributionAnnotation(user, file, start, end, null);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     int deletionStart = 45;
@@ -1136,7 +1129,7 @@ public class AnnotationManagerTest {
     /* check assertions */
     end -= deletionOffset;
     expectedSelectionRanges = createSelectionRange(start, end);
-    expectedContributionRanges = createContributionRanges(start, end);
+    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
     assertEquals(1, selectionAnnotations.size());
@@ -1163,7 +1156,6 @@ public class AnnotationManagerTest {
     int start = 40;
     int end = 50;
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
-    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     SelectionAnnotation selectionAnnotation =
         new SelectionAnnotation(
@@ -1171,8 +1163,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+        new ContributionAnnotation(user, file, start, end, null);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     int deletionStart = 48;
@@ -1184,7 +1175,7 @@ public class AnnotationManagerTest {
     /* check assertions */
     end = deletionStart;
     expectedSelectionRanges = createSelectionRange(start, end);
-    expectedContributionRanges = createContributionRanges(start, end);
+    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
     assertEquals(1, selectionAnnotations.size());
@@ -1210,7 +1201,6 @@ public class AnnotationManagerTest {
     int start = 40;
     int end = 50;
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
-    List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     SelectionAnnotation selectionAnnotation =
         new SelectionAnnotation(
@@ -1218,8 +1208,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+        new ContributionAnnotation(user, file, start, end, null);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     int deletionStart = 30;
@@ -1242,12 +1231,16 @@ public class AnnotationManagerTest {
    * annotation position should not change in any case.
    */
   @Test
-  public void testMoveAnnotationsAfterDeletionEditor() {
+  public void testMoveAnnotationsAfterDeletionEditor() throws Exception {
     /* setup */
     int start = 40;
     int end = 50;
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
+
+    prepareMockAddRemoveRangeHighlighters();
+    mockAddContributionRangeHighlighters(expectedContributionRanges);
+    replayMockAddRemoveRangeHighlighters();
 
     SelectionAnnotation selectionAnnotation =
         new SelectionAnnotation(
@@ -1255,8 +1248,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, editor, createAnnotationRanges(expectedContributionRanges, true));
+        new ContributionAnnotation(user, file, start, end, editor);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     int deletionStartBefore = 50;
@@ -1406,8 +1398,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+        new ContributionAnnotation(user, file, start, end, null);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     int deletionStartBefore = 50;
@@ -1552,8 +1543,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+        new ContributionAnnotation(user, file, start, end, null);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     assertAnnotationIntegrity(selectionAnnotation, user, file, expectedSelectionRanges, null);
@@ -1589,7 +1579,7 @@ public class AnnotationManagerTest {
    * their range highlighter.
    */
   @Test
-  public void testUpdateAnnotationStore() {
+  public void testUpdateAnnotationStore() throws Exception {
     /* setup */
     int start = 12;
     int end = 34;
@@ -1632,7 +1622,7 @@ public class AnnotationManagerTest {
                 })
             .collect(Collectors.toList());
 
-    List<AnnotationRange> contributionAnnotationRanges =
+    List<Pair<Pair<Integer, Integer>, RangeHighlighter>> contributionRangePairs =
         startContributionRanges
             .stream()
             .map(
@@ -1654,16 +1644,20 @@ public class AnnotationManagerTest {
 
                   EasyMock.replay(rangeHighlighter);
 
-                  return new AnnotationRange(rangeStart, rangeEnd, rangeHighlighter);
+                  return new ImmutablePair<>(range, rangeHighlighter);
                 })
             .collect(Collectors.toList());
+
+    prepareMockAddRemoveRangeHighlighters();
+    mockAddContributionRangeHighlightersWithGivenRangeHighlighters(contributionRangePairs);
+    replayMockAddRemoveRangeHighlighters();
 
     SelectionAnnotation selectionAnnotation =
         new SelectionAnnotation(user, file, editor, selectionAnnotationRanges);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(user, file, editor, contributionAnnotationRanges);
+        new ContributionAnnotation(user, file, start, end, editor);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     /* call to test */
@@ -1691,7 +1685,7 @@ public class AnnotationManagerTest {
    * annotation store.
    */
   @Test
-  public void testUpdateAnnotationStoreRemoveInvalidAnnotations() {
+  public void testUpdateAnnotationStoreRemoveInvalidAnnotations() throws Exception {
     /* setup */
     int start = 12;
     int end = 34;
@@ -1725,7 +1719,7 @@ public class AnnotationManagerTest {
                 })
             .collect(Collectors.toList());
 
-    List<AnnotationRange> contributionAnnotationRanges =
+    List<Pair<Pair<Integer, Integer>, RangeHighlighter>> contributionRangePairs =
         startContributionRanges
             .stream()
             .map(
@@ -1744,16 +1738,20 @@ public class AnnotationManagerTest {
 
                   EasyMock.replay(rangeHighlighter);
 
-                  return new AnnotationRange(rangeStart, rangeEnd, rangeHighlighter);
+                  return new ImmutablePair<>(range, rangeHighlighter);
                 })
             .collect(Collectors.toList());
+
+    prepareMockAddRemoveRangeHighlighters();
+    mockAddContributionRangeHighlightersWithGivenRangeHighlighters(contributionRangePairs);
+    replayMockAddRemoveRangeHighlighters();
 
     SelectionAnnotation selectionAnnotation =
         new SelectionAnnotation(user, file, editor, selectionAnnotationRanges);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(user, file, editor, contributionAnnotationRanges);
+        new ContributionAnnotation(user, file, start, end, editor);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     /* call to test */
@@ -1774,12 +1772,16 @@ public class AnnotationManagerTest {
    * annotation ranges.
    */
   @Test
-  public void testRemoveLocalRepresentation() {
+  public void testRemoveLocalRepresentation() throws Exception {
     /* setup */
     int start = 40;
     int end = 50;
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
+
+    prepareMockAddRemoveRangeHighlighters();
+    mockAddContributionRangeHighlighters(expectedContributionRanges);
+    replayMockAddRemoveRangeHighlighters();
 
     SelectionAnnotation selectionAnnotation =
         new SelectionAnnotation(
@@ -1787,8 +1789,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, editor, createAnnotationRanges(expectedContributionRanges, true));
+        new ContributionAnnotation(user, file, start, end, editor);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     /* call to test */
@@ -1814,7 +1815,7 @@ public class AnnotationManagerTest {
    * should be changed.
    */
   @Test
-  public void testRemoveLocalRepresentationDifferentFile() {
+  public void testRemoveLocalRepresentationDifferentFile() throws Exception {
     /* setup */
     IFile file2 = EasyMock.createNiceMock(IFile.class);
 
@@ -1823,14 +1824,17 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
+    prepareMockAddRemoveRangeHighlighters();
+    mockAddContributionRangeHighlighters(expectedContributionRanges);
+    replayMockAddRemoveRangeHighlighters();
+
     SelectionAnnotation selectionAnnotation =
         new SelectionAnnotation(
             user, file, editor, createAnnotationRanges(expectedSelectionRanges, true));
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, editor, createAnnotationRanges(expectedContributionRanges, true));
+        new ContributionAnnotation(user, file, start, end, editor);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     /* call to test */
@@ -1867,23 +1871,26 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
+    prepareMockAddRemoveRangeHighlighters();
+    mockAddContributionRangeHighlighters(expectedContributionRanges);
+    replayMockAddRemoveRangeHighlighters();
+
     List<AnnotationRange> selectionAnnotationRanges =
         createAnnotationRanges(expectedSelectionRanges, true);
+
     SelectionAnnotation selectionAnnotation =
         new SelectionAnnotation(user, file, editor, selectionAnnotationRanges);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
-    List<AnnotationRange> contributionAnnotationRanges =
-        createAnnotationRanges(expectedContributionRanges, true);
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(user, file, editor, contributionAnnotationRanges);
+        new ContributionAnnotation(user, file, start, end, editor);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     prepareMockAddRemoveRangeHighlighters();
     mockAddSelectionRangeHighlighters(expectedSelectionRanges);
     mockAddContributionRangeHighlighters(expectedContributionRanges);
     mockRemoveRangeHighlighters(editor, selectionAnnotationRanges);
-    mockRemoveRangeHighlighters(editor, contributionAnnotationRanges);
+    mockRemoveRangeHighlighters(editor, contributionAnnotation.getAnnotationRanges());
     replayMockAddRemoveRangeHighlighters();
 
     /* call to mock */
@@ -1923,15 +1930,17 @@ public class AnnotationManagerTest {
         new SelectionAnnotation(user, file, editor, selectionAnnotationRanges);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
-    List<AnnotationRange> contributionAnnotationRanges =
-        createAnnotationRanges(expectedContributionRanges, true);
+    prepareMockAddRemoveRangeHighlighters();
+    mockAddContributionRangeHighlighters(expectedContributionRanges);
+    replayMockAddRemoveRangeHighlighters();
+
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(user, file, editor, contributionAnnotationRanges);
+        new ContributionAnnotation(user, file, start, end, editor);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     prepareMockAddRemoveRangeHighlighters();
     mockRemoveRangeHighlighters(editor, selectionAnnotationRanges);
-    mockRemoveRangeHighlighters(editor, contributionAnnotationRanges);
+    mockRemoveRangeHighlighters(editor, contributionAnnotation.getAnnotationRanges());
     replayMockAddRemoveRangeHighlighters();
 
     /* calls to test */
@@ -1966,8 +1975,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+        new ContributionAnnotation(user, file, start, end, null);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     /* calls to test */
@@ -1997,21 +2005,23 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
+    prepareMockAddRemoveRangeHighlighters();
+    mockAddContributionRangeHighlighters(expectedContributionRanges);
+    replayMockAddRemoveRangeHighlighters();
+
     List<AnnotationRange> selectionAnnotationRanges =
         createAnnotationRanges(expectedSelectionRanges, true);
     SelectionAnnotation selectionAnnotation =
         new SelectionAnnotation(user, file, editor, selectionAnnotationRanges);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
-    List<AnnotationRange> contributionAnnotationRanges =
-        createAnnotationRanges(expectedContributionRanges, true);
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(user, file, editor, contributionAnnotationRanges);
+        new ContributionAnnotation(user, file, start, end, editor);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     prepareMockAddRemoveRangeHighlighters();
     mockRemoveRangeHighlighters(editor, selectionAnnotationRanges);
-    mockRemoveRangeHighlighters(editor, contributionAnnotationRanges);
+    mockRemoveRangeHighlighters(editor, contributionAnnotation.getAnnotationRanges());
     replayMockAddRemoveRangeHighlighters();
 
     /* calls to test */
@@ -2048,8 +2058,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+        new ContributionAnnotation(user, file, start, end, null);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     /* calls to test */
@@ -2083,15 +2092,18 @@ public class AnnotationManagerTest {
 
     List<AnnotationRange> selectionAnnotationRanges =
         createAnnotationRanges(expectedSelectionRanges, true);
-    List<AnnotationRange> contributionAnnotationRanges =
-        createAnnotationRanges(expectedContributionRanges, true);
+
+    prepareMockAddRemoveRangeHighlighters();
+    mockAddContributionRangeHighlighters(expectedContributionRanges, file);
+    mockAddContributionRangeHighlighters(expectedContributionRanges, file2);
+    replayMockAddRemoveRangeHighlighters();
 
     SelectionAnnotation selectionAnnotation1 =
         new SelectionAnnotation(user, file, editor, selectionAnnotationRanges);
     selectionAnnotationStore.addAnnotation(selectionAnnotation1);
 
     ContributionAnnotation contributionAnnotation1 =
-        new ContributionAnnotation(user, file, editor, contributionAnnotationRanges);
+        new ContributionAnnotation(user, file, start, end, editor);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation1);
 
     SelectionAnnotation selectionAnnotation2 =
@@ -2099,7 +2111,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation2);
 
     ContributionAnnotation contributionAnnotation2 =
-        new ContributionAnnotation(user2, file, editor, contributionAnnotationRanges);
+        new ContributionAnnotation(user2, file, start, end, editor);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation2);
 
     SelectionAnnotation selectionAnnotation3 =
@@ -2107,7 +2119,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation3);
 
     ContributionAnnotation contributionAnnotation3 =
-        new ContributionAnnotation(user, file2, editor, contributionAnnotationRanges);
+        new ContributionAnnotation(user, file2, start, end, editor);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation3);
 
     SelectionAnnotation selectionAnnotation4 =
@@ -2115,12 +2127,15 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation4);
 
     ContributionAnnotation contributionAnnotation4 =
-        new ContributionAnnotation(user2, file2, editor, contributionAnnotationRanges);
+        new ContributionAnnotation(user2, file2, start, end, editor);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation4);
 
     prepareMockAddRemoveRangeHighlighters();
-    mockRemoveRangeHighlighters(editor, selectionAnnotationRanges);
-    mockRemoveRangeHighlighters(editor, contributionAnnotationRanges);
+    mockRemoveRangeHighlighters(editor, selectionAnnotation1.getAnnotationRanges());
+    mockRemoveRangeHighlighters(editor, contributionAnnotation1.getAnnotationRanges());
+    mockRemoveRangeHighlighters(editor, contributionAnnotation2.getAnnotationRanges());
+    mockRemoveRangeHighlighters(editor, contributionAnnotation3.getAnnotationRanges());
+    mockRemoveRangeHighlighters(editor, contributionAnnotation4.getAnnotationRanges());
     replayMockAddRemoveRangeHighlighters();
 
     /* calls to test */
@@ -2154,8 +2169,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+        new ContributionAnnotation(user, file, start, end, null);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     /* call to test */
@@ -2198,8 +2212,7 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
-        new ContributionAnnotation(
-            user, file, null, createAnnotationRanges(expectedContributionRanges, false));
+        new ContributionAnnotation(user, file, start, end, null);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     /* call to test */
@@ -2340,8 +2353,8 @@ public class AnnotationManagerTest {
   }
 
   /**
-   * Must be called before the first call to {@link #mockAddRangeHighlighters(List, TextAttributes)}
-   * or {@link #mockRemoveRangeHighlighters(Editor, List)}.
+   * Must be called before the first call to {@link #mockAddRangeHighlighters(List, TextAttributes,
+   * IFile)} or {@link #mockRemoveRangeHighlighters(Editor, List)}.
    */
   private void prepareMockAddRemoveRangeHighlighters() {
     PowerMock.mockStaticPartial(
@@ -2350,14 +2363,24 @@ public class AnnotationManagerTest {
 
   private void mockAddSelectionRangeHighlighters(List<Pair<Integer, Integer>> ranges)
       throws Exception {
+    mockAddSelectionRangeHighlighters(ranges, file);
+  }
 
-    mockAddRangeHighlighters(ranges, selectionTextAttributes);
+  private void mockAddSelectionRangeHighlighters(List<Pair<Integer, Integer>> ranges, IFile file)
+      throws Exception {
+
+    mockAddRangeHighlighters(ranges, selectionTextAttributes, file);
   }
 
   private void mockAddContributionRangeHighlighters(List<Pair<Integer, Integer>> ranges)
       throws Exception {
+    mockAddContributionRangeHighlighters(ranges, file);
+  }
 
-    mockAddRangeHighlighters(ranges, contributionTextAttributes);
+  private void mockAddContributionRangeHighlighters(List<Pair<Integer, Integer>> ranges, IFile file)
+      throws Exception {
+
+    mockAddRangeHighlighters(ranges, contributionTextAttributes, file);
   }
 
   /**
@@ -2369,16 +2392,80 @@ public class AnnotationManagerTest {
    * call to this method to replay the added mocking logic.
    *
    * @param ranges the ranges to mock
+   * @param textAttributes the text attributes of the annotation; either {@link
+   *     #selectionTextAttributes} or {@link #contributionTextAttributes}
+   * @param file the file of the annotation
    * @throws Exception see {@link PowerMock#expectPrivate(Object, Method, Object...)}
    */
   private void mockAddRangeHighlighters(
-      List<Pair<Integer, Integer>> ranges, TextAttributes textAttributes) throws Exception {
+      List<Pair<Integer, Integer>> ranges, TextAttributes textAttributes, IFile file)
+      throws Exception {
 
     for (Pair<Integer, Integer> range : ranges) {
       int rangeStart = range.getLeft();
       int rangeEnd = range.getRight();
 
       RangeHighlighter rangeHighlighter = mockRangeHighlighter(rangeStart, rangeEnd);
+
+      PowerMock.expectPrivate(
+              AbstractEditorAnnotation.class,
+              "addRangeHighlighter",
+              rangeStart,
+              rangeEnd,
+              editor,
+              textAttributes,
+              file)
+          .andStubReturn(rangeHighlighter);
+    }
+  }
+
+  private void mockAddSelectionRangeHighlightersWithGivenRangeHighlighters(
+      List<Pair<Pair<Integer, Integer>, RangeHighlighter>> rangePairs) throws Exception {
+
+    mockAddRangeHighlightersWithGivenRangeHighlighters(rangePairs, selectionTextAttributes);
+  }
+
+  private void mockAddContributionRangeHighlightersWithGivenRangeHighlighters(
+      List<Pair<Pair<Integer, Integer>, RangeHighlighter>> rangePairs) throws Exception {
+
+    mockAddRangeHighlightersWithGivenRangeHighlighters(rangePairs, contributionTextAttributes);
+  }
+
+  private void mockAddRangeHighlightersWithGivenRangeHighlighters(
+      List<Pair<Pair<Integer, Integer>, RangeHighlighter>> rangePairs,
+      TextAttributes textAttributes)
+      throws Exception {
+
+    mockAddRangeHighlightersWithGivenRangeHighlighters(rangePairs, textAttributes, file);
+  }
+
+  /**
+   * Mocks the method creating the actual range highlighters in the editor for the list of given
+   * ranges to return the given range highlighter.
+   *
+   * <p>{@link #prepareMockAddRemoveRangeHighlighters()} must be called before the first call to
+   * this methods and {@link #replayMockAddRemoveRangeHighlighters()} must be called after the last
+   * call to this method to replay the added mocking logic.
+   *
+   * @param rangePairs the pairs of ranges and their highlighters with which to create the mock
+   * @param textAttributes the text attributes of the annotation; either {@link
+   *     #selectionTextAttributes} or {@link #contributionTextAttributes}
+   * @param file the file of the annotation
+   * @throws Exception see {@link PowerMock#expectPrivate(Object, Method, Object...)}
+   */
+  private void mockAddRangeHighlightersWithGivenRangeHighlighters(
+      List<Pair<Pair<Integer, Integer>, RangeHighlighter>> rangePairs,
+      TextAttributes textAttributes,
+      IFile file)
+      throws Exception {
+
+    for (Pair<Pair<Integer, Integer>, RangeHighlighter> rangePair : rangePairs) {
+      Pair<Integer, Integer> range = rangePair.getLeft();
+
+      RangeHighlighter rangeHighlighter = rangePair.getRight();
+
+      int rangeStart = range.getLeft();
+      int rangeEnd = range.getRight();
 
       PowerMock.expectPrivate(
               AbstractEditorAnnotation.class,
@@ -2417,8 +2504,8 @@ public class AnnotationManagerTest {
   }
 
   /**
-   * Must be called after the last call to {@link #mockAddRangeHighlighters(List, TextAttributes)}
-   * or {@link #mockRemoveRangeHighlighters(Editor, List)}.
+   * Must be called after the last call to {@link #mockAddRangeHighlighters(List, TextAttributes,
+   * IFile)} or {@link #mockRemoveRangeHighlighters(Editor, List)}.
    */
   private void replayMockAddRemoveRangeHighlighters() {
     PowerMock.replay(AbstractEditorAnnotation.class);

--- a/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
+++ b/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
@@ -209,7 +209,7 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedRange = createSelectionRange(start, end);
 
     prepareMockAddRemoveRangeHighlighters();
-    mockAddSelectionRangeHighlighters(expectedRange);
+    mockAddRemoveSelectionRangeHighlighters(expectedRange, file, editor);
     replayMockAddRemoveRangeHighlighters();
 
     SelectionAnnotation selectionAnnotation =
@@ -221,11 +221,6 @@ public class AnnotationManagerTest {
     start = 15;
     end = 22;
     expectedRange = createSelectionRange(start, end);
-
-    prepareMockAddRemoveRangeHighlighters();
-    mockRemoveRangeHighlighters(editor, selectionAnnotation.getAnnotationRanges());
-    mockAddSelectionRangeHighlighters(expectedRange);
-    replayMockAddRemoveRangeHighlighters();
 
     /* call to test */
     annotationManager.addSelectionAnnotation(user, file, start, end, null);
@@ -386,7 +381,7 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedRange = createSelectionRange(start, end);
 
     prepareMockAddRemoveRangeHighlighters();
-    mockAddSelectionRangeHighlighters(expectedRange);
+    mockAddRemoveSelectionRangeHighlighters(expectedRange, file, editor);
     replayMockAddRemoveRangeHighlighters();
 
     SelectionAnnotation selectionAnnotation =
@@ -394,10 +389,6 @@ public class AnnotationManagerTest {
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     assertEquals(1, selectionAnnotationStore.getAnnotations().size());
-
-    prepareMockAddRemoveRangeHighlighters();
-    mockRemoveRangeHighlighters(editor, selectionAnnotation.getAnnotationRanges());
-    replayMockAddRemoveRangeHighlighters();
 
     /* call to test */
     annotationManager.removeSelectionAnnotation(user, file);
@@ -623,7 +614,7 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedRanges = createContributionRanges(start, end);
 
     prepareMockAddRemoveRangeHighlighters();
-    mockAddContributionRangeHighlighters(expectedRanges);
+    mockAddRemoveContributionRangeHighlighters(expectedRanges, file, editor);
     replayMockAddRemoveRangeHighlighters();
 
     ContributionAnnotation contributionAnnotation =
@@ -639,10 +630,6 @@ public class AnnotationManagerTest {
     List<ContributionAnnotation> contributionAnnotations =
         contributionAnnotationQueue.getAnnotations();
     assertTrue(contributionAnnotations.contains(contributionAnnotation));
-
-    prepareMockAddRemoveRangeHighlighters();
-    mockRemoveRangeHighlighters(editor, contributionAnnotation.getAnnotationRanges());
-    replayMockAddRemoveRangeHighlighters();
 
     /* call to test */
     annotationManager.addContributionAnnotation(user, file, 0, 1, null);
@@ -1763,8 +1750,8 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     prepareMockAddRemoveRangeHighlighters();
-    mockAddSelectionRangeHighlighters(expectedSelectionRanges);
-    mockAddContributionRangeHighlighters(expectedContributionRanges);
+    mockAddRemoveSelectionRangeHighlighters(expectedSelectionRanges, file, editor);
+    mockAddRemoveContributionRangeHighlighters(expectedContributionRanges, file, editor);
     replayMockAddRemoveRangeHighlighters();
 
     SelectionAnnotation selectionAnnotation =
@@ -1774,11 +1761,6 @@ public class AnnotationManagerTest {
     ContributionAnnotation contributionAnnotation =
         new ContributionAnnotation(user, file, start, end, editor);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
-
-    prepareMockAddRemoveRangeHighlighters();
-    mockRemoveRangeHighlighters(editor, selectionAnnotation.getAnnotationRanges());
-    mockRemoveRangeHighlighters(editor, contributionAnnotation.getAnnotationRanges());
-    replayMockAddRemoveRangeHighlighters();
 
     /* call to test */
     annotationManager.removeLocalRepresentation(file);
@@ -1862,8 +1844,8 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     prepareMockAddRemoveRangeHighlighters();
-    mockAddSelectionRangeHighlighters(expectedSelectionRanges);
-    mockAddContributionRangeHighlighters(expectedContributionRanges);
+    mockAddRemoveSelectionRangeHighlighters(expectedSelectionRanges, file, editor);
+    mockAddRemoveContributionRangeHighlighters(expectedContributionRanges, file, editor);
     replayMockAddRemoveRangeHighlighters();
 
     SelectionAnnotation selectionAnnotation =
@@ -1873,13 +1855,6 @@ public class AnnotationManagerTest {
     ContributionAnnotation contributionAnnotation =
         new ContributionAnnotation(user, file, start, end, editor);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
-
-    prepareMockAddRemoveRangeHighlighters();
-    mockAddSelectionRangeHighlighters(expectedSelectionRanges);
-    mockAddContributionRangeHighlighters(expectedContributionRanges);
-    mockRemoveRangeHighlighters(editor, selectionAnnotation.getAnnotationRanges());
-    mockRemoveRangeHighlighters(editor, contributionAnnotation.getAnnotationRanges());
-    replayMockAddRemoveRangeHighlighters();
 
     /* call to mock */
     annotationManager.reloadAnnotations();
@@ -1913,8 +1888,8 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     prepareMockAddRemoveRangeHighlighters();
-    mockAddSelectionRangeHighlighters(expectedSelectionRanges);
-    mockAddContributionRangeHighlighters(expectedContributionRanges);
+    mockAddRemoveSelectionRangeHighlighters(expectedSelectionRanges, file, editor);
+    mockAddRemoveContributionRangeHighlighters(expectedContributionRanges, file, editor);
     replayMockAddRemoveRangeHighlighters();
 
     SelectionAnnotation selectionAnnotation =
@@ -1924,11 +1899,6 @@ public class AnnotationManagerTest {
     ContributionAnnotation contributionAnnotation =
         new ContributionAnnotation(user, file, start, end, editor);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
-
-    prepareMockAddRemoveRangeHighlighters();
-    mockRemoveRangeHighlighters(editor, selectionAnnotation.getAnnotationRanges());
-    mockRemoveRangeHighlighters(editor, contributionAnnotation.getAnnotationRanges());
-    replayMockAddRemoveRangeHighlighters();
 
     /* calls to test */
     annotationManager.removeAnnotations(user);
@@ -1991,8 +1961,8 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     prepareMockAddRemoveRangeHighlighters();
-    mockAddSelectionRangeHighlighters(expectedSelectionRanges);
-    mockAddContributionRangeHighlighters(expectedContributionRanges);
+    mockAddRemoveSelectionRangeHighlighters(expectedSelectionRanges, file, editor);
+    mockAddRemoveContributionRangeHighlighters(expectedContributionRanges, file, editor);
     replayMockAddRemoveRangeHighlighters();
 
     SelectionAnnotation selectionAnnotation =
@@ -2002,11 +1972,6 @@ public class AnnotationManagerTest {
     ContributionAnnotation contributionAnnotation =
         new ContributionAnnotation(user, file, start, end, editor);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
-
-    prepareMockAddRemoveRangeHighlighters();
-    mockRemoveRangeHighlighters(editor, selectionAnnotation.getAnnotationRanges());
-    mockRemoveRangeHighlighters(editor, contributionAnnotation.getAnnotationRanges());
-    replayMockAddRemoveRangeHighlighters();
 
     /* calls to test */
     annotationManager.removeAnnotations(file);
@@ -2073,10 +2038,10 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     prepareMockAddRemoveRangeHighlighters();
-    mockAddSelectionRangeHighlighters(expectedSelectionRanges, file);
-    mockAddSelectionRangeHighlighters(expectedSelectionRanges, file2);
-    mockAddContributionRangeHighlighters(expectedContributionRanges, file);
-    mockAddContributionRangeHighlighters(expectedContributionRanges, file2);
+    mockAddRemoveSelectionRangeHighlighters(expectedSelectionRanges, file, editor);
+    mockAddRemoveSelectionRangeHighlighters(expectedSelectionRanges, file2, editor);
+    mockAddRemoveContributionRangeHighlighters(expectedContributionRanges, file, editor);
+    mockAddRemoveContributionRangeHighlighters(expectedContributionRanges, file2, editor);
     replayMockAddRemoveRangeHighlighters();
 
     SelectionAnnotation selectionAnnotation1 =
@@ -2110,13 +2075,6 @@ public class AnnotationManagerTest {
     ContributionAnnotation contributionAnnotation4 =
         new ContributionAnnotation(user2, file2, start, end, editor);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation4);
-
-    prepareMockAddRemoveRangeHighlighters();
-    mockRemoveRangeHighlighters(editor, selectionAnnotation1.getAnnotationRanges());
-    mockRemoveRangeHighlighters(editor, selectionAnnotation3.getAnnotationRanges());
-    mockRemoveRangeHighlighters(editor, contributionAnnotation1.getAnnotationRanges());
-    mockRemoveRangeHighlighters(editor, contributionAnnotation3.getAnnotationRanges());
-    replayMockAddRemoveRangeHighlighters();
 
     /* calls to test */
     annotationManager.dispose();
@@ -2309,90 +2267,75 @@ public class AnnotationManagerTest {
   }
 
   /**
-   * Must be called before the first call to {@link #mockAddRangeHighlighters(List, TextAttributes,
-   * IFile)} or {@link #mockRemoveRangeHighlighters(Editor, List)}.
+   * Must be called before the first call to {@link
+   * #mockAddRangeHighlightersWithGivenRangeHighlighters(List, TextAttributes, IFile)} or {@link
+   * #mockAddRemoveRangeHighlighters(List, IFile, Editor, TextAttributes)}.
    */
   private void prepareMockAddRemoveRangeHighlighters() {
     PowerMock.mockStaticPartial(
         AbstractEditorAnnotation.class, "addRangeHighlighter", "removeRangeHighlighter");
   }
 
-  private void mockAddSelectionRangeHighlighters(List<Pair<Integer, Integer>> ranges)
-      throws Exception {
-    mockAddSelectionRangeHighlighters(ranges, file);
+  /**
+   * Must be called after the last call to {@link
+   * #mockAddRangeHighlightersWithGivenRangeHighlighters(List, TextAttributes, IFile)} or {@link
+   * #mockAddRemoveRangeHighlighters(List, IFile, Editor, TextAttributes)}.
+   */
+  private void replayMockAddRemoveRangeHighlighters() {
+    PowerMock.replay(AbstractEditorAnnotation.class);
   }
 
-  private void mockAddSelectionRangeHighlighters(List<Pair<Integer, Integer>> ranges, IFile file)
-      throws Exception {
+  /**
+   * Verifies that all added range highlighter removal mocks where called at least once. This can be
+   * used to check whether the local representation of removed annotations was also removed.
+   *
+   * @see #mockAddRemoveRangeHighlighters(List, IFile, Editor, TextAttributes)
+   */
+  private void verifyRemovalCall() {
+    PowerMock.verify(AnnotationManager.class);
+  }
 
+  private void mockAddSelectionRangeHighlighters(List<Pair<Integer, Integer>> ranges)
+      throws Exception {
     mockAddRangeHighlighters(ranges, selectionTextAttributes, file);
   }
 
   private void mockAddContributionRangeHighlighters(List<Pair<Integer, Integer>> ranges)
       throws Exception {
-    mockAddContributionRangeHighlighters(ranges, file);
-  }
-
-  private void mockAddContributionRangeHighlighters(List<Pair<Integer, Integer>> ranges, IFile file)
-      throws Exception {
-
     mockAddRangeHighlighters(ranges, contributionTextAttributes, file);
   }
 
   /**
-   * Mocks the method creating the actual range highlighters in the editor for the list of given
-   * ranges.
-   *
-   * <p>{@link #prepareMockAddRemoveRangeHighlighters()} must be called before the first call to
-   * this methods and {@link #replayMockAddRemoveRangeHighlighters()} must be called after the last
-   * call to this method to replay the added mocking logic.
-   *
-   * @param ranges the ranges to mock
-   * @param textAttributes the text attributes of the annotation; either {@link
-   *     #selectionTextAttributes} or {@link #contributionTextAttributes}
-   * @param file the file of the annotation
-   * @throws Exception see {@link PowerMock#expectPrivate(Object, Method, Object...)}
+   * Calls {@link #mockAddContributionRangeHighlightersWithGivenRangeHighlighters(List)} with an
+   * internally created list of mocked range highlighters.
    */
   private void mockAddRangeHighlighters(
       List<Pair<Integer, Integer>> ranges, TextAttributes textAttributes, IFile file)
       throws Exception {
 
+    List<Pair<Pair<Integer, Integer>, RangeHighlighter>> rangePairs =
+        new ArrayList<>(ranges.size());
+
     for (Pair<Integer, Integer> range : ranges) {
-      int rangeStart = range.getLeft();
-      int rangeEnd = range.getRight();
+      RangeHighlighter rangeHighlighter = mockRangeHighlighter(range.getLeft(), range.getRight());
 
-      RangeHighlighter rangeHighlighter = mockRangeHighlighter(rangeStart, rangeEnd);
-
-      PowerMock.expectPrivate(
-              AbstractEditorAnnotation.class,
-              "addRangeHighlighter",
-              rangeStart,
-              rangeEnd,
-              editor,
-              textAttributes,
-              file)
-          .andStubReturn(rangeHighlighter);
+      rangePairs.add(new ImmutablePair<>(range, rangeHighlighter));
     }
+
+    mockAddRangeHighlightersWithGivenRangeHighlighters(rangePairs, textAttributes, file);
   }
 
   private void mockAddSelectionRangeHighlightersWithGivenRangeHighlighters(
       List<Pair<Pair<Integer, Integer>, RangeHighlighter>> rangePairs) throws Exception {
 
-    mockAddRangeHighlightersWithGivenRangeHighlighters(rangePairs, selectionTextAttributes);
+    mockAddRangeHighlightersWithGivenRangeHighlighters(rangePairs, selectionTextAttributes, file);
   }
 
   private void mockAddContributionRangeHighlightersWithGivenRangeHighlighters(
       List<Pair<Pair<Integer, Integer>, RangeHighlighter>> rangePairs) throws Exception {
 
-    mockAddRangeHighlightersWithGivenRangeHighlighters(rangePairs, contributionTextAttributes);
-  }
-
-  private void mockAddRangeHighlightersWithGivenRangeHighlighters(
-      List<Pair<Pair<Integer, Integer>, RangeHighlighter>> rangePairs,
-      TextAttributes textAttributes)
-      throws Exception {
-
-    mockAddRangeHighlightersWithGivenRangeHighlighters(rangePairs, textAttributes, file);
+    mockAddRangeHighlightersWithGivenRangeHighlighters(
+        rangePairs, contributionTextAttributes, file);
   }
 
   /**
@@ -2435,10 +2378,21 @@ public class AnnotationManagerTest {
     }
   }
 
+  private void mockAddRemoveSelectionRangeHighlighters(
+      List<Pair<Integer, Integer>> ranges, IFile file, Editor editor) throws Exception {
+
+    mockAddRemoveRangeHighlighters(ranges, file, editor, selectionTextAttributes);
+  }
+
+  private void mockAddRemoveContributionRangeHighlighters(
+      List<Pair<Integer, Integer>> ranges, IFile file, Editor editor) throws Exception {
+
+    mockAddRemoveRangeHighlighters(ranges, file, editor, contributionTextAttributes);
+  }
+
   /**
-   * Mocks the method removing the actual range highlighters from the editor for the given
-   * annotation. The mock still removes the range highlighter objects from the given annotation
-   * ranges as this would normally also be done in <code>removeRangeHighlighter(...)</code>.
+   * Mocks the addition and removal of range highlighters for the given ranges to the given editor
+   * and file with the given text attributes.
    *
    * <p>When using this call, it is also advised to call {@link PowerMock#verify(Object...)} on
    * <code>AbstractEditorAnnotation.class</code> to ensure that the {@link
@@ -2448,41 +2402,37 @@ public class AnnotationManagerTest {
    * this methods and {@link #replayMockAddRemoveRangeHighlighters()} must be called after the last
    * call to this method to replay the added mocking logic.
    *
-   * @param editor the editor whose range highlighter removal to mock
-   * @param annotationRanges the annotation range whose highlighter removal to mock
+   * @param ranges the ranges whose highlighter addition and removal to mock
+   * @param file the file of the annotation
+   * @param editor the editor of the annotation
+   * @param textAttributes the text attributes of the annotation
    * @throws Exception see {@link PowerMock#expectPrivate(Object, Method, Object...)}
    */
-  private void mockRemoveRangeHighlighters(Editor editor, List<AnnotationRange> annotationRanges)
+  private void mockAddRemoveRangeHighlighters(
+      List<Pair<Integer, Integer>> ranges, IFile file, Editor editor, TextAttributes textAttributes)
       throws Exception {
 
-    for (AnnotationRange annotationRange : annotationRanges) {
-      RangeHighlighter rangeHighlighter = annotationRange.getRangeHighlighter();
+    for (Pair<Integer, Integer> range : ranges) {
+      int rangeStart = range.getLeft();
+      int rangeEnd = range.getRight();
 
-      if (rangeHighlighter == null) {
-        continue;
-      }
+      RangeHighlighter rangeHighlighter = mockRangeHighlighter(rangeStart, rangeEnd);
+
+      PowerMock.expectPrivate(
+              AbstractEditorAnnotation.class,
+              "addRangeHighlighter",
+              rangeStart,
+              rangeEnd,
+              editor,
+              textAttributes,
+              file)
+          .andStubReturn(rangeHighlighter);
 
       PowerMock.expectPrivate(
               AbstractEditorAnnotation.class, "removeRangeHighlighter", editor, rangeHighlighter)
           .atLeastOnce()
           .asStub();
     }
-  }
-
-  /**
-   * Must be called after the last call to {@link #mockAddRangeHighlighters(List, TextAttributes,
-   * IFile)} or {@link #mockRemoveRangeHighlighters(Editor, List)}.
-   */
-  private void replayMockAddRemoveRangeHighlighters() {
-    PowerMock.replay(AbstractEditorAnnotation.class);
-  }
-
-  /**
-   * Verifies that all added range highlighter removal mocks where called at least once. This can be
-   * used to check whether the local representation of removed annotations was also removed.
-   */
-  private void verifyRemovalCall() {
-    PowerMock.verify(AnnotationManager.class);
   }
 
   private RangeHighlighter mockRangeHighlighter(int rangeStart, int rangeEnd) {

--- a/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
+++ b/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
@@ -2151,7 +2151,7 @@ public class AnnotationManagerTest {
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     /* call to test */
-    annotationManager.updateAnnotationPath(file, file2);
+    annotationManager.updateAnnotationFile(file, file2);
 
     /* check assertions */
     List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
@@ -2192,7 +2192,7 @@ public class AnnotationManagerTest {
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     /* call to test */
-    annotationManager.updateAnnotationPath(file2, file3);
+    annotationManager.updateAnnotationFile(file2, file3);
 
     /* check assertions */
     List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();

--- a/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
+++ b/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
@@ -206,19 +206,24 @@ public class AnnotationManagerTest {
     int end = 5;
     List<Pair<Integer, Integer>> expectedRange = createSelectionRange(start, end);
 
+    prepareMockAddRemoveRangeHighlighters();
+    mockAddSelectionRangeHighlighters(expectedRange);
+    replayMockAddRemoveRangeHighlighters();
+
     SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(user, file, editor, createAnnotationRanges(expectedRange, true));
+        new SelectionAnnotation(user, file, start, end, editor);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     assertEquals(1, selectionAnnotationStore.getAnnotations().size());
 
-    prepareMockAddRemoveRangeHighlighters();
-    mockRemoveRangeHighlighters(editor, selectionAnnotation.getAnnotationRanges());
-    replayMockAddRemoveRangeHighlighters();
-
     start = 15;
     end = 22;
     expectedRange = createSelectionRange(start, end);
+
+    prepareMockAddRemoveRangeHighlighters();
+    mockRemoveRangeHighlighters(editor, selectionAnnotation.getAnnotationRanges());
+    mockAddSelectionRangeHighlighters(expectedRange);
+    replayMockAddRemoveRangeHighlighters();
 
     /* call to test */
     annotationManager.addSelectionAnnotation(user, file, start, end, null);
@@ -378,8 +383,12 @@ public class AnnotationManagerTest {
     int end = 5;
     List<Pair<Integer, Integer>> expectedRange = createSelectionRange(start, end);
 
+    prepareMockAddRemoveRangeHighlighters();
+    mockAddSelectionRangeHighlighters(expectedRange);
+    replayMockAddRemoveRangeHighlighters();
+
     SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(user, file, editor, createAnnotationRanges(expectedRange, true));
+        new SelectionAnnotation(user, file, start, end, editor);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     assertEquals(1, selectionAnnotationStore.getAnnotations().size());
@@ -655,9 +664,7 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
-    SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(
-            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    SelectionAnnotation selectionAnnotation = new SelectionAnnotation(user, file, start, end, null);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -691,11 +698,8 @@ public class AnnotationManagerTest {
     /* setup */
     int start = 40;
     int end = 50;
-    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
 
-    SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(
-            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    SelectionAnnotation selectionAnnotation = new SelectionAnnotation(user, file, start, end, null);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -712,7 +716,7 @@ public class AnnotationManagerTest {
     /* check assertions */
     start += additionOffset;
     end += additionOffset;
-    expectedSelectionRanges = createSelectionRange(start, end);
+    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
@@ -741,11 +745,8 @@ public class AnnotationManagerTest {
     /* setup */
     int start = 40;
     int end = 50;
-    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
 
-    SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(
-            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    SelectionAnnotation selectionAnnotation = new SelectionAnnotation(user, file, start, end, null);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -762,7 +763,8 @@ public class AnnotationManagerTest {
     /* check assertions */
     int newSelectionStart = start;
     int newSelectionEnd = end + additionOffset;
-    expectedSelectionRanges = createSelectionRange(newSelectionStart, newSelectionEnd);
+    List<Pair<Integer, Integer>> expectedSelectionRanges =
+        createSelectionRange(newSelectionStart, newSelectionEnd);
 
     int newContributionStartFirstHalve = start;
     int newContributionEndFirstHalve = additionStart;
@@ -804,12 +806,12 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     prepareMockAddRemoveRangeHighlighters();
+    mockAddSelectionRangeHighlighters(expectedSelectionRanges);
     mockAddContributionRangeHighlighters(expectedContributionRanges);
     replayMockAddRemoveRangeHighlighters();
 
     SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(
-            user, file, editor, createAnnotationRanges(expectedSelectionRanges, true));
+        new SelectionAnnotation(user, file, start, end, editor);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -895,9 +897,7 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
-    SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(
-            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    SelectionAnnotation selectionAnnotation = new SelectionAnnotation(user, file, start, end, null);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -977,9 +977,7 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
-    SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(
-            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    SelectionAnnotation selectionAnnotation = new SelectionAnnotation(user, file, start, end, null);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -1013,11 +1011,8 @@ public class AnnotationManagerTest {
     /* setup */
     int start = 40;
     int end = 50;
-    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
 
-    SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(
-            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    SelectionAnnotation selectionAnnotation = new SelectionAnnotation(user, file, start, end, null);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -1034,7 +1029,7 @@ public class AnnotationManagerTest {
     /* check assertions */
     start -= deletionOffset;
     end -= deletionOffset;
-    expectedSelectionRanges = createSelectionRange(start, end);
+    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
@@ -1061,11 +1056,8 @@ public class AnnotationManagerTest {
     /* setup */
     int start = 40;
     int end = 50;
-    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
 
-    SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(
-            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    SelectionAnnotation selectionAnnotation = new SelectionAnnotation(user, file, start, end, null);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -1082,7 +1074,7 @@ public class AnnotationManagerTest {
     /* check assertions */
     start = deletionStart;
     end -= deletionOffset;
-    expectedSelectionRanges = createSelectionRange(start, end);
+    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
@@ -1108,11 +1100,8 @@ public class AnnotationManagerTest {
     /* setup */
     int start = 40;
     int end = 50;
-    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
 
-    SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(
-            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    SelectionAnnotation selectionAnnotation = new SelectionAnnotation(user, file, start, end, null);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -1128,7 +1117,7 @@ public class AnnotationManagerTest {
 
     /* check assertions */
     end -= deletionOffset;
-    expectedSelectionRanges = createSelectionRange(start, end);
+    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
@@ -1155,11 +1144,8 @@ public class AnnotationManagerTest {
     /* setup */
     int start = 40;
     int end = 50;
-    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
 
-    SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(
-            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    SelectionAnnotation selectionAnnotation = new SelectionAnnotation(user, file, start, end, null);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -1174,7 +1160,7 @@ public class AnnotationManagerTest {
 
     /* check assertions */
     end = deletionStart;
-    expectedSelectionRanges = createSelectionRange(start, end);
+    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     List<SelectionAnnotation> selectionAnnotations = selectionAnnotationStore.getAnnotations();
@@ -1200,11 +1186,8 @@ public class AnnotationManagerTest {
     /* setup */
     int start = 40;
     int end = 50;
-    List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
 
-    SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(
-            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    SelectionAnnotation selectionAnnotation = new SelectionAnnotation(user, file, start, end, null);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -1239,12 +1222,12 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     prepareMockAddRemoveRangeHighlighters();
+    mockAddSelectionRangeHighlighters(expectedSelectionRanges);
     mockAddContributionRangeHighlighters(expectedContributionRanges);
     replayMockAddRemoveRangeHighlighters();
 
     SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(
-            user, file, editor, createAnnotationRanges(expectedSelectionRanges, true));
+        new SelectionAnnotation(user, file, start, end, editor);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -1392,9 +1375,7 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
-    SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(
-            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    SelectionAnnotation selectionAnnotation = new SelectionAnnotation(user, file, start, end, null);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -1537,9 +1518,7 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
-    SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(
-            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    SelectionAnnotation selectionAnnotation = new SelectionAnnotation(user, file, start, end, null);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -1596,7 +1575,7 @@ public class AnnotationManagerTest {
      * Mock range highlighters to return initial position for initialization check and adjusted
      * position for all subsequent calls.
      */
-    List<AnnotationRange> selectionAnnotationRanges =
+    List<Pair<Pair<Integer, Integer>, RangeHighlighter>> selectionRangePairs =
         startSelectionRanges
             .stream()
             .map(
@@ -1618,7 +1597,7 @@ public class AnnotationManagerTest {
 
                   EasyMock.replay(rangeHighlighter);
 
-                  return new AnnotationRange(rangeStart, rangeEnd, rangeHighlighter);
+                  return new ImmutablePair<>(range, rangeHighlighter);
                 })
             .collect(Collectors.toList());
 
@@ -1649,11 +1628,12 @@ public class AnnotationManagerTest {
             .collect(Collectors.toList());
 
     prepareMockAddRemoveRangeHighlighters();
+    mockAddSelectionRangeHighlightersWithGivenRangeHighlighters(selectionRangePairs);
     mockAddContributionRangeHighlightersWithGivenRangeHighlighters(contributionRangePairs);
     replayMockAddRemoveRangeHighlighters();
 
     SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(user, file, editor, selectionAnnotationRanges);
+        new SelectionAnnotation(user, file, start, end, editor);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -1696,7 +1676,7 @@ public class AnnotationManagerTest {
      * Mock range highlighters to return 'isValid=true' for initialization check and 'isValid=false'
      *  for all subsequent calls.
      */
-    List<AnnotationRange> selectionAnnotationRanges =
+    List<Pair<Pair<Integer, Integer>, RangeHighlighter>> selectionRangePairs =
         startSelectionRanges
             .stream()
             .map(
@@ -1715,7 +1695,7 @@ public class AnnotationManagerTest {
 
                   EasyMock.replay(rangeHighlighter);
 
-                  return new AnnotationRange(rangeStart, rangeEnd, rangeHighlighter);
+                  return new ImmutablePair<>(range, rangeHighlighter);
                 })
             .collect(Collectors.toList());
 
@@ -1743,11 +1723,12 @@ public class AnnotationManagerTest {
             .collect(Collectors.toList());
 
     prepareMockAddRemoveRangeHighlighters();
+    mockAddSelectionRangeHighlightersWithGivenRangeHighlighters(selectionRangePairs);
     mockAddContributionRangeHighlightersWithGivenRangeHighlighters(contributionRangePairs);
     replayMockAddRemoveRangeHighlighters();
 
     SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(user, file, editor, selectionAnnotationRanges);
+        new SelectionAnnotation(user, file, start, end, editor);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -1780,12 +1761,12 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     prepareMockAddRemoveRangeHighlighters();
+    mockAddSelectionRangeHighlighters(expectedSelectionRanges);
     mockAddContributionRangeHighlighters(expectedContributionRanges);
     replayMockAddRemoveRangeHighlighters();
 
     SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(
-            user, file, editor, createAnnotationRanges(expectedSelectionRanges, true));
+        new SelectionAnnotation(user, file, start, end, editor);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -1825,12 +1806,12 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     prepareMockAddRemoveRangeHighlighters();
+    mockAddSelectionRangeHighlighters(expectedSelectionRanges);
     mockAddContributionRangeHighlighters(expectedContributionRanges);
     replayMockAddRemoveRangeHighlighters();
 
     SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(
-            user, file, editor, createAnnotationRanges(expectedSelectionRanges, true));
+        new SelectionAnnotation(user, file, start, end, editor);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -1872,14 +1853,12 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     prepareMockAddRemoveRangeHighlighters();
+    mockAddSelectionRangeHighlighters(expectedSelectionRanges);
     mockAddContributionRangeHighlighters(expectedContributionRanges);
     replayMockAddRemoveRangeHighlighters();
 
-    List<AnnotationRange> selectionAnnotationRanges =
-        createAnnotationRanges(expectedSelectionRanges, true);
-
     SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(user, file, editor, selectionAnnotationRanges);
+        new SelectionAnnotation(user, file, start, end, editor);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -1889,7 +1868,7 @@ public class AnnotationManagerTest {
     prepareMockAddRemoveRangeHighlighters();
     mockAddSelectionRangeHighlighters(expectedSelectionRanges);
     mockAddContributionRangeHighlighters(expectedContributionRanges);
-    mockRemoveRangeHighlighters(editor, selectionAnnotationRanges);
+    mockRemoveRangeHighlighters(editor, selectionAnnotation.getAnnotationRanges());
     mockRemoveRangeHighlighters(editor, contributionAnnotation.getAnnotationRanges());
     replayMockAddRemoveRangeHighlighters();
 
@@ -1924,22 +1903,21 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
-    List<AnnotationRange> selectionAnnotationRanges =
-        createAnnotationRanges(expectedSelectionRanges, true);
-    SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(user, file, editor, selectionAnnotationRanges);
-    selectionAnnotationStore.addAnnotation(selectionAnnotation);
-
     prepareMockAddRemoveRangeHighlighters();
+    mockAddSelectionRangeHighlighters(expectedSelectionRanges);
     mockAddContributionRangeHighlighters(expectedContributionRanges);
     replayMockAddRemoveRangeHighlighters();
+
+    SelectionAnnotation selectionAnnotation =
+        new SelectionAnnotation(user, file, start, end, editor);
+    selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
         new ContributionAnnotation(user, file, start, end, editor);
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     prepareMockAddRemoveRangeHighlighters();
-    mockRemoveRangeHighlighters(editor, selectionAnnotationRanges);
+    mockRemoveRangeHighlighters(editor, selectionAnnotation.getAnnotationRanges());
     mockRemoveRangeHighlighters(editor, contributionAnnotation.getAnnotationRanges());
     replayMockAddRemoveRangeHighlighters();
 
@@ -1969,9 +1947,7 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
-    SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(
-            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    SelectionAnnotation selectionAnnotation = new SelectionAnnotation(user, file, start, end, null);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -2006,13 +1982,12 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
     prepareMockAddRemoveRangeHighlighters();
+    mockAddSelectionRangeHighlighters(expectedSelectionRanges);
     mockAddContributionRangeHighlighters(expectedContributionRanges);
     replayMockAddRemoveRangeHighlighters();
 
-    List<AnnotationRange> selectionAnnotationRanges =
-        createAnnotationRanges(expectedSelectionRanges, true);
     SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(user, file, editor, selectionAnnotationRanges);
+        new SelectionAnnotation(user, file, start, end, editor);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -2020,7 +1995,7 @@ public class AnnotationManagerTest {
     contributionAnnotationQueue.addAnnotation(contributionAnnotation);
 
     prepareMockAddRemoveRangeHighlighters();
-    mockRemoveRangeHighlighters(editor, selectionAnnotationRanges);
+    mockRemoveRangeHighlighters(editor, selectionAnnotation.getAnnotationRanges());
     mockRemoveRangeHighlighters(editor, contributionAnnotation.getAnnotationRanges());
     replayMockAddRemoveRangeHighlighters();
 
@@ -2052,9 +2027,7 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
-    SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(
-            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    SelectionAnnotation selectionAnnotation = new SelectionAnnotation(user, file, start, end, null);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -2090,16 +2063,15 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
-    List<AnnotationRange> selectionAnnotationRanges =
-        createAnnotationRanges(expectedSelectionRanges, true);
-
     prepareMockAddRemoveRangeHighlighters();
+    mockAddSelectionRangeHighlighters(expectedSelectionRanges, file);
+    mockAddSelectionRangeHighlighters(expectedSelectionRanges, file2);
     mockAddContributionRangeHighlighters(expectedContributionRanges, file);
     mockAddContributionRangeHighlighters(expectedContributionRanges, file2);
     replayMockAddRemoveRangeHighlighters();
 
     SelectionAnnotation selectionAnnotation1 =
-        new SelectionAnnotation(user, file, editor, selectionAnnotationRanges);
+        new SelectionAnnotation(user, file, start, end, editor);
     selectionAnnotationStore.addAnnotation(selectionAnnotation1);
 
     ContributionAnnotation contributionAnnotation1 =
@@ -2107,7 +2079,7 @@ public class AnnotationManagerTest {
     contributionAnnotationQueue.addAnnotation(contributionAnnotation1);
 
     SelectionAnnotation selectionAnnotation2 =
-        new SelectionAnnotation(user2, file, editor, selectionAnnotationRanges);
+        new SelectionAnnotation(user2, file, start, end, editor);
     selectionAnnotationStore.addAnnotation(selectionAnnotation2);
 
     ContributionAnnotation contributionAnnotation2 =
@@ -2115,7 +2087,7 @@ public class AnnotationManagerTest {
     contributionAnnotationQueue.addAnnotation(contributionAnnotation2);
 
     SelectionAnnotation selectionAnnotation3 =
-        new SelectionAnnotation(user, file2, editor, selectionAnnotationRanges);
+        new SelectionAnnotation(user, file2, start, end, editor);
     selectionAnnotationStore.addAnnotation(selectionAnnotation3);
 
     ContributionAnnotation contributionAnnotation3 =
@@ -2123,7 +2095,7 @@ public class AnnotationManagerTest {
     contributionAnnotationQueue.addAnnotation(contributionAnnotation3);
 
     SelectionAnnotation selectionAnnotation4 =
-        new SelectionAnnotation(user2, file2, editor, selectionAnnotationRanges);
+        new SelectionAnnotation(user2, file2, start, end, editor);
     selectionAnnotationStore.addAnnotation(selectionAnnotation4);
 
     ContributionAnnotation contributionAnnotation4 =
@@ -2132,6 +2104,9 @@ public class AnnotationManagerTest {
 
     prepareMockAddRemoveRangeHighlighters();
     mockRemoveRangeHighlighters(editor, selectionAnnotation1.getAnnotationRanges());
+    mockRemoveRangeHighlighters(editor, selectionAnnotation2.getAnnotationRanges());
+    mockRemoveRangeHighlighters(editor, selectionAnnotation3.getAnnotationRanges());
+    mockRemoveRangeHighlighters(editor, selectionAnnotation4.getAnnotationRanges());
     mockRemoveRangeHighlighters(editor, contributionAnnotation1.getAnnotationRanges());
     mockRemoveRangeHighlighters(editor, contributionAnnotation2.getAnnotationRanges());
     mockRemoveRangeHighlighters(editor, contributionAnnotation3.getAnnotationRanges());
@@ -2163,9 +2138,7 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
-    SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(
-            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    SelectionAnnotation selectionAnnotation = new SelectionAnnotation(user, file, start, end, null);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -2206,9 +2179,7 @@ public class AnnotationManagerTest {
     List<Pair<Integer, Integer>> expectedSelectionRanges = createSelectionRange(start, end);
     List<Pair<Integer, Integer>> expectedContributionRanges = createContributionRanges(start, end);
 
-    SelectionAnnotation selectionAnnotation =
-        new SelectionAnnotation(
-            user, file, null, createAnnotationRanges(expectedSelectionRanges, false));
+    SelectionAnnotation selectionAnnotation = new SelectionAnnotation(user, file, start, end, null);
     selectionAnnotationStore.addAnnotation(selectionAnnotation);
 
     ContributionAnnotation contributionAnnotation =
@@ -2259,26 +2230,6 @@ public class AnnotationManagerTest {
     }
 
     return expectedRanges;
-  }
-
-  private List<AnnotationRange> createAnnotationRanges(
-      List<Pair<Integer, Integer>> ranges, boolean addRangeHighlighters) {
-    return ranges
-        .stream()
-        .map(
-            range -> {
-              int rangeStart = range.getLeft();
-              int rangeEnd = range.getRight();
-
-              if (addRangeHighlighters) {
-                RangeHighlighter rangeHighlighter = mockRangeHighlighter(rangeStart, rangeEnd);
-
-                return new AnnotationRange(rangeStart, rangeEnd, rangeHighlighter);
-              } else {
-                return new AnnotationRange(rangeStart, rangeEnd);
-              }
-            })
-        .collect(Collectors.toList());
   }
 
   /**

--- a/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
+++ b/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
@@ -96,16 +96,18 @@ public class AnnotationManagerTest {
 
     PowerMock.mockStaticPartial(SelectionAnnotation.class, "getSelectionTextAttributes");
 
-    EasyMock.expect(SelectionAnnotation.getSelectionTextAttributes(editor, user))
+    PowerMock.expectPrivate(SelectionAnnotation.class, "getSelectionTextAttributes", editor, user)
         .andStubReturn(selectionTextAttributes);
-    EasyMock.expect(SelectionAnnotation.getSelectionTextAttributes(editor, user2))
+    PowerMock.expectPrivate(SelectionAnnotation.class, "getSelectionTextAttributes", editor, user2)
         .andStubReturn(selectionTextAttributes);
 
     PowerMock.mockStaticPartial(ContributionAnnotation.class, "getContributionTextAttributes");
 
-    EasyMock.expect(ContributionAnnotation.getContributionTextAttributes(editor, user))
+    PowerMock.expectPrivate(
+            ContributionAnnotation.class, "getContributionTextAttributes", editor, user)
         .andStubReturn(contributionTextAttributes);
-    EasyMock.expect(ContributionAnnotation.getContributionTextAttributes(editor, user2))
+    PowerMock.expectPrivate(
+            ContributionAnnotation.class, "getContributionTextAttributes", editor, user2)
         .andStubReturn(contributionTextAttributes);
 
     PowerMock.replay(SelectionAnnotation.class, ContributionAnnotation.class);


### PR DESCRIPTION
This PR moves most of the business logic dealing with updating the positioning and managing the contained ranges and range highlighters into the annotation objects. This was done to make it easier to implement further differences between the annotation types, in particular adding the caret annotation feature to the selection annotation (see feature request #367).

The methods are moved separately and tests are updated after every move to minimize the possibility of introducing a defect during the refactoring.

Continuation of #960.

### Reviewing This PR

I would suggest reviewing this PR commit by commit. The testing logic could get a bit ugly during the refactoring but should be somewhat cleaned up by the end.

### Commits

<details><summary><b>[REFACTOR][I] Move addition adjustment logic into annotation object</b></summary>
<br>

Moves the logic to adjust the position of a local annotation according
to an addition in the annotated file into the annotation object.

</details>

<details><summary><b>[INTERNAL][I] Move deletion adjustment logic into annotation object</b></summary>
<br>

Moves the logic to adjust the position of a local annotation according
to a deletion in the annotated file into the annotation object.

</details>

<details><summary><b>[INTERNAL][I] Move methods to add and remove range </b></summary>
<br>

Creates a simplified copy of the method to create and remove range
highlighters in AbstractEditorAnnotation. These methods will replace the
usage of the old methods for this purpose in AnnotationManager.

Marks the old methods for this purpose as deprecated.

</details>

<details><summary><b>[INTERNAL][I] Add methods to determine text attributes for annotations</b></summary>
<br>

Creates methods in the annotation implementations to obtain the text
attribute to use for their range highlighters. The text attributes
define how the highlighting is displayed in the editor (color, border,
etc.).

</details>

<details><summary><b>[INTERNAL][I] Use new range highlighter methods in annotation manager</b></summary>
<br>

Adjusts the logic in AnnotationManager to use
AbstractEditorAnnotation.addRangeHighlighter() and
removeRangeHighlighter() instead of the local methods. These usages
outside of annotation implementations is only temporary and will be
removed as part of moving the rest of the annotation logic into the
annotation objects.

Removes the old methods for adding and removing range highlighters from
AnnotationManager.

Adjusts the tests for the annotation manager to correctly mock the new
calls dealing with range highlighters.

</details>

<details><summary><b>[INTERNAL][I] Move creation of contibution annotation ranges into CTOR</b></summary>
<br>

Moves the construction of the annotation ranges and range highlighters
for contribution annotations into the contribution annotation
constructor.

Adjusts the mocking logic for the range highlighter removal to correctly
use the annotation ranges contained in the annotation. This is now
necessary as they will contain different mock objects for the range
highlighters.

Adds mocking logic for the range highlighter addition before every CTOR
call passing an editor. This is now necessary as we can no longer pass
the prepare annotation ranges to the annotation since they are now build
internally.

</details>

<details><summary><b>[INTERNAL][I] Move creation of selection annotation ranges into CTOR</b></summary>
<br>

Moves the construction of the annotation ranges and range highlighters
for selection annotations into the selection annotation constructor.

Adjusts the range highlighter mocking setup to match the contribution
annotation handling introduced in the last commit.

</details>

<details><summary><b>[INTERNAL][I] Move addition of local representation into annotation</b></summary>
<br>

Moves the method to add the local representation to an annotation into
the annotation object. Each annotation implementation must implement
this method itself as its range highlighter setup might differ.

</details>

<details><summary><b>[INTERNAL][I] Remove range highlighter as part of local representation</b></summary>
<br>

Adjusts the logic of
AbstractEditorAnnotation.removeLocalRepresentation(...) to also remove
the held range highlighters from the held editor.

Removes all direct calls to
AbstractEditorAnnotation.removeRangeHighlighter(...) from
AnnotationManager.

Adjusts the javadoc of removeLocalRepresentation(...) to reflect the new
functionality.

Adjusts the testing logic accordingly.

</details>

<b>[REFACTOR][I] Make methods to obtain annotation text attributes private</b>

<b>[REFACTOR][I] Do minor refactorings in AnnotationManager</b>

<details><summary><b>[REFACTOR][I] Move checkRange() into annotation object</b></summary>
<br>

Also adjusts the working to fit all usages.

</details>

<b>[REFACTOR][I] Rename updateAnnotationPath() to updateAnnotationFile()</b>

<details><summary><b>[INTERNAL][I] Simplify range highlighter mocking logic</b></summary>
<br>

Adds a method offering to mock both adding and removing the same range
highlighter. This simplify test setups that want to both add and remove
range highlighters, e.g. adding the range highlighter during the setup
steps and then remove it during the test steps.

Adjusts mockAddRangeHighlighters() to call
mockAddRangeHighlightersWithGivenRangeHighlighters internally, making it
the new base method for mocking the addition of range highlighters.

Removes unnecessary test helper methods.

</details>

<b>[REFACTOR][I] Improve ContributionAnnotation CTOR iteration</b>