### PR TITLE
Migrate sender resource selection logic to use new resource implementation (ref-point migration 4/10)

### DIFF
--- a/eclipse/src/saros/ui/widgets/viewer/project/BaseResourceSelectionComposite.java
+++ b/eclipse/src/saros/ui/widgets/viewer/project/BaseResourceSelectionComposite.java
@@ -666,10 +666,15 @@ public abstract class BaseResourceSelectionComposite extends ViewerComposite<Che
     ISarosSession sarosSession = sessionManager.getSession();
 
     if (sarosSession != null) {
-      Set<IContainer> referencePointParents =
-          getReferencePointParents(sarosSession.getReferencePoints());
+      Set<IReferencePoint> referencePoints = sarosSession.getReferencePoints();
 
-      sanitizedResources.removeAll(referencePointParents);
+      Set<IContainer> referencePointParents = getReferencePointParents(referencePoints);
+
+      sanitizedResources.removeIf(
+          container ->
+              referencePointParents.contains(container)
+                  || sarosSession.isShared(
+                      ResourceConverter.convertToResource(referencePoints, container)));
     }
 
     List<IContainer> sanitizedBaseContainers =

--- a/eclipse/src/saros/ui/widgets/viewer/project/BaseResourceSelectionComposite.java
+++ b/eclipse/src/saros/ui/widgets/viewer/project/BaseResourceSelectionComposite.java
@@ -66,7 +66,7 @@ public abstract class BaseResourceSelectionComposite extends ViewerComposite<Che
   private static final String SERIALIZATION_SEPARATOR = "**#**";
   private static final String SERIALIZATION_SEPARATOR_REGEX = "\\*\\*#\\*\\*";
 
-  protected final CheckboxTreeViewer checkboxTreeViewer;
+  private final CheckboxTreeViewer checkboxTreeViewer;
 
   protected final List<BaseResourceSelectionListener> resourceSelectionListeners;
 

--- a/eclipse/src/saros/ui/widgets/viewer/project/BaseResourceSelectionComposite.java
+++ b/eclipse/src/saros/ui/widgets/viewer/project/BaseResourceSelectionComposite.java
@@ -8,12 +8,10 @@ import java.util.List;
 import java.util.Set;
 import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IContainer;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.viewers.CheckStateChangedEvent;
 import org.eclipse.jface.viewers.CheckboxTreeViewer;
 import org.eclipse.jface.viewers.ICheckStateListener;
@@ -37,7 +35,6 @@ import saros.ui.util.LayoutUtils;
 import saros.ui.widgets.viewer.ViewerComposite;
 import saros.ui.widgets.viewer.project.events.BaseResourceSelectionListener;
 import saros.ui.widgets.viewer.project.events.ResourceSelectionChangedEvent;
-import saros.util.ArrayUtils;
 
 /**
  * Base UI allowing the user to select (complete) resource trees in the current workspace.
@@ -658,33 +655,6 @@ public abstract class BaseResourceSelectionComposite extends ViewerComposite<Che
         this.resourceSelectionListeners) {
       resourceSelectionListener.resourceSelectionChanged(event);
     }
-  }
-
-  /**
-   * Returns the displayed resources.
-   *
-   * @return the displayed resources
-   */
-  public List<IResource> getResources() {
-    WorkbenchContentProvider contentProvider =
-        (WorkbenchContentProvider) getViewer().getContentProvider();
-
-    Object[] objects = contentProvider.getElements(getViewer().getInput());
-    return ArrayUtils.getAdaptableObjects(objects, IResource.class, Platform.getAdapterManager());
-  }
-
-  /**
-   * Returns how many projects are displayed.
-   *
-   * @return how many projects are displayed
-   */
-  public int getProjectsCount() {
-    WorkbenchContentProvider contentProvider =
-        (WorkbenchContentProvider) getViewer().getContentProvider();
-
-    Object[] objects = contentProvider.getElements(getViewer().getInput());
-    return ArrayUtils.getAdaptableObjects(objects, IProject.class, Platform.getAdapterManager())
-        .size();
   }
 
   @Override

--- a/eclipse/src/saros/ui/widgets/viewer/project/BaseResourceSelectionComposite.java
+++ b/eclipse/src/saros/ui/widgets/viewer/project/BaseResourceSelectionComposite.java
@@ -442,8 +442,7 @@ public abstract class BaseResourceSelectionComposite extends ViewerComposite<Che
       prevSelected.push(selected);
     }
 
-    selectedBaseResources = new ArrayList<>();
-
+    List<IResource> newSelectedResources;
     /*
      * Do not combine the two ifs! lastSelected can be empty now because of
      * the modifications...
@@ -454,20 +453,17 @@ public abstract class BaseResourceSelectionComposite extends ViewerComposite<Che
        * selection (which we want to undo). Using it would not undo
        * anything.
        */
-      List<IResource> newSelected = lastSelected.peek();
-
-      checkboxTreeViewer.setCheckedElements(newSelected.toArray());
-      applyAdditionalSelections(newSelected);
-
-      selectedBaseResources.addAll(newSelected);
+      newSelectedResources = lastSelected.peek();
 
     } else {
       /*
        * No previous selection available, so unset all selections (set to
        * initial state)
        */
-      checkboxTreeViewer.setCheckedElements(new Object[0]);
+      newSelectedResources = new ArrayList<>();
     }
+
+    setSelectedResourcesInternal(newSelectedResources);
 
     // Need to update the controls (if there are any)
     updateRedoUndoControls();
@@ -479,16 +475,11 @@ public abstract class BaseResourceSelectionComposite extends ViewerComposite<Che
    */
   protected void redoSelection() {
     if (!prevSelected.isEmpty()) {
-      List<IResource> selectedElements = prevSelected.pop();
+      List<IResource> newSelectedResources = prevSelected.pop();
 
-      lastSelected.push(selectedElements);
+      lastSelected.push(newSelectedResources);
 
-      checkboxTreeViewer.setCheckedElements(selectedElements.toArray());
-      applyAdditionalSelections(selectedElements);
-
-      selectedBaseResources = new ArrayList<>(selectedElements);
-
-      // Disable redo button if no redo possible anymore
+      setSelectedResourcesInternal(newSelectedResources);
 
     } else {
       log.debug("Cannot redo, no more snapshots!");

--- a/eclipse/src/saros/ui/widgets/viewer/project/ResourceSelectionComposite.java
+++ b/eclipse/src/saros/ui/widgets/viewer/project/ResourceSelectionComposite.java
@@ -379,7 +379,7 @@ public class ResourceSelectionComposite extends BaseResourceSelectionComposite {
     if (newProject != null) {
       getViewer().refresh();
       List<IResource> selectedResources = new ArrayList<IResource>();
-      selectedResources.addAll(this.getSelectedResources());
+      selectedResources.addAll(this.getSelectedBaseContainers());
       /*
        * HINT: do not directly use the return value of
        * getSelectedResources because that is an abstract collection which

--- a/eclipse/src/saros/ui/widgets/viewer/project/ResourceSelectionComposite.java
+++ b/eclipse/src/saros/ui/widgets/viewer/project/ResourceSelectionComposite.java
@@ -378,8 +378,7 @@ public class ResourceSelectionComposite extends BaseResourceSelectionComposite {
     // If a project was successfully added: select it
     if (newProject != null) {
       getViewer().refresh();
-      List<IResource> selectedResources = new ArrayList<IResource>();
-      selectedResources.addAll(this.getSelectedBaseContainers());
+      List<IResource> selectedResources = new ArrayList<>(getSelectedBaseContainers());
       /*
        * HINT: do not directly use the return value of
        * getSelectedResources because that is an abstract collection which
@@ -387,8 +386,7 @@ public class ResourceSelectionComposite extends BaseResourceSelectionComposite {
        */
       selectedResources.add(newProject);
 
-      checkboxTreeViewer.setCheckedElements(selectedResources.toArray());
-      checkboxTreeViewer.setSubtreeChecked(newProject, true);
+      setSelectedResources(selectedResources);
     }
   }
 

--- a/eclipse/src/saros/ui/wizards/AddResourcesToSessionWizard.java
+++ b/eclipse/src/saros/ui/wizards/AddResourcesToSessionWizard.java
@@ -1,7 +1,9 @@
 package saros.ui.wizards;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.Wizard;
@@ -41,9 +43,10 @@ public class AddResourcesToSessionWizard extends Wizard {
     addPage(resourceSelectionWizardPage);
   }
 
+  // TODO adjust once CollaborationUtils has been migrated
   @Override
   public boolean performFinish() {
-    List<IResource> selectedResources = resourceSelectionWizardPage.getSelectedResources();
+    List<IContainer> selectedResources = resourceSelectionWizardPage.getSelectedResources();
 
     if (selectedResources == null || selectedResources.isEmpty()) return false;
 
@@ -51,7 +54,7 @@ public class AddResourcesToSessionWizard extends Wizard {
 
     SarosView.clearNotifications();
 
-    CollaborationUtils.addResourcesToSession(selectedResources);
+    CollaborationUtils.addResourcesToSession(new ArrayList<>(selectedResources));
 
     return true;
   }

--- a/eclipse/src/saros/ui/wizards/StartSessionWizard.java
+++ b/eclipse/src/saros/ui/wizards/StartSessionWizard.java
@@ -1,7 +1,9 @@
 package saros.ui.wizards;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.Wizard;
@@ -64,10 +66,11 @@ public class StartSessionWizard extends Wizard {
    *
    * <p>The chosen resources are put into collections to be sent to the chosen contacts.
    */
+  // TODO adjust once CollaborationUtils has been migrated
   @Override
   public boolean performFinish() {
 
-    List<IResource> selectedResources = resourceSelectionWizardPage.getSelectedResources();
+    List<IContainer> selectedResources = resourceSelectionWizardPage.getSelectedResources();
 
     List<JID> selectedContacts = contactSelectionWizardPage.getSelectedContacts();
 
@@ -79,7 +82,7 @@ public class StartSessionWizard extends Wizard {
 
     SarosView.clearNotifications();
 
-    CollaborationUtils.startSession(selectedResources, selectedContacts);
+    CollaborationUtils.startSession(new ArrayList<>(selectedResources), selectedContacts);
 
     return true;
   }

--- a/eclipse/src/saros/ui/wizards/pages/ResourceSelectionWizardPage.java
+++ b/eclipse/src/saros/ui/wizards/pages/ResourceSelectionWizardPage.java
@@ -102,36 +102,28 @@ public class ResourceSelectionWizardPage extends WizardPage {
         new Runnable() {
           @Override
           public void run() {
+            resourceSelectionComposite.addResourceSelectionListener(resourceSelectionListener);
 
-            final List<IResource> selectedResources = new ArrayList<IResource>();
-
-            if (preselectedResources != null && preselectedResources.size() > 0) {
-
-              selectedResources.addAll(preselectedResources);
-              resourceSelectionComposite.setSelectedResources(selectedResources);
+            if (preselectedResources != null && !preselectedResources.isEmpty()) {
+              resourceSelectionComposite.setSelectedResources(
+                  new ArrayList<>(preselectedResources));
             }
 
             preselectedResources = null; // GC
 
-            resourceSelectionComposite.addResourceSelectionListener(resourceSelectionListener);
-            /*
-             * If nothing is selected and only one project exists in the
-             * workspace, select it in the Wizard.
-             */
-            if (selectedResources.size() == 0
-                && resourceSelectionComposite.getProjectsCount() == 1) {
+            if (!resourceSelectionComposite.getSelectedBaseContainers().isEmpty()) {
+              /*
+               * Add the current automatically applied selection to the
+               * undo-stack, so the user can undo it, and undo/redo works
+               * properly.
+               */
+              resourceSelectionComposite.rememberSelection();
 
-              selectedResources.addAll(resourceSelectionComposite.getResources());
+              setPageComplete(true);
 
-              resourceSelectionComposite.setSelectedResources(selectedResources);
+            } else {
+              setPageComplete(false);
             }
-            /*
-             * Add the current automatically applied selection to the
-             * undo-stack, so the user can undo it, and undo/redo works
-             * properly.
-             */
-            resourceSelectionComposite.rememberSelection();
-            setPageComplete(selectedResources.size() > 0);
           }
         };
 

--- a/eclipse/src/saros/ui/wizards/pages/ResourceSelectionWizardPage.java
+++ b/eclipse/src/saros/ui/wizards/pages/ResourceSelectionWizardPage.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import org.apache.log4j.Logger;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
@@ -162,11 +163,10 @@ public class ResourceSelectionWizardPage extends WizardPage {
   /*
    * WizardPage Results
    */
-
-  public List<IResource> getSelectedResources() {
+  public List<IContainer> getSelectedResources() {
     if (resourceSelectionComposite == null || resourceSelectionComposite.isDisposed()) return null;
 
-    return resourceSelectionComposite.getSelectedResources();
+    return resourceSelectionComposite.getSelectedBaseContainers();
   }
 
   /** Saves the current selection under a fixed name "-Last selection-" */


### PR DESCRIPTION
Migrates the logic to select which resources to start a resources negotiation with of Saros/E to use the new resource model introduced in #1023. Outdated javadoc and method names that are not directly related to the changed logic will be updated in a separate clean-up PR at the end.

Completely rewrites the wizard to select local resources to start a resource negotiation with. The new implementation still uses the old tree model to avoid having to introduce even more new logic. This somewhat worsens the usability as the current tree model does not allow disabling elements. As a result, "illegal" changes are just reverted internally as we can't stop the user from interacting with the tree nodes. See issue #1041.

### Reviewing this PR

I would suggest reviewing this PR commit by commit.

### Commits

<details><summary><b>[UI][E] Update BaseResourceSelectionComposite selection logic</b></summary>
<br>

Updates the logic validating and updating user selections in the
BaseResourceSelectionComposite to match the new resource model.

Changes the logic to allow the user to choose any sub-tree.

Adjusts the logic to disallow the user to deselect any inner resource of
a selected sub-tree. This is done by directly reverting the deselection
internally. In such cases, the resource selection change listener is not
called. This was chosen as a workaround to ensure the user always
selects a complete sub-tree. This workaround was necessary as the
Eclipse CheckboxTreeViewer does not allow disabling tree nodes, meaning
there is no way of disallowing the user to choose an invalid selection.
This could have theoretically also been avoided by simply disabling the
"Next" button on illegal input, but this offers even worse usability in
my opinion.

The UI should be updated to include a user message if they try to create
such an illegal change. This is not included in this commit.

If the user checks a file, its parent folder as well as its other
children resources are checked automatically. This workaround is
necessary as the new resource sharing model only allows reference points
to represent container (and not files).

Removes the dirty hack only displaying project entries as it is no
longer required.

</details>

<details><summary><b>[INTERNAL][E] Update logic storing which resources were selected</b></summary>
<br>

Adjusts BaseResourceSelectionComposite to store the resources directly
checked by the user. This makes it easier to determine which base
resources were checked by the user as we are only interested in such
resources.

</details>

<details><summary><b>[INTERNAL][E] Update logic to set selections</b></summary>
<br>

Updates the logic in BaseResourceSelectionComposite for setting new
selections to work with the held list of checked resources.

Moves the old method to setSelectedResourcesInternal. Adds a new method
setSelectedResources that first reduces the given set of resources to
the contained base resources. This is done to ensure that our set of
held base resources does not contain any child resources, which would
result in Saros creating nested reference points.

</details>

<details><summary><b>[INTERNAL][E] Update undo logic in BaseResourceSelectionComposite</b></summary>
<br>

Updates the undo logic in BaseResourceSelectionComposite to work with
the new logic.

Adjusts it to no longer track grayed resources as this option is no
longer used.

Restricts the tracking to the base resources. Additional selections will
be made after the base state has been restored.

Adjusts the logic to also correctly restore the held list of selected
base resources.

Replaces the usage of Stack with LinkedList (as a Deque) to avoid the
performance penalty of using a synchronized collection.

</details>

<details><summary><b>[REFACTOR][E] Clean up BaseResourceSelectionComposite</b></summary>
<br>

Reduced the visibility of the methods and variables to its (sensible)
minimum.

Moved all instance variables to the top of the class.

Moved the CTOR below the declaration of the instance variables.

Unified the wording for "selected"/"checked" resources. Now always
addresses the resources as "selected".

Introduced a static constant for the prefix of resource selection
settings entries.

Moved the instantiation of collections used in the class into the CTOR.

Adjusted javadoc.

</details>

<details><summary><b>[INTERNAL][E] Notify change listeners for undo and redo</b></summary>
<br>

Uses setSelectedResourcesInternal(...) when applying undos and redos to
also notify the selection change listeners.

</details>

<details><summary><b>[INTERNAL][E] Fix file handling in BaseResourceSelectionComposite</b></summary>
<br>

Ensures that the parent resource of selected files is always used. With
the previous logic, even though the parent was displayed as selected,
the file was still held in the internal base selection list.

Adjusts setSelectedResources(...) to filter out any given file by using
its parent instead.

Adjusts the check state listener by pulling the file check out of
handleSelectionStateChanged(...). This allows the listener logic to
correctly use the parent resource for files for the other calls as well.

</details>

<details><summary><b>[REFACTOR][E] Use IContainer in BaseResourceSelectionComposite</b></summary>
<br>

Use IConainer to hold the selected resources in
BaseResourceSelectionComposite. This makes it easier to convert the
selected resources to reference points.


Adjusts javadoc and variable and method names accordingly.

</details>

<details><summary><b>[FIX][E] Use setSelectedResources(...) in ResourceSelectionComposite</b></summary>
<br>

uses setSelectedResources(...) in the logic creating new projects in
ResourceSelectionComposite. This ensures that the necessary listeners
are called and the internal state is updated correctly for the
additional selection.

Makes checkboxTreeViewer private in BaseResourceSelectionComposite as it
is now no longer accessed from outside the class. This ensures that the
model can't be updated incorrectly from the outside.

</details>

<details><summary><b>[INTERNAL][E] Adjust logic setting initial resource selection</b></summary>
<br>

Moves the addition of the selection listener before setting the
preselected resources to ensure that we are informed about the state
change.

Get list of displayed projects and use it directly to set the preset if
only one project is shown instead of using all shown resources.
Subsequently removes the method used to obtain all displayed resources.

Adjusts logic checking the initial input to also display the error
warning if no resources were selected by default.

</details>

<details><summary><b>[INTERNAL][E] Filter out parent resources of shared reference points</b></summary>
<br>

Adjusts BaseReosurceSelectionComposite to filter out resources which are
parents of already shared reference points and don't contain any further
shareable children. This is necessary to ensure that the user does not
try to create nested reference points.

Further adjusts the logic to also filter out files contained in parents
of already shared resources as they can't be shared with the current
reference point setup (as this would require a direct parent of a
reference point to be a reference point, leading to nested reference
points).

Adds a method to determine all reference point parent resources without
any shareable child resources.

Reference point parent resources that still have shareable children are
still displayed, but their selection by the user is seen as invalid and
reverted by the dialog (again to ensure that we don't create nested
reference points).

Filters out any such resource selections in the set of given resources
to select when setSelectedResources(...) is called.

</details>

<details><summary><b>[FIX][E] Filter out already shared resources when setting selection</b></summary>
<br>

Adjusts the "external" method setSelectedResources(...) to filter out
selected resources that are already shared.

Otherwise, this calling the method with resources which are already
shared leads to the change listener still being called with the alleged
new selected resources, leading to the wizard being finishable without a
valid selection.

</details>