### PR TITLE
[FIX][CORE] Fix handling of empty selection in text selection activity

### DIFF
--- a/core/src/saros/activities/TextSelectionActivity.java
+++ b/core/src/saros/activities/TextSelectionActivity.java
@@ -86,6 +86,24 @@ public class TextSelectionActivity extends AbstractResourceActivity<IFile> {
    * @return the text selection contained in the activity
    */
   public TextSelection getSelection() {
+    if (startLine == -1 && startInLineOffset == -1 && endLine == -1 && endInLineOffset == -1) {
+      return TextSelection.EMPTY_SELECTION;
+
+    } else if (startLine == -1
+        || startInLineOffset == -1
+        || endLine == -1
+        || endInLineOffset == -1) {
+      throw new IllegalStateException(
+          "Encountered illegal selection values - sl: "
+              + startLine
+              + ", so: "
+              + startInLineOffset
+              + ", el: "
+              + endLine
+              + ", eo: "
+              + endInLineOffset);
+    }
+
     TextPosition startPosition = new TextPosition(startLine, startInLineOffset);
     TextPosition endPosition = new TextPosition(endLine, endInLineOffset);
 


### PR DESCRIPTION
Adjusts TextSelectionActivity.getSelection() to correctly return
TextSelection.EMPTY_SELECTION if all selection values are -1.

Adds an exception if only some values are -1. This should in theory not
be possible as a valid handling of all >=0 or all ==-1 is enforced by
the TextSelection constructor.