### PR TITLE
Migrate local resource handler to reference points (ref-point migration 5/5)

### DIFF
--- a/intellij/src/saros/core/ui/util/CollaborationUtils.java
+++ b/intellij/src/saros/core/ui/util/CollaborationUtils.java
@@ -128,15 +128,15 @@ public class CollaborationUtils {
       return;
     }
 
+    leaveSessionUnconditionally();
+  }
+
+  /**
+   * Leaves the session unconditionally. Does not check whether there is actually a running session.
+   */
+  public static void leaveSessionUnconditionally() {
     ThreadUtils.runSafeAsync(
-        "StopSession",
-        log,
-        new Runnable() {
-          @Override
-          public void run() {
-            sessionManager.stopSession(SessionEndReason.LOCAL_USER_LEFT);
-          }
-        });
+        "StopSession", log, () -> sessionManager.stopSession(SessionEndReason.LOCAL_USER_LEFT));
   }
 
   /**

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -684,7 +684,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
 
             return true;
           }
-
+          // TODO decide how to handle moved versions of ignored resources
           if (newFolderIsShared) {
             IFolder newFolder =
                 newParentWrapper
@@ -706,9 +706,20 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
                     .getProject()
                     .getFolder(oldFolderWrapper.getProjectRelativePath().append(relativePath));
 
-            IActivity newFolderDeletedActivity = new FolderDeletedActivity(user, oldFolder);
+            if (!session.isShared(oldFolder)) {
+              log.debug(
+                  "Ignoring non-shared child folder move - folder: "
+                      + oldFolder
+                      + ", old parent: "
+                      + oldFolderWrapper
+                      + ", new Parent: "
+                      + newParent);
 
-            queuedDeletionActivities.addFirst(newFolderDeletedActivity);
+            } else {
+              IActivity oldFolderDeletedActivity = new FolderDeletedActivity(user, oldFolder);
+
+              queuedDeletionActivities.addFirst(oldFolderDeletedActivity);
+            }
           }
 
           return true;
@@ -830,6 +841,7 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
       cleanUpBackgroundEditorPool(oldFileWrapper);
 
     } else if (newFileIsShared) {
+      // TODO decide how to handle moved versions of ignored resources
       // moved file into shared reference point
       byte[] fileContent = getContent(oldFile);
 

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -251,13 +251,22 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
       return;
     }
 
-    // TODO figure out if this can happen
-    log.warn(
-        "Detected unhandled content change on the virtual file level "
-            + "for "
-            + virtualFile
-            + ", requested by: "
-            + virtualFileEvent.getRequestor());
+    if (!virtualFile.getFileType().isBinary()) {
+      // modification already handled by document modification handler
+      log.debug(
+          "Ignoring content change on the virtual file level for text resource "
+              + virtualFile
+              + ", requested by: "
+              + virtualFileEvent.getRequestor());
+
+    } else {
+      // TODO handle content changes for non-text resources; see #996
+      log.warn(
+          "Detected unhandled content change on the virtual file level for non-text resource "
+              + virtualFile
+              + ", requested by: "
+              + virtualFileEvent.getRequestor());
+    }
   }
 
   /**

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -460,8 +460,12 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
           IFolder childFolder =
               (IFolder) VirtualFileConverter.convertToResource(fileOrDir, baseReferencePoint);
 
-          if (childFolder == null) {
-            log.debug("Skipping deleted folder as no IFile could be obtained " + fileOrDir);
+          if (childFolder == null || !session.isShared(childFolder)) {
+            log.debug(
+                "Ignoring non-shared child folder deletion: "
+                    + fileOrDir
+                    + ", parent folder: "
+                    + container);
 
             return true;
           }

--- a/intellij/src/saros/intellij/ui/Messages.java
+++ b/intellij/src/saros/intellij/ui/Messages.java
@@ -216,5 +216,12 @@ public class Messages {
   public static String ColorPreferences_user_example_text_contribution;
   public static String ColorPreferences_user_example_text_selection;
 
+  public static String LocalFilesystemModificationHandler_deleted_reference_point_title;
+  public static String LocalFilesystemModificationHandler_deleted_reference_point_message;
+  public static String
+      LocalFilesystemModificationHandler_moved_reference_point_into_exclusion_title;
+  public static String
+      LocalFilesystemModificationHandler_moved_reference_point_into_exclusion_message;
+
   private Messages() {}
 }

--- a/intellij/src/saros/intellij/ui/messages.properties
+++ b/intellij/src/saros/intellij/ui/messages.properties
@@ -198,3 +198,8 @@ ColorPreferences_default_user_description=the default user
 ColorPreferences_user_description=user {0}
 ColorPreferences_user_example_text_contribution=This is what <contrib{0}>a contribution annotation</contrib{0}> for {1} would look like.
 ColorPreferences_user_example_text_selection=This is what <sel{0}>a selection annotation</sel{0}> for {1} would look like.
+
+LocalFilesystemModificationHandler_deleted_reference_point_title=Deleted Shared Reference Point - Left Session
+LocalFilesystemModificationHandler_deleted_reference_point_message=Deleting the local representation of a shared reference point is not supported. Saros left the running session.\nDeleted directory: {0}
+LocalFilesystemModificationHandler_moved_reference_point_into_exclusion_title=Moved Shared Reference Point Into Excluded Directory - Left Session
+LocalFilesystemModificationHandler_moved_reference_point_into_exclusion_message=Moving the local representation of a shared reference point into an excluded directory is not supported. Saros left the running session.\nMoved directory: {0}\nNew parent directory: {1}


### PR DESCRIPTION
Migrates the logic handling local filesystem modifications to the new reference point based resource implementation. Adjust the logic to correctly handle specific edge-cases of the new resource system.

I would suggest reviewing this PR commit by commit.

### Commits
<details><summary><b>[INTERNAL][I] Migrate filesystem handler to support new sharing logic</b></summary>
<br>

Removes all references to the old sharing logic/resource implementation.

Adjusts the logic to ignore moves/renames of reference point base
resources.

Removes no longer necessary, module specific logic and TODOs.

Adjusts the file filter to only filter out excluded files. Even
filtering out excluded resources is merely a performance optimization
and may be removed in the future.

</details>

<details><summary><b>[INTERNAL][I] Leave session if shared reference point is invalidated</b></summary>
<br>

Adjusts the logic in LocalFilesystemModificationHandler to leave the
running session if the base resource of a shared reference point is
deleted or moved into an excluded directory. In both of theses cases,
the base of the reference point becomes "unshareable". As this state can
not be resolved by Saros, it is best to leave the session and have the
user deal with it (e.g. by setting up a new session on the reduced
session scope).

Dispatches an error notification informing the user of the issue and the
subsequent session end.

</details>

<details><summary><b>[INTERNAL][I] Check whether deleted child resources are shared</b></summary>
<br>

Adds a check ensuring that deleted child resources are actually shared
before sending a deletion activity for them.

</details>

<details><summary><b>[LOG][I] Drop log level for filesystem changes for text files</b></summary>
<br>

Drops the log level of unhandled filesystem modifications of text files
to debug.  These seem  to occur quite frequently but are all also passed
to the document modification listeners if the resource is representable
by a document.

Adds a TODO to handle such content changes for non-text files. See #996.

</details>

<details><summary><b>[INTERNAL][I] Ignore moved non-shared child folders</b></summary>
<br>

Adjusts the handling of moved folders to check whether moved child
folders are actually shared.

Adds TODOs to decide how to handle the target versions of ignored moved
resources. If an ignored resource is moved into a shared directory,
should the new resources in the shared directory be shared as well?

</details>