### PR TITLE
[INTERNAL][E] Introduce reference point based resource implementation

### DIFF
--- a/eclipse/src/saros/filesystem/EclipseContainerImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseContainerImpl.java
@@ -7,6 +7,11 @@ import java.util.List;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
 
+/**
+ * @deprecated no longer necessary, use {@link EclipseFolderImplV2} or {@link
+ *     EclipseReferencePointImpl}
+ */
+@Deprecated
 public class EclipseContainerImpl extends EclipseResourceImpl implements IContainer {
 
   EclipseContainerImpl(org.eclipse.core.resources.IContainer delegate) {

--- a/eclipse/src/saros/filesystem/EclipseFileImplV2.java
+++ b/eclipse/src/saros/filesystem/EclipseFileImplV2.java
@@ -11,20 +11,21 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 
-/** @deprecated use {@link EclipseFileImplV2} instead */
-@Deprecated
-public class EclipseFileImpl extends EclipseResourceImpl implements IFile {
+/** Eclipse implementation of the Saros file interface. */
+// TODO rename to EclipseFile
+public class EclipseFileImplV2 extends EclipseResourceImplV2 implements IFile {
+  private static final Logger log = Logger.getLogger(EclipseFileImplV2.class);
 
-  private static final Logger log = Logger.getLogger(EclipseFileImpl.class);
-
-  EclipseFileImpl(org.eclipse.core.resources.IFile delegate) {
-    super(delegate);
+  /** @see EclipseResourceImplV2#EclipseResourceImplV2(EclipseReferencePointImpl, IPath) */
+  EclipseFileImplV2(EclipseReferencePointImpl referencePoint, IPath relativePath) {
+    super(referencePoint, relativePath);
   }
 
   @Override
   public String getCharset() throws IOException {
     try {
       return getDelegate().getCharset();
+
     } catch (CoreException e) {
       throw new IOException(e);
     }
@@ -95,6 +96,7 @@ public class EclipseFileImpl extends EclipseResourceImpl implements IFile {
   public InputStream getContents() throws IOException {
     try {
       return getDelegate().getContents();
+
     } catch (CoreException e) {
       throw new IOException(e);
     }
@@ -114,19 +116,20 @@ public class EclipseFileImpl extends EclipseResourceImpl implements IFile {
   public void create(InputStream input) throws IOException {
     try {
       getDelegate().create(input, false, null);
+
     } catch (CoreException | OperationCanceledException e) {
       throw new IOException(e);
     }
   }
 
   /**
-   * Returns the original {@link org.eclipse.core.resources.IFile IFile} object.
+   * Returns an {@link org.eclipse.core.resources.IFile} object representing this file.
    *
-   * @return
+   * @return an {@link org.eclipse.core.resources.IFile} object representing this file
    */
   @Override
   public org.eclipse.core.resources.IFile getDelegate() {
-    return (org.eclipse.core.resources.IFile) delegate;
+    return referencePoint.getFileDelegate(relativePath);
   }
 
   @Override

--- a/eclipse/src/saros/filesystem/EclipseFileImplV2.java
+++ b/eclipse/src/saros/filesystem/EclipseFileImplV2.java
@@ -65,7 +65,6 @@ public class EclipseFileImplV2 extends EclipseResourceImplV2 implements IFile {
 
     if (!file.exists()) return;
 
-    String projectEncoding = file.getProject().getDefaultCharset();
     String fileEncoding = file.getCharset();
 
     if (encoding.equals(fileEncoding)) {
@@ -74,13 +73,15 @@ public class EclipseFileImplV2 extends EclipseResourceImplV2 implements IFile {
       return;
     }
 
+    String parentContainerEncoding = file.getParent().getDefaultCharset();
+
     // use inherited encoding if possible
-    if (encoding.equals(projectEncoding)) {
+    if (encoding.equals(parentContainerEncoding)) {
       log.debug(
           "changing encoding for file "
               + file
-              + " to use default project encoding: "
-              + projectEncoding);
+              + " to inherit parent container encoding: "
+              + parentContainerEncoding);
 
       file.setCharset(null, new NullProgressMonitor());
 

--- a/eclipse/src/saros/filesystem/EclipseFolderImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseFolderImpl.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.OperationCanceledException;
 
+/** @deprecated use {@link EclipseFolderImplV2} instead */
+@Deprecated
 public class EclipseFolderImpl extends EclipseContainerImpl implements IFolder {
 
   EclipseFolderImpl(org.eclipse.core.resources.IFolder delegate) {

--- a/eclipse/src/saros/filesystem/EclipseFolderImplV2.java
+++ b/eclipse/src/saros/filesystem/EclipseFolderImplV2.java
@@ -1,0 +1,114 @@
+package saros.filesystem;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.OperationCanceledException;
+
+/** Eclipse implementation of the Saros folder interface. */
+// TODO rename to EclipseFolder
+public class EclipseFolderImplV2 extends EclipseResourceImplV2 implements IFolder {
+
+  /** @see EclipseResourceImplV2#EclipseResourceImplV2(EclipseReferencePointImpl, IPath) */
+  EclipseFolderImplV2(EclipseReferencePointImpl referencePoint, IPath relativePath) {
+    super(referencePoint, relativePath);
+  }
+
+  @Override
+  public boolean exists(IPath path) {
+    Objects.requireNonNull(path, "Given path must not be null");
+
+    return getDelegate().exists(((EclipsePathImpl) path).getDelegate());
+  }
+
+  @Override
+  public List<IResource> members() throws IOException {
+    org.eclipse.core.resources.IResource[] containedResources;
+
+    try {
+      containedResources = getDelegate().members();
+
+    } catch (CoreException e) {
+      throw new IOException(e);
+    }
+
+    List<IResource> result = new ArrayList<>(containedResources.length);
+
+    for (org.eclipse.core.resources.IResource containedResource : containedResources) {
+      String name = containedResource.getName();
+
+      IPath childPath = relativePath.append(name);
+
+      if (containedResource.getType() == org.eclipse.core.resources.IResource.FILE) {
+        result.add(new EclipseFileImplV2(referencePoint, childPath));
+
+      } else if (containedResource.getType() == org.eclipse.core.resources.IResource.FOLDER) {
+        result.add(new EclipseFolderImplV2(referencePoint, childPath));
+
+      } else {
+        throw new IllegalStateException(
+            "Should not be able to encounter root or project in inner tree - " + containedResource);
+      }
+    }
+
+    return result;
+  }
+
+  @Override
+  public IFile getFile(String pathString) {
+    return getFile(ResourceConverter.convertToPath(pathString));
+  }
+
+  @Override
+  public IFile getFile(IPath path) {
+    Objects.requireNonNull(path, "Given path must not be null");
+
+    if (path.segmentCount() == 0) {
+      throw new IllegalArgumentException("Can not create file handle for an empty path");
+    }
+
+    IPath referencePointRelativeChildPath = relativePath.append(path);
+
+    return new EclipseFileImplV2(referencePoint, referencePointRelativeChildPath);
+  }
+
+  @Override
+  public IFolder getFolder(String pathString) {
+    return getFolder(ResourceConverter.convertToPath(pathString));
+  }
+
+  @Override
+  public IFolder getFolder(IPath path) {
+    Objects.requireNonNull(path, "Given path must not be null");
+
+    if (path.segmentCount() == 0) {
+      throw new IllegalArgumentException("Can not create folder handle for an empty path");
+    }
+
+    IPath referencePointRelativeChildPath = relativePath.append(path);
+
+    return new EclipseFolderImplV2(referencePoint, referencePointRelativeChildPath);
+  }
+
+  @Override
+  public void create() throws IOException {
+    try {
+      getDelegate().create(false, true, null);
+
+    } catch (CoreException | OperationCanceledException e) {
+      throw new IOException(e);
+    }
+  }
+
+  /**
+   * Returns an {@link org.eclipse.core.resources.IFolder} object representing this folder.
+   *
+   * @return an {@link org.eclipse.core.resources.IFolder} object representing this folder
+   */
+  @Override
+  public org.eclipse.core.resources.IFolder getDelegate() {
+    return referencePoint.getFolderDelegate(relativePath);
+  }
+}

--- a/eclipse/src/saros/filesystem/EclipseProjectImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseProjectImpl.java
@@ -1,5 +1,7 @@
 package saros.filesystem;
 
+/** @deprecated use {@link EclipseReferencePointImpl} instead */
+@Deprecated
 public class EclipseProjectImpl extends EclipseContainerImpl implements IReferencePoint {
 
   EclipseProjectImpl(org.eclipse.core.resources.IProject delegate) {

--- a/eclipse/src/saros/filesystem/EclipseReferencePointImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseReferencePointImpl.java
@@ -1,0 +1,289 @@
+package saros.filesystem;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.apache.log4j.Logger;
+import org.eclipse.core.runtime.CoreException;
+
+/** Eclipse implementation of the Saros reference point interface. */
+// TODO rename to EclipseReferencePoint
+public class EclipseReferencePointImpl implements IReferencePoint {
+  private static Logger log = Logger.getLogger(EclipseReferencePointImpl.class);
+
+  /** The delegate represented by the reference point. */
+  private final org.eclipse.core.resources.IContainer delegate;
+
+  /**
+   * Instantiates an Eclipse reference point object.
+   *
+   * @param delegate the delegate resource represented by the reference point
+   * @throws NullPointerException if the given delegate is <code>null</code>
+   * @throws IllegalArgumentException if the given delegate does not exist
+   */
+  public EclipseReferencePointImpl(org.eclipse.core.resources.IContainer delegate) {
+    Objects.requireNonNull(delegate, "The given delegate must not be null");
+
+    if (!delegate.exists()) {
+      throw new IllegalArgumentException("The given delegate must exist - " + delegate);
+    }
+
+    this.delegate = delegate;
+  }
+
+  /**
+   * Returns the delegate represented by this reference point.
+   *
+   * @return the delegate represented by this reference point
+   */
+  org.eclipse.core.resources.IContainer getDelegate() {
+    return delegate;
+  }
+
+  @Override
+  public EclipsePathImpl getReferencePointRelativePath() {
+    return new EclipsePathImpl(org.eclipse.core.runtime.Path.EMPTY);
+  }
+
+  @Override
+  public boolean exists() {
+    return delegate.exists();
+  }
+
+  @Override
+  public String getName() {
+    return delegate.getName();
+  }
+
+  @Override
+  public boolean exists(IPath path) {
+    Objects.requireNonNull(path, "Given path must not be null");
+
+    return delegate.exists(((EclipsePathImpl) path).getDelegate());
+  }
+
+  @Override
+  public List<IResource> members() throws IOException {
+    org.eclipse.core.resources.IResource[] containedResources;
+
+    try {
+      containedResources = delegate.members();
+
+    } catch (CoreException e) {
+      throw new IOException(e);
+    }
+
+    List<IResource> result = new ArrayList<>(containedResources.length);
+
+    for (org.eclipse.core.resources.IResource containedResource : containedResources) {
+      String name = containedResource.getName();
+
+      IPath childPath = ResourceConverter.convertToPath(name);
+
+      if (containedResource.getType() == org.eclipse.core.resources.IResource.FILE) {
+        result.add(new EclipseFileImplV2(this, childPath));
+
+      } else if (containedResource.getType() == org.eclipse.core.resources.IResource.FOLDER) {
+        result.add(new EclipseFolderImplV2(this, childPath));
+
+      } else {
+        throw new IllegalStateException(
+            "Encounter root or project in inner tree - " + containedResource);
+      }
+    }
+
+    return result;
+  }
+
+  @Override
+  public saros.filesystem.IFile getFile(String pathString) {
+    return getFile(ResourceConverter.convertToPath(pathString));
+  }
+
+  @Override
+  public saros.filesystem.IFile getFile(IPath path) {
+    Objects.requireNonNull(path, "Given path must not be null");
+
+    if (path.segmentCount() == 0) {
+      throw new IllegalArgumentException("Can not create file handle for an empty path");
+    }
+
+    return new EclipseFileImplV2(this, path);
+  }
+
+  @Override
+  public saros.filesystem.IFolder getFolder(String pathString) {
+    return getFolder(ResourceConverter.convertToPath(pathString));
+  }
+
+  @Override
+  public saros.filesystem.IFolder getFolder(IPath path) {
+    Objects.requireNonNull(path, "Given path must not be null");
+
+    if (path.segmentCount() == 0) {
+      throw new IllegalArgumentException("Can not create folder handle for an empty path");
+    }
+
+    return new EclipseFolderImplV2(this, path);
+  }
+
+  /**
+   * Returns the file delegate for the given relative path.
+   *
+   * @param relativePath relative path to the file
+   * @return the delegate for the given relative path
+   * @throws NullPointerException if the given path is <code>null</code>
+   * @throws IllegalArgumentException if the given path is absolute or empty
+   * @see org.eclipse.core.resources.IContainer#getFile(org.eclipse.core.runtime.IPath)
+   */
+  org.eclipse.core.resources.IFile getFileDelegate(IPath relativePath) {
+    Objects.requireNonNull(relativePath, "Given path must not be null");
+
+    if (relativePath.segmentCount() == 0) {
+      throw new IllegalArgumentException("Given path must not be empty");
+
+    } else if (relativePath.isAbsolute()) {
+      throw new IllegalArgumentException("Given path must not be absolute");
+    }
+
+    return delegate.getFile(((EclipsePathImpl) relativePath).getDelegate());
+  }
+
+  /**
+   * Returns the folder delegate for the given relative path.
+   *
+   * @param relativePath relative path to the folder
+   * @return the delegate for the given relative path
+   * @throws NullPointerException if the given path is <code>null</code>
+   * @throws IllegalArgumentException if the given path is absolute or empty
+   * @see org.eclipse.core.resources.IContainer#getFolder(org.eclipse.core.runtime.IPath)
+   */
+  org.eclipse.core.resources.IFolder getFolderDelegate(IPath relativePath) {
+    Objects.requireNonNull(relativePath, "Given path must not be null");
+
+    if (relativePath.segmentCount() == 0) {
+      throw new IllegalArgumentException("Given path must not be empty");
+
+    } else if (relativePath.isAbsolute()) {
+      throw new IllegalArgumentException("Given path must not be absolute");
+    }
+
+    return delegate.getFolder(((EclipsePathImpl) relativePath).getDelegate());
+  }
+
+  /**
+   * Returns a resource object representing the given resource delegate.
+   *
+   * @param resourceDelegate the resource delegate for which to get a resource object
+   * @return a resource object representing the given resource delegate or <code>null</code> if no
+   *     relative path could be constructed between the reference point delegate and the given
+   *     resource delegate
+   * @throws NullPointerException if the given delegate is <code>null</code>
+   * @throws IllegalArgumentException if the given delegate is the reference point delegate or is
+   *     not a file or a folder
+   */
+  IResource getResource(org.eclipse.core.resources.IResource resourceDelegate) {
+    Objects.requireNonNull(resourceDelegate, "Given resource delegate must not be null");
+
+    if (resourceDelegate.equals(delegate)) {
+      throw new IllegalArgumentException(
+          "Given resource delegate must not be the reference point delegate - " + delegate);
+    }
+
+    if (resourceDelegate.getType() == org.eclipse.core.resources.IResource.FILE) {
+      return getFile((org.eclipse.core.resources.IFile) resourceDelegate);
+
+    } else if (resourceDelegate.getType() == org.eclipse.core.resources.IResource.FOLDER) {
+      return getFolder((org.eclipse.core.resources.IFolder) resourceDelegate);
+
+    } else {
+      log.debug(
+          "Given resource delegate is not a file or a folder; can't be non-reference-point resource; found type: "
+              + delegate.getType()
+              + " - "
+              + delegate);
+
+      return null;
+    }
+  }
+
+  /**
+   * Returns a file object representing the given file delegate.
+   *
+   * @param fileDelegate the file delegate for which to get a file object
+   * @return a file object representing the given file delegate or <code>null</code> if no relative
+   *     path could be constructed between the reference point delegate and the given file delegate
+   * @throws NullPointerException if the given delegate is <code>null</code>
+   */
+  IFile getFile(org.eclipse.core.resources.IFile fileDelegate) {
+    Objects.requireNonNull(fileDelegate, "Given file delegate must not be null");
+
+    IPath relativePath = getReferencePointRelativePath(fileDelegate);
+
+    if (relativePath == null) {
+      return null;
+    }
+
+    return new EclipseFileImplV2(this, relativePath);
+  }
+
+  /**
+   * Returns a folder object representing the given folder delegate.
+   *
+   * @param folderDelegate the folder delegate for which to get a folder object
+   * @return a folder object representing the given folder delegate or <code>null</code> if no
+   *     relative path could be constructed between the reference point delegate and the given
+   *     folder delegate
+   * @throws NullPointerException if the given delegate is <code>null</code>
+   * @throws IllegalArgumentException if the given delegate is the reference point delegate
+   */
+  IFolder getFolder(org.eclipse.core.resources.IFolder folderDelegate) {
+    Objects.requireNonNull(folderDelegate, "Given folder delegate must not be null");
+
+    if (folderDelegate.equals(delegate)) {
+      throw new IllegalArgumentException(
+          "Given folder delegate must not be the reference point delegate - " + delegate);
+    }
+
+    IPath relativePath = getReferencePointRelativePath(folderDelegate);
+
+    if (relativePath == null) {
+      return null;
+    }
+
+    return new EclipseFolderImplV2(this, relativePath);
+  }
+
+  /**
+   * Returns the path to the given resource relative to this reference point.
+   *
+   * @param resource the Eclipse resource for which to get the relative path
+   * @return a relative path for the given resource or <code>null</code> if there is no relative
+   *     path from the reference point to the resource
+   * @throws NullPointerException if the given resource is <code>null</code>
+   */
+  private IPath getReferencePointRelativePath(org.eclipse.core.resources.IResource resource) {
+    Objects.requireNonNull(resource, "Given resource must not be null");
+
+    org.eclipse.core.runtime.IPath referencePointPath = delegate.getFullPath();
+    org.eclipse.core.runtime.IPath resourcePath = resource.getFullPath();
+
+    if (!referencePointPath.isPrefixOf(resourcePath)) {
+      return null;
+    }
+
+    org.eclipse.core.runtime.IPath relativePath = resourcePath.makeRelativeTo(referencePointPath);
+
+    if (relativePath.equals(resourcePath)) {
+      return null;
+    }
+
+    return ResourceConverter.convertToPath(relativePath);
+  }
+
+  @Override
+  public String toString() {
+    return "[" + getClass().getSimpleName() + " : " + delegate + "]";
+  }
+}

--- a/eclipse/src/saros/filesystem/EclipseResourceImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseResourceImpl.java
@@ -9,6 +9,8 @@ import java.io.IOException;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.OperationCanceledException;
 
+/** @deprecated use {@link EclipseResourceImplV2} instead */
+@Deprecated
 public class EclipseResourceImpl implements IResource {
 
   protected final org.eclipse.core.resources.IResource delegate;

--- a/eclipse/src/saros/filesystem/EclipseResourceImplV2.java
+++ b/eclipse/src/saros/filesystem/EclipseResourceImplV2.java
@@ -1,0 +1,138 @@
+package saros.filesystem;
+
+import static saros.filesystem.IResource.Type.FOLDER;
+
+import java.io.IOException;
+import java.util.Objects;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.OperationCanceledException;
+
+/** Abstract Eclipse implementation of the Saros resource interface. */
+// TODO rename to AbstractEclipseResource
+public abstract class EclipseResourceImplV2 implements IResource {
+
+  /** The reference point this resource belongs to. */
+  protected final EclipseReferencePointImpl referencePoint;
+
+  /** The reference-point-relative path for this resource. */
+  protected final IPath relativePath;
+
+  /**
+   * Instantiates an Eclipse resource object.
+   *
+   * @param referencePoint the reference point the resource is located beneath
+   * @param relativePath the relative path from the reference point
+   * @throws NullPointerException if the given reference point or path is <code>null</code>
+   * @throws IllegalArgumentException if the given path is absolute or empty
+   */
+  public EclipseResourceImplV2(EclipseReferencePointImpl referencePoint, IPath relativePath) {
+    Objects.requireNonNull(referencePoint, "The given reference point must not be null");
+    Objects.requireNonNull(relativePath, "The given relative path must not be null");
+
+    if (relativePath.segmentCount() == 0) {
+      throw new IllegalArgumentException("Given path must not be empty");
+
+    } else if (relativePath.isAbsolute()) {
+      throw new IllegalArgumentException("The given path must not be absolute - " + relativePath);
+    }
+
+    this.referencePoint = referencePoint;
+    this.relativePath = relativePath;
+  }
+
+  @Override
+  public boolean exists() {
+    return getDelegate().exists();
+  }
+
+  @Override
+  public String getName() {
+    return relativePath.lastSegment();
+  }
+
+  @Override
+  public IReferencePoint getReferencePoint() {
+    return referencePoint;
+  }
+
+  @Override
+  public IPath getReferencePointRelativePath() {
+    return relativePath;
+  }
+
+  @Override
+  public IContainer getParent() {
+    if (relativePath.segmentCount() <= 1) {
+      return referencePoint;
+    }
+
+    return new EclipseFolderImplV2(referencePoint, relativePath.removeLastSegments(1));
+  }
+
+  @Override
+  public boolean isIgnored() {
+    return isGitConfig() || isDerived();
+  }
+
+  /**
+   * Returns whether this resource is seen as derived by the local Eclipse instance.
+   *
+   * @return whether this resource is seen as derived by the local Eclipse instance
+   * @see org.eclipse.core.resources.IResource#isDerived(int)
+   */
+  boolean isDerived() {
+    return getDelegate().isDerived(org.eclipse.core.resources.IResource.CHECK_ANCESTORS);
+  }
+
+  /**
+   * Returns whether this resource is part of the git configuration directory.
+   *
+   * @return whether this resource is part of the git configuration directory
+   */
+  private boolean isGitConfig() {
+    String path = getReferencePointRelativePath().toPortableString();
+
+    return (path.startsWith(".git/")
+        || path.contains("/.git/")
+        || getType() == FOLDER && (path.endsWith("/.git") || path.equals(".git")));
+  }
+
+  @Override
+  public void delete() throws IOException {
+    try {
+      getDelegate().delete(org.eclipse.core.resources.IResource.KEEP_HISTORY, null);
+
+    } catch (CoreException | OperationCanceledException e) {
+      throw new IOException(e);
+    }
+  }
+
+  /**
+   * Returns an {@link org.eclipse.core.resources.IResource} object representing this resource.
+   *
+   * @return an {@link org.eclipse.core.resources.IResource} object representing this resource
+   */
+  public abstract org.eclipse.core.resources.IResource getDelegate();
+
+  @Override
+  public int hashCode() {
+    return referencePoint.hashCode() + 31 * relativePath.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null) return false;
+    if (getClass() != obj.getClass()) return false;
+
+    EclipseResourceImplV2 other = (EclipseResourceImplV2) obj;
+
+    return this.referencePoint.equals(other.referencePoint)
+        && this.relativePath.equals(other.relativePath);
+  }
+
+  @Override
+  public String toString() {
+    return "[" + getClass().getSimpleName() + " : " + relativePath + " - " + referencePoint + "]";
+  }
+}

--- a/eclipse/src/saros/filesystem/ResourceAdapterFactory.java
+++ b/eclipse/src/saros/filesystem/ResourceAdapterFactory.java
@@ -3,13 +3,21 @@ package saros.filesystem;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Factory to create adapters from Eclipse {@link org.eclipse.core.resources.IResource resources} to
  * Saros Core {@linkplain saros.filesystem.IResource resources}.
+ *
+ * @deprecated use {@link ResourceConverter} instead
  */
+@Deprecated
 public class ResourceAdapterFactory {
 
+  /**
+   * @deprecated use {@link ResourceConverter#convertToPath(org.eclipse.core.runtime.IPath)} instead
+   */
+  @Deprecated
   public static IPath create(org.eclipse.core.runtime.IPath path) {
 
     if (path == null) return null;
@@ -17,38 +25,42 @@ public class ResourceAdapterFactory {
     return new EclipsePathImpl(path);
   }
 
+  /** @deprecated should not be needed anymore */
+  @Deprecated
   public static IReferencePoint create(org.eclipse.core.resources.IProject project) {
     return (IReferencePoint) adapt(project);
   }
 
+  /**
+   * @deprecated use {@link ResourceConverter#convertToFile(Set, org.eclipse.core.resources.IFile)}
+   *     or {@link ResourceConverter#convertToFile(IReferencePoint,
+   *     org.eclipse.core.resources.IFile)} instead
+   */
+  @Deprecated
   public static IFile create(org.eclipse.core.resources.IFile file) {
     return (IFile) adapt(file);
   }
 
+  /**
+   * @deprecated use {@link ResourceConverter#convertToContainer(Set,
+   *     org.eclipse.core.resources.IContainer)} or {@link
+   *     ResourceConverter#convertToContainer(IReferencePoint,
+   *     org.eclipse.core.resources.IContainer)} instead
+   */
+  @Deprecated
   public static IFolder create(org.eclipse.core.resources.IFolder folder) {
     return (IFolder) adapt(folder);
   }
 
+  /**
+   * @deprecated use {@link ResourceConverter#convertToResource(Set,
+   *     org.eclipse.core.resources.IResource)} or {@link
+   *     ResourceConverter#convertToResource(IReferencePoint, org.eclipse.core.resources.IResource)}
+   *     instead
+   */
+  @Deprecated
   public static IResource create(org.eclipse.core.resources.IResource resource) {
     return adapt(resource);
-  }
-
-  /**
-   * Converts a collection of Eclipse resources to Saros Core file system resources. The elements
-   * contained in the returned list have the same order as returned by the iterator of the
-   * collection.
-   *
-   * @param resources collection of Eclipse resources
-   * @return list which will the contain the converted resources or <code>null</code> if resources
-   *     was <code>null</code>
-   */
-  public static List<IResource> convertTo(
-      Collection<? extends org.eclipse.core.resources.IResource> resources) {
-    if (resources == null) return null;
-
-    List<IResource> out = new ArrayList<IResource>(resources.size());
-    convertTo(resources, out);
-    return out;
   }
 
   /**
@@ -57,7 +69,9 @@ public class ResourceAdapterFactory {
    * @param resource a Saros Core resource
    * @return the corresponding Eclipse {@linkplain org.eclipse.core.resources.IResource resource} or
    *     <code>null</code> if resource is <code>null</code>
+   * @deprecated use {@link ResourceConverter#getDelegate(IResource)}
    */
+  @Deprecated
   public static org.eclipse.core.resources.IResource convertBack(IResource resource) {
 
     if (resource == null) return null;
@@ -73,7 +87,10 @@ public class ResourceAdapterFactory {
    * @param resources collection of Saros Core resources
    * @return list which will the contain the converted resources or <code>null</code> if resources
    *     was <code>null</code>
+   * @deprecated no longer supported; pull loop outside and use {@link
+   *     ResourceConverter#getDelegate(IResource)}
    */
+  @Deprecated
   public static List<org.eclipse.core.resources.IResource> convertBack(
       Collection<? extends IResource> resources) {
     if (resources == null) return null;
@@ -89,7 +106,11 @@ public class ResourceAdapterFactory {
    *
    * @param in collection of Eclipse resources
    * @param out collection which will the contain the converted resources
+   * @deprecated no longer supported; pull loop outside and use {@link
+   *     ResourceConverter#convertToResource(Set, org.eclipse.core.resources.IResource)} or {@link
+   *     ResourceConverter#convertToResource(IReferencePoint, org.eclipse.core.resources.IResource)}
    */
+  @Deprecated
   public static void convertTo(
       Collection<? extends org.eclipse.core.resources.IResource> in,
       Collection<? super IResource> out) {
@@ -102,7 +123,10 @@ public class ResourceAdapterFactory {
    *
    * @param in collection of Saros Core file system resources
    * @param out collection which will the contain the converted resources
+   * @deprecated no longer supported; pull loop outside and use {@link
+   *     ResourceConverter#getDelegate(IResource)}
    */
+  @Deprecated
   public static void convertBack(
       Collection<? extends IResource> in,
       Collection<? super org.eclipse.core.resources.IResource> out) {

--- a/eclipse/src/saros/filesystem/ResourceConverter.java
+++ b/eclipse/src/saros/filesystem/ResourceConverter.java
@@ -1,0 +1,254 @@
+package saros.filesystem;
+
+import java.util.Objects;
+import java.util.Set;
+import org.eclipse.core.runtime.Path;
+
+/** Utility class providing static methods to convert between Eclipse and Saros Resource objects. */
+public class ResourceConverter {
+  /**
+   * Converts the given string into an IPath object.
+   *
+   * @param pathString the path string to convert
+   * @return an IPath object representing the given string path
+   * @throws NullPointerException if the given string is <code>null</code> or the path represented
+   *     by the string is absolute
+   */
+  public static IPath convertToPath(String pathString) {
+    Objects.requireNonNull(pathString, "Given string must not be null");
+
+    Path path = new Path(pathString);
+
+    return convertToPath(path);
+  }
+
+  /**
+   * Returns an IPath object representing the given Eclipse delegate.
+   *
+   * @param eclipseDelegate the Eclipse path delegate
+   * @return an IPath object representing the given Eclipse delegate
+   * @throws NullPointerException if the given path is <code>null</code> or is absolute
+   */
+  public static IPath convertToPath(org.eclipse.core.runtime.IPath eclipseDelegate) {
+    Objects.requireNonNull(eclipseDelegate, "Given Eclipse path must not be null");
+
+    if (eclipseDelegate.isAbsolute()) {
+      throw new IllegalArgumentException("Given path must not be absolute - " + eclipseDelegate);
+    }
+
+    return new EclipsePathImpl(eclipseDelegate);
+  }
+
+  /**
+   * Returns the resource representing the given resource delegate.
+   *
+   * <p>Returns the reference point if the given delegate is represented by one of the given
+   * reference points.
+   *
+   * @param referencePoints the shared reference points
+   * @param resourceDelegate the resource delegate for which to get a resource
+   * @return the resource representing the given resource delegate or <code>null</code> if the given
+   *     delegate does not belong to the given reference point
+   * @throws NullPointerException if the given set of reference points or resource delegate is
+   *     <code>null</code>
+   */
+  public static IResource convertToResource(
+      Set<IReferencePoint> referencePoints, org.eclipse.core.resources.IResource resourceDelegate) {
+
+    Objects.requireNonNull(referencePoints, "Given set of reference points must not be null");
+
+    for (IReferencePoint referencePoint : referencePoints) {
+      IResource resource = convertToResource(referencePoint, resourceDelegate);
+
+      if (resource != null) {
+        return resource;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Returns the resource representing the given resource delegate.
+   *
+   * <p>Returns the given reference point if the given delegate is represented by the reference
+   * point.
+   *
+   * @param referencePoint a shared reference point
+   * @param resourceDelegate the resource delegate for which to get a resource
+   * @return the resource representing the given resource delegate or <code>null</code> if the given
+   *     delegate does not belong to the given reference point
+   * @throws NullPointerException if the given reference points or resource delegate is <code>null
+   *     </code>
+   */
+  public static IResource convertToResource(
+      IReferencePoint referencePoint, org.eclipse.core.resources.IResource resourceDelegate) {
+
+    Objects.requireNonNull(referencePoint, "Given reference point must not be null");
+
+    EclipseReferencePointImpl eclipseReferencePoint = (EclipseReferencePointImpl) referencePoint;
+
+    if (eclipseReferencePoint.getDelegate().equals(resourceDelegate)) {
+      return referencePoint;
+    }
+
+    return eclipseReferencePoint.getResource(resourceDelegate);
+  }
+
+  /**
+   * Returns the file representing the given file delegate.
+   *
+   * @param referencePoints the shared reference points
+   * @param fileDelegate the file delegate for which to get a file
+   * @return the file representing the given file delegate or <code>null</code> if the given
+   *     delegate does not belong to the given reference point
+   * @throws NullPointerException if the given set of reference points or file delegate is <code>
+   *     null</code>
+   */
+  public static IFile convertToFile(
+      Set<IReferencePoint> referencePoints, org.eclipse.core.resources.IFile fileDelegate) {
+
+    return (IFile) convertToResource(referencePoints, fileDelegate);
+  }
+
+  /**
+   * Returns the file representing the given file delegate.
+   *
+   * @param referencePoint a shared reference point
+   * @param fileDelegate the file delegate for which to get a file
+   * @return the file representing the given file delegate or <code>null</code> if the given
+   *     delegate does not belong to the given reference point
+   * @throws NullPointerException if the given reference points or file delegate is <code>null
+   *     </code>
+   */
+  public static IFile convertToFile(
+      IReferencePoint referencePoint, org.eclipse.core.resources.IFile fileDelegate) {
+
+    return (IFile) convertToResource(referencePoint, fileDelegate);
+  }
+
+  /**
+   * Returns the container representing the given container delegate.
+   *
+   * <p>Returns the reference point if the given delegate is represented by one of the given
+   * reference points.
+   *
+   * @param referencePoints the shared reference points
+   * @param containerDelegate the container delegate for which to get a container
+   * @return the container representing the given container delegate or <code>null</code> if the
+   *     given delegate does not belong to the given reference point
+   * @throws NullPointerException if the given set of reference points or container delegate is
+   *     <code>null</code>
+   */
+  public static IContainer convertToContainer(
+      Set<IReferencePoint> referencePoints,
+      org.eclipse.core.resources.IContainer containerDelegate) {
+
+    return (IContainer) convertToResource(referencePoints, containerDelegate);
+  }
+
+  /**
+   * Returns the container representing the given container delegate.
+   *
+   * <p>Returns the given reference point if the given delegate is represented by the reference
+   * point.
+   *
+   * @param referencePoint a shared reference point
+   * @param containerDelegate the container delegate for which to get a container
+   * @return the container representing the given container delegate or <code>null</code> if the
+   *     given delegate does not belong to the given reference point
+   * @throws NullPointerException if the given reference points or container delegate is <code>null
+   *     </code>
+   */
+  public static IContainer convertToContainer(
+      IReferencePoint referencePoint, org.eclipse.core.resources.IContainer containerDelegate) {
+
+    return (IContainer) convertToResource(referencePoint, containerDelegate);
+  }
+
+  /**
+   * Returns the Eclipse delegate represented by the given an IPath object.
+   *
+   * @param path the path whose delegate to get
+   * @return the Eclipse delegate represented by the given an IPath object
+   * @throws NullPointerException if the given path is <code>null</code>
+   */
+  public static org.eclipse.core.runtime.IPath getDelegate(IPath path) {
+    Objects.requireNonNull(path, "Given path must not be null");
+
+    EclipsePathImpl eclipsePath = (EclipsePathImpl) path;
+
+    return eclipsePath.getDelegate();
+  }
+
+  /**
+   * Returns the Eclipse delegate represented by the given resource.
+   *
+   * @param resource the resource whose delegate to get
+   * @return the Eclipse delegate represented by the given resource
+   * @throws NullPointerException if the given resource is <code>null</code>
+   */
+  public static org.eclipse.core.resources.IResource getDelegate(IResource resource) {
+    Objects.requireNonNull(resource, "Given resource must not be null");
+
+    switch (resource.getType()) {
+      case REFERENCE_POINT:
+        return getDelegate((IReferencePoint) resource);
+
+      case FILE:
+        return getDelegate((IFile) resource);
+
+      case FOLDER:
+        return getDelegate((IFolder) resource);
+
+      default:
+        throw new IllegalStateException(
+            "Encountered unhandled resource type " + resource.getType() + " - " + resource);
+    }
+  }
+
+  /**
+   * Returns the Eclipse delegate represented by the given reference point.
+   *
+   * @param referencePoint the reference point whose delegate to get
+   * @return the Eclipse delegate represented by the given reference point
+   * @throws NullPointerException if the given reference point is <code>null</code>
+   */
+  public static org.eclipse.core.resources.IContainer getDelegate(IReferencePoint referencePoint) {
+    Objects.requireNonNull(referencePoint, "Given reference point must not be null");
+
+    EclipseReferencePointImpl eclipseReferencePoint = (EclipseReferencePointImpl) referencePoint;
+
+    return eclipseReferencePoint.getDelegate();
+  }
+
+  /**
+   * Returns the Eclipse delegate represented by the given file.
+   *
+   * @param file the file whose delegate to get
+   * @return the Eclipse delegate represented by the given file
+   * @throws NullPointerException if the given file is <code>null</code>
+   */
+  public static org.eclipse.core.resources.IFile getDelegate(IFile file) {
+    Objects.requireNonNull(file, "Given file must not be null");
+
+    EclipseFileImplV2 eclipseFile = (EclipseFileImplV2) file;
+
+    return eclipseFile.getDelegate();
+  }
+
+  /**
+   * Returns the Eclipse delegate represented by the given folder.
+   *
+   * @param folder the folder whose delegate to get
+   * @return the Eclipse delegate represented by the given folder
+   * @throws NullPointerException if the given folder is <code>null</code>
+   */
+  public static org.eclipse.core.resources.IFolder getDelegate(IFolder folder) {
+    Objects.requireNonNull(folder, "Given folder must not be null");
+
+    EclipseFolderImplV2 eclipseFile = (EclipseFolderImplV2) folder;
+
+    return eclipseFile.getDelegate();
+  }
+}


### PR DESCRIPTION
This is my current draft for the new Eclipse resource implementation. The details of the implementation might still change a bit if I encounter any trouble while migrating Saros/E to the new resource implementation but should be stable in general.

A full review of the class is not sensible quite yet (as it still might change), but I would appreciate some feedback on the general design of the implementation.

### Commits
#### [INTERNAL][E] Introduce reference point based resource implementation

Adds new resource implementation based on the reference point model.

The new resource implementation somewhat resembles the new IntelliJ
resource implementation. This is due to both implementations now
operating on the same resource model and being bound by the same
restrictions (i.e. the Eclipse implementation now also having to deal
with relative resources instead of solely relying on the Eclipse
delegates).

Adds ResourceConverter as a replacement for ResourceAdapterFactory.

Marks the old resource implementations as deprecated.

Marks ResourceAdapterFactory as deprecated and removes an unused method.