### PR TITLE
[FIX][I] Fix Saros opening editors for files created during negotiation

### DIFF
--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -308,8 +308,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
     dispatchActivity(activity);
 
-    // TODO check whether the editor is actually open locally
-    if (!createdVirtualFile.isDirectory()) {
+    if (!createdVirtualFile.isDirectory() && ProjectAPI.isOpen(project, createdVirtualFile)) {
       setUpCreatedFileState((IFile) resource);
     }
   }


### PR DESCRIPTION
Adds a check to the method generateResourceCreationActivitiy of
LocalFilesystemModificationHandler to ensure that the file is actually
open in a local editor before setting it up (which in turn would cause
such an editor to open).

The previous behavior of always setting up the editor for the created
file caused an issue where an editor was opened for resources created as
part of the project negotiation. This is due to the local filesystem
handler not being disabled during the project negotiation (as they are
not accessible to the core). As a result, the handler is called for file
creations that were the result of a received activity. To stop a
ping-pong of such activities, the dispatching of such activities is
dropped. The rest of the logic is still executed, part of which tries to
set up the editor for the created file (based on the assumption that
IntelliJ always opens an editor for the created file).
This issue is now avoided due to the logic actually checking whether the
resource is open in a local editor.