### PR TITLE
[INTERNAL][STF] Fix wrong eclipse endpoint

### DIFF
--- a/eclipse/plugin.xml
+++ b/eclipse/plugin.xml
@@ -56,7 +56,7 @@
       </decorator>
    </extension>
    <extension
-         point="org.eclipse.ui.preference_pages">
+         point="org.eclipse.ui.preferencePages">
       <page
             class="saros.ui.preference_pages.GeneralPreferencePage"
             id="saros.preferences"


### PR DESCRIPTION
PR #1010 also changed the name of the used
eclipse endpoint from `preferencesPages` -> `preference_pages`
(which is not an existing endpoint).

Fixes #1014