### PR TITLE
Mark Saros/I as compatible with all JetBrains IDEs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,13 +43,6 @@ jobs:
         echo "::set-env name=SHORT_SHA::$short_sha"
       shell: 'bash'
 
-    # Uncomment <depends> entries in order to make Saros/I installable in all JetBrains IDEs
-    - name: Prepare Saros/I plugin.xml
-      if: github.ref == 'refs/heads/master'
-      run: |
-        sed -i 's/<!--depends/<depends/g' intellij/resources/META-INF/plugin.xml
-        sed -i 's/depends-->/depends>/g' intellij/resources/META-INF/plugin.xml
-
     # Build
     - name: Build and test with Gradle
       run: |

--- a/intellij/resources/META-INF/plugin.xml
+++ b/intellij/resources/META-INF/plugin.xml
@@ -11,7 +11,8 @@
   <change-notes>
     <![CDATA[
         <ul>
-            <li>Bumped minimal required IntelliJ version to 2019.2.3</li>
+            <li>Bumped minimal required version to 2019.2.3.</li>
+            <li>Enables support for all <a href="https://www.jetbrains.org/intellij/sdk/docs/intro/intellij_platform.html#ides-based-on-the-intellij-platform">IDEs based on the IntelliJ platform.</a></li>
             <li>Adds support for caret/cursor annotations.</li>
             <li>Adjusts the selection annotation logic to correctly display backwards selections.</li>
             <li>Fixed <a href="https://github.com/saros-project/saros/pull/223">#223</a> - Re-creating a file deleted during a session now no longer leads to a desynchronization.</li>
@@ -37,10 +38,8 @@
   <idea-version since-build="192.6817.14"/>
 
   <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html on how to target different products -->
-  <!-- ATTENTION: the following "depends" tags are automatically uncommented by nightly-rel.yml. Make sure that changes do not break the logic. -->
-  <!-- uncomment to enable plugin in all products -->
-  <!--depends>com.intellij.modules.platform</depends-->
-  <!--depends>com.intellij.modules.lang</depends-->
+  <depends>com.intellij.modules.platform</depends>
+  <depends>com.intellij.modules.lang</depends>
 
   <application-components>
     <component>


### PR DESCRIPTION
#### [I] Mark Saros/I as compatible with all JetBrains IDEs

Declares the basic module dependencies in the Saros/I plugin.xml,
thereby declaring it as compatible with all JetBrains IDEs.

This was done as JetBrains no longer allows pushing new plugin versions
to the JetBrains Plugin Repository which don't declare any module
dependencies (i.e. are "legacy plugins").

As the compatibility with other JetBrains IDEs was planned after the
upcoming reference point migration anyway, rather then manually
declaring the dependency to other IntelliJ-specific modules, it seems
more sensible to allow the compatibility now and inform the users that
compatibility with other JetBrains IDEs is not well tested (but should
generally work).

Plugin verification and smoke tests with CLion, PyCharm, WebStorm, and
Rider did not reveal any issues. The plugin verifier run of the
JetBrains Plugin Repository release should check for all other IDEs and
possible versions.

Updates the change notes to reflect that Saros is now compatible with
all JetBrains IDEs.

Resolves #443.

#### [BUILD][I] Remove logic to uncomment Saros/I module dependencies

Removes the GitHub workflow step uncommenting the module dependencies in
the Saros/I plugin.xml. This step is now no longer needed as all
JetBrains IDEs are supported by default.