### PR TITLE
[BUILD] Add workflow running PMD on changes to the ruleset

### DIFF
--- a/.github/workflows/build_pmd.yml
+++ b/.github/workflows/build_pmd.yml
@@ -1,0 +1,32 @@
+# Has to be the same name as in build in order to require the same check in GitHub
+name: Build
+
+on:
+  push:
+    paths:
+      - 'ruleset.xml'
+  pull_request:
+    paths:
+      - 'ruleset.xml'
+
+jobs:
+
+  run-pmd:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - name: Static Code Analysis
+      run: |
+        ./gradlew \
+          --continue \
+          pmdMain


### PR DESCRIPTION
Adds the GitHub workflow build_pmd which is run on any push or pull
request matching the branch name 'pr/pmd/**' or modifying the pmd
ruleset file.

This action ensures that the PMD ruleset applies without any issues
before merging onto master. This is necessary as Codacy, which runs our
PMD checks, only uses the ruleset file of the master branch.