### PR TITLE
[FIX][BUILD] Fixes issues with PowerMock and the Java 11 Build

### DIFF
--- a/.github/workflows/build_jdk11.yml
+++ b/.github/workflows/build_jdk11.yml
@@ -2,6 +2,10 @@
 name: Build JDK 11
 
 on:
+  push:
+    branches:
+      - 'pr/build/11/**'
+
   schedule:
     # Monday at 8:00
     - cron: '0 8 * * 1'

--- a/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
+++ b/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import saros.filesystem.IFile;
@@ -44,6 +45,7 @@ import saros.session.User;
   AnnotationStore.class,
   AnnotationQueue.class
 })
+@PowerMockIgnore("javax.swing.JComponent")
 public class AnnotationManagerTest {
 
   /** Selection annotation store held in the annotation manager. */


### PR DESCRIPTION
#### [FIX][BUILD] Fixes issues with PowerMock and the Java 11 Build

Adds the PowerMockIgnore annotations for "javax.swing.JComponent" to
avoid issues when mocking the IntelliJ interface Editor on Java 11.

#### [BUILD] Adjust Java 11 build to run on branches 'pr/build/11/**'