### PR TITLE
Small Smack Simplifications

### DIFF
--- a/core/src/saros/communication/chat/AbstractChatService.java
+++ b/core/src/saros/communication/chat/AbstractChatService.java
@@ -1,8 +1,8 @@
 package saros.communication.chat;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
-import org.jivesoftware.smack.XMPPException;
 
 /**
  * Parent class for chat services. It provides convenience methods for notifying registered
@@ -53,11 +53,11 @@ public abstract class AbstractChatService implements IChatService {
    * in the XMPP/network layer.
    *
    * @param chat the {@link IChat} that has been aborted
-   * @param exception {@link XMPPException} that has been thrown
+   * @param errorMessage Optional an describing error message
    */
-  public void notifyChatAborted(IChat chat, XMPPException exception) {
+  public void notifyChatAborted(IChat chat, String errorMessage) {
     for (IChatServiceListener listener : chatServiceListeners) {
-      listener.chatAborted(chat, exception);
+      listener.chatAborted(chat, Optional.ofNullable(errorMessage));
     }
   }
 }

--- a/core/src/saros/communication/chat/IChat.java
+++ b/core/src/saros/communication/chat/IChat.java
@@ -39,7 +39,7 @@ public interface IChat {
    * @param message the message to send
    * @throws XMPPException
    */
-  public void sendMessage(Message message) throws XMPPException;
+  public void sendMessage(Message message) throws Exception;
 
   /**
    * Sends the specified text as a message to the other chat participants.
@@ -47,7 +47,7 @@ public interface IChat {
    * @param text the specified text as a message to the other chat participant.
    * @throws XMPPException
    */
-  public void sendMessage(String text) throws XMPPException;
+  public void sendMessage(String text) throws Exception;
 
   /**
    * Set this chat's {@link ChatState} and notify participants of the change.
@@ -55,7 +55,7 @@ public interface IChat {
    * @param newState {@link ChatState} to set
    * @throws XMPPException
    */
-  public void setCurrentState(ChatState newState) throws XMPPException;
+  public void setCurrentState(ChatState newState) throws Exception;
 
   /**
    * Add {@link ChatElement} to this chat's history.

--- a/core/src/saros/communication/chat/IChatServiceListener.java
+++ b/core/src/saros/communication/chat/IChatServiceListener.java
@@ -1,6 +1,6 @@
 package saros.communication.chat;
 
-import org.jivesoftware.smack.XMPPException;
+import java.util.Optional;
 
 /** This listener is invoked with notifications related to an {@link IChat}s life cycle. */
 public interface IChatServiceListener {
@@ -26,8 +26,8 @@ public interface IChatServiceListener {
    * layer.
    *
    * @param chat the {@link IChat} that has been aborted
-   * @param exception {@link XMPPException} that has been thrown or <code>null</code> if the chat
-   *     has not been created yet
+   * @param errorMessage Optional an describing error message, always empty if the chat has not been
+   *     created yet
    */
-  public void chatAborted(IChat chat, XMPPException exception);
+  public void chatAborted(IChat chat, Optional<String> errorMessage);
 }

--- a/core/src/saros/communication/chat/muc/MultiUserChatService.java
+++ b/core/src/saros/communication/chat/muc/MultiUserChatService.java
@@ -103,7 +103,7 @@ public class MultiUserChatService extends AbstractChatService {
     try {
       createdRoom = chat.connect();
     } catch (XMPPException e) {
-      notifyChatAborted(chat, e);
+      notifyChatAborted(chat, e.getMessage());
       log.error("Couldn't join chat: " + preferences.getRoom(), e);
       return null;
     }

--- a/core/src/saros/net/util/XMPPUtils.java
+++ b/core/src/saros/net/util/XMPPUtils.java
@@ -288,11 +288,11 @@ public class XMPPUtils {
   /**
    * Returns the service for multiuser chat.
    *
-   * @param connection the current XMPP connection
-   * @param service a service, normally the domain of a XMPP server
    * @return the service for the multiuser chat or <code>null</code> if it could not be determined
    */
-  public static String getMultiUserChatService(Connection connection, String service) {
+  public static String getMultiUserChatService() {
+    Connection connection = defaultConnectionService.getConnection();
+    String service = connection.getServiceName();
 
     ServiceDiscoveryManager manager = ServiceDiscoveryManager.getInstanceFor(connection);
 

--- a/eclipse/src/saros/communication/chat/muc/negotiation/MUCNegotiationManager.java
+++ b/eclipse/src/saros/communication/chat/muc/negotiation/MUCNegotiationManager.java
@@ -5,15 +5,12 @@ import java.util.Map;
 import java.util.Random;
 import org.apache.log4j.Logger;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.jivesoftware.smack.Connection;
 import saros.communication.chat.muc.MultiUserChatPreferences;
 import saros.negotiation.hooks.ISessionNegotiationHook;
 import saros.negotiation.hooks.SessionNegotiationHookManager;
 import saros.net.util.XMPPUtils;
 import saros.net.xmpp.JID;
-import saros.net.xmpp.XMPPConnectionService;
 import saros.preferences.EclipsePreferenceConstants;
-import saros.repackaged.picocontainer.annotations.Nullable;
 import saros.session.ISarosSession;
 import saros.session.ISarosSessionManager;
 
@@ -39,8 +36,6 @@ public class MUCNegotiationManager {
   private final IPreferenceStore preferences;
 
   private final String password;
-
-  private final XMPPConnectionService connectionService;
 
   private final ISarosSessionManager sessionManager;
 
@@ -106,11 +101,9 @@ public class MUCNegotiationManager {
 
   public MUCNegotiationManager(
       ISarosSessionManager sessionManager,
-      @Nullable XMPPConnectionService connectionService,
       IPreferenceStore preferences,
       SessionNegotiationHookManager hooks) {
     this.sessionManager = sessionManager;
-    this.connectionService = connectionService;
     this.preferences = preferences;
     this.password = String.valueOf(random.nextInt());
 
@@ -162,12 +155,7 @@ public class MUCNegotiationManager {
     if (useCustomMUCService && customMUCService != null && !customMUCService.isEmpty())
       return customMUCService;
 
-    if (connectionService != null) {
-      Connection connection = connectionService.getConnection();
-
-      if (connection != null)
-        service = XMPPUtils.getMultiUserChatService(connection, connection.getServiceName());
-    }
+    service = XMPPUtils.getMultiUserChatService();
 
     if (service == null) service = customMUCService;
 

--- a/eclipse/src/saros/ui/widgets/chat/ChatControl.java
+++ b/eclipse/src/saros/ui/widgets/chat/ChatControl.java
@@ -25,7 +25,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
-import org.jivesoftware.smack.XMPPException;
 import org.jivesoftware.smackx.ChatState;
 import saros.SarosPluginContext;
 import saros.communication.chat.ChatElement;
@@ -700,7 +699,7 @@ public final class ChatControl extends Composite {
   private void determineCurrentState() {
     try {
       chat.setCurrentState(getInputText().isEmpty() ? ChatState.inactive : ChatState.composing);
-    } catch (XMPPException ex) {
+    } catch (Exception ex) {
       log.error(ex.getMessage(), ex);
     }
   }

--- a/eclipse/src/saros/ui/widgets/chat/ChatRoomsComposite.java
+++ b/eclipse/src/saros/ui/widgets/chat/ChatRoomsComposite.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.apache.log4j.Logger;
@@ -22,7 +23,6 @@ import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
-import org.jivesoftware.smack.XMPPException;
 import saros.SarosPluginContext;
 import saros.communication.chat.IChat;
 import saros.communication.chat.IChatServiceListener;
@@ -367,7 +367,7 @@ public class ChatRoomsComposite extends ListExplanatoryComposite {
         }
 
         @Override
-        public void chatAborted(IChat chat, XMPPException exception) {
+        public void chatAborted(IChat chat, Optional<String> chatErrorMessage) {
 
           if (!(chat instanceof MultiUserChat)) return;
 
@@ -387,9 +387,8 @@ public class ChatRoomsComposite extends ListExplanatoryComposite {
                 MessageFormat.format(
                     Messages.ChatRoomsComposite_muc_error_connecting_failed,
                     mucService,
-                    exception == null
-                        ? Messages.ChatRoomsComposite_muc_error_connecting_failed_unknown_error
-                        : exception.getMessage());
+                    chatErrorMessage.orElse(
+                        Messages.ChatRoomsComposite_muc_error_connecting_failed_unknown_error));
           }
 
           SWTUtils.runSafeSWTAsync(


### PR DESCRIPTION
#### [CORE][E] Chat Replace XMPPException with ErrorMsg
Instead of leaking the XMPPException class in ChatServiceListener out
of core, return a error message.

#### [CORE][E] Replace XMPPException with Exception
This is not ideal, but removes another explicit XMPPException reference.

#### [CORE][E] Simplify MultiUserChatService retrieval
Use the always available defaultConnectionService, which is the same as the one passed.