### PR TITLE
Migrate filesystem handlers to use new resource implementation (ref-point migration 2/10)

### DIFF
--- a/eclipse/src/saros/project/ProjectDeltaVisitor.java
+++ b/eclipse/src/saros/project/ProjectDeltaVisitor.java
@@ -18,16 +18,13 @@ import saros.activities.FolderDeletedActivity;
 import saros.activities.IResourceActivity;
 import saros.editor.EditorManager;
 import saros.filesystem.IFolder;
+import saros.filesystem.IReferencePoint;
 import saros.filesystem.ResourceAdapterFactory;
 import saros.session.ISarosSession;
 import saros.session.User;
 import saros.util.FileUtils;
 
-/**
- * Visits the resource changes in a shared project.
- *
- * <p><b>Note:</b> The visitor has to be reset in order to be reused.
- */
+/** Visits the resource changes in a shared project. */
 final class ProjectDeltaVisitor implements IResourceDeltaVisitor {
 
   private static final Logger log = Logger.getLogger(ProjectDeltaVisitor.class);
@@ -40,25 +37,23 @@ final class ProjectDeltaVisitor implements IResourceDeltaVisitor {
 
   private final ISarosSession session;
 
-  private List<IResourceActivity<? extends saros.filesystem.IResource>> resourceActivities =
-      new ArrayList<>(CAPACITY_THRESHOLD);
+  /** The reference point whose resources the delta visitor is iterating. */
+  private final IReferencePoint referencePoint;
 
-  public ProjectDeltaVisitor(ISarosSession session, EditorManager editorManager) {
+  private final List<IResourceActivity<? extends saros.filesystem.IResource>> resourceActivities;
+
+  public ProjectDeltaVisitor(
+      ISarosSession session, EditorManager editorManager, IReferencePoint referencePoint) {
     this.session = session;
     this.editorManager = editorManager;
+    this.referencePoint = referencePoint;
     this.user = session.getLocalUser();
+
+    this.resourceActivities = new ArrayList<>(CAPACITY_THRESHOLD);
   }
 
   public List<IResourceActivity<? extends saros.filesystem.IResource>> getActivities() {
     return sort(resourceActivities);
-  }
-
-  public void reset() {
-    if (resourceActivities.size() > CAPACITY_THRESHOLD) {
-      resourceActivities = new ArrayList<>(CAPACITY_THRESHOLD);
-    } else {
-      resourceActivities.clear();
-    }
   }
 
   @Override

--- a/eclipse/src/saros/session/resources/validation/ResourceChangeValidator.java
+++ b/eclipse/src/saros/session/resources/validation/ResourceChangeValidator.java
@@ -71,14 +71,13 @@ public class ResourceChangeValidator extends ModelProvider {
 
       IResourceDelta referencePointDelta = delta.findMember(referencePointDelegate.getFullPath());
 
-      final ResourceDeltaVisitor visitor = new ResourceDeltaVisitor(referencePoint, currentSession);
-
-      if (referencePointDelta != null) {
+      if (referencePointDelta == null) {
         continue;
       }
 
+      final ResourceDeltaVisitor visitor = new ResourceDeltaVisitor(referencePoint, currentSession);
       try {
-        delta.accept(visitor);
+        referencePointDelta.accept(visitor);
       } catch (CoreException e) {
         log.warn(
             "error occurred during delta visitation, some resources might have not been checked", //$NON-NLS-1$

--- a/eclipse/src/saros/session/resources/validation/ResourceDeltaVisitor.java
+++ b/eclipse/src/saros/session/resources/validation/ResourceDeltaVisitor.java
@@ -1,6 +1,5 @@
 package saros.session.resources.validation;
 
-import java.util.Set;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IResourceDeltaVisitor;
@@ -22,9 +21,13 @@ final class ResourceDeltaVisitor implements IResourceDeltaVisitor {
 
   private boolean isMovingProject = false;
 
+  /** The reference point whose resources the delta visitor is iterating. */
+  private final IReferencePoint referencePoint;
+
   private final ISarosSession session;
 
-  ResourceDeltaVisitor(final ISarosSession session) {
+  ResourceDeltaVisitor(final IReferencePoint referencePoint, final ISarosSession session) {
+    this.referencePoint = referencePoint;
     this.session = session;
   }
 
@@ -35,9 +38,8 @@ final class ResourceDeltaVisitor implements IResourceDeltaVisitor {
 
     if (resource.getType() == IResource.ROOT) return true;
 
-    Set<IReferencePoint> sharedReferencePoints = session.getReferencePoints();
     saros.filesystem.IResource resourceWrapper =
-        ResourceConverter.convertToResource(sharedReferencePoints, resource);
+        ResourceConverter.convertToResource(referencePoint, resource);
 
     if (resourceWrapper == null || !session.isShared(resourceWrapper)) return true;
 


### PR DESCRIPTION
Migrates the filesystem handler logic of Saros/E to use the new resource model introduced in #1023. Outdated javadoc and method names that are not directly related to the changed logic will be updated in a separate clean-up PR at the end.

### Reviewing this PR

I would suggest reviewing this PR commit by commit.

### Commits

<details><summary><b>[INTERNAL][E] Migrate ResourceDeltaVisitor to new resource impls</b></summary>
<br>

Adjusts the logic to check for reference points instead of projects.

</details>

<details><summary><b>[INTERNAL][E] Skip non-shared resources for ResourceDeltaVisitor</b></summary>
<br>

Adjusts ResourceChangeValidator to only check resource deltas for the
shared reference points. This avoid iterating all non-shared resources.

Adjusts ResourceDeltaVisitor to get passed the reference point to use.
This skips guessing which reference point the resource could belong to.

</details>

<details><summary><b>[INTERNAL][E] Improve logic to ignore deltas caused by opening projects </b></summary>
<br>

Adjusts the logic in SharedResourcesManager used to determine whether a
resource delta was caused by opening a project. Instead of manually
tracking the state of shared projects, the new filter instead checks
whether the delta describes a project being opened.

Removes the tracking logic for open shared projects.

</details>

<details><summary><b>[INTERNAL][E] Skip non-shared resources for ProjectDeltaVisitor</b></summary>
<br>

Adjusts SharedResourcesManager to only call ProjectDeltaVisitor on
deltas for the shared reference points. This avoids a lot of overhead
otherwise caused by iterating and converting all non-shared changed
resources.

Adjusts ProjectDeltaVisitor to get passed a reference point object to
use. This skips having to guess which reference point the resources
belong to.

Removes ProjectDeltaVisitor.reset() as there now is one visitor per
reference point, meaning it does not have to get reset.

Adds the utility method createProjectReferencePointMapping which creates
a map of projects onto their contained reference points. This is useful
to quickly access all reference points for a specific project. This is
needed as we still filter by projects to check whether the resource
delta was created by the project being opened.

</details>

<b>[INTERNAL][E] Migrate ProjectDeltaVisitor to new resource impls</b>

<details><summary><b>[INTERNAL][E] Check if resources are shared in ProjectDeltaVisitor</b></summary>
<br>

Adds a check whether the changed resources are actually shared to the
ProjectDeltaVisitor. Even though it specifically only deals with deltas
affecting resources below a shared reference point, there might still be
resources that are not part of the session as they are seen as ignored.
This is defined through IResource.isIgnored().

Adjusts the move logic to create partial activities if the source or the
target file is not shared. If the source is not shared, a creation
activity is dispatched instead of the move activity. If the target is
not shared, a deletion activity is dispatched instead of the move
activity.

</details>