### PR TITLE
Introduce reference point resources (ref-point migration 1/5)

### DIFF
--- a/intellij/src/saros/intellij/filesystem/IntelliJFileImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFileImpl.java
@@ -23,6 +23,8 @@ import saros.filesystem.IProject;
 import saros.filesystem.IResource;
 import saros.intellij.runtime.FilesystemRunner;
 
+/** @deprecated use {@link IntellijFileImplV2} instead */
+@Deprecated
 public final class IntelliJFileImpl extends IntelliJResourceImpl implements IFile {
   private static final Logger log = Logger.getLogger(IntelliJFileImpl.class);
 

--- a/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
@@ -23,6 +23,8 @@ import saros.filesystem.IResource;
 import saros.intellij.project.filesystem.IntelliJPathImpl;
 import saros.intellij.runtime.FilesystemRunner;
 
+/** @deprecated use {@link IntellijFolderImplV2} instead */
+@Deprecated
 public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IFolder {
   private static final Logger log = Logger.getLogger(IntelliJFolderImpl.class);
 

--- a/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
@@ -26,7 +26,12 @@ import saros.filesystem.IResource;
 import saros.intellij.project.filesystem.IntelliJPathImpl;
 import saros.intellij.runtime.FilesystemRunner;
 
-/** A <code>IntelliJProjectImpl</code> represents a specific module loaded in a specific project. */
+/**
+ * A <code>IntelliJProjectImpl</code> represents a specific module loaded in a specific project.
+ *
+ * @deprecated use {@link IntellijReferencePointImpl} instead
+ */
+@Deprecated
 public final class IntelliJProjectImpl extends IntelliJResourceImpl implements IProject {
   private static final Logger log = Logger.getLogger(IntelliJProjectImpl.class);
 

--- a/intellij/src/saros/intellij/filesystem/IntelliJResourceImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJResourceImpl.java
@@ -12,6 +12,8 @@ import org.jetbrains.annotations.NotNull;
 import saros.filesystem.IResource;
 import saros.intellij.editor.ProjectAPI;
 
+/** @deprecated use {@link IntellijResourceImplV2} instead */
+@Deprecated
 public abstract class IntelliJResourceImpl implements IResource {
 
   @Override

--- a/intellij/src/saros/intellij/filesystem/IntellijFileImplV2.java
+++ b/intellij/src/saros/intellij/filesystem/IntellijFileImplV2.java
@@ -1,0 +1,225 @@
+package saros.intellij.filesystem;
+
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.util.ThrowableComputable;
+import com.intellij.openapi.vfs.VirtualFile;
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.file.FileAlreadyExistsException;
+import org.apache.commons.io.IOUtils;
+import org.apache.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import saros.filesystem.IFile;
+import saros.filesystem.IPath;
+import saros.filesystem.IResource;
+import saros.intellij.runtime.FilesystemRunner;
+
+/** Intellij implementation of the Saros file interface. */
+// TODO rename to IntellijFile
+public class IntellijFileImplV2 extends IntellijResourceImplV2 implements IFile {
+  private static final Logger log = Logger.getLogger(IntellijFileImplV2.class);
+
+  public IntellijFileImplV2(
+      @NotNull IntellijReferencePointImpl referencePoint, @NotNull IPath relativePath) {
+
+    super(referencePoint, relativePath);
+  }
+
+  @Override
+  public boolean exists() {
+    if (!referencePoint.exists()) {
+      return false;
+    }
+
+    VirtualFile virtualFile = getVirtualFile();
+
+    return existsInternal(virtualFile);
+  }
+
+  /**
+   * Returns whether the given virtual file is not <code>null</code>, exists, and is a file.
+   *
+   * @param virtualFile the virtual file to check
+   * @return whether the given virtual file is not <code>null</code>, exists, and is a file
+   */
+  private static boolean existsInternal(@Nullable VirtualFile virtualFile) {
+    return virtualFile != null && virtualFile.exists() && !virtualFile.isDirectory();
+  }
+
+  @Override
+  public void delete() throws IOException {
+    FilesystemRunner.runWriteAction(
+        (ThrowableComputable<Void, IOException>)
+            () -> {
+              deleteInternal();
+
+              return null;
+            },
+        ModalityState.defaultModalityState());
+  }
+
+  /**
+   * Deletes the file in the filesystem.
+   *
+   * @throws IOException if the resource is a directory or the deletion failed
+   * @see VirtualFile#delete(Object)
+   */
+  private void deleteInternal() throws IOException {
+    VirtualFile virtualFile = getVirtualFile();
+
+    if (virtualFile == null || !virtualFile.exists()) {
+      log.debug("Ignoring file deletion request for " + this + " as it does not exist.");
+
+      return;
+    }
+
+    if (virtualFile.isDirectory()) {
+      throw new IOException("Failed to delete " + this + " as it is not a file");
+    }
+
+    virtualFile.delete(this);
+  }
+
+  @Override
+  @Nullable
+  public String getCharset() throws IOException {
+    VirtualFile virtualFile = getVirtualFile();
+
+    if (!existsInternal(virtualFile)) {
+      throw new FileNotFoundException(
+          "Could not obtain charset for " + this + " as it does not exist or is not valid");
+    }
+
+    return virtualFile.getCharset().name();
+  }
+
+  @Override
+  public void setCharset(@Nullable String charset) throws IOException {
+    if (charset == null) {
+      return;
+    }
+
+    VirtualFile virtualFile = getVirtualFile();
+
+    if (!existsInternal(virtualFile)) {
+      throw new FileNotFoundException(
+          "Could not set charset for " + this + " as it does not exist or is not valid");
+    }
+
+    virtualFile.setCharset(Charset.forName(charset));
+  }
+
+  @Override
+  @NotNull
+  public InputStream getContents() throws IOException {
+    VirtualFile virtualFile = getVirtualFile();
+
+    if (!existsInternal(virtualFile)) {
+      throw new FileNotFoundException(
+          "Could not obtain contents for " + this + " as it does not exist or is not valid");
+    }
+
+    return virtualFile.getInputStream();
+  }
+
+  @Override
+  public void setContents(@Nullable InputStream input) throws IOException {
+    FilesystemRunner.runWriteAction(
+        (ThrowableComputable<Void, IOException>)
+            () -> {
+              setContentsInternal(input);
+
+              return null;
+            },
+        ModalityState.defaultModalityState());
+  }
+
+  /**
+   * Sets the content of the file.
+   *
+   * @param input an input stream to write into the file
+   * @throws IOException if the file does not exist or could not be written to
+   * @see IOUtils#copy(InputStream, OutputStream)
+   */
+  private void setContentsInternal(@Nullable InputStream input) throws IOException {
+    VirtualFile virtualFile = getVirtualFile();
+
+    if (!existsInternal(virtualFile)) {
+      throw new FileNotFoundException(
+          "Could not set contents of " + this + " as it does not exist or is not valid.");
+    }
+
+    try (InputStream in = input == null ? new ByteArrayInputStream(new byte[0]) : input;
+        OutputStream out = virtualFile.getOutputStream(this)) {
+
+      IOUtils.copy(in, out);
+    }
+  }
+
+  @Override
+  public void create(@Nullable InputStream input) throws IOException {
+    FilesystemRunner.runWriteAction(
+        (ThrowableComputable<Void, IOException>)
+            () -> {
+              createInternal(input);
+
+              return null;
+            },
+        ModalityState.defaultModalityState());
+  }
+
+  /**
+   * Creates this file in the local filesystem with the given content.
+   *
+   * @param input an input stream to write into the file
+   * @throws FileAlreadyExistsException if a resource with the same name already exists
+   * @throws FileNotFoundException if the parent directory of this file does not exist
+   */
+  private void createInternal(@Nullable InputStream input) throws IOException {
+    IResource parent = getParent();
+
+    VirtualFile parentFile = referencePoint.findVirtualFile(parent.getProjectRelativePath());
+
+    if (parentFile == null || !parentFile.exists()) {
+      throw new FileNotFoundException(
+          "Could not create "
+              + this
+              + " as its parent folder "
+              + parent
+              + " does not exist or is not valid");
+    }
+
+    VirtualFile virtualFile = parentFile.findChild(getName());
+
+    if (virtualFile != null && virtualFile.exists()) {
+      throw new FileAlreadyExistsException(
+          "Could not create "
+              + this
+              + " as a resource with the same name already exists: "
+              + virtualFile);
+    }
+
+    parentFile.createChildData(this, getName());
+
+    if (input != null) {
+      setContents(input);
+    }
+  }
+
+  @Override
+  public long getSize() throws IOException {
+    VirtualFile virtualFile = getVirtualFile();
+
+    if (!existsInternal(virtualFile)) {
+      throw new FileNotFoundException(
+          "Could not obtain the size for " + this + " as it does not exist or is not valid");
+    }
+
+    return virtualFile.getLength();
+  }
+}

--- a/intellij/src/saros/intellij/filesystem/IntellijFolderImplV2.java
+++ b/intellij/src/saros/intellij/filesystem/IntellijFolderImplV2.java
@@ -1,0 +1,203 @@
+package saros.intellij.filesystem;
+
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.util.ThrowableComputable;
+import com.intellij.openapi.vfs.VirtualFile;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import saros.filesystem.IFile;
+import saros.filesystem.IFolder;
+import saros.filesystem.IPath;
+import saros.filesystem.IResource;
+import saros.intellij.project.filesystem.IntelliJPathImpl;
+import saros.intellij.runtime.FilesystemRunner;
+
+/** Intellij implementation of the Saros folder interface. */
+// TODO rename to IntellijFolder
+public class IntellijFolderImplV2 extends IntellijResourceImplV2 implements IFolder {
+  private static final Logger log = Logger.getLogger(IntellijFolderImplV2.class);
+
+  public IntellijFolderImplV2(
+      @NotNull IntellijReferencePointImpl referencePoint, @NotNull IPath relativePath) {
+
+    super(referencePoint, relativePath);
+  }
+
+  @Override
+  public boolean exists() {
+    if (!referencePoint.exists()) {
+      return false;
+    }
+
+    VirtualFile virtualFile = getVirtualFile();
+
+    return existsInternal(virtualFile);
+  }
+
+  /**
+   * whether the given virtual file is not <code>null</code>, exists, and is a directory.
+   *
+   * @param virtualFile the virtual file to check
+   * @return whether the given virtual file is not <code>null</code>, exists, and is a directory
+   */
+  private static boolean existsInternal(@Nullable VirtualFile virtualFile) {
+    return virtualFile != null && virtualFile.exists() && virtualFile.isDirectory();
+  }
+
+  @Override
+  public boolean exists(@NotNull IPath path) {
+    return referencePoint.exists(relativePath.append(path));
+  }
+
+  @Override
+  @NotNull
+  public List<IResource> members() throws IOException {
+    VirtualFile folder = getVirtualFile();
+
+    if (folder == null || !folder.exists()) {
+      throw new FileNotFoundException(
+          "Could not obtain child resources for " + this + " as it does not exist or is not valid");
+    }
+
+    if (!folder.isDirectory()) {
+      throw new IOException(
+          "Could not obtain child resources for " + this + " as it is not a directory.");
+    }
+
+    List<IResource> result = new ArrayList<>();
+
+    VirtualFile[] children = folder.getChildren();
+
+    for (VirtualFile child : children) {
+      IPath childPath = relativePath.append(IntelliJPathImpl.fromString(child.getName()));
+
+      result.add(
+          child.isDirectory()
+              ? new IntellijFolderImplV2(referencePoint, childPath)
+              : new IntellijFileImplV2(referencePoint, childPath));
+    }
+
+    return result;
+  }
+
+  @Override
+  @NotNull
+  public IFile getFile(@NotNull String pathString) {
+    return getFile(IntelliJPathImpl.fromString(pathString));
+  }
+
+  @Override
+  @NotNull
+  public IFile getFile(@NotNull IPath path) {
+    if (path.segmentCount() == 0) {
+      throw new IllegalArgumentException("Can not create file handle for an empty path");
+    }
+
+    IPath referencePointRelativeChildPath = relativePath.append(path);
+
+    return new IntellijFileImplV2(referencePoint, referencePointRelativeChildPath);
+  }
+
+  @Override
+  @NotNull
+  public IFolder getFolder(@NotNull String pathString) {
+    return getFolder(IntelliJPathImpl.fromString(pathString));
+  }
+
+  @Override
+  @NotNull
+  public IFolder getFolder(@NotNull IPath path) {
+    if (path.segmentCount() == 0) {
+      throw new IllegalArgumentException("Can not create folder handle for an empty path");
+    }
+
+    IPath referencePointRelativeChildPath = relativePath.append(path);
+
+    return new IntellijFolderImplV2(referencePoint, referencePointRelativeChildPath);
+  }
+
+  @Override
+  public void delete() throws IOException {
+    FilesystemRunner.runWriteAction(
+        (ThrowableComputable<Void, IOException>)
+            () -> {
+              deleteInternal();
+
+              return null;
+            },
+        ModalityState.defaultModalityState());
+  }
+
+  /**
+   * Deletes the folder in the filesystem.
+   *
+   * @throws IOException if the resource is a file or the deletion failed
+   * @see VirtualFile#delete(Object)
+   */
+  private void deleteInternal() throws IOException {
+    VirtualFile virtualFile = getVirtualFile();
+
+    if (virtualFile == null || !virtualFile.exists()) {
+      log.debug("Ignoring file deletion request for " + this + " as folder does not exist");
+
+      return;
+    }
+
+    if (!virtualFile.isDirectory()) {
+      throw new IOException("Failed to delete " + this + " as it is not a folder");
+    }
+
+    virtualFile.delete(IntellijFolderImplV2.this);
+  }
+
+  @Override
+  public void create() throws IOException {
+    FilesystemRunner.runWriteAction(
+        (ThrowableComputable<Void, IOException>)
+            () -> {
+              createInternal();
+
+              return null;
+            },
+        ModalityState.defaultModalityState());
+  }
+
+  /**
+   * Creates the folder in the local filesystem.
+   *
+   * @throws FileAlreadyExistsException if a resource with the same name already exists
+   * @throws FileNotFoundException if the parent directory of the folder does not exist
+   */
+  private void createInternal() throws IOException {
+    IResource parent = getParent();
+
+    VirtualFile parentFile = referencePoint.findVirtualFile(parent.getProjectRelativePath());
+
+    if (parentFile == null || !parentFile.exists()) {
+      throw new FileNotFoundException(
+          "Could not create "
+              + this
+              + " as its parent folder "
+              + parent
+              + " does not exist or is not valid");
+    }
+
+    VirtualFile virtualFile = parentFile.findChild(getName());
+
+    if (virtualFile != null && virtualFile.exists()) {
+      throw new FileAlreadyExistsException(
+          "Could not create "
+              + this
+              + " as a resource with the same name already exists: "
+              + virtualFile);
+    }
+
+    parentFile.createChildDirectory(this, getName());
+  }
+}

--- a/intellij/src/saros/intellij/filesystem/IntellijReferencePointImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntellijReferencePointImpl.java
@@ -1,0 +1,277 @@
+package saros.intellij.filesystem;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import saros.filesystem.IFile;
+import saros.filesystem.IFolder;
+import saros.filesystem.IPath;
+import saros.filesystem.IProject;
+import saros.filesystem.IResource;
+import saros.intellij.project.filesystem.IntelliJPathImpl;
+
+/** Intellij implementation of the Saros reference point interface. */
+// TODO rename to IntellijReferencePoint
+public class IntellijReferencePointImpl implements IProject {
+  private static final Logger log = Logger.getLogger(IntellijReferencePointImpl.class);
+
+  /** The project instance the reference point is bound to. */
+  private final Project project;
+
+  /** The virtual file represented by this reference point. */
+  private final VirtualFile virtualFile;
+
+  public IntellijReferencePointImpl(@NotNull Project project, @NotNull VirtualFile virtualFile) {
+
+    if (!project.isInitialized()) {
+      throw new IllegalArgumentException("The given project must be initialized - " + project);
+    }
+
+    if (!virtualFile.exists()) {
+      throw new IllegalArgumentException("The given virtual file must exist - " + virtualFile);
+
+    } else if (!virtualFile.isDirectory()) {
+      throw new IllegalArgumentException(
+          "The given virtual file must be a directory - " + virtualFile);
+    }
+
+    this.project = project;
+    this.virtualFile = virtualFile;
+  }
+
+  /**
+   * Returns the project instance the reference point is bound to.
+   *
+   * @return the project instance the reference point is bound to
+   */
+  // TODO rename 'getProject' once Saros project has been renamed to reference point
+  @NotNull
+  public Project getIntellijProject() {
+    return project;
+  }
+
+  /**
+   * Returns the virtual file represented by this reference point.
+   *
+   * @return the virtual file represented by this reference point
+   */
+  @NotNull
+  VirtualFile getVirtualFile() {
+    return virtualFile;
+  }
+
+  @Override
+  public boolean exists(@NotNull IPath path) {
+    if (!virtualFile.exists()) {
+      return false;
+    }
+
+    VirtualFile file = findVirtualFile(path);
+
+    return file != null && file.exists();
+  }
+
+  @Override
+  @NotNull
+  public List<IResource> members() {
+    List<IResource> result = new ArrayList<>();
+
+    VirtualFile[] children = virtualFile.getChildren();
+
+    for (VirtualFile child : children) {
+      IPath childPath = IntelliJPathImpl.fromString(child.getName());
+
+      result.add(
+          child.isDirectory()
+              ? new IntellijFolderImplV2(this, childPath)
+              : new IntellijFileImplV2(this, childPath));
+    }
+
+    return result;
+  }
+
+  @Override
+  public boolean exists() {
+    return virtualFile.exists();
+  }
+
+  @Override
+  @NotNull
+  public String getName() {
+    return virtualFile.getName();
+  }
+
+  @Override
+  @NotNull
+  public IPath getProjectRelativePath() {
+    return IntelliJPathImpl.EMPTY;
+  }
+
+  /**
+   * Returns the path to the given file relative to the virtual file represented by this reference
+   * point.
+   *
+   * <p><b>Note:</b> This methods expects that the given <code>VirtualFile</code> exists.
+   *
+   * @param file the <code>VirtualFile</code> to get the relative path for
+   * @return a relative path for the given file or <code>null</code> if there is no relative path
+   *     from the reference point to the file
+   */
+  @Nullable
+  private IPath getReferencePointRelativePath(@NotNull VirtualFile file) {
+
+    String referencePointPath = virtualFile.getPath();
+    String filePath = file.getPath();
+
+    if (!filePath.startsWith(referencePointPath)) {
+      return null;
+    }
+
+    try {
+      Path relativePath = Paths.get(referencePointPath).relativize(Paths.get(filePath));
+
+      return IntelliJPathImpl.fromString(relativePath.toString());
+
+    } catch (IllegalArgumentException e) {
+      log.warn(
+          "Could not find a relative path from the base file "
+              + virtualFile
+              + " to the file "
+              + file,
+          e);
+
+      return null;
+    }
+  }
+
+  @Override
+  @NotNull
+  public IFile getFile(@NotNull String pathString) {
+    return getFile(IntelliJPathImpl.fromString(pathString));
+  }
+
+  @Override
+  @NotNull
+  public IFile getFile(@NotNull IPath path) {
+    if (path.segmentCount() == 0) {
+      throw new IllegalArgumentException("Can not create file handle for an empty path");
+    }
+
+    return new IntellijFileImplV2(this, path);
+  }
+
+  /**
+   * Returns an <code>IFile</code> for the given file.
+   *
+   * @param file the <code>VirtualFile</code> to get the <code>IFile</code> for
+   * @return an <code>IFile</code> for the given file or <code>null</code> if the given file is a
+   *     directory, does not exist, or the relative path of the file could not be constructed
+   */
+  @Nullable
+  IFile getFile(@NotNull VirtualFile file) {
+    if (!file.exists() || file.isDirectory()) {
+      return null;
+    }
+
+    IPath relativePath = getReferencePointRelativePath(file);
+
+    return relativePath != null ? new IntellijFileImplV2(this, relativePath) : null;
+  }
+
+  @Override
+  @NotNull
+  public IFolder getFolder(@NotNull String pathString) {
+    return getFolder(IntelliJPathImpl.fromString(pathString));
+  }
+
+  @Override
+  @NotNull
+  public IFolder getFolder(@NotNull IPath path) {
+    if (path.segmentCount() == 0) {
+      throw new IllegalArgumentException("Can not create folder handle for an empty path");
+    }
+
+    return new IntellijFolderImplV2(this, path);
+  }
+
+  /**
+   * Returns an <code>IFolder</code> for the given file.
+   *
+   * @param file the <code>VirtualFile</code> to get the <code>IFolder</code> for
+   * @return an <code>IFolder</code> for the given file or <code>null</code> if the given file is
+   *     not a directory, does not exist, or the relative path of the file could not be constructed
+   * @throws IllegalArgumentException if the given virtual file is the reference point file
+   */
+  @Nullable
+  IFolder getFolder(@NotNull VirtualFile file) {
+    if (file.equals(virtualFile)) {
+      throw new IllegalArgumentException("Given virtual file must not be the reference point file");
+
+    } else if (!file.exists() || !file.isDirectory()) {
+      return null;
+    }
+
+    IPath relativePath = getReferencePointRelativePath(file);
+
+    return relativePath != null ? new IntellijFolderImplV2(this, relativePath) : null;
+  }
+
+  /**
+   * Returns an <code>IResource</code> for the given file.
+   *
+   * @param file the <code>VirtualFile</code> to get the <code>IResource</code> for
+   * @return an <code>IResource</code> for the given file or <code>null</code> if the given file
+   *     does not exist or the relative path of the file could not be constructed
+   * @throws IllegalArgumentException if the given virtual file is the reference point file
+   */
+  @Nullable
+  IResource getResource(@NotNull VirtualFile file) {
+    if (file.isDirectory()) {
+      return getFolder(file);
+    } else {
+      return getFile(file);
+    }
+  }
+
+  /**
+   * Returns the virtual file for the given relative path.
+   *
+   * @param relativePath relative path to the file
+   * @return the virtual file or <code>null</code> if there is no such file in the VFS snapshot
+   */
+  @Nullable
+  VirtualFile findVirtualFile(@NotNull IPath relativePath) {
+    if (relativePath.isAbsolute()) return null;
+
+    if (relativePath.segmentCount() == 0) return virtualFile;
+
+    return virtualFile.findFileByRelativePath(relativePath.toString());
+  }
+
+  @Override
+  public int hashCode() {
+    return virtualFile.hashCode();
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    if (this == obj) return true;
+    if (obj == null) return false;
+    if (getClass() != obj.getClass()) return false;
+
+    IntellijReferencePointImpl other = (IntellijReferencePointImpl) obj;
+
+    return this.virtualFile.equals(other.virtualFile);
+  }
+
+  @Override
+  public String toString() {
+    return "[" + getClass().getSimpleName() + " : " + virtualFile + "]";
+  }
+}

--- a/intellij/src/saros/intellij/filesystem/IntellijResourceImplV2.java
+++ b/intellij/src/saros/intellij/filesystem/IntellijResourceImplV2.java
@@ -1,0 +1,140 @@
+package saros.intellij.filesystem;
+
+import static saros.filesystem.IResource.Type.FOLDER;
+
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import saros.filesystem.IContainer;
+import saros.filesystem.IPath;
+import saros.filesystem.IProject;
+import saros.filesystem.IResource;
+import saros.intellij.editor.ProjectAPI;
+
+/** Abstract Intellij implementation of the Saros resource interface. */
+// TODO rename to AbstractIntellijResource
+public abstract class IntellijResourceImplV2 implements IResource {
+
+  /** Reference point to which this resource belongs. */
+  protected final IntellijReferencePointImpl referencePoint;
+
+  /** Relative path from the given reference point. */
+  protected final IPath relativePath;
+
+  /**
+   * Instantiates an Intellij resource object.
+   *
+   * @param referencePoint the reference point the resource is located beneath
+   * @param relativePath the relative path from the reference point
+   * @throws IllegalArgumentException if the given path is absolute or empty
+   */
+  public IntellijResourceImplV2(
+      @NotNull IntellijReferencePointImpl referencePoint, @NotNull IPath relativePath) {
+
+    if (relativePath.segmentCount() == 0) {
+      throw new IllegalArgumentException("Given path must not be empty");
+    }
+    if (relativePath.isAbsolute()) {
+      throw new IllegalArgumentException("The given path must not be absolute - " + relativePath);
+    }
+
+    this.referencePoint = referencePoint;
+    this.relativePath = relativePath;
+  }
+
+  /**
+   * Returns the virtual file represented by this resource.
+   *
+   * @return the virtual file represented by this resource or <code>null</code> if no such resource
+   *     exists in the local VFS snapshot
+   */
+  @Nullable
+  protected VirtualFile getVirtualFile() {
+    return referencePoint.findVirtualFile(relativePath);
+  }
+
+  @Override
+  @NotNull
+  public String getName() {
+    return relativePath.lastSegment();
+  }
+
+  @Override
+  @NotNull
+  public IContainer getParent() {
+    if (relativePath.segmentCount() <= 1) {
+      return referencePoint;
+    }
+
+    return new IntellijFolderImplV2(referencePoint, relativePath.removeLastSegments(1));
+  }
+
+  @Override
+  @NotNull
+  public IProject getProject() {
+    return referencePoint;
+  }
+
+  @Override
+  @NotNull
+  public IPath getProjectRelativePath() {
+    return relativePath;
+  }
+
+  @Override
+  public boolean isIgnored() {
+    return isGitConfig() || isExcluded();
+  }
+
+  /**
+   * Returns whether this resource is part of the git configuration directory.
+   *
+   * @return whether this resource is part of the git configuration directory
+   */
+  private boolean isGitConfig() {
+    String path = relativePath.toPortableString();
+
+    return (path.startsWith(".git/")
+        || path.contains("/.git/")
+        || getType() == FOLDER && (path.endsWith("/.git") || path.equals(".git")));
+  }
+
+  /**
+   * Returns whether the resource is located under an excluded root in its project.
+   *
+   * <p>Nonexistent resources are reported as excluded.
+   *
+   * @return whether the resource is located under an excluded root in its project
+   */
+  private boolean isExcluded() {
+    VirtualFile virtualFile = getVirtualFile();
+
+    if (virtualFile == null) {
+      return true;
+    }
+
+    return ProjectAPI.isExcluded(referencePoint.getIntellijProject(), virtualFile);
+  }
+
+  @Override
+  public int hashCode() {
+    return referencePoint.hashCode() + 31 * relativePath.hashCode();
+  }
+
+  @Override
+  public boolean equals(@Nullable Object obj) {
+    if (this == obj) return true;
+    if (obj == null) return false;
+    if (getClass() != obj.getClass()) return false;
+
+    IntellijResourceImplV2 other = (IntellijResourceImplV2) obj;
+
+    return this.referencePoint.equals(other.referencePoint)
+        && this.relativePath.equals(other.relativePath);
+  }
+
+  @Override
+  public String toString() {
+    return "[" + getClass().getSimpleName() + " : " + relativePath + " - " + referencePoint + "]";
+  }
+}


### PR DESCRIPTION
#### [INTERNAL][I] Introduce new resource implementation

Introduces the new reference point based resource implementation. The
implementation is based on the existing implementation that was then
simplified and adjusted to use reference points.

The new implementation is not used anywhere yet.

Marks the old resource implementations as deprecated.

#### [INTERNAL][I] Adjust VirtualFileConverter to support new resource impls

Adds methods for the new reference point based resource implementations
to VirtualFileConverter.

Marks the old methods as deprecated.