### PR TITLE
[BUILD] Create initial PMD ruleset

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ ext.projectsToConfigure = subprojects - project(':saros.picocontainer')
 configure(projectsToConfigure) { projectToConf ->
 
   apply plugin: 'java' // default java build plugin
+  apply plugin: 'pmd'
   apply plugin: 'saros.gradle.eclipse.plugin'
 
   repositories {
@@ -59,6 +60,17 @@ configure(projectsToConfigure) { projectToConf ->
     // avoid that the whole dependency tree is released
     releaseDep.transitive = false
   }
+
+
+
+  pmd {
+      toolVersion = "6.22.0"
+      consoleOutput = true
+      ruleSetFiles = files(rootProject.file("ruleset.xml"))
+      ruleSets = []
+  }
+
+
 
   test {
 

--- a/core/src/saros/communication/connection/ConnectionHandler.java
+++ b/core/src/saros/communication/connection/ConnectionHandler.java
@@ -55,7 +55,7 @@ public class ConnectionHandler {
           final Exception error =
               state == ConnectionState.ERROR ? connectionService.getConnectionError() : null;
 
-          setConnectionState(state, error, true);
+          setConnectionState(state, error);
         }
       };
 
@@ -303,8 +303,7 @@ public class ConnectionHandler {
     return connectionConfiguration;
   }
 
-  private void setConnectionState(
-      final ConnectionState state, final Exception error, final boolean fireChanges) {
+  private void setConnectionState(final ConnectionState state, final Exception error) {
     synchronized (notifyLock) {
       this.currentConnectionState = state;
       this.currentConnectionError = error;

--- a/core/src/saros/editor/colorstorage/ColorIDSetStorage.java
+++ b/core/src/saros/editor/colorstorage/ColorIDSetStorage.java
@@ -1,7 +1,6 @@
 package saros.editor.colorstorage;
 
 import com.thoughtworks.xstream.XStream;
-import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -151,8 +150,6 @@ public final class ColorIDSetStorage {
   private synchronized void save() {
 
     String serializedData = null;
-
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
 
     try {
       serializedData = createXStream().toXML(currentAvailableSets);

--- a/core/src/saros/negotiation/IncomingSessionNegotiation.java
+++ b/core/src/saros/negotiation/IncomingSessionNegotiation.java
@@ -173,7 +173,7 @@ public class IncomingSessionNegotiation extends SessionNegotiation {
 
       startSession(monitor);
 
-      sendInvitationCompleted(monitor);
+      sendInvitationCompleted();
 
       awaitFinalAcknowledgement(monitor);
     } catch (Exception e) {
@@ -311,7 +311,7 @@ public class IncomingSessionNegotiation extends SessionNegotiation {
   }
 
   /** Signal the host that the session invitation is complete (from the client's perspective). */
-  private void sendInvitationCompleted(IProgressMonitor monitor) throws IOException {
+  private void sendInvitationCompleted() throws IOException {
     transmitter.send(
         ISarosSession.SESSION_CONNECTION_ID,
         getPeer(),

--- a/core/src/saros/negotiation/OutgoingSessionNegotiation.java
+++ b/core/src/saros/negotiation/OutgoingSessionNegotiation.java
@@ -182,7 +182,7 @@ public final class OutgoingSessionNegotiation extends SessionNegotiation {
       applySessionParameters(
           actualSessionParameters, sarosSession.getHost().getPreferences(), clientProperties);
 
-      User newUser = completeInvitation(clientProperties, monitor);
+      completeInvitation(clientProperties, monitor);
 
       monitor.done();
 
@@ -452,7 +452,7 @@ public final class OutgoingSessionNegotiation extends SessionNegotiation {
    *
    * @throws IOException
    */
-  private User completeInvitation(IPreferenceStore properties, IProgressMonitor monitor)
+  private void completeInvitation(IPreferenceStore properties, IProgressMonitor monitor)
       throws IOException {
 
     log.debug(this + " : synchronizing user list");
@@ -489,8 +489,6 @@ public final class OutgoingSessionNegotiation extends SessionNegotiation {
     }
 
     log.debug(this + " : session negotiation finished");
-
-    return user;
   }
 
   private void createCollectors() {

--- a/core/src/saros/session/internal/LeaveAndKickHandler.java
+++ b/core/src/saros/session/internal/LeaveAndKickHandler.java
@@ -79,7 +79,7 @@ public class LeaveAndKickHandler implements Startable {
       return;
     }
 
-    stopSession(user, SessionEndReason.KICKED);
+    stopSession(SessionEndReason.KICKED);
   }
 
   private void leaveReceived(JID from) {
@@ -91,7 +91,7 @@ public class LeaveAndKickHandler implements Startable {
     }
 
     if (user.isHost()) {
-      stopSession(user, SessionEndReason.HOST_LEFT);
+      stopSession(SessionEndReason.HOST_LEFT);
       return;
     }
 
@@ -116,7 +116,7 @@ public class LeaveAndKickHandler implements Startable {
         });
   }
 
-  private void stopSession(final User user, final SessionEndReason reason) {
+  private void stopSession(final SessionEndReason reason) {
     ThreadUtils.runSafeAsync(
         "stop-host",
         log,

--- a/eclipse/src/saros/ui/actions/ChangeXMPPAccountAction.java
+++ b/eclipse/src/saros/ui/actions/ChangeXMPPAccountAction.java
@@ -21,7 +21,6 @@ import saros.communication.connection.IConnectionStateListener;
 import saros.net.ConnectionState;
 import saros.net.xmpp.JID;
 import saros.repackaged.picocontainer.annotations.Inject;
-import saros.session.ISarosSessionManager;
 import saros.ui.ImageManager;
 import saros.ui.Messages;
 import saros.ui.util.SWTUtils;
@@ -42,8 +41,6 @@ public class ChangeXMPPAccountAction extends Action implements IMenuCreator, Dis
   @Inject private XMPPAccountStore accountService;
 
   @Inject private ConnectionHandler connectionHandler;
-
-  @Inject private ISarosSessionManager sarosSessionManager;
 
   private boolean isConnectionError;
 

--- a/eclipse/src/saros/ui/eventhandler/NegotiationHandler.java
+++ b/eclipse/src/saros/ui/eventhandler/NegotiationHandler.java
@@ -18,7 +18,6 @@ import saros.negotiation.ProjectNegotiation;
 import saros.negotiation.SessionNegotiation;
 import saros.net.util.XMPPUtils;
 import saros.net.xmpp.JID;
-import saros.net.xmpp.XMPPConnectionService;
 import saros.session.INegotiationHandler;
 import saros.session.ISarosSessionManager;
 import saros.ui.ImageManager;
@@ -192,8 +191,7 @@ public class NegotiationHandler implements INegotiationHandler {
 
   private final ISarosSessionManager sessionManager;
 
-  public NegotiationHandler(
-      ISarosSessionManager sessionManager, XMPPConnectionService connectionService) {
+  public NegotiationHandler(ISarosSessionManager sessionManager) {
     sessionManager.setNegotiationHandler(this);
     this.sessionManager = sessionManager;
   }

--- a/eclipse/src/saros/ui/preferencePages/GeneralPreferencePage.java
+++ b/eclipse/src/saros/ui/preferencePages/GeneralPreferencePage.java
@@ -317,11 +317,6 @@ public final class GeneralPreferencePage extends FieldEditorPreferencePage
     addField(new BooleanFieldEditor(PreferenceConstants.AUTO_CONNECT, STARTUP_CONNECT_TEXT, group));
   }
 
-  private void createConcurrentUndoField(Composite group) {
-    addField(
-        new BooleanFieldEditor(PreferenceConstants.CONCURRENT_UNDO, CONCURRENT_UNDO_TEXT, group));
-  }
-
   @Override
   public void init(IWorkbench workbench) {
     // Nothing to initialize

--- a/eclipse/src/saros/ui/widgets/ColorChooser.java
+++ b/eclipse/src/saros/ui/widgets/ColorChooser.java
@@ -74,7 +74,7 @@ public class ColorChooser extends Composite {
     setLayout(layout);
 
     for (int colorId = 0; colorId < SarosAnnotation.SIZE; colorId++) {
-      ColorLabel label = createColorLabel(this, style, colorId);
+      ColorLabel label = createColorLabel(style, colorId);
       label.setPreferredSize(50, 50);
       colorLabels.add(label);
     }
@@ -88,7 +88,7 @@ public class ColorChooser extends Composite {
         });
   }
 
-  private ColorLabel createColorLabel(Composite parent, int style, int colorId) {
+  private ColorLabel createColorLabel(int style, int colorId) {
     ColorLabel label = new ColorLabel(this, style);
 
     Color color = SarosAnnotation.getUserColor(colorId);

--- a/intellij/src/saros/core/monitoring/Status.java
+++ b/intellij/src/saros/core/monitoring/Status.java
@@ -6,6 +6,7 @@ package saros.core.monitoring;
  *
  * <p>TODO Check whether this actually necessary
  */
+@SuppressWarnings({"PMD.UnusedFormalParameter"})
 public class Status implements IStatus {
   public static final Status CANCEL_STATUS = new Status(0);
   public static final Status OK_STATUS = new Status(1);

--- a/lsp/src/saros/lsp/SarosLanguageServer.java
+++ b/lsp/src/saros/lsp/SarosLanguageServer.java
@@ -15,7 +15,9 @@ import saros.lsp.extensions.server.account.IAccountService;
 import saros.lsp.service.DocumentServiceStub;
 import saros.lsp.service.WorkspaceServiceStub;
 
-/** Implmenentation of the Saros language server. */
+/** Implementation of the Saros language server. */
+// TODO: Remove SuppressWarning after Server and Client interaction is on master branch
+@SuppressWarnings({"PMD.UnusedPrivateField"})
 public class SarosLanguageServer implements ISarosLanguageServer, ISarosLanguageClientAware {
 
   private static final Logger log = Logger.getLogger(SarosLanguageServer.class);

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,0 +1,12 @@
+<ruleset name="saros_ruleset"
+		xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+	<description>Saros ruleset</description>
+
+    <rule ref="category/java/bestpractices.xml/UnusedFormalParameter" />
+    <rule ref="category/java/bestpractices.xml/UnusedImports" />
+    <rule ref="category/java/bestpractices.xml/UnusedLocalVariable" />
+    <rule ref="category/java/bestpractices.xml/UnusedPrivateField" />
+    <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod" />
+</ruleset>

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -4,8 +4,9 @@
 		xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
 	<description>Saros ruleset</description>
 
+    <!-- Already checked by google-java-format and leads to fale positives: https://github.com/pmd/pmd/issues/1639 -->
+    <!--rule ref="category/java/bestpractices.xml/UnusedImports" /-->
     <rule ref="category/java/bestpractices.xml/UnusedFormalParameter" />
-    <rule ref="category/java/bestpractices.xml/UnusedImports" />
     <rule ref="category/java/bestpractices.xml/UnusedLocalVariable" />
     <rule ref="category/java/bestpractices.xml/UnusedPrivateField" />
     <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod" />

--- a/server/src/saros/server/session/JoinSessionRequestHandler.java
+++ b/server/src/saros/server/session/JoinSessionRequestHandler.java
@@ -43,9 +43,7 @@ public final class JoinSessionRequestHandler {
                 new Runnable() {
                   @Override
                   public void run() {
-                    handleInvitationRequest(
-                        new JID(packet.getFrom()),
-                        JoinSessionRequestExtension.PROVIDER.getPayload(packet));
+                    handleInvitationRequest(new JID(packet.getFrom()));
                   }
                 });
           } catch (RejectedExecutionException e) {
@@ -61,7 +59,7 @@ public final class JoinSessionRequestHandler {
         joinSessionRequestListener, JoinSessionRequestExtension.PROVIDER.getPacketFilter());
   }
 
-  private void handleInvitationRequest(final JID from, JoinSessionRequestExtension extension) {
+  private void handleInvitationRequest(final JID from) {
 
     sessionManager.invite(from, "Invitation by request");
   }

--- a/stf/src/saros/stf/client/tester/RealTester.java
+++ b/stf/src/saros/stf/client/tester/RealTester.java
@@ -5,7 +5,6 @@ import java.rmi.NotBoundException;
 import java.rmi.RemoteException;
 import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
-import org.apache.log4j.Logger;
 import saros.net.xmpp.JID;
 import saros.stf.server.rmi.controlbot.IControlBot;
 import saros.stf.server.rmi.remotebot.IRemoteBot;
@@ -18,8 +17,6 @@ import saros.stf.server.rmi.superbot.ISuperBot;
  * nicely. STF is short for Saros Test Framework.
  */
 class RealTester implements AbstractTester {
-
-  private static final Logger log = Logger.getLogger(RealTester.class);
 
   private IRemoteWorkbenchBot bot;
   private ISuperBot superBot;


### PR DESCRIPTION
I propose to use one static code analysis tool per language (instead of multiple that are currently enabled)
with a corresponding configuration/ruleset-file that allows enabling the checks in the IDE.

Therefore, I created an initial PMD file that only contains the "Unused*" rules.
(The GitHub Action integration is just for showing the violations. AFAIK codacy
uses only ruleset files that are already on the master branch.)

There are currently ~40 violations of these rules. We should:
* Fix the violations
* Mark the rule as required
* Enhance the ruleset in the future (PMD's [best-practices ruleset](https://pmd.github.io/latest/pmd_rules_java_bestpractices.html) is a good starting point)