### PR TITLE
[DOC] Bump jquery from 3.4.1 to 3.5.1

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "bootstrap": "~4.4.1",
-    "jquery": "~3.4.1",
+    "jquery": "~3.5.1",
     "mermaid": "~8.4.8",
     "popper.js": "~1.16.1"
   }


### PR DESCRIPTION
Update jquery from 3.4.1 -> 3.5.1