### PR TITLE
Clean up IWorkspace

### DIFF
--- a/core/src/saros/filesystem/IWorkspace.java
+++ b/core/src/saros/filesystem/IWorkspace.java
@@ -34,20 +34,4 @@ public interface IWorkspace {
    */
   public void run(IWorkspaceRunnable runnable, IResource[] resources)
       throws IOException, OperationCanceledException;
-
-  /**
-   * @deprecated the concept of a central workspace for the IDE instance does not apply to all IDE
-   *     models (see the IntelliJ project/module model). This method will be removed from the
-   *     interface in a future patch.
-   */
-  @Deprecated
-  public IProject getProject(String project);
-
-  /**
-   * @deprecated the concept of a central workspace for the IDE instance does not apply to all IDE
-   *     models (see the IntelliJ project/module model). This method will be removed from the
-   *     interface in a future patch.
-   */
-  @Deprecated
-  public IPath getLocation();
 }

--- a/eclipse/src/saros/filesystem/EclipseWorkspaceImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseWorkspaceImpl.java
@@ -108,18 +108,4 @@ public class EclipseWorkspaceImpl implements IWorkspace {
       throw new OperationCanceledException(e);
     }
   }
-
-  /** @deprecated See {@link IWorkspace}. */
-  @Override
-  @Deprecated
-  public IProject getProject(String project) {
-    return ResourceAdapterFactory.create(delegate.getRoot().getProject(project));
-  }
-
-  /** @deprecated See {@link IWorkspace}. */
-  @Override
-  @Deprecated
-  public IPath getLocation() {
-    return ResourceAdapterFactory.create(delegate.getRoot().getLocation());
-  }
 }

--- a/intellij/src/saros/intellij/project/filesystem/IntelliJWorkspaceImpl.java
+++ b/intellij/src/saros/intellij/project/filesystem/IntelliJWorkspaceImpl.java
@@ -2,8 +2,6 @@ package saros.intellij.project.filesystem;
 
 import java.io.IOException;
 import saros.exceptions.OperationCanceledException;
-import saros.filesystem.IPath;
-import saros.filesystem.IProject;
 import saros.filesystem.IResource;
 import saros.filesystem.IWorkspace;
 import saros.filesystem.IWorkspaceRunnable;
@@ -19,44 +17,5 @@ public class IntelliJWorkspaceImpl implements IWorkspace {
   public void run(IWorkspaceRunnable runnable, IResource[] resources)
       throws IOException, OperationCanceledException {
     run(runnable);
-  }
-
-  /**
-   * This method always throws an <code>UnsupportedOperationException</code>.
-   *
-   * <p>In Intellij, module names can not be used to uniquely identify modules in an application
-   * context. There can be any number of open project that can each contain a module with the same
-   * name. This makes it impossible to implement a general method that just uses the module name.
-   *
-   * @param moduleName the name of the module to instantiate an <code>IProject</code> object for
-   * @return nothing as it always throws an <code>UnsupportedOperationException</code>
-   * @throws UnsupportedOperationException always
-   * @deprecated does not make sense in the context of Intellij IDEA
-   */
-  @Deprecated
-  @Override
-  public IProject getProject(final String moduleName) {
-    throw new UnsupportedOperationException(
-        "Modules names can not be used to uniquely identify modules in Intellij in an application context.");
-  }
-
-  /**
-   * This method always throws an <code>UnsupportedOperationException</code>.
-   *
-   * <p>In Intellij, there is no such concept as a centralized workspace directory for the IDE. Each
-   * Intellij application can have any number of projects open which each can have any number of
-   * modules. Each module in turn can have any number of content roots which define the content of
-   * the module. In the filesystem, there is no correlation between the location of any of the above
-   * mentioned parts. This makes it impossible to determine a general workspace directory.
-   *
-   * @return nothing as it always throws an <code>UnsupportedOperationException</code>
-   * @throws UnsupportedOperationException always
-   * @deprecated does not make sense in the context of Intellij IDEA
-   */
-  @Deprecated
-  @Override
-  public IPath getLocation() {
-    throw new UnsupportedOperationException(
-        "There is no such concept as a centralized workspace directory for Intellij.");
   }
 }

--- a/server/src/saros/server/console/ShareCommand.java
+++ b/server/src/saros/server/console/ShareCommand.java
@@ -6,18 +6,18 @@ import java.util.List;
 import java.util.Set;
 import org.apache.log4j.Logger;
 import saros.filesystem.IProject;
-import saros.filesystem.IWorkspace;
 import saros.server.filesystem.ServerProjectImpl;
+import saros.server.filesystem.ServerWorkspaceImpl;
 import saros.session.ISarosSession;
 import saros.session.ISarosSessionManager;
 
 public class ShareCommand extends ConsoleCommand {
   private static final Logger log = Logger.getLogger(ShareCommand.class);
   private final ISarosSessionManager sessionManager;
-  private final IWorkspace workspace;
+  private final ServerWorkspaceImpl workspace;
 
   public ShareCommand(
-      ISarosSessionManager sessionManager, IWorkspace workspace, ServerConsole console) {
+      ISarosSessionManager sessionManager, ServerWorkspaceImpl workspace, ServerConsole console) {
     this.sessionManager = sessionManager;
     this.workspace = workspace;
     console.registerCommand(this);

--- a/server/src/saros/server/filesystem/ServerContainerImpl.java
+++ b/server/src/saros/server/filesystem/ServerContainerImpl.java
@@ -11,7 +11,6 @@ import saros.filesystem.IFile;
 import saros.filesystem.IFolder;
 import saros.filesystem.IPath;
 import saros.filesystem.IResource;
-import saros.filesystem.IWorkspace;
 
 /**
  * Server implementation of the {@link IContainer} interface. Every type of container is implemented
@@ -25,7 +24,7 @@ public abstract class ServerContainerImpl extends ServerResourceImpl implements 
    * @param workspace the containing workspace
    * @param path the container's path relative to the workspace's root
    */
-  public ServerContainerImpl(IWorkspace workspace, IPath path) {
+  public ServerContainerImpl(ServerWorkspaceImpl workspace, IPath path) {
     super(workspace, path);
   }
 

--- a/server/src/saros/server/filesystem/ServerFileImpl.java
+++ b/server/src/saros/server/filesystem/ServerFileImpl.java
@@ -15,7 +15,6 @@ import java.nio.file.StandardCopyOption;
 import org.apache.log4j.Logger;
 import saros.filesystem.IFile;
 import saros.filesystem.IPath;
-import saros.filesystem.IWorkspace;
 
 /** Server implementation of the {@link IFile} interface. */
 public class ServerFileImpl extends ServerResourceImpl implements IFile {
@@ -32,7 +31,7 @@ public class ServerFileImpl extends ServerResourceImpl implements IFile {
    * @param workspace the containing workspace
    * @param path the file's path relative to the workspace's root
    */
-  public ServerFileImpl(IWorkspace workspace, IPath path) {
+  public ServerFileImpl(ServerWorkspaceImpl workspace, IPath path) {
     super(workspace, path);
   }
 

--- a/server/src/saros/server/filesystem/ServerFolderImpl.java
+++ b/server/src/saros/server/filesystem/ServerFolderImpl.java
@@ -8,7 +8,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import saros.filesystem.IFolder;
 import saros.filesystem.IPath;
-import saros.filesystem.IWorkspace;
 
 /** Server implementation of the {@link IFolder} interface. */
 public class ServerFolderImpl extends ServerContainerImpl implements IFolder {
@@ -19,7 +18,7 @@ public class ServerFolderImpl extends ServerContainerImpl implements IFolder {
    * @param workspace the containing workspace
    * @param path the folder's path relative to the workspace's root
    */
-  public ServerFolderImpl(IWorkspace workspace, IPath path) {
+  public ServerFolderImpl(ServerWorkspaceImpl workspace, IPath path) {
     super(workspace, path);
   }
 

--- a/server/src/saros/server/filesystem/ServerProjectImpl.java
+++ b/server/src/saros/server/filesystem/ServerProjectImpl.java
@@ -5,7 +5,6 @@ import static saros.filesystem.IResource.Type.PROJECT;
 import java.io.IOException;
 import java.nio.file.Files;
 import saros.filesystem.IProject;
-import saros.filesystem.IWorkspace;
 
 /** Server implementation of the {@link IProject} interface. */
 public class ServerProjectImpl extends ServerContainerImpl implements IProject {
@@ -15,7 +14,7 @@ public class ServerProjectImpl extends ServerContainerImpl implements IProject {
    * @param workspace the containing workspace
    * @param name the project's name
    */
-  public ServerProjectImpl(IWorkspace workspace, String name) {
+  public ServerProjectImpl(ServerWorkspaceImpl workspace, String name) {
     super(workspace, ServerPathImpl.fromString(name));
   }
 

--- a/server/src/saros/server/filesystem/ServerResourceImpl.java
+++ b/server/src/saros/server/filesystem/ServerResourceImpl.java
@@ -6,7 +6,6 @@ import saros.filesystem.IContainer;
 import saros.filesystem.IPath;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
-import saros.filesystem.IWorkspace;
 
 /**
  * Server implementation of the {@link IResource} interface. It represents each resource directly as
@@ -14,7 +13,7 @@ import saros.filesystem.IWorkspace;
  */
 public abstract class ServerResourceImpl implements IResource {
 
-  private IWorkspace workspace;
+  private ServerWorkspaceImpl workspace;
   private IPath path;
 
   /**
@@ -23,7 +22,7 @@ public abstract class ServerResourceImpl implements IResource {
    * @param workspace the containing workspace
    * @param path the resource's path relative to the workspace's root
    */
-  public ServerResourceImpl(IWorkspace workspace, IPath path) {
+  public ServerResourceImpl(ServerWorkspaceImpl workspace, IPath path) {
     this.path = path;
     this.workspace = workspace;
   }
@@ -33,7 +32,7 @@ public abstract class ServerResourceImpl implements IResource {
    *
    * @return the containing workspace
    */
-  public IWorkspace getWorkspace() {
+  public ServerWorkspaceImpl getWorkspace() {
     return workspace;
   }
 

--- a/server/src/saros/server/filesystem/ServerWorkspaceImpl.java
+++ b/server/src/saros/server/filesystem/ServerWorkspaceImpl.java
@@ -23,16 +23,10 @@ public class ServerWorkspaceImpl implements IWorkspace {
     this.location = location;
   }
 
-  /** @deprecated See {@link IWorkspace}. */
-  @Override
-  @Deprecated
   public IPath getLocation() {
     return location;
   }
 
-  /** @deprecated See {@link IWorkspace}. */
-  @Override
-  @Deprecated
   public IProject getProject(String name) {
     return new ServerProjectImpl(this, name);
   }

--- a/server/src/saros/server/session/NegotiationHandler.java
+++ b/server/src/saros/server/session/NegotiationHandler.java
@@ -8,7 +8,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.apache.log4j.Logger;
 import saros.filesystem.IProject;
-import saros.filesystem.IWorkspace;
 import saros.monitoring.NullProgressMonitor;
 import saros.negotiation.AbstractIncomingProjectNegotiation;
 import saros.negotiation.AbstractOutgoingProjectNegotiation;
@@ -21,6 +20,7 @@ import saros.negotiation.SessionNegotiation;
 import saros.net.xmpp.JID;
 import saros.server.ServerConfig;
 import saros.server.filesystem.ServerProjectImpl;
+import saros.server.filesystem.ServerWorkspaceImpl;
 import saros.server.progress.ConsoleProgressIndicator;
 import saros.session.INegotiationHandler;
 import saros.session.ISarosSessionManager;
@@ -31,7 +31,7 @@ public class NegotiationHandler implements INegotiationHandler {
   private static final Logger log = Logger.getLogger(NegotiationHandler.class);
 
   private final ISarosSessionManager sessionManager;
-  private final IWorkspace workspace;
+  private final ServerWorkspaceImpl workspace;
   private final ThreadPoolExecutor sessionExecutor =
       new ThreadPoolExecutor(
           0,
@@ -49,7 +49,7 @@ public class NegotiationHandler implements INegotiationHandler {
           new LinkedBlockingQueue<Runnable>(),
           new NamedThreadFactory("ServerProjectNegotiation-"));
 
-  public NegotiationHandler(ISarosSessionManager sessionManager, IWorkspace workspace) {
+  public NegotiationHandler(ISarosSessionManager sessionManager, ServerWorkspaceImpl workspace) {
     sessionManager.setNegotiationHandler(this);
     this.sessionManager = sessionManager;
     this.workspace = workspace;

--- a/server/test/junit/saros/server/filesystem/FileSystemTestUtils.java
+++ b/server/test/junit/saros/server/filesystem/FileSystemTestUtils.java
@@ -10,7 +10,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.apache.commons.io.FileUtils;
 import saros.filesystem.IPath;
-import saros.filesystem.IWorkspace;
 
 /**
  * Provides utility methods for the server file system implementation tests. These methods are meant
@@ -64,7 +63,7 @@ class FileSystemTestUtils {
    * @param path workspace-relative path of the file to create
    * @throws IOException
    */
-  public static void createFile(IWorkspace workspace, String path) throws IOException {
+  public static void createFile(ServerWorkspaceImpl workspace, String path) throws IOException {
 
     createFile(workspace, path, null);
   }
@@ -78,7 +77,7 @@ class FileSystemTestUtils {
    * @param content the created file's text content, or <code>null</code> to create an empty file
    * @throws IOException if the file creation fails
    */
-  public static void createFile(IWorkspace workspace, String path, String content)
+  public static void createFile(ServerWorkspaceImpl workspace, String path, String content)
       throws IOException {
 
     IPath absolutePath = workspace.getLocation().append(path);
@@ -100,7 +99,7 @@ class FileSystemTestUtils {
    * @param path workspace-relative path of the folder to create
    * @throws IOException if the folder creation fails
    */
-  public static void createFolder(IWorkspace workspace, String path) throws IOException {
+  public static void createFolder(ServerWorkspaceImpl workspace, String path) throws IOException {
 
     IPath absolutePath = workspace.getLocation().append(path);
     Files.createDirectories(nioPath(absolutePath));
@@ -112,7 +111,7 @@ class FileSystemTestUtils {
    * @param workspace the workspace to do the check in
    * @param path the path to check
    */
-  public static void assertResourceExists(IWorkspace workspace, String path) {
+  public static void assertResourceExists(ServerWorkspaceImpl workspace, String path) {
     assertTrue(resourceLocation(workspace, path).toFile().exists());
   }
 
@@ -122,7 +121,7 @@ class FileSystemTestUtils {
    * @param workspace the workspace to do the check in
    * @param path the path to check
    */
-  public static void assertResourceNotExists(IWorkspace workspace, String path) {
+  public static void assertResourceNotExists(ServerWorkspaceImpl workspace, String path) {
     assertFalse(resourceLocation(workspace, path).toFile().exists());
   }
 
@@ -132,7 +131,7 @@ class FileSystemTestUtils {
    * @param workspace the workspace to do the check in
    * @param path the path to check
    */
-  public static void assertIsFolder(IWorkspace workspace, String path) {
+  public static void assertIsFolder(ServerWorkspaceImpl workspace, String path) {
     assertTrue(resourceLocation(workspace, path).toFile().isDirectory());
   }
 
@@ -144,8 +143,8 @@ class FileSystemTestUtils {
    * @param expectedContent the text content that the file should have
    * @throws IOException if reading the file fails
    */
-  public static void assertFileHasContent(IWorkspace workspace, String path, String expectedContent)
-      throws IOException {
+  public static void assertFileHasContent(
+      ServerWorkspaceImpl workspace, String path, String expectedContent) throws IOException {
 
     IPath location = resourceLocation(workspace, path);
     byte[] actualContent = Files.readAllBytes(nioPath(location));
@@ -156,7 +155,7 @@ class FileSystemTestUtils {
     return ((ServerPathImpl) path).getDelegate();
   }
 
-  private static IPath resourceLocation(IWorkspace workspace, String path) {
+  private static IPath resourceLocation(ServerWorkspaceImpl workspace, String path) {
     return workspace.getLocation().append(path);
   }
 }

--- a/server/test/junit/saros/server/filesystem/ServerContainerImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerContainerImplTest.java
@@ -23,13 +23,12 @@ import saros.filesystem.IContainer;
 import saros.filesystem.IPath;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
-import saros.filesystem.IWorkspace;
 
 public class ServerContainerImplTest extends EasyMockSupport {
 
   private static class ExampleContainer extends ServerContainerImpl {
 
-    public ExampleContainer(IPath path, IWorkspace workspace) {
+    public ExampleContainer(IPath path, ServerWorkspaceImpl workspace) {
       super(workspace, path);
     }
 
@@ -42,12 +41,12 @@ public class ServerContainerImplTest extends EasyMockSupport {
   private static final String CONTAINER_PATH = "project/folder";
 
   private IContainer container;
-  private IWorkspace workspace;
+  private ServerWorkspaceImpl workspace;
   private IProject project;
 
   @Before
   public void setUp() throws Exception {
-    workspace = createMock(IWorkspace.class);
+    workspace = createMock(ServerWorkspaceImpl.class);
     project = createMock(IProject.class);
 
     expect(workspace.getLocation()).andStubReturn(createWorkspaceFolder());

--- a/server/test/junit/saros/server/filesystem/ServerFileImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerFileImplTest.java
@@ -24,17 +24,16 @@ import org.junit.Test.None;
 import saros.filesystem.IFile;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
-import saros.filesystem.IWorkspace;
 
 public class ServerFileImplTest extends EasyMockSupport {
 
   private IFile file;
-  private IWorkspace workspace;
+  private ServerWorkspaceImpl workspace;
   private IProject project;
 
   @Before
   public void setUp() throws Exception {
-    workspace = createMock(IWorkspace.class);
+    workspace = createMock(ServerWorkspaceImpl.class);
     project = createMock(IProject.class);
 
     expect(workspace.getLocation()).andStubReturn(createWorkspaceFolder());

--- a/server/test/junit/saros/server/filesystem/ServerFolderImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerFolderImplTest.java
@@ -17,7 +17,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.Test.None;
 import saros.filesystem.IFolder;
-import saros.filesystem.IWorkspace;
 
 public class ServerFolderImplTest extends EasyMockSupport {
 
@@ -25,11 +24,11 @@ public class ServerFolderImplTest extends EasyMockSupport {
   private static final String FOLDER_PARENT_PATH = "project";
 
   private IFolder folder;
-  private IWorkspace workspace;
+  private ServerWorkspaceImpl workspace;
 
   @Before
   public void setUp() throws Exception {
-    workspace = createMock(IWorkspace.class);
+    workspace = createMock(ServerWorkspaceImpl.class);
     expect(workspace.getLocation()).andStubReturn(createWorkspaceFolder());
 
     replayAll();

--- a/server/test/junit/saros/server/filesystem/ServerProjectImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerProjectImplTest.java
@@ -14,16 +14,15 @@ import saros.filesystem.IFile;
 import saros.filesystem.IFolder;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
-import saros.filesystem.IWorkspace;
 
 public class ServerProjectImplTest extends EasyMockSupport {
 
   private IProject project;
-  private IWorkspace workspace;
+  private ServerWorkspaceImpl workspace;
 
   @Before
   public void setUp() throws Exception {
-    workspace = createMock(IWorkspace.class);
+    workspace = createMock(ServerWorkspaceImpl.class);
     expect(workspace.getLocation()).andStubReturn(createWorkspaceFolder());
 
     replayAll();

--- a/server/test/junit/saros/server/filesystem/ServerResourceImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerResourceImplTest.java
@@ -19,13 +19,12 @@ import saros.filesystem.IFolder;
 import saros.filesystem.IPath;
 import saros.filesystem.IProject;
 import saros.filesystem.IResource;
-import saros.filesystem.IWorkspace;
 
 public class ServerResourceImplTest extends EasyMockSupport {
 
   private static class ExampleResource extends ServerResourceImpl {
 
-    public ExampleResource(IPath path, IWorkspace workspace) {
+    public ExampleResource(IPath path, ServerWorkspaceImpl workspace) {
       super(workspace, path);
     }
 
@@ -41,13 +40,13 @@ public class ServerResourceImplTest extends EasyMockSupport {
   }
 
   private IResource resource;
-  private IWorkspace workspace;
+  private ServerWorkspaceImpl workspace;
   private IProject project;
   private IFolder parent;
 
   @Before
   public void setUp() throws Exception {
-    workspace = createMock(IWorkspace.class);
+    workspace = createMock(ServerWorkspaceImpl.class);
     project = createMock(IProject.class);
     parent = createMock(IFolder.class);
 

--- a/server/test/junit/saros/server/filesystem/ServerWorkspaceImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerWorkspaceImplTest.java
@@ -16,14 +16,13 @@ import org.junit.Test;
 import saros.exceptions.OperationCanceledException;
 import saros.filesystem.IPath;
 import saros.filesystem.IProject;
-import saros.filesystem.IWorkspace;
 import saros.filesystem.IWorkspaceRunnable;
 import saros.monitoring.IProgressMonitor;
 
 public class ServerWorkspaceImplTest extends EasyMockSupport {
 
   private IPath workspaceLocation;
-  private IWorkspace workspace;
+  private ServerWorkspaceImpl workspace;
 
   @Before
   public void setUp() throws Exception {


### PR DESCRIPTION
#### [INTERNAL][SERVER] Use ServerWorkspaceImpl directly

Refactors the Server resource handling to use ServerWorkspaceImpl
directly. This was done to allow the methods 'getProject()' and
'getLocation()' to be removed from the interface without having to
adjust the server implementation.

#### [API][CORE] Remove IWorkspace.getProject() and getLocation()

Removes the methods IWorkspace.getProject() and getLocation() as they
were no longer being used in the core.