### PR TITLE
[INTERNAL][I] Ignore "Unused Property" warning in messages.properties

### DIFF
--- a/intellij/src/saros/intellij/ui/messages.properties
+++ b/intellij/src/saros/intellij/ui/messages.properties
@@ -1,3 +1,4 @@
+# suppress inspection "UnusedProperty" for whole file
 AddProjectToSessionWizard_title=Add Modules
 AddProjectToSessionWizard_module_creation_failed_title=Module Creation Failed – Negotiation Aborted
 AddProjectToSessionWizard_module_creation_failed_message_condition=The module {0} could not be created. The project negotiation was aborted.\nTo get help with this problem


### PR DESCRIPTION
Adds a comment to ignore the "Unused Property" warning in the
messages.properties files. This is necessary as IntelliJ does not detect
the fields as being used as they are injected through the use of
reflections.