### PR TITLE
[BUILD] Fix remaining "Unused*" violations

### DIFF
--- a/.github/workflows/build_pmd.yml
+++ b/.github/workflows/build_pmd.yml
@@ -29,4 +29,4 @@ jobs:
       run: |
         ./gradlew \
           --continue \
-          pmdMain
+          pmdMain pmdTest

--- a/buildSrc/src/main/java/saros/gradle/intellij/IntellijConfigurator.java
+++ b/buildSrc/src/main/java/saros/gradle/intellij/IntellijConfigurator.java
@@ -28,7 +28,7 @@ class IntellijConfigurator {
    * intellij instances via gradle with the {@code runIde} task.
    */
   void configure(SarosIntellijExtension sarosExtension, IntelliJPluginExtension intellijExtension) {
-    configureDefaultParams(intellijExtension, sarosExtension);
+    configureDefaultParams(intellijExtension);
     configureRunIdeIntellijInstallation(intellijExtension, sarosExtension);
   }
 
@@ -59,8 +59,7 @@ class IntellijConfigurator {
   }
 
   /** Sets the default parameters of the intellij plugin */
-  private void configureDefaultParams(
-      IntelliJPluginExtension intellijExtension, SarosIntellijExtension sarosExtension) {
+  private void configureDefaultParams(IntelliJPluginExtension intellijExtension) {
     intellijExtension.setUpdateSinceUntilBuild(false);
   }
 

--- a/core/test/junit/saros/negotiation/FileListDiffTest.java
+++ b/core/test/junit/saros/negotiation/FileListDiffTest.java
@@ -15,7 +15,6 @@ public class FileListDiffTest {
   private static final String FILE_A = FOLDER_SRC + "file_a";
   private static final String FILE_B = FOLDER_SRC + "file_b";
   private static final String FILE_C = FOLDER_SRC + "file_c";
-  private static final String FILE_D = FOLDER_SRC + "file_d";
 
   private static final String FOLDER_A = FOLDER_SRC + "folder_a/";
   private static final String FOLDER_B = FOLDER_SRC + "folder_b/";

--- a/core/test/junit/saros/net/internal/DataTransferManagerTest.java
+++ b/core/test/junit/saros/net/internal/DataTransferManagerTest.java
@@ -354,8 +354,6 @@ public class DataTransferManagerTest {
 
     connectionListener.getValue().connectionStateChanged(connectionMock, ConnectionState.CONNECTED);
 
-    TransferDescription description = TransferDescription.newDescription();
-
     assertNull(dtm.getConnection("foo", new JID("foo@bar.com")));
   }
 

--- a/intellij/src/saros/intellij/ui/eventhandler/ConnectingFailureHandler.java
+++ b/intellij/src/saros/intellij/ui/eventhandler/ConnectingFailureHandler.java
@@ -1,23 +1,17 @@
 package saros.intellij.ui.eventhandler;
 
-import saros.account.XMPPAccount;
 import saros.communication.connection.ConnectionHandler;
-import saros.communication.connection.IConnectingFailureCallback;
 import saros.intellij.ui.util.NotificationPanel;
 import saros.ui.CoreMessages;
 
 /** Callback handler informing the user of a failed XMPP connection attempt. */
 public class ConnectingFailureHandler {
 
-  @SuppressWarnings("FieldCanBeLocal")
-  private final IConnectingFailureCallback connectingFailureCallback = this::handleConnectionFailed;
-
   public ConnectingFailureHandler(ConnectionHandler connectionHandler) {
-    connectionHandler.setCallback(connectingFailureCallback);
-  }
-
-  public void handleConnectionFailed(XMPPAccount account, String errorMessage) {
-    // TODO offer user possibility of adjusting settings and re-connect
-    NotificationPanel.showError(errorMessage, CoreMessages.ConnectingFailureHandler_title);
+    connectionHandler.setCallback(
+        (account, errorMessage) -> {
+          // TODO offer user possibility of adjusting settings and re-connect
+          NotificationPanel.showError(errorMessage, CoreMessages.ConnectingFailureHandler_title);
+        });
   }
 }

--- a/intellij/src/saros/intellij/ui/eventhandler/ConnectingFailureHandler.java
+++ b/intellij/src/saros/intellij/ui/eventhandler/ConnectingFailureHandler.java
@@ -16,7 +16,7 @@ public class ConnectingFailureHandler {
     connectionHandler.setCallback(connectingFailureCallback);
   }
 
-  private void handleConnectionFailed(XMPPAccount account, String errorMessage) {
+  public void handleConnectionFailed(XMPPAccount account, String errorMessage) {
     // TODO offer user possibility of adjusting settings and re-connect
     NotificationPanel.showError(errorMessage, CoreMessages.ConnectingFailureHandler_title);
   }


### PR DESCRIPTION
* Fix pmdTest violations
* Fix new violation

@stefaus I changed the method in ConnectionFailureHandler from private to public. Probably `@SuppressWarnings` is a better solution or implementing the interface via lambda. What do you think?