### PR TITLE
[INTERNAL][API] Ignore micro/patch version for compatibility check

### DIFF
--- a/core/src/saros/versioning/Version.java
+++ b/core/src/saros/versioning/Version.java
@@ -131,10 +131,6 @@ public class Version implements Comparable<Version> {
 
     result = minor - other.minor;
 
-    if (result != 0) return result;
-
-    result = micro - other.micro;
-
     return result;
   }
 

--- a/core/test/junit/saros/versioning/VersionManagerTest.java
+++ b/core/test/junit/saros/versioning/VersionManagerTest.java
@@ -106,7 +106,7 @@ public class VersionManagerTest {
   @Test
   public void testlocalVersionOlder() {
     Version local = Version.parseVersion("1.1.1.r1");
-    Version remote = Version.parseVersion("1.1.2.r1");
+    Version remote = Version.parseVersion("1.2.1.r1");
 
     init(local, remote);
 
@@ -118,7 +118,7 @@ public class VersionManagerTest {
 
   @Test
   public void testlocalVersionNewer() {
-    Version local = Version.parseVersion("1.1.2.r1");
+    Version local = Version.parseVersion("1.2.1.r1");
     Version remote = Version.parseVersion("1.1.1.r1");
 
     init(local, remote);
@@ -127,5 +127,18 @@ public class VersionManagerTest {
         versionManagerLocal.determineVersionCompatibility(bobContact);
 
     assertEquals(Compatibility.NEWER, result.getCompatibility());
+  }
+
+  @Test
+  public void testlocalVersionNewerMicro() {
+    Version local = Version.parseVersion("1.1.2.r1");
+    Version remote = Version.parseVersion("1.1.1.r1");
+
+    init(local, remote);
+
+    VersionCompatibilityResult result =
+        versionManagerLocal.determineVersionCompatibility(bobContact);
+
+    assertEquals(Compatibility.OK, result.getCompatibility());
   }
 }


### PR DESCRIPTION
Adjusts the version compatibility logic to only check for major and
minor versions and ignore micro/patch versions. This allows us to push
out bugfix releases without breaking compatibility without having to
first implement a more sophisticated version compatibility logic.