### PR TITLE
[API][CORE] Return list for IContainer.members()

### DIFF
--- a/core/src/saros/filesystem/IContainer.java
+++ b/core/src/saros/filesystem/IContainer.java
@@ -1,6 +1,7 @@
 package saros.filesystem;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Represents a handle for a container in the (virtual) file system. Containers are defined as
@@ -26,7 +27,7 @@ public interface IContainer extends IResource {
    * @throws IOException if the container does not exist or the contained resources could not be
    *     read
    */
-  IResource[] members() throws IOException;
+  List<IResource> members() throws IOException;
 
   /**
    * Returns a handle for the file with the given relative path to this resource.

--- a/core/src/saros/negotiation/FileListFactory.java
+++ b/core/src/saros/negotiation/FileListFactory.java
@@ -1,7 +1,6 @@
 package saros.negotiation;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.LinkedList;
@@ -100,9 +99,9 @@ public class FileListFactory {
   private static List<IFile> calculateMembers(final FileList list, final IProject project)
       throws IOException {
 
-    List<IResource> resources = Arrays.asList(project.members());
+    List<IResource> resources = project.members();
 
-    if (resources.size() == 0) return Collections.emptyList();
+    if (resources.isEmpty()) return Collections.emptyList();
 
     Deque<IResource> stack = new LinkedList<>(resources);
 
@@ -126,7 +125,7 @@ public class FileListFactory {
           break;
 
         case FOLDER:
-          stack.addAll(Arrays.asList(((IFolder) resource).members()));
+          stack.addAll(((IFolder) resource).members());
           list.addPath(path, null, true);
           break;
       }

--- a/core/test/junit/saros/negotiation/FileListTest.java
+++ b/core/test/junit/saros/negotiation/FileListTest.java
@@ -16,6 +16,7 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
@@ -112,23 +113,31 @@ public class FileListTest {
 
     final IProject project = EasyMock.createMock(IProject.class);
 
-    final IFolder barFolder = createFolderMock(project, "bar", new IResource[0]);
+    final IFolder barFolder = createFolderMock(project, "bar", Collections.emptyList());
 
-    final IFolder foobarfooFolder = createFolderMock(project, "foobar/foo", new IResource[0]);
+    final IFolder foobarfooFolder =
+        createFolderMock(project, "foobar/foo", Collections.emptyList());
 
     final IFile infoTxtFile = createFileMock(project, "info.txt", "1234", "UTF-8");
 
     final IFile foobarInfoTxtFile =
         createFileMock(project, "foobar/info.txt", "12345", "ISO-8859-1");
 
-    final IFolder foobarFolder =
-        createFolderMock(project, "foobar", new IResource[] {foobarfooFolder, foobarInfoTxtFile});
+    List<IResource> fooBarFolderMembers = new ArrayList<>();
+    fooBarFolderMembers.add(foobarfooFolder);
+    fooBarFolderMembers.add(foobarInfoTxtFile);
+
+    final IFolder foobarFolder = createFolderMock(project, "foobar", fooBarFolderMembers);
 
     EasyMock.expect(project.getName()).andStubReturn("foo");
 
+    List<IResource> projectMembers = new ArrayList<>();
+    projectMembers.add(barFolder);
+    projectMembers.add(infoTxtFile);
+    projectMembers.add(foobarFolder);
+
     try {
-      EasyMock.expect(project.members())
-          .andStubReturn(new IResource[] {barFolder, infoTxtFile, foobarFolder});
+      EasyMock.expect(project.members()).andStubReturn(projectMembers);
     } catch (IOException e) {
       // cannot happen
     }
@@ -186,7 +195,7 @@ public class FileListTest {
   }
 
   private static IFolder createFolderMock(
-      final IProject project, final String path, final IResource[] members) {
+      final IProject project, final String path, final List<IResource> members) {
 
     final IPath relativePath = createPathMock(path);
 

--- a/eclipse/src/saros/filesystem/EclipseContainerImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseContainerImpl.java
@@ -19,7 +19,7 @@ public class EclipseContainerImpl extends EclipseResourceImpl implements IContai
   }
 
   @Override
-  public IResource[] members() throws IOException {
+  public List<IResource> members() throws IOException {
     org.eclipse.core.resources.IResource[] resources;
 
     try {
@@ -28,7 +28,7 @@ public class EclipseContainerImpl extends EclipseResourceImpl implements IContai
       List<IResource> result = new ArrayList<IResource>(resources.length);
       ResourceAdapterFactory.convertTo(Arrays.asList(resources), result);
 
-      return result.toArray(new IResource[0]);
+      return result;
     } catch (CoreException e) {
       throw new IOException(e);
     }

--- a/intellij/src/saros/core/ui/util/CollaborationUtils.java
+++ b/intellij/src/saros/core/ui/util/CollaborationUtils.java
@@ -2,7 +2,6 @@ package saros.core.ui.util;
 
 import com.intellij.openapi.project.Project;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -238,7 +237,7 @@ public class CollaborationUtils {
 
         Pair<Long, Long> fileCountAndSize;
 
-        fileCountAndSize = getFileCountAndSize(Arrays.asList(project.members()));
+        fileCountAndSize = getFileCountAndSize(project.members());
 
         result.append(
             String.format(
@@ -303,8 +302,7 @@ public class CollaborationUtils {
           try {
             IContainer container = (IContainer) resource;
 
-            Pair<Long, Long> subFileCountAndSize =
-                getFileCountAndSize(Arrays.asList(container.members()));
+            Pair<Long, Long> subFileCountAndSize = getFileCountAndSize(container.members());
 
             totalFileSize += subFileCountAndSize.getLeft();
             totalFileCount += subFileCountAndSize.getRight();

--- a/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJFolderImpl.java
@@ -43,7 +43,7 @@ public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IF
 
   @NotNull
   @Override
-  public IResource[] members() throws IOException {
+  public List<IResource> members() throws IOException {
     // TODO run as read action
 
     final VirtualFile folder = project.findVirtualFile(path);
@@ -75,7 +75,7 @@ public final class IntelliJFolderImpl extends IntelliJResourceImpl implements IF
               : new IntelliJFileImpl(project, childPath));
     }
 
-    return result.toArray(new IResource[0]);
+    return result;
   }
 
   // TODO unify with IntelliJProjectImpl.getFile(...) and getFolder(...)

--- a/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
+++ b/intellij/src/saros/intellij/filesystem/IntelliJProjectImpl.java
@@ -118,7 +118,7 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
 
   @NotNull
   @Override
-  public IResource[] members() {
+  public List<IResource> members() {
     final List<IResource> result = new ArrayList<>();
 
     final VirtualFile[] children = getModuleContentRoot(module).getChildren();
@@ -139,7 +139,7 @@ public final class IntelliJProjectImpl extends IntelliJResourceImpl implements I
               : new IntelliJFileImpl(this, childPath));
     }
 
-    return result.toArray(new IResource[0]);
+    return result;
   }
 
   @Override

--- a/server/src/saros/server/filesystem/ServerContainerImpl.java
+++ b/server/src/saros/server/filesystem/ServerContainerImpl.java
@@ -34,7 +34,7 @@ public abstract class ServerContainerImpl extends ServerResourceImpl implements 
   }
 
   @Override
-  public IResource[] members() throws IOException {
+  public List<IResource> members() throws IOException {
     List<IResource> members = new ArrayList<>();
 
     File[] memberFiles = getLocation().toFile().listFiles();
@@ -55,7 +55,7 @@ public abstract class ServerContainerImpl extends ServerResourceImpl implements 
       members.add(member);
     }
 
-    return members.toArray(new IResource[members.size()]);
+    return members;
   }
 
   @Override

--- a/server/test/junit/saros/server/filesystem/ServerContainerImplTest.java
+++ b/server/test/junit/saros/server/filesystem/ServerContainerImplTest.java
@@ -11,8 +11,8 @@ import static saros.server.filesystem.FileSystemTestUtils.createWorkspaceFolder;
 import static saros.server.filesystem.FileSystemTestUtils.path;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.easymock.EasyMockSupport;
 import org.junit.After;
@@ -90,23 +90,16 @@ public class ServerContainerImplTest extends EasyMockSupport {
     createFile(workspace, CONTAINER_PATH + "/file");
     createFolder(workspace, CONTAINER_PATH + "/subfolder");
 
-    IResource[] members = container.members();
-    assertEquals(2, members.length);
+    List<IResource> members = container.members();
+    assertEquals(2, members.size());
 
-    Arrays.sort(
-        members,
-        new Comparator<IResource>() {
-          @Override
-          public int compare(IResource r1, IResource r2) {
-            return r1.getName().compareTo(r2.getName());
-          }
-        });
+    members.sort(Comparator.comparing(IResource::getName));
 
-    ServerResourceImpl member0 = (ServerResourceImpl) members[0];
+    ServerResourceImpl member0 = (ServerResourceImpl) members.get(0);
     assertEquals(path(CONTAINER_PATH + "/file"), member0.getFullPath());
     assertEquals(IResource.Type.FILE, member0.getType());
 
-    ServerResourceImpl member1 = (ServerResourceImpl) members[1];
+    ServerResourceImpl member1 = (ServerResourceImpl) members.get(1);
     assertEquals(path(CONTAINER_PATH + "/subfolder"), member1.getFullPath());
     assertEquals(IResource.Type.FOLDER, member1.getType());
   }


### PR DESCRIPTION
Adjusts IContainer.members() to return a list instead of an array. This
simplifies the implementation and usage of the method which previously
required multiple conversions into an array and back into a list.