### PR TITLE
Add default resouce methods

### DIFF
--- a/core/src/saros/filesystem/IFile.java
+++ b/core/src/saros/filesystem/IFile.java
@@ -72,4 +72,8 @@ public interface IFile extends IResource {
    * @throws IOException if an I/O error occurred
    */
   public long getSize() throws IOException;
+
+  default Type getType() {
+    return Type.FILE;
+  }
 }

--- a/core/src/saros/filesystem/IFolder.java
+++ b/core/src/saros/filesystem/IFolder.java
@@ -35,4 +35,8 @@ public interface IFolder extends IContainer {
    * @throws IOException if the folder creation failed or the resource already exists
    */
   void create() throws IOException;
+
+  default Type getType() {
+    return Type.FOLDER;
+  }
 }

--- a/core/src/saros/filesystem/IProject.java
+++ b/core/src/saros/filesystem/IProject.java
@@ -21,8 +21,65 @@
 
 package saros.filesystem;
 
+import java.io.IOException;
+
 /**
- * This interface is under development. It currently equals its Eclipse counterpart. If not
- * mentioned otherwise all offered methods are equivalent to their Eclipse counterpart.
+ * Represents a project in the local (virtual) file system.
+ *
+ * <p>Defines the project specific default behavior of methods defined by {@link IContainer}.
+ *
+ * <p>This interface is under development. It is currently a placeholder and will be reworked once
+ * the migration to reference points is completed.
  */
-public interface IProject extends IContainer {}
+public interface IProject extends IContainer {
+  /**
+   * Returns an empty path.
+   *
+   * @return an empty path
+   */
+  IPath getProjectRelativePath();
+
+  /**
+   * Always throws an IO exception.
+   *
+   * <p>Deleting a project resource is not supported.
+   *
+   * @throws IOException always
+   */
+  default void delete() throws IOException {
+    throw new IOException("Deleting project resources is not supported - tried to delete " + this);
+  }
+
+  /**
+   * Always returns <code>null</code>.
+   *
+   * <p>Resources above the shared project can not be described through (conventional) relative
+   * paths. Additionally, such resources are not part of the shared scope and should therefore not
+   * be of interest for Saros.
+   *
+   * @return <code>null</code>
+   */
+  default IContainer getParent() {
+    return null;
+  }
+
+  /**
+   * Returns a reference to itself.
+   *
+   * @return a reference to itself
+   */
+  default IProject getProject() {
+    return this;
+  }
+
+  /**
+   * Returns <code>false</code>.
+   *
+   * <p>Projects are the base for all shared resources and can therefore not be ignored.
+   *
+   * @return <code>false</code>
+   */
+  default boolean isIgnored() {
+    return false;
+  }
+}

--- a/core/src/saros/filesystem/IProject.java
+++ b/core/src/saros/filesystem/IProject.java
@@ -72,6 +72,10 @@ public interface IProject extends IContainer {
     return this;
   }
 
+  default Type getType() {
+    return Type.PROJECT;
+  }
+
   /**
    * Returns <code>false</code>.
    *


### PR DESCRIPTION

#### [API][CORE] Add default implementations for specific IProject methods

Overwrites specific methods of IContainer in IProject to specify the
differing behavior for projects.

Adds default implementations for specific methods in IProjects that have
a constant behavior.

#### [API][CORE] Add default implementations for IResource.getType()

Adds default implementations of getType() for IProject, IFile, and
IFolder returning the corresponding type.