### PR TITLE
[I] Adjust documentation for release 0.3.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,9 +25,9 @@ A clear and concise description of what you expected to happen.
 Please provide the corresponding log files, but be sure to **remove or obfuscate sensitive data** you don't want to publish. Please also make sure only to include the log files concerning the session you encountered the bug in.
 
 You can find the log files in the following locations:
-* IntelliJ IDEA:
-  The log files for JetBrains IDEs are located in the IDE system directory (here called `IDE_SYSTEM_DIR`).
-  An overview over all configurations is given  on https://intellij-support.jetbrains.com/hc/en-us/articles/206544519-Directories-used-by-the-IDE-to-store-settings-caches-plugins-and-logs
+* IntelliJ platform based IDEs:
+  The log files for IntelliJ platform based IDEs are located in the IDE system directory (here called `IDE_SYSTEM_DIR`).
+  An overview over all configurations is given on https://intellij-support.jetbrains.com/hc/en-us/articles/206544519-Directories-used-by-the-IDE-to-store-settings-caches-plugins-and-logs
 
   For releases 2019.3 and earlier, see https://www.jetbrains.com/help/idea/2019.3/tuning-the-ide.html#system-directory
   For release 2020.1 and later, see https://www.jetbrains.com/help/idea/2020.1/tuning-the-ide.html#system-directory
@@ -44,7 +44,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Environment (please complete the following information):**
  - OS: [e.g. Windows 10, Linux Debian Jessie]
- - IDE [e.g. Eclipse 2018-09, IntelliJ IDEA 2019.1.3]
+ - IDE [e.g. Eclipse 2018-09, IntelliJ IDEA 2019.2.3]
  - Saros Version [e.g. 15.0.0]
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -17,7 +17,7 @@ A clear and concise description of what you want to happen.
 A clear and concise description of any alternative solutions or features you've considered.
 
 **IDE**
-Are you talking about the IntelliJ IDEA or Eclipse plug-in?
+Are you talking about the IntelliJ IDEA (or other IntelliJ platform based IDEs) or Eclipse plug-in?
 
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/297b67607a5f4b5b8d00d0446615849b)](https://www.codacy.com/manual/Saros/saros)
 [![Gitter](https://img.shields.io/gitter/room/saros-project/saros?color=%2346BC99&logo=gitter)](https://gitter.im/saros-project/saros)
 [![Release Saros/E](https://img.shields.io/badge/Saros%2FE-15.0.0-blue?logo=eclipse)](https://github.com/saros-project/saros/releases/tag/saros-eclipse-15.0.0)
-[![Release Saros/I](https://img.shields.io/badge/Saros%2FI-0.2.2-blue?logo=intellij-idea)](https://github.com/saros-project/saros/releases/tag/saros-intellij-0.2.2)
+[![Release Saros/I](https://img.shields.io/badge/Saros%2FI-0.3.0-blue?logo=intellij-idea)](https://github.com/saros-project/saros/releases/tag/saros-intellij-0.3.0)
 
 Saros is an Open Source plugin for connecting multiple IDEs for distributed collaborative software development.
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Saros is an Open Source plugin for connecting multiple IDEs for distributed coll
 - Or add this update-site: https://www.saros-project.org/update-site/eclipse
 
 ### IntelliJ alpha release
-Please read the [details about restrictions](https://www.saros-project.org/documentation/getting-started.html?tab=intellij#restrictions) first, because Saros for IntelliJ is still a first alpha release!
+Please read the [details about restrictions](https://www.saros-project.org/documentation/getting-started.html?tab=intellij#restrictions) first, because Saros for IntelliJ is still an alpha release!
 
-- Search for "Saros" in the IntelliJ Marketplace (this requires the `alpha` release channel; more information on this is given on the [installation](https://www.saros-project.org/documentation/installation.html?tab=intellij) page)
+- Search for "Saros" in the JetBrains Plugin Repository (this requires the `alpha` release channel; more information on this is given on the [installation](https://www.saros-project.org/documentation/installation.html?tab=intellij) page)
 - Or Download the plugin zip from our [release page](https://github.com/saros-project/saros/releases)
 
 ## How to use Saros

--- a/docs/_data/releases/current.yml
+++ b/docs/_data/releases/current.yml
@@ -1,1 +1,1 @@
-intellij: /releases/saros-i_0.2.2.html
+intellij: /releases/saros-i_0.3.0.html

--- a/docs/_data/releases/sidebar.yml
+++ b/docs/_data/releases/sidebar.yml
@@ -5,6 +5,8 @@
 
 - title: Saros for IntelliJ
   sublinks:
+  - title: 0.3.0
+    url: /releases/saros-i_0.3.0.html
   - title: 0.2.2
     url: /releases/saros-i_0.2.2.html
   - title: 0.2.1

--- a/docs/contribute/development-environment.md
+++ b/docs/contribute/development-environment.md
@@ -9,7 +9,7 @@ If you want to execute the STF tests it is recommended to use Eclipse. Otherwise
 
 * You have to [clone](https://help.github.com/articles/cloning-a-repository/) the Saros repository with [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
 * You need a **Java 8 JDK**.
-* *Optional:* You can use a local **IntelliJ IDEA** installation (version `2018.2.7` or newer) for dependency resolution by setting the **system-wide environment variable `INTELLIJ_HOME`** to the IntelliJ installation directory that contains the directory `lib`.
+* *Optional:* You can use a local **IntelliJ IDEA** installation (version `2019.2.3` or newer) for dependency resolution by setting the **system-wide environment variable `INTELLIJ_HOME`** to the IntelliJ installation directory that contains the directory `lib`.
 If the `INTELLIJ_HOME` variable is not set, the intellij-gradle-plugin will download and use the IntelliJ version specified in the `build.gradle` file of the 'intellij' project.
 * *Optional:* You can also set the **system-wide environment variable `SAROS_INTELLIJ_SANDBOX`** to specify the base directory in which the IntelliJ sandboxes will be created. Otherwise, the directory `intellij/build` in the repository will be used by default.
 

--- a/docs/contribute/saros-testing-framework.md
+++ b/docs/contribute/saros-testing-framework.md
@@ -59,7 +59,7 @@ Therefore the current workaround is to execute the Gradle task `generateLibAll` 
 
 ## IntelliJ
 
-We are currently working on an version of STF that work with the HTML-GUI and therefore with both IDEs, but for now it is not possible to run the Eclipse STF tests from within IntelliJ or execute STF tests for IntelliJ.
+It is not possible to run the Eclipse STF tests from within IntelliJ or execute STF tests for IntelliJ.
 However IntelliJ/Gradle supports to run multiple IntelliJ instances from within IntelliJ in order to test Saros by hand.
 
 ### Run Multiple IntelliJ Instances for Testing

--- a/docs/documentation/faq.md
+++ b/docs/documentation/faq.md
@@ -86,7 +86,7 @@ In the following we are using these definitions:
 {% endcollapsible %}
 {% collapsible How many users does Saros support? %}
 
-Saros supports up to 5 users (see [here](/releases/saros-i_0.2.2.html#number-of-participants) for the current restrictions in IntelliJ).
+Saros supports up to 5 users (see [here](/releases/saros-i_0.3.0.html#number-of-participants) for the current restrictions in IntelliJ).
 However, this is not a hard limit. But the sixth and seventh and n-th user will get the same gray-ish color.
 
 {% endcollapsible %}

--- a/docs/documentation/faq.md
+++ b/docs/documentation/faq.md
@@ -46,7 +46,7 @@ In the following we are using these definitions:
 |Name         |IDE                                              |Category    |Self-hosted |
 |-------------|-------------------------------------------------|------------|------------|
 |FlooBits     |Atom, Emacs, IntelliJ IDEA, Neovim, Sublime Text |Commercial  |Yes         |
-|Saros        |Eclipse, IntelliJ IDEA                           |Open-Source |Yes         |
+|Saros        |Eclipse, IntelliJ IDEA (and [IDEs based on the IntelliJ platform](https://www.jetbrains.org/intellij/sdk/docs/intro/intellij_platform.html#ides-based-on-the-intellij-platform))         |Open-Source |Yes         |
 |Live Share   |Visual Studio (Code)                             |Freeware    |No          |
 |Teletype     |Atom                                             |Open-Source |Yes         |
 
@@ -86,7 +86,7 @@ In the following we are using these definitions:
 {% endcollapsible %}
 {% collapsible How many users does Saros support? %}
 
-Saros supports up to 5 users (see [here](/releases/saros-i_0.3.0.html#number-of-participants) for the current restrictions in IntelliJ).
+Saros supports up to 5 users (see [here](/releases/saros-i_0.3.0.html#number-of-participants) for the current restrictions in Saros/I).
 However, this is not a hard limit. But the sixth and seventh and n-th user will get the same gray-ish color.
 
 {% endcollapsible %}
@@ -149,13 +149,13 @@ workspace directory is shown if you open `"Switch Workspace" > "Other..."`.
 {% endcapture %}
 {% capture intellij %}
 
-The log files for JetBrains IDEs are located in the IDE system directory (here called `IDE_SYSTEM_DIR`).
+The log files for [IntelliJ platform based IDEs](https://www.jetbrains.org/intellij/sdk/docs/intro/intellij_platform.html#ides-based-on-the-intellij-platform) are located in the IDE system directory (here called `IDE_SYSTEM_DIR`).
 An overview over all configurations is given on [the support forum](https://intellij-support.jetbrains.com/hc/en-us/articles/206544519-Directories-used-by-the-IDE-to-store-settings-caches-plugins-and-logs).
 For specific releases, see the information for [2019.3 and earlier](https://www.jetbrains.com/help/idea/2019.3/tuning-the-ide.html#system-directory) or [2020.1 and later](https://www.jetbrains.com/help/idea/2020.1/tuning-the-ide.html#system-directory).
 
 The Saros log files are located in `[IDE_SYSTEM_DIR]/log/SarosLogs/*.log`.
 
-If you are encountering IntelliJ IDEA errors connected to Saros (which will be displayed by a red, blinking symbol in the bottom right corner of the IntelliJ project view; the error can be viewed in more detail by clicking the symbol), please also include the IntelliJ IDEA logs.
+If you are encountering IDE errors connected to Saros (which will be displayed by a red, blinking symbol in the bottom right corner of the project view; the error can be viewed in more detail by clicking the symbol), please also include the IDE logs.
 They are located in `[IDE_SYSTEM_DIR]/log/` and are named `idea.log` (the log will be truncated at some point and older logs will be moved to `idea.log.1`, etc.).
 Please have a look at the contained timestamps to provide the correct file.
 

--- a/docs/documentation/getting-started.md
+++ b/docs/documentation/getting-started.md
@@ -236,7 +236,7 @@ For more complex modules, it is advised to share the module structure some other
     project with your own copy, Saros will automatically add, change, or
     delete all files as necessary.
 -   Saros will share all files which are not marked as *derived* by
-    Eclipse or *excluded* by IntelliJ, because it should be possible to recreate such files
+    Eclipse or *excluded* by [IntelliJ platform based IDEs](https://www.jetbrains.org/intellij/sdk/docs/intro/intellij_platform.html#ides-based-on-the-intellij-platform), because it should be possible to recreate such files
     (`.class` files for instance) at the client's side. If you use a
     build tool such as Maven, it might be necessary to manually set the
     resulting files or folders to *derived* or *excluded* on both the host's side (so they won't be copied to the client) and the client's side (otherwise

--- a/docs/documentation/getting-started.md
+++ b/docs/documentation/getting-started.md
@@ -156,7 +156,7 @@ in the Saros instances of your invited contacts (with synchronizing files, copyi
 - Choose the section "Contacts" in the window on the left side of the Saros view.
 - Choose a friend that is online.
 - Right-click the name of that friend. This will open a list of all open projects. Each project contains a list of its shareable modules.
-  - If the module you would like to share is not listed, it most likely does not adhere to the mentioned restrictions (see [module restrictions](/releases/saros-i_0.2.2.html#module-restrictions)).
+  - If the module you would like to share is not listed, it most likely does not adhere to the mentioned restrictions (see [module restrictions](/releases/saros-i_0.3.0.html#module-restrictions)).
 - Choose the module that is supposed to be shared from the displayed list of modules.
 
 *Alternatively:*
@@ -179,7 +179,7 @@ You can currently only share a single module. A module has to adhere to the foll
 - The module must have exactly one content root.
 
 Sharing a module will only share resources belonging to that module, not resources belonging to sub-module located inside a content root of the module.
-Creating such a sub-module during a session will lead to an inconsistent state that can not be resolved by Saros. See [Known Bugs](/releases/saros-i_0.2.2.html#known-bugs).
+Creating such a sub-module during a session will lead to an inconsistent state that can not be resolved by Saros. See [Known Bugs](/releases/saros-i_0.3.0.html#known-bugs).
 
 ###### **Working With Newly Created Modules**
 
@@ -220,7 +220,7 @@ For more complex modules, it is advised to share the module structure some other
     - Specify the module base path.
   - *To use an existing module:* Choose "Use existing module"
     - Select a module from the drop-down menu.
-      - If the module you would like to share is not listed, it most likely does not adhere to the mentioned restrictions (see [module restrictions](/releases/saros-i_0.2.2.html#module-restrictions)).
+      - If the module you would like to share is not listed, it most likely does not adhere to the mentioned restrictions (see [module restrictions](/releases/saros-i_0.3.0.html#module-restrictions)).
 - Click "Next".
   - If an existing local module was chosen, a list of local file changes that will be made during the negotiation will be shown. These are the differences between the local version of the module and the version held by the host. The shown actions are the actions necessary to align the local module with the host module.
   - **Warning:** Any local differences will be removed during the project negotiation. These adjustments will only be done if the "Finish" button is selected. If the project negotiation is aborted at this stage, no local files are changed.

--- a/docs/documentation/how-tos/change-colors.md
+++ b/docs/documentation/how-tos/change-colors.md
@@ -25,7 +25,7 @@ contributions. Therefore, the preferences are not located at the Saros preferenc
 {% endcapture %}
 {% capture intellij %}
 
-* Open the [IntelliJ settings/preferences menu](https://www.jetbrains.com/help/idea/settings-preferences-dialog.html).
+* Open the [settings/preferences menu](https://www.jetbrains.com/help/idea/settings-preferences-dialog.html).
 * Navigate to `"Editor" > "Color Scheme" > "Saros"`.
 * Select the color scheme to change the colors for.
 * Expand the user whose colors to change.

--- a/docs/documentation/how-tos/manage-xmpp-accounts.md
+++ b/docs/documentation/how-tos/manage-xmpp-accounts.md
@@ -63,7 +63,7 @@ Saros account preferences. You can open these preferences:
 
 {% alert warning %}
 ## Note
-As mentioned in the section [missing features](/releases/saros-i_0.2.2.html#missing-features), Saros for IntelliJ **does currently not support the creation, management, or deletion of XMPP accounts**.
+As mentioned in the section [missing features](/releases/saros-i_0.3.0.html#missing-features), Saros for IntelliJ **does currently not support the creation, management, or deletion of XMPP accounts**.
 
 If you accidentally made a typo while entering your username or password, the created account entry can currently only be changed or deleted through Saros for Eclipse.
 

--- a/docs/documentation/index.md
+++ b/docs/documentation/index.md
@@ -6,8 +6,8 @@ toc: false
 Saros is an Open Source IDE plugin for distributed collaborative software development.
 
 It works with and within **Eclipse**. Saros users can use all Eclipse functionality as usual.<br/>
-We are working on an **IntelliJ** version as well. See the [release notes](/releases) of our
-latest alpha release for more information.
+We are working on a version for **IntelliJ** (and [IDEs based on the IntelliJ platform](https://www.jetbrains.org/intellij/sdk/docs/intro/intellij_platform.html#ides-based-on-the-intellij-platform)) as well. See
+the [release notes](/releases) of our latest alpha release for more information.
 
 ## Saros is a real-time collaborative editor.
 

--- a/docs/documentation/installation.md
+++ b/docs/documentation/installation.md
@@ -64,7 +64,7 @@ or from within Eclipse:
 {% endcapture %}
 {% capture intellij %}
 This is still an alpha release of Saros/I, so expect it to be a bit rough around the edges. Before using the plugin for the first time, please have a look at the release
-notes, especially the [disclaimer](/releases/saros-i_0.2.2.html#disclaimer) and the current [restrictions of the plugin](/releases/saros-i_0.2.2.html#restrictions).
+notes, especially the [disclaimer](/releases/saros-i_0.3.0.html#disclaimer) and the current [restrictions of the plugin](/releases/saros-i_0.3.0.html#restrictions).
 
 Saros/I can be installed from the JetBrains plugin repository or from disk.
 

--- a/docs/documentation/installation.md
+++ b/docs/documentation/installation.md
@@ -20,6 +20,7 @@ Saros/E requires
 Saros/I requires
  - `JDK 8` or newer
  - `IntelliJ 2019.2.3` or newer (download [here](https://www.jetbrains.com/idea/download/))
+   - Other [IDEs based on the IntelliJ platform](https://www.jetbrains.org/intellij/sdk/docs/intro/intellij_platform.html#ides-based-on-the-intellij-platform) version `2019.2.3` or newer are supported as well
 
 {% endcapture %}
 {% include ide-tabs.html eclipse=eclipse intellij=intellij %}
@@ -72,26 +73,26 @@ Saros/I can be installed from the JetBrains plugin repository or from disk.
 
 Saros/I is currently released through the `alpha` release channel. To be able find the plugin on the market place, you will first have to add the `alpha` release channel to your list of plugin repositories. A guide on how to do this is given [here](https://plugins.jetbrains.com/docs/marketplace/custom-release-channels.html#CustomReleaseChannels-ConfiguringaCustomChannelinIntelliJPlatformBasedIDEs).
 
-- Open the [IntelliJ settings/preferences menu](https://www.jetbrains.com/help/idea/settings-preferences-dialog.html).
+- Open the [settings/preferences menu](https://www.jetbrains.com/help/idea/settings-preferences-dialog.html).
 - Select the "Plugins" section.
 - Select the tab "Marketplace".
 - Search for "Saros" in the search bar and select the entry from the list.
 - Click the "Install" button.
 - Close the settings menu.
-- Restart IntelliJ.
+- Restart the IDE.
 
 
 ### From Disk
 The zip file containing the plugin can be downloaded from our [release page](https://github.com/saros-project/saros/releases).
 
 
-- Open the [IntelliJ settings/preferences menu](https://www.jetbrains.com/help/idea/settings-preferences-dialog.html).
+- Open the [settings/preferences menu](https://www.jetbrains.com/help/idea/settings-preferences-dialog.html).
 - Select the "Plugins" section.
 - Click the settings icon (gear/cog) and choose "Install plugin from disk...".
 - Navigate to the directory containing the plugin zip.
 - Select the zip file.
 - Click OK.
-- Restart IntelliJ.
+- Restart the IDE.
 
 {% endcapture %}
 

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -2,7 +2,7 @@
 title: Get Saros
 ---
 
-See the installation documentation for [Eclipse](../documentation/installation.html?tab=eclipse) and [IntelliJ](../documentation/installation.html?tab=intellij) for more information about prerequisites and more detailed installation instructions.
+See the installation documentation for [Eclipse](../documentation/installation.html?tab=eclipse) and [IntelliJ (and IntelliJ platform based IDEs)](../documentation/installation.html?tab=intellij) for more information about prerequisites and more detailed installation instructions.
 
 See **latest release notes** about the current release:
 * **Saros for Eclipse (Saros/E)**: [15.0.0](saros-e_15.0.0.md)
@@ -18,10 +18,10 @@ Update site <https://www.saros-project.org/update-site/eclipse>
 
 Find latest release in [GitHub](https://github.com/saros-project/saros/releases)
 
-## IntelliJ Marketplace
+## JetBrains Plugin Repository
 
-You can install the plugin through the IntelliJ plugin marketplace. This requires the `alpha` release channel. More information can be found [here](../documentation/installation.html?tab=intellij#from-the-plugin-repository).
+You can install the plugin through the JetBrains plugin repository. This requires the `alpha` release channel. More information can be found [here](../documentation/installation.html?tab=intellij#from-the-plugin-repository).
 
-## IntelliJ Zip
+## IntelliJ (and [IntelliJ platform based IDEs](https://www.jetbrains.org/intellij/sdk/docs/intro/intellij_platform.html#ides-based-on-the-intellij-platform)) Zip
 
 Find latest release in [GitHub](https://github.com/saros-project/saros/releases)

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -6,7 +6,7 @@ See the installation documentation for [Eclipse](../documentation/installation.h
 
 See **latest release notes** about the current release:
 * **Saros for Eclipse (Saros/E)**: [15.0.0](saros-e_15.0.0.md)
-* **Saros for IntelliJ (Saros/I)**: [0.2.2](saros-i_0.2.2.md)
+* **Saros for IntelliJ (Saros/I)**: [0.3.0](saros-i_0.3.0.md)
 
 ## Eclipse Update Site
 

--- a/docs/releases/saros-i_0.3.0.md
+++ b/docs/releases/saros-i_0.3.0.md
@@ -19,6 +19,7 @@ Furthermore, there are still some known bugs in the current release. Please have
 Saros/I 0.3.0 requires
  - `JDK 8` or newer
  - `IntelliJ 2019.2.3` or newer
+   - Other [IDEs based on the IntelliJ platform](https://www.jetbrains.org/intellij/sdk/docs/intro/intellij_platform.html#ides-based-on-the-intellij-platform) version `2019.2.3` or newer are supported as well
 
 Saros/I can be installed from the JetBrains plugin repository or from disk. A detailed guide is given [here](../documentation/installation.html?tab=intellij).
 
@@ -28,7 +29,8 @@ The current release `0.3.0` is not compatible with the previous Saros/I releases
 
 ## Changes
 
-- Bumped minimal required IntelliJ version to `2019.2.3`.
+- Bumped minimal required version to `2019.2.3`.
+- Enable support for all [IDEs based on the IntelliJ platform](https://www.jetbrains.org/intellij/sdk/docs/intro/intellij_platform.html#ides-based-on-the-intellij-platform).
 - Adds support for caret/cursor annotations.
 - Adjusts the selection annotation logic to correctly display backwards selections.
 - Fixed [#223](https://github.com/saros-project/saros/pull/223) - Re-creating a file deleted during a session now no longer leads to a desynchronization.
@@ -129,13 +131,13 @@ Please make it clear that the issue is dealing with Saros/I.
 
 When reporting a bug that concerns the plugin behavior, please provide the Saros log file (or all relevant excerpts) for a session where the bug was encountered.
 
-The log files for JetBrains IDEs are located in the IDE system directory (here called`IDE_SYSTEM_DIR`).
+The log files for [IntelliJ platform based IDEs](https://www.jetbrains.org/intellij/sdk/docs/intro/intellij_platform.html#ides-based-on-the-intellij-platform) are located in the IDE system directory (here called`IDE_SYSTEM_DIR`).
 An overview over all configurations is given on [the support forum](https://intellij-support.jetbrains.com/hc/en-us/articles/206544519-Directories-used-by-the-IDE-to-store-settings-caches-plugins-and-logs).
 For specific releases, see the information for [2019.3 and earlier](https://www.jetbrains.com/help/idea/2019.3/tuning-the-ide.html#system-directory) or [2020.1 and later](https://www.jetbrains.com/help/idea/2020.1/tuning-the-ide.html#system-directory).
 
 The Saros log files are located in `[IDE_SYSTEM_DIR]/log/SarosLogs/*.log`.
 
-If you are encountering IntelliJ IDEA errors connected to Saros (which will be displayed by a red, blinking symbol in the bottom right corner of the IntelliJ project view; the error can be viewed in more detail by clicking the symbol), please also include the IntelliJ IDEA logs.
+If you are encountering IDE errors connected to Saros (which will be displayed by a red, blinking symbol in the bottom right corner of the project view; the error can be viewed in more detail by clicking the symbol), please also include the IDE logs.
 They are located in `[IDE_SYSTEM_DIR]/log/` and are named `idea.log` (the log will be truncated at some point and older logs will be moved to `idea.log.1`, etc.).
 Please have a look at the contained timestamps to provide the correct file.
 

--- a/docs/releases/saros-i_0.3.0.md
+++ b/docs/releases/saros-i_0.3.0.md
@@ -1,0 +1,142 @@
+---
+title: Saros/I 0.3.0 Release Notes
+---
+
+This is an alpha release of Saros/I, so expect it to still be a bit rough around the edges.
+There are still some [restrictions](#restrictions) that apply to the usage and some basic [features are still missing](#missing-features).
+
+
+## Disclaimer
+
+Saros/I does not include sub-modules when sharing a module (see [module restrictions](#module-restrictions)).
+As a consequence, such sub-modules might not be present for all session participants.
+If a participant deletes a shared directory that contains a sub-module in the local setup of another participant, this sub-module will be deleted without any notice.
+
+Furthermore, there are still some known bugs in the current release. Please have a look at the section [Known Bugs](#known-bugs).
+
+## Installation
+
+Saros/I 0.3.0 requires
+ - `JDK 8` or newer
+ - `IntelliJ 2019.2.3` or newer
+
+Saros/I can be installed from the JetBrains plugin repository or from disk. A detailed guide is given [here](../documentation/installation.html?tab=intellij).
+
+## Compatibility
+
+The current release `0.3.0` is not compatible with the previous Saros/I releases or other Saros plugins (like Saros/E).
+
+## Changes
+
+- Bumped minimal required IntelliJ version to `2019.2.3`.
+- Adds support for caret/cursor annotations.
+- Adjusts the selection annotation logic to correctly display backwards selections.
+- Fixed [#223](https://github.com/saros-project/saros/pull/223) - Re-creating a file deleted during a session now no longer leads to a desynchronization.
+- Fixed [#711](https://github.com/saros-project/saros/pull/711) - Editors for shared non-text resources are now ignored by Saros.
+- Fixed [#821](https://github.com/saros-project/saros/pull/821) - Disconnecting from the XMPP account during a session now no longer freezes the UI.
+- Fixed [#891](https://github.com/saros-project/saros/pull/891) - Users are now notified about failed connection attempts to the XMPP server instead of just failing silently.
+- Fixed [#922](https://github.com/saros-project/saros/pull/922) - Saros now explicitly ignores '.git' folders.
+- Fixed [#931](https://github.com/saros-project/saros/pull/931) - Saros now saves all modified documents on session start instead of only the ones with open editors.
+
+## Features
+
+This alpha version provides most of the basic functionality of Saros.
+You can
+
+- add existing XMPP-accounts
+- add contacts to XMPP-accounts
+- start a session with another person
+  - Sessions in Saros/I are currently limited to two participants (host and one client)
+- share exactly one module through Saros; the shared module must meet the restrictions described [here](#module-restrictions)
+- transfer the initial content of the module shared by the host to all participating clients
+- work on shared resources
+- create, delete, and move resources in the shared module
+- interact freely with non-shared resources
+- follow other participants of the session ([follow mode](../documentation/features.md#follow-mode))
+
+For a guide on how to use Saros/I, have a look at our [Getting Started](../documentation/getting-started.html?tab=intellij) page.
+
+## Restrictions
+
+Some of the implemented features are still subject to some restrictions:
+
+### Module Restrictions
+
+You can currently only share a single module. A module has to adhere to the following restrictions to be shareable through Saros:
+
+- The module must have exactly one content root.
+
+Sharing a module will only share resources belonging to that module, not resources belonging to sub-module located inside a content root of the module.
+Creating such a sub-module during a session will lead to an inconsistent state that can not be resolved by Saros. See [Known Bugs](#known-bugs).
+
+### Working With Newly Created Modules
+
+To share a newly created module, you will have to have saved your project at least once before trying to start a session.
+This is necessary as the module file for a new module is only written to disk the first time the module is saved.
+
+You can check if the module file was written to disk by looking at the base directory of the module. It should contain a `*.iml` file with the same name as the module.
+
+### Resource Exclusion Options Are Not Shared
+
+Saros/I does not currently share which resources are marked as 'Excluded' with other participants. This can lead to a situation where another participant creates a resource on their side that already exists as an excluded resource locally. This leads to a session desync. See [Known Bugs](#known-bugs).
+
+### Number of Participants
+
+Currently, Saros/I is restricted to two-participant sessions, meaning you can only create session containing the host and a single client.
+
+
+## Missing Features
+
+As this is only the first alpha release, there are still a lot of main features that are not yet implemented:
+
+- Multi-user sessions
+- Sharing multiple modules
+- Sharing whole projects
+- Display viewport annotations
+- Display file awareness annotations (feature request [#114](https://github.com/saros-project/saros/issues/114))
+- Display user color in Saros view
+- Adjustable Saros settings (besides colors)
+- Creation, management or deletion of XMPP accounts
+
+### Missing Secondary Features
+
+These are features that are part of the functionality provided by Saros/E but are not seen as a crucial aspects of the plugin and are therefore have a lower priority:
+
+- Chat
+
+## Known Bugs
+
+There are some bugs in the alpha version of Saros/I that we are already aware of and that are going to be fixed in a later release. Some notable bugs are mentioned here. For a full overview, you can have a look at our [issue tracker](https://github.com/saros-project/saros/issues?q=is%3Aissue+label%3A%22Area%3A+IntelliJ%22+label%3A%22Type%3A+Bug%22+is%3Aopen).
+
+- [#116](https://github.com/saros-project/saros/issues/116) - The position of local text selection is not updated correctly for closed files when text edits are received through Saros.
+- [#610](https://github.com/saros-project/saros/issues/610) - Contact entries in the Saros view are not sorted correctly.
+- [#683](https://github.com/saros-project/saros/issues/683) - Creating a file with an unknown file extension (or without a file extension) leads to a session desynchronization. Opening the file on the other side, choosing a file type, and then running the recovery might repair the session, but the state could also be irreparable, requiring a session restart.
+- [#698](https://github.com/saros-project/saros/issues/698) - Creating a submodule in a shared directory leads to a session desync.
+- [#699](https://github.com/saros-project/saros/issues/699) - Which resource are marked as excluded is not shared between participants.
+- [#707](https://github.com/saros-project/saros/issues/707) - Client line endings are overwritten with host line endings when starting a session.
+- [#822](https://github.com/saros-project/saros/issues/822) - The state of the Saros view is not reset correctly when the the host is unexpectedly disconnected from the XMPP server.
+- [#888](https://github.com/saros-project/saros/issues/888) - Session and Contacts tab in Saros view is collapsed when non-host participant leaves the session.
+- [#958](https://github.com/saros-project/saros/issues/958) - Annotations remain in editor after session end if file was open in multiple editors.
+- [#962](https://github.com/saros-project/saros/issues/962) - Saros annotations overshadow the local selection.
+- [#964](https://github.com/saros-project/saros/issues/964) - Edits can remove caret annotations.
+
+### Report a Bug
+
+If you encounter any other bugs not mentioned above, we would appreciate it if you would report them to our issue tracker (after checking that they have not already been reported).
+
+Our current bug tracker can be found on our [GitHub page](https://github.com/saros-project/saros/issues).
+Please make it clear that the issue is dealing with Saros/I.
+
+When reporting a bug that concerns the plugin behavior, please provide the Saros log file (or all relevant excerpts) for a session where the bug was encountered.
+
+The log files for JetBrains IDEs are located in the IDE system directory (here called`IDE_SYSTEM_DIR`).
+An overview over all configurations is given on [the support forum](https://intellij-support.jetbrains.com/hc/en-us/articles/206544519-Directories-used-by-the-IDE-to-store-settings-caches-plugins-and-logs).
+For specific releases, see the information for [2019.3 and earlier](https://www.jetbrains.com/help/idea/2019.3/tuning-the-ide.html#system-directory) or [2020.1 and later](https://www.jetbrains.com/help/idea/2020.1/tuning-the-ide.html#system-directory).
+
+The Saros log files are located in `[IDE_SYSTEM_DIR]/log/SarosLogs/*.log`.
+
+If you are encountering IntelliJ IDEA errors connected to Saros (which will be displayed by a red, blinking symbol in the bottom right corner of the IntelliJ project view; the error can be viewed in more detail by clicking the symbol), please also include the IntelliJ IDEA logs.
+They are located in `[IDE_SYSTEM_DIR]/log/` and are named `idea.log` (the log will be truncated at some point and older logs will be moved to `idea.log.1`, etc.).
+Please have a look at the contained timestamps to provide the correct file.
+
+Before attaching any log files, please make sure to redact any private information that you do not wish to make publicly available.


### PR DESCRIPTION
#### [I] Adjust documentation for release 0.3.0

Updates all mentions of the current Saros/I release to 0.3.0.

Adds the release notes page for release 0.3.0.

Bumps the release version badge displayed on the README.md page to
0.3.0.

#### [DOC][I] Adjust doc to fit support for all JetBrains IDEs

Adjusts the documentation to reflect that 'Saros for IntelliJ' is now
compatible with all JetBrains IDEs. (We might have to think about
changing the name to make this easier.)

Tries to replace mentions of 'IntelliJ' with 'JetBrains' where sensible
or specify that other JetBrains IDEs are supported as well.

Replaces mentions of 'IntelliJ IDEA' with just 'the IDE' when talking
about interacting with the IDE the plugin is running on.