### PR TITLE
Fix minor issues

### DIFF
--- a/docs/contribute/best-practices.md
+++ b/docs/contribute/best-practices.md
@@ -36,7 +36,7 @@ is not acceptable to make a member part of a package's API
 *   For local variables and parameters: In principle, the same rule
     applies as for class variables. But since local variables and
     parameters have a limited scope, the additional information gained
-    through the presence of a final modifer is not tremendous.
+    through the presence of a final modifier is not tremendous.
     Therefore, we tend to not use the final keyword here.
 *   For methods: By default, don't make them final, unless you have good
     reason not to. After all, we want to use
@@ -277,7 +277,7 @@ running operation to the user
 * The name of the sub-task, as set using `subTask(String)`
 
 This information is typically presented to the user as a Dialog with a
-message being equal to the taskname of the top level progress monitor, a
+message being equal to the task name of the top level progress monitor, a
 progress bar showing the growing amount of work already done and a label
 for the current sub-task which switches every time the sub-task is being
 set.

--- a/docs/contribute/deprecated/html-gui.md
+++ b/docs/contribute/deprecated/html-gui.md
@@ -13,7 +13,7 @@ In the following you find a list of pro and cons for each approach and why we we
 The solution based on the SWT browser used the SWTBrowser which was delivered with the swt toolkit that is released with eclipse.
 
 ### Eclipse Integration
-In order to build and test Saros it was necessary to download an OS specific SWT version (this was handeled by the build tool). It was easy to
+In order to build and test Saros it was necessary to download an OS specific SWT version (this was handled by the build tool). It was easy to
 release the solution for eclipse, because eclipse already provides a swt version, because the whole IDE is written in swt.
 
 ### IntelliJ Integration
@@ -54,7 +54,7 @@ One approach that might work for eclipse, but not Intellij (therefore we never t
 * Create osgi bundles for each JavaFX module for each platform
 * Add a corresponding `Eclipse-PlatformFilter:` to the manifest file.
 * Add the line `Java-Module: <JavaFX module name>` to the manifest file.
-* Provide all bundles via an update-site an hope that the eclipse plugin installer decides which platform is required and installes only the required version.
+* Provide all bundles via an update-site an hope that the eclipse plugin installer decides which platform is required and installs only the required version.
 * The `org.eclipse.fx.osgi` bundle should detect the JavaFX bundle and add it to the class or module path during runtime.
 
 ### IntelliJ Tests
@@ -114,11 +114,11 @@ separately. To build the JavaScript application, navigate to
 `ui.frontend/html` and run `npm run build`.
 Alternatively it is also possible to run `npm run watch`, which builds
 the application once and then listens to any future changes and
-automatically rebuilds everytime.
+automatically rebuilds every time.
 
 ### Run the HTML-GUI
 
-* Perform the IDE specific setup steps as descibed above.
+* Perform the IDE specific setup steps as described above.
 * Install javascript dependencies and build the pages as described above.
 * Start an intellij/eclipse test instance and search for the saros html view.
 

--- a/docs/contribute/documentation.md
+++ b/docs/contribute/documentation.md
@@ -128,7 +128,7 @@ Example:
 #### Compile and Show Documentation
 
 * Execute `bundle exec jekyll serve`
-  * This command spawns a webserver on port 4000
+  * This command spawns a web server on port 4000
 * Open you browser and open `localhost:4000`
 * Use `bundle exec jekyll serve -i` for the interactive mode that reloads the page after content changes.
 

--- a/docs/contribute/guidelines.md
+++ b/docs/contribute/guidelines.md
@@ -120,7 +120,7 @@ is not acceptable to make a member part of a package's API
 *   For local variables and parameters: In principle, the same rule
     applies as for class variables. But since local variables and
     parameters have a limited scope, the additional information gained
-    through the presence of a final modifer is not tremendous.
+    through the presence of a final modifier is not tremendous.
     Therefore, we tend to not use the final keyword here.
 *   For methods: By default, don't make them final, unless you have good
     reason not to. After all, we want to use

--- a/docs/contribute/open-topics.md
+++ b/docs/contribute/open-topics.md
@@ -21,7 +21,7 @@ Nevertheless the topic is on hold mainly because it is mandatory to change the w
 Goal of this topic is to speed up the initial file sharing process at session starts.
 Instead of waiting for full synchronization, this feature prioritizes files and allows direct access after receiving.
 This main goal has already been achieved, but users are still bound to the read-only mode during project sharing and optimizations are open / on hold for merging.
-More Infos can be found in this [thesis](https://www.inf.fu-berlin.de/inst/ag-se/theses/Moll18-saros-session-start.pdf) (German only).
+More information can be found in this [thesis](https://www.inf.fu-berlin.de/inst/ag-se/theses/Moll18-saros-session-start.pdf) (German only).
 
 An Overview of the current work state is documented here: [Project Board: Instant Session Start Feature](https://github.com/saros-project/saros/projects/15) and a broader view at [Project Board: Session Start Topics](https://github.com/saros-project/saros/projects/18).
 
@@ -30,7 +30,7 @@ An Overview of the current work state is documented here: [Project Board: Instan
 
 Corresponding Pull Requests:
 * [Add JGit facade](https://github.com/saros-project/saros/pull/428)
-* [Add Activties to Share Commit](https://github.com/saros-project/saros/pull/444)
+* [Add Activities to Share Commit](https://github.com/saros-project/saros/pull/444)
 
 A former contributor started an implementation of a basic git support.
 The main idea was to send differences between the git history of two developers as [git bundle](https://git-scm.com/docs/git-bundle). The determination of the differences was 

--- a/docs/contribute/processes/review.md
+++ b/docs/contribute/processes/review.md
@@ -93,7 +93,7 @@ In case you don't know yet:
     *   Even if you perform a review in such a pair session, the
         reviewer should still post his remarks in Gerrit, so others can
         learn from the mistakes and defects you two found.
-*   Since we require two reviewers for each pull request, *everytime* you
+*   Since we require two reviewers for each pull request, *every time* you
     submit a new pull request (or new version of a pull request) you need to do at
     least *two reviews* yourself to maintain that ratio. Having a hard
     time getting others to review your pull request? Be a role model and do a

--- a/docs/contribute/refactoring-filesystem.md
+++ b/docs/contribute/refactoring-filesystem.md
@@ -15,7 +15,7 @@ The structure of the IntelliJ filesystem can be read [here](https://www.jetbrain
 
 The new approach is to leave the project-based architecture of Saros:
 
-A Saros user should be able to share an any subtree of his resources with Saros. The root of the subtree must have an absolute path on each Saros user's enviroment. It doesn't matter, where the the subtree is located (ex. On *C*: oder *D*: drive), but what the absolute paths unites is, that they mean the same reference (IReferencePoint). That means that every Saros user can choose for themselves where the resources are located. If a user uses Windows, the resources can be located in `C:` or `D:` drive. If a user uses Linux, the resources can be located in `/home/path/to/bar`. So the absolute paths of the resources are different, but if they start a session and want sharing their resources, the resources have the same reference point even though they have different absolute paths. Every Saros instance should know, where an IReferencePoint object is located in the local file system, so that the resources can be determined in combination of an IReferencePoint and a relative path to the resource.
+A Saros user should be able to share an any subtree of his resources with Saros. The root of the subtree must have an absolute path on each Saros user's environment. It doesn't matter, where the the subtree is located (ex. On *C*: oder *D*: drive), but what the absolute paths unites is, that they mean the same reference (IReferencePoint). That means that every Saros user can choose for themselves where the resources are located. If a user uses Windows, the resources can be located in `C:` or `D:` drive. If a user uses Linux, the resources can be located in `/home/path/to/bar`. So the absolute paths of the resources are different, but if they start a session and want sharing their resources, the resources have the same reference point even though they have different absolute paths. Every Saros instance should know, where an IReferencePoint object is located in the local file system, so that the resources can be determined in combination of an IReferencePoint and a relative path to the resource.
 
 The IReferencePoint can be look like this:
 
@@ -85,10 +85,10 @@ For introducing the reference point based interfaces, but also keeping project-b
 2.  Insert the reference point based interface
 3.  Implement the reference point based interface
 4.  Remove the project-based interface's implementation and reference this to the reference point based interface
-5.  Find alle usages of project-based interfaces and reference them to reference point based interface
+5.  Find all usages of project-based interfaces and reference them to reference point based interface
 6.  Delete project based interface
 
-This procedure has the adventages, that the parallel development of Saros is provided, so that developer can use the reference point based interfaces and the (still) untouched components are not affected directly. After all usages references the reference point based interface, the project based one can be deleted.
+This procedure has the advantages, that the parallel development of Saros is provided, so that developer can use the reference point based interfaces and the (still) untouched components are not affected directly. After all usages references the reference point based interface, the project based one can be deleted.
 
 There are other refactoring situations to handle for reaching to final state:
 
@@ -98,7 +98,7 @@ Because of the project-based architecture many classes and methods contain the k
 
 #### Insert Parameter:
 
-There are some situations during the refactoring, that a Saros project for example determated resources, which the reference point can not do. So the affected methods should be extended by a ReferencePointManager, so that previous functionalities still remains.
+There are some situations during the refactoring, that a Saros project for example determined resources, which the reference point can not do. So the affected methods should be extended by a ReferencePointManager, so that previous functionalities still remains.
 
 #### Remove Parameter:
 

--- a/docs/contribute/saros-testing-framework.md
+++ b/docs/contribute/saros-testing-framework.md
@@ -46,7 +46,7 @@ Therefore the current workaround is to execute the Gradle task `generateLibAll` 
 
 ### Run Tests
 
-1.  Start the **requiered launch configurations** which are located
+1.  Start the **required launch configurations** which are located
     in the directory `stf/launch` by **right clicking the
     launch file** and chose **Run As > Saros\_STF\_\<name\>**. This
     will start a new Eclipse instance with the selected launch

--- a/docs/documentation/awareness-information.md
+++ b/docs/documentation/awareness-information.md
@@ -12,7 +12,7 @@ If you are following another participant you see something like:
 
 ![followee list](images/awareness/eclipse_session_list_followee_view.png)
 
-## File Navigations
+## File Navigation
 
 In the package explorer:
 - ![active file](how-tos/images/icons-e/active_file.png) A colored dot decorates the file that a participant has currently
@@ -32,7 +32,7 @@ In the Saros view's session list shows which participant has which editor focuse
 
 The position of a participant's cursor appears in the file and
 the character behind the cursor is highlighted with the
-corrsponding color.
+corresponding color.
 
 ## Selections
 

--- a/docs/documentation/faq.md
+++ b/docs/documentation/faq.md
@@ -109,7 +109,7 @@ attribute on your own: Just right-click on the respective directory,
 select "Properties", and check the attribute "Derived".
 
 **Git:** To make completely sure that Saros won't mess with your
-precious versioning data, you might consider a folder layout where your
+versioning data, you might consider a folder layout where your
 Eclipse project(s) reside on a level below the .git folder (see below).
 That's the way we organize our own source code (even though we do so for
 other reasons).
@@ -303,7 +303,7 @@ bugs look into our [issue tracker](https://github.com/saros-project/saros/issues
     when accepting a session invitation.
 
 *   Refactoring operations can produce a huge number of events to be
-    transfered by Saros, which may take very long and can thus be
+    transferred by Saros, which may take very long and can thus be
     confusing for participants.
 
 *   In particular, on-the-fly refactorings such as 'rename' perform one

--- a/docs/documentation/features.md
+++ b/docs/documentation/features.md
@@ -3,7 +3,7 @@ title: Features of Saros
 toc: false
 ---
 
-Saros comes with a **boundle of nice features**.
+Saros comes with a **bundle of nice features**.
 
 ## Collaborative Real-Time File Editing
 

--- a/docs/documentation/getting-started.md
+++ b/docs/documentation/getting-started.md
@@ -168,11 +168,11 @@ in the Saros instances of your invited contacts (with synchronizing files, copyi
 {% alert info %}
 ##### Current restrictions
 
-**Number of Participants**
+###### **Number of Participants**
 
 Currently, Saros/I is restricted to two-participant sessions, meaning you can only create session containing the host and a single client.
 
-**Share only a single module**
+###### **Share only a single module**
 
 You can currently only share a single module. A module has to adhere to the following restrictions to be shareable through Saros:
 
@@ -181,14 +181,14 @@ You can currently only share a single module. A module has to adhere to the foll
 Sharing a module will only share resources belonging to that module, not resources belonging to sub-module located inside a content root of the module.
 Creating such a sub-module during a session will lead to an inconsistent state that can not be resolved by Saros. See [Known Bugs](/releases/saros-i_0.2.2.html#known-bugs).
 
-**Working With Newly Created Modules**
+###### **Working With Newly Created Modules**
 
 To share a newly created module, you will have to have saved your project at least once before trying to start a session.
 This is necessary as the module file for a new module is only written to disk the first time the module is saved.
 
 You can check if the module file was written to disk by looking at the base directory of the module. It should contain a `*.iml` file with the same name as the module.
 
-**Sharing Complex Modules**
+###### **Sharing Complex Modules**
 
 Even though Saros offers the option to create the module on the client side as part of the session, this should only be used for relatively simple modules.
 For more complex modules, it is advised to share the module structure some other way (e.g. a VCS) before starting a session. Saros currently does not set up things like libraries or module dependencies, meaning they would have to be configured by hand.

--- a/docs/documentation/installation.md
+++ b/docs/documentation/installation.md
@@ -57,7 +57,7 @@ or from within Eclipse:
 
 1.  Download the [latest *saros-dropin-\*.zip*
     from GitHub](https://github.com/saros-project/saros/releases).
-2.  Uncompress the archives into the dropins folder of your
+2.  Decompress the archives into the dropins folder of your
     Eclipse installation.
 3.  Restart Eclipse.
 


### PR DESCRIPTION
#### [DOC] Make restriction headings actual headings

Adjusts the "Restrictions" section in the guide for starting a session
in Saros/I to feature headings instead of bold text. This was done so
that they also support smart anchors, making it easier to link to them.

#### [DOC] Fix typos