### PR TITLE
Migrate internal classes to use new resource implementation (ref-point migration 1/10)

### DIFF
--- a/eclipse/src/saros/concurrent/undo/UndoManager.java
+++ b/eclipse/src/saros/concurrent/undo/UndoManager.java
@@ -38,8 +38,8 @@ import saros.concurrent.undo.OperationHistory.Type;
 import saros.editor.EditorManager;
 import saros.editor.ISharedEditorListener;
 import saros.editor.internal.EditorAPI;
-import saros.filesystem.EclipseFileImpl;
 import saros.filesystem.IFile;
+import saros.filesystem.ResourceConverter;
 import saros.preferences.Preferences;
 import saros.repackaged.picocontainer.Disposable;
 import saros.repackaged.picocontainer.annotations.Inject;
@@ -487,7 +487,7 @@ public class UndoManager extends AbstractActivityConsumer implements Disposable 
 
     List<ITextOperation> textOps = activity.toOperation().getTextOperations();
 
-    org.eclipse.core.resources.IFile file = ((EclipseFileImpl) currentActiveEditor).getDelegate();
+    org.eclipse.core.resources.IFile file = ResourceConverter.getDelegate(currentActiveEditor);
 
     FileEditorInput input = new FileEditorInput(file);
     IDocumentProvider provider = EditorAPI.connect(input);

--- a/eclipse/src/saros/editor/EditorManager.java
+++ b/eclipse/src/saros/editor/EditorManager.java
@@ -54,9 +54,9 @@ import saros.editor.remote.UserEditorStateManager;
 import saros.editor.text.LineRange;
 import saros.editor.text.TextPosition;
 import saros.editor.text.TextSelection;
-import saros.filesystem.EclipseFileImpl;
 import saros.filesystem.IReferencePoint;
 import saros.filesystem.ResourceAdapterFactory;
+import saros.filesystem.ResourceConverter;
 import saros.observables.FileReplacementInProgressObservable;
 import saros.repackaged.picocontainer.annotations.Inject;
 import saros.session.AbstractActivityConsumer;
@@ -441,7 +441,7 @@ public class EditorManager implements IEditorManager {
   }
 
   private String doGetContent(saros.filesystem.IFile wrappedFile) {
-    IFile file = ((EclipseFileImpl) wrappedFile).getDelegate();
+    IFile file = ResourceConverter.getDelegate(wrappedFile);
     FileEditorInput input = new FileEditorInput(file);
 
     IDocumentProvider provider = EditorAPI.connect(input);
@@ -467,7 +467,7 @@ public class EditorManager implements IEditorManager {
       return null;
     }
 
-    IFile file = ((EclipseFileImpl) wrappedFile).getDelegate();
+    IFile file = ResourceConverter.getDelegate(wrappedFile);
 
     String lineSeparator = FileUtil.getLineSeparator(file);
 
@@ -703,7 +703,7 @@ public class EditorManager implements IEditorManager {
     log.trace(".execTextEdit invoked");
 
     saros.filesystem.IFile fileWrapper = textEdit.getResource();
-    IFile file = ((EclipseFileImpl) fileWrapper).getDelegate();
+    IFile file = ResourceConverter.getDelegate(fileWrapper);
 
     if (!file.exists()) {
       log.error("TextEditActivity refers to file which" + " is not available locally: " + textEdit);
@@ -1169,7 +1169,7 @@ public class EditorManager implements IEditorManager {
    */
   private boolean isDirty(saros.filesystem.IFile wrappedFile) throws FileNotFoundException {
 
-    IFile file = ((EclipseFileImpl) wrappedFile).getDelegate();
+    IFile file = ResourceConverter.getDelegate(wrappedFile);
 
     if (file == null || !file.exists()) {
       throw new FileNotFoundException("File not found: " + wrappedFile);
@@ -1197,7 +1197,7 @@ public class EditorManager implements IEditorManager {
   public void saveEditor(saros.filesystem.IFile wrappedFile) {
     checkThreadAccess();
 
-    IFile file = ((EclipseFileImpl) wrappedFile).getDelegate();
+    IFile file = ResourceConverter.getDelegate(wrappedFile);
 
     log.trace(".saveEditor (" + file.getName() + ") invoked");
 

--- a/eclipse/src/saros/editor/EditorManager.java
+++ b/eclipse/src/saros/editor/EditorManager.java
@@ -375,7 +375,7 @@ public class EditorManager implements IEditorManager {
 
     this.preferenceStore = preferenceStore;
 
-    editorPool = new EditorPool(this);
+    editorPool = new EditorPool(this, sessionManager);
     partListener = new SafePartListener2(log, new EditorPartListener(this));
 
     registerCustomAnnotations();
@@ -997,7 +997,7 @@ public class EditorManager implements IEditorManager {
   }
 
   private void partClosedOfFile(IEditorPart editorPart, saros.filesystem.IFile file) {
-    editorPool.remove(editorPart);
+    editorPool.remove(editorPart, file);
     openEditorFiles.remove(file);
 
     ITextViewer viewer = EditorAPI.getViewer(editorPart);

--- a/eclipse/src/saros/editor/EditorManager.java
+++ b/eclipse/src/saros/editor/EditorManager.java
@@ -374,7 +374,7 @@ public class EditorManager implements IEditorManager {
 
     this.preferenceStore = preferenceStore;
 
-    editorPool = new EditorPool(this, sessionManager);
+    editorPool = new EditorPool(this);
     partListener = new SafePartListener2(log, new EditorPartListener(this));
 
     registerCustomAnnotations();
@@ -860,11 +860,13 @@ public class EditorManager implements IEditorManager {
       return;
     }
 
+    saros.filesystem.IFile wrappedFile = convertToFile(resource.getAdapter(IFile.class));
+
     /*
      * side effect: this method call also locks the editor part if the user
      * has no write access or if the session is currently locked
      */
-    editorPool.add(editorPart);
+    editorPool.add(editorPart, wrappedFile);
 
     final ITextViewer viewer = EditorAPI.getViewer(editorPart);
 

--- a/eclipse/src/saros/editor/EditorPool.java
+++ b/eclipse/src/saros/editor/EditorPool.java
@@ -301,6 +301,9 @@ final class EditorPool {
     dirtyStateListener.unregisterAll();
 
     assert getAllEditors().size() == 0;
+    assert editorInputMap.isEmpty();
+
+    editorParts.clear();
   }
 
   /** Changes the editable state of all editors currently managed by this pool. */

--- a/eclipse/src/saros/editor/RemoteWriteAccessManager.java
+++ b/eclipse/src/saros/editor/RemoteWriteAccessManager.java
@@ -9,8 +9,8 @@ import org.apache.log4j.Logger;
 import org.eclipse.ui.part.FileEditorInput;
 import saros.activities.EditorActivity;
 import saros.editor.internal.EditorAPI;
-import saros.filesystem.EclipseFileImpl;
 import saros.filesystem.IFile;
+import saros.filesystem.ResourceConverter;
 import saros.session.AbstractActivityConsumer;
 import saros.session.IActivityConsumer;
 import saros.session.ISarosSession;
@@ -127,7 +127,7 @@ public class RemoteWriteAccessManager extends AbstractActivityConsumer {
 
     assert !connectedUserWithWriteAccessFiles.contains(fileWrapper);
 
-    org.eclipse.core.resources.IFile file = ((EclipseFileImpl) fileWrapper).getDelegate();
+    org.eclipse.core.resources.IFile file = ResourceConverter.getDelegate(fileWrapper);
     if (!file.exists()) {
       log.error(
           "Attempting to connect to file which" + " is not available locally: " + fileWrapper,
@@ -150,7 +150,7 @@ public class RemoteWriteAccessManager extends AbstractActivityConsumer {
 
     connectedUserWithWriteAccessFiles.remove(fileWrapper);
 
-    org.eclipse.core.resources.IFile file = ((EclipseFileImpl) fileWrapper).getDelegate();
+    org.eclipse.core.resources.IFile file = ResourceConverter.getDelegate(fileWrapper);
     EditorAPI.disconnect(new FileEditorInput(file));
   }
 

--- a/eclipse/src/saros/editor/internal/EditorAPI.java
+++ b/eclipse/src/saros/editor/internal/EditorAPI.java
@@ -42,8 +42,8 @@ import org.eclipse.ui.texteditor.ITextEditorActionConstants;
 import saros.editor.text.LineRange;
 import saros.editor.text.TextPosition;
 import saros.editor.text.TextSelection;
-import saros.filesystem.EclipseFileImpl;
 import saros.filesystem.ResourceAdapterFactory;
+import saros.filesystem.ResourceConverter;
 import saros.ui.dialogs.WarningMessageDialog;
 import saros.ui.util.SWTUtils;
 import saros.ui.views.SarosView;
@@ -104,7 +104,7 @@ public class EditorAPI {
    * @return the opened editor or <code>null</code> if the editor couldn't be opened.
    */
   public static IEditorPart openEditor(saros.filesystem.IFile wrappedFile, boolean activate) {
-    IFile file = ((EclipseFileImpl) wrappedFile).getDelegate();
+    IFile file = ResourceConverter.getDelegate(wrappedFile);
 
     if (!file.exists()) {
       log.error("EditorAPI cannot open file which does not exist: " + file, new StackTrace());

--- a/eclipse/src/saros/editor/internal/EditorAPI.java
+++ b/eclipse/src/saros/editor/internal/EditorAPI.java
@@ -42,7 +42,6 @@ import org.eclipse.ui.texteditor.ITextEditorActionConstants;
 import saros.editor.text.LineRange;
 import saros.editor.text.TextPosition;
 import saros.editor.text.TextSelection;
-import saros.filesystem.ResourceAdapterFactory;
 import saros.filesystem.ResourceConverter;
 import saros.ui.dialogs.WarningMessageDialog;
 import saros.ui.util.SWTUtils;
@@ -678,16 +677,6 @@ public class EditorAPI {
       log.error("could not get active window", e);
       return null;
     }
-  }
-
-  /**
-   * @return the file the given editor is displaying or null if the given editor is not showing a
-   *     file or the file is not referenced via a path in the project.
-   */
-  public static saros.filesystem.IFile getEditorFile(IEditorPart editorPart) {
-    IFile resource = getEditorResource(editorPart).getAdapter(IFile.class);
-
-    return (resource == null) ? null : ResourceAdapterFactory.create(resource);
   }
 
   /**

--- a/eclipse/src/saros/editor/internal/SharedDocumentProvider.java
+++ b/eclipse/src/saros/editor/internal/SharedDocumentProvider.java
@@ -1,11 +1,14 @@
 package saros.editor.internal;
 
+import java.util.Set;
 import org.apache.log4j.Logger;
 import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.editors.text.TextFileDocumentProvider;
 import saros.SarosPluginContext;
 import saros.annotations.Component;
-import saros.filesystem.ResourceAdapterFactory;
+import saros.filesystem.IReferencePoint;
+import saros.filesystem.IResource;
+import saros.filesystem.ResourceConverter;
 import saros.repackaged.picocontainer.annotations.Inject;
 import saros.session.ISarosSession;
 import saros.session.ISarosSessionManager;
@@ -93,7 +96,10 @@ public final class SharedDocumentProvider extends TextFileDocumentProvider {
 
     IFileEditorInput fileEditorInput = (IFileEditorInput) element;
 
-    return currentSession.isShared(
-        ResourceAdapterFactory.create(fileEditorInput.getFile().getProject()));
+    final Set<IReferencePoint> sharedReferencePoints = currentSession.getReferencePoints();
+    final IResource resource =
+        ResourceConverter.convertToResource(sharedReferencePoints, fileEditorInput.getFile());
+
+    return resource != null && currentSession.isShared(resource);
   }
 }

--- a/eclipse/src/saros/filesystem/EclipsePathFactory.java
+++ b/eclipse/src/saros/filesystem/EclipsePathFactory.java
@@ -1,7 +1,5 @@
 package saros.filesystem;
 
-import org.eclipse.core.runtime.Path;
-
 public class EclipsePathFactory implements IPathFactory {
 
   @Override
@@ -15,13 +13,6 @@ public class EclipsePathFactory implements IPathFactory {
 
   @Override
   public IPath fromString(String pathString) {
-    if (pathString == null) throw new NullPointerException("Given string is null");
-
-    Path path = new Path(pathString);
-
-    if (path.isAbsolute())
-      throw new IllegalArgumentException("Given string denotes an absolute path: " + pathString);
-
-    return ResourceAdapterFactory.create(path);
+    return ResourceConverter.convertToPath(pathString);
   }
 }

--- a/eclipse/src/saros/filesystem/EclipseWorkspaceImpl.java
+++ b/eclipse/src/saros/filesystem/EclipseWorkspaceImpl.java
@@ -3,6 +3,7 @@ package saros.filesystem;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -81,7 +82,11 @@ public class EclipseWorkspaceImpl implements IWorkspace {
         new EclipseRunnableAdapter(runnable);
 
     final List<org.eclipse.core.resources.IResource> eclipseResources =
-        ResourceAdapterFactory.convertBack(resources != null ? Arrays.asList(resources) : null);
+        resources == null
+            ? null
+            : Arrays.stream(resources)
+                .map(ResourceConverter::getDelegate)
+                .collect(Collectors.toList());
 
     final ISchedulingRule schedulingRule;
 

--- a/eclipse/src/saros/filesystem/checksum/EclipseAbsolutePathResolver.java
+++ b/eclipse/src/saros/filesystem/checksum/EclipseAbsolutePathResolver.java
@@ -1,8 +1,8 @@
 package saros.filesystem.checksum;
 
 import org.eclipse.core.runtime.IPath;
-import saros.filesystem.EclipseFileImpl;
 import saros.filesystem.IFile;
+import saros.filesystem.ResourceConverter;
 
 /**
  * Helper class returning the location of the given <code>IFile</code>.
@@ -13,7 +13,7 @@ public class EclipseAbsolutePathResolver implements IAbsolutePathResolver {
 
   @Override
   public String getAbsolutePath(IFile file) {
-    org.eclipse.core.resources.IFile eclipseFile = ((EclipseFileImpl) file).getDelegate();
+    org.eclipse.core.resources.IFile eclipseFile = ResourceConverter.getDelegate(file);
 
     IPath eclipsePath = eclipseFile.getLocation();
 

--- a/eclipse/src/saros/filesystem/checksum/FileContentNotifierBridge.java
+++ b/eclipse/src/saros/filesystem/checksum/FileContentNotifierBridge.java
@@ -3,14 +3,21 @@ package saros.filesystem.checksum;
 import java.util.Arrays;
 import java.util.Deque;
 import java.util.LinkedList;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.ResourcesPlugin;
-import saros.filesystem.ResourceAdapterFactory;
+import saros.SarosPluginContext;
+import saros.filesystem.IReferencePoint;
+import saros.filesystem.ResourceConverter;
+import saros.repackaged.picocontainer.annotations.Inject;
+import saros.session.ISarosSession;
+import saros.session.ISarosSessionManager;
 
 /**
  * Bridge class that maps Eclipse Resource change events to unique identifiers by retrieving the
@@ -21,6 +28,10 @@ import saros.filesystem.ResourceAdapterFactory;
 public class FileContentNotifierBridge
     implements IFileContentChangedNotifier, IResourceChangeListener {
 
+  private static final Logger log = Logger.getLogger(FileContentNotifierBridge.class);
+
+  @Inject private ISarosSessionManager sarosSessionManager;
+
   private CopyOnWriteArrayList<IFileContentChangedListener> fileContentChangedListeners =
       new CopyOnWriteArrayList<IFileContentChangedListener>();
 
@@ -29,9 +40,21 @@ public class FileContentNotifierBridge
         .addResourceChangeListener(this, IResourceChangeEvent.POST_CHANGE);
   }
 
+  private void initialize() {
+    SarosPluginContext.initComponent(this);
+  }
+
   @Override
   public void resourceChanged(IResourceChangeEvent event) {
     if (event.getDelta() == null) return;
+
+    if (sarosSessionManager == null) {
+      initialize();
+
+      if (sarosSessionManager == null) {
+        throw new IllegalStateException("Failed to inject saros session manager instance");
+      }
+    }
 
     Deque<IResourceDelta> stack = new LinkedList<IResourceDelta>();
 
@@ -51,8 +74,32 @@ public class FileContentNotifierBridge
 
         final IFile file = delta.getResource().getAdapter(IFile.class);
 
-        for (IFileContentChangedListener listener : fileContentChangedListeners)
-          listener.fileContentChanged(ResourceAdapterFactory.create(file));
+        final ISarosSession sarosSession = sarosSessionManager.getSession();
+        if (sarosSession == null) {
+          if (log.isTraceEnabled()) {
+            log.trace("Ignoring resource change without a running session for file " + file);
+          }
+          return;
+        }
+
+        Set<IReferencePoint> sharedReferencePoints = sarosSession.getReferencePoints();
+        saros.filesystem.IFile fileWrapper =
+            ResourceConverter.convertToFile(sharedReferencePoints, file);
+
+        if (fileWrapper == null) {
+          if (log.isTraceEnabled()) {
+            log.trace("Ignoring resource change for non-shared file " + file);
+          }
+          return;
+        }
+
+        for (IFileContentChangedListener listener : fileContentChangedListeners) {
+          try {
+            listener.fileContentChanged(fileWrapper);
+          } catch (RuntimeException e) {
+            log.error("internal error in listener: " + listener, e);
+          }
+        }
       }
     }
   }

--- a/eclipse/src/saros/project/FileActivityConsumer.java
+++ b/eclipse/src/saros/project/FileActivityConsumer.java
@@ -11,7 +11,7 @@ import org.eclipse.core.runtime.CoreException;
 import saros.activities.FileActivity;
 import saros.activities.IActivity;
 import saros.editor.EditorManager;
-import saros.filesystem.ResourceAdapterFactory;
+import saros.filesystem.ResourceConverter;
 import saros.repackaged.picocontainer.Startable;
 import saros.session.AbstractActivityConsumer;
 import saros.session.ISarosSession;
@@ -136,9 +136,9 @@ public class FileActivityConsumer extends AbstractActivityConsumer implements St
   private void handleFileMove(FileActivity activity)
       throws CoreException, IOException, IllegalCharsetNameException, UnsupportedCharsetException {
 
-    final IFile fileDestination = toEclipseIFile(activity.getResource());
+    final IFile fileDestination = ResourceConverter.getDelegate(activity.getResource());
 
-    final IFile fileToMove = toEclipseIFile(activity.getOldResource());
+    final IFile fileToMove = ResourceConverter.getDelegate(activity.getOldResource());
 
     FileUtils.mkdirs(fileDestination);
 
@@ -154,7 +154,7 @@ public class FileActivityConsumer extends AbstractActivityConsumer implements St
 
     editorManager.closeEditor(fileWrapper, false);
 
-    final IFile file = toEclipseIFile(fileWrapper);
+    final IFile file = ResourceConverter.getDelegate(fileWrapper);
 
     if (file.exists()) FileUtils.delete(file);
     else log.warn("could not delete file " + file + " because it does not exist");
@@ -165,7 +165,7 @@ public class FileActivityConsumer extends AbstractActivityConsumer implements St
 
     saros.filesystem.IFile sarosFile = activity.getResource();
 
-    final IFile file = toEclipseIFile(sarosFile);
+    final IFile file = ResourceConverter.getDelegate(sarosFile);
 
     final String encoding = activity.getEncoding();
     final byte[] newContent = activity.getContent();
@@ -181,9 +181,5 @@ public class FileActivityConsumer extends AbstractActivityConsumer implements St
     }
 
     if (encoding != null) sarosFile.setCharset(encoding);
-  }
-
-  private static IFile toEclipseIFile(saros.filesystem.IFile file) {
-    return (IFile) ResourceAdapterFactory.convertBack(file);
   }
 }

--- a/eclipse/src/saros/project/FolderActivityConsumer.java
+++ b/eclipse/src/saros/project/FolderActivityConsumer.java
@@ -6,7 +6,7 @@ import org.eclipse.core.runtime.CoreException;
 import saros.activities.FolderCreatedActivity;
 import saros.activities.FolderDeletedActivity;
 import saros.activities.IActivity;
-import saros.filesystem.EclipseFolderImpl;
+import saros.filesystem.EclipseFolderImplV2;
 import saros.repackaged.picocontainer.Startable;
 import saros.session.AbstractActivityConsumer;
 import saros.session.ISarosSession;
@@ -56,7 +56,7 @@ public final class FolderActivityConsumer extends AbstractActivityConsumer imple
 
     saros.filesystem.IFolder folderWrapper = activity.getResource();
 
-    IFolder folder = ((EclipseFolderImpl) folderWrapper).getDelegate();
+    IFolder folder = ((EclipseFolderImplV2) folderWrapper).getDelegate();
 
     try {
       FileUtils.create(folder);
@@ -70,7 +70,7 @@ public final class FolderActivityConsumer extends AbstractActivityConsumer imple
 
     saros.filesystem.IFolder folderWrapper = activity.getResource();
 
-    IFolder folder = ((EclipseFolderImpl) folderWrapper).getDelegate();
+    IFolder folder = ((EclipseFolderImplV2) folderWrapper).getDelegate();
 
     try {
       if (folder.exists()) FileUtils.delete(folder);

--- a/eclipse/src/saros/util/EclipseCollaborationUtilsImpl.java
+++ b/eclipse/src/saros/util/EclipseCollaborationUtilsImpl.java
@@ -2,8 +2,10 @@ package saros.util;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import org.eclipse.core.resources.IResource;
 import saros.filesystem.IReferencePoint;
-import saros.filesystem.ResourceAdapterFactory;
+import saros.filesystem.ResourceConverter;
 import saros.net.xmpp.JID;
 import saros.ui.util.CollaborationUtils;
 import saros.ui.util.ICollaborationUtils;
@@ -15,7 +17,7 @@ public class EclipseCollaborationUtilsImpl implements ICollaborationUtils {
 
   @Override
   public void startSession(Set<IReferencePoint> referencePoints, List<JID> contacts) {
-    CollaborationUtils.startSession(ResourceAdapterFactory.convertBack(referencePoints), contacts);
+    CollaborationUtils.startSession(getDelegates(referencePoints), contacts);
   }
 
   @Override
@@ -25,11 +27,22 @@ public class EclipseCollaborationUtilsImpl implements ICollaborationUtils {
 
   @Override
   public void addReferencePointsToSession(Set<IReferencePoint> referencePoints) {
-    CollaborationUtils.addResourcesToSession(ResourceAdapterFactory.convertBack(referencePoints));
+    CollaborationUtils.addResourcesToSession(getDelegates(referencePoints));
   }
 
   @Override
   public void addContactsToSession(List<JID> contacts) {
     CollaborationUtils.addContactsToSession(contacts);
+  }
+
+  private List<IResource> getDelegates(Set<IReferencePoint> referencePoints) {
+    if (referencePoints == null) {
+      return null;
+    }
+
+    return referencePoints
+        .stream()
+        .map(ResourceConverter::getDelegate)
+        .collect(Collectors.toList());
   }
 }

--- a/eclipse/test/junit/saros/project/FileActivityConsumerTest.java
+++ b/eclipse/test/junit/saros/project/FileActivityConsumerTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import saros.activities.FileActivity;
 import saros.activities.FileActivity.Purpose;
 import saros.activities.FileActivity.Type;
-import saros.filesystem.EclipseFileImpl;
+import saros.filesystem.EclipseFileImplV2;
 import saros.net.xmpp.JID;
 import saros.session.User;
 
@@ -43,7 +43,7 @@ public class FileActivityConsumerTest {
   private IFile file;
 
   /** Mocked saros file wrapper to test. */
-  private EclipseFileImpl eclipseFileWrapper;
+  private EclipseFileImplV2 eclipseFileWrapper;
 
   private SharedResourcesManager resourceChangeListener;
 
@@ -65,7 +65,7 @@ public class FileActivityConsumerTest {
 
     // set up eclipse resource mock
     file = createMock(IFile.class);
-    eclipseFileWrapper = createNiceMock(EclipseFileImpl.class);
+    eclipseFileWrapper = createNiceMock(EclipseFileImplV2.class);
 
     expect(file.getContents()).andStubReturn(new ByteArrayInputStream(FILE_CONTENT));
 


### PR DESCRIPTION
Migrates the internal logic of Saros/E to use the new resource model introduced in #1023. The UI and filesystem handler logic is migrated separately in follow-up PRs. Outdated javadoc and method names that are not directly related to the changed logic will be updated in a separate clean-up PR at the end.

Most of the changes made in this PR are relatively simple as they just replace the usage of the old resource implementation with the new one and usage of the `ResourceAdapterFactory` with `ResourceConverter`.

### Reviewing this PR

I would suggest reviewing this PR commit by commit. 


### Commits

<b>[INTERNAL][E] Migrate FolderActivityConsumer to new resource impl</b>

<details><summary><b>[INTERNAL][E] Partially migrate CollaborationUtils to new resource impls</b></summary>
<br>

Migrates the internal logic of CollaborationUtils to use the new
resource implementations. The logic dealing with the UI and old sharing
assumptions (e.g. that only projects are shared) will be migrated in a
followup commit.

</details>

<b>[REFACTOR][E] Replace manual unwrapping with calls to ResourceConverter</b>

<b>[INTERNAL][E] Migrate FileActivityConsumer to new resource impls</b>

<b>[INTERNAL][E] Migrate EditorPool to new resource impls</b>

<details><summary><b>[FIX][E] Correctly tear down Editor pool mapping</b></summary>
<br>

Adjusts EditorPool.removeAllEditors() to correctly tear down the inner
data structures, ensuring that no mapping is held after the call.

</details>

<b>[INTERNAL][E] Migrate SharedDocumentProvider to new resource impls</b>

<b>[INTERNAL][E] Use ResourceConverter in EclipsePathFactory</b>

<b>[INTERNAL][E] Migrate EclipseWorkspaceImpl to new resource impls</b>

<details><summary><b>[INTERNAL][E] Migrate FileContentNotifierBridge to new resource impls</b></summary>
<br>

This migration uncovered further issues in the separation between the
plugin and session context. The checksum cache is instantiated inside
the plugin context as it is used by the resource negotiations, whose
factories are also part of the plugin context.

With the new logic, the notifier only works if there is a running
session that has a valid reference point mapping as we otherwise can't
compute Saros file objects for the modified Eclipse files. This is due
to Saros file objects being relative to their reference point.

In a future patch, the separation between the plugin in session context
should be improved by moving the resource negotiation factories to a
separate class located in the session context. This would also allow the
EditorManager to be moved into the session context.

As the checksum cache implementation also can't be used before a valid
reference point mapping is established, it we could also consider
splitting the resource negotiation into a resource mapping negotiation
and then a resource content negotiation to better differentiate between
the two phases and avoid illegal usage of the checksum cache.

To avoid cyclic dependency issues with the Saros session manager, it has
to be injected later on.

</details>

<b>[INTERNAL][E] Migrate EclipseCollaborationUtilsImpl</b>

<details><summary><b>[INTERNAL][STF] Migrate Eclipse PackageExplorerView</b></summary>
<br>

Adds a nullcheck for the obtained Eclipse resource object as the new
converter no longer accepts null values.

</details>

<details><summary><b>[INTERNAL][E] Remove EditorAPI.getEditorFile(IEditorPart)</b></summary>
<br>

Removes EditorAPI.getEditorFile(IEditorPart). The method only offers
additional logic to convert from Eclipse resource objects to Saros
resource objects. This is not the responsibility of the editor API.

Adds convenience method convertToFile(IFile) to EditorManager. The
method can be used to convert Eclipse file objects into Saros file
objects using the current set of shared reference points and
ResourceConverter.convertToFile(Set, IFile).

Replaces the usage of EditorAPI.getEditorFile(IEditorPart) with calling
EditorAPI.getEditorResource(IEditorPart) and subsequently converting it
using convertToFile(IFile).

</details>

<b>[INTERNAL][E] Migrate EditorManager to new resource impls</b>