### PR TITLE
Add support for backwards selections

### DIFF
--- a/core/src/saros/activities/TextSelectionActivity.java
+++ b/core/src/saros/activities/TextSelectionActivity.java
@@ -46,6 +46,10 @@ public class TextSelectionActivity extends AbstractResourceActivity<IFile> {
   @XStreamAsAttribute
   private final int endInLineOffset;
 
+  @XStreamAlias("bs")
+  @XStreamAsAttribute
+  private final boolean isBackwardsSelection;
+
   /**
    * Instantiates a new text selection activity.
    *
@@ -55,6 +59,7 @@ public class TextSelectionActivity extends AbstractResourceActivity<IFile> {
    * @throws IllegalArgumentException if the source or file is <code>null</code>
    */
   public TextSelectionActivity(User source, TextSelection selection, IFile file) {
+
     super(source, file);
 
     if (file == null) throw new IllegalArgumentException("file must not be null");
@@ -66,6 +71,8 @@ public class TextSelectionActivity extends AbstractResourceActivity<IFile> {
     TextPosition endPosition = selection.getEndPosition();
     this.endLine = endPosition.getLineNumber();
     this.endInLineOffset = endPosition.getInLineOffset();
+
+    this.isBackwardsSelection = selection.isBackwardsSelection();
   }
 
   @Override
@@ -82,7 +89,7 @@ public class TextSelectionActivity extends AbstractResourceActivity<IFile> {
     TextPosition startPosition = new TextPosition(startLine, startInLineOffset);
     TextPosition endPosition = new TextPosition(endLine, endInLineOffset);
 
-    return new TextSelection(startPosition, endPosition);
+    return new TextSelection(startPosition, endPosition, isBackwardsSelection);
   }
 
   @Override
@@ -114,6 +121,8 @@ public class TextSelectionActivity extends AbstractResourceActivity<IFile> {
         + endLine
         + ", in-line offset: "
         + endInLineOffset
+        + ", is backwards: "
+        + isBackwardsSelection
         + ", src: "
         + getSource()
         + ", file: "

--- a/core/src/saros/editor/text/TextSelection.java
+++ b/core/src/saros/editor/text/TextSelection.java
@@ -5,11 +5,16 @@ import java.util.Objects;
 /**
  * Immutable representation of a text selection through two text positions.
  *
+ * <p>Optionally, the selection can be declared as a backwards selection through the usage of {@link
+ * #isBackwardsSelection}. A backwards selection is a selection where the cursor is located at the
+ * start of the selection.
+ *
  * @see TextPosition
  */
 public class TextSelection {
   private final TextPosition startPosition;
   private final TextPosition endPosition;
+  private final boolean isBackwardsSelection;
 
   /**
    * An empty text selection.
@@ -26,20 +31,32 @@ public class TextSelection {
   public static final TextSelection EMPTY_SELECTION = new TextSelection();
 
   /**
+   * Calls {@link TextSelection#TextSelection(TextPosition, TextPosition, boolean)} with <code>
+   * isBackwardsSelection=false</code>.
+   */
+  public TextSelection(TextPosition startPosition, TextPosition endPosition) {
+    this(startPosition, endPosition, false);
+  }
+
+  /**
    * Creates a text selection for the given parameters. This selection object describes a generic
    * text range.
    *
-   * <p>Both the start and end position must not be null and must be valid.
+   * <p>Both the start and end position must not be null, must be valid, and the start position must
+   * not be after the end position.
    *
    * <p>For an empty selection, use {@link #EMPTY_SELECTION}.
    *
    * @param startPosition the starting position of the selection
    * @param endPosition the end position of the selection
+   * @param isBackwardsSelection whether the selection is a backwards selection
    * @throws NullPointerException if the given start position or end position is <code>null</code>
-   * @throws IllegalArgumentException if the given start position or end position is not valid
+   * @throws IllegalArgumentException if the given start position or end position is not valid or
+   *     the start position is located after the end position
    * @see TextPosition#isValid()
    */
-  public TextSelection(TextPosition startPosition, TextPosition endPosition) {
+  public TextSelection(
+      TextPosition startPosition, TextPosition endPosition, boolean isBackwardsSelection) {
     Objects.requireNonNull(startPosition, "Starting position must not be null");
     Objects.requireNonNull(endPosition, "End position must not be null");
 
@@ -51,14 +68,25 @@ public class TextSelection {
               + endPosition);
     }
 
+    if (startPosition.compareTo(endPosition) > 0) {
+      throw new IllegalStateException(
+          "The given selection range must be forward facing (start<=end). s: "
+              + startPosition
+              + ", e: "
+              + endPosition
+              + " - for backwards selections, use the parameter isBackwardsSelection instead");
+    }
+
     this.startPosition = startPosition;
     this.endPosition = endPosition;
+    this.isBackwardsSelection = isBackwardsSelection;
   }
 
   /** Private constructor for empty text selection objects. */
   private TextSelection() {
     this.startPosition = TextPosition.INVALID_TEXT_POSITION;
     this.endPosition = TextPosition.INVALID_TEXT_POSITION;
+    this.isBackwardsSelection = false;
   }
 
   /**
@@ -77,6 +105,18 @@ public class TextSelection {
    */
   public TextPosition getEndPosition() {
     return endPosition;
+  }
+
+  /**
+   * Returns whether this selection is a backwards selection.
+   *
+   * <p>A backwards selection is a selection where the cursor is located at the start of the
+   * selection.
+   *
+   * @return whether this selection is a backwards selection
+   */
+  public boolean isBackwardsSelection() {
+    return isBackwardsSelection;
   }
 
   /**
@@ -100,12 +140,14 @@ public class TextSelection {
         + startPosition
         + ", end position: "
         + endPosition
+        + ", is backwards: "
+        + isBackwardsSelection
         + "]";
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(startPosition, endPosition);
+    return Objects.hash(startPosition, endPosition, isBackwardsSelection);
   }
 
   @Override
@@ -121,6 +163,7 @@ public class TextSelection {
     TextSelection that = (TextSelection) o;
 
     return this.startPosition.equals(that.startPosition)
-        && this.endPosition.equals(that.endPosition);
+        && this.endPosition.equals(that.endPosition)
+        && this.isBackwardsSelection == that.isBackwardsSelection;
   }
 }

--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -358,7 +358,7 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
             int start = offsets.first;
             int end = offsets.second;
 
-            boolean isBackwardsSelection = false;
+            boolean isBackwardsSelection = textSelection.isBackwardsSelection();
 
             annotationManager.addSelectionAnnotation(
                 user, file, start, end, editor, isBackwardsSelection);
@@ -449,8 +449,8 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
    * the file for the editor.
    *
    * <p><b>NOTE:</b> This should only be used to transfer pre-existing selection. To notify other
-   * participants about new selections, {@link #generateSelection(IFile, Editor, int, int, boolean)}
-   * should be used instead.
+   * participants about new selections, {@link #generateSelection(IFile, SelectionEvent)} should be
+   * used instead.
    *
    * <p><b>NOTE:</b> This class is meant for internal use only and should generally not be used
    * outside the editor package. If you still need to access this method, please consider whether


### PR DESCRIPTION
Extends TextSelectionActivity to allow specifying the direction of the
selection. This was done to support backwards selections.

Adds a new constructor setting isBackwardsSelection=false by default to
allow for compatibility with implementations not supporting backwards
selections (yet).

Adds the requirement for the given selection range to be forwards facing
(start<=end) to allow for a unified handling of backwards selections.