### PR TITLE
Migrating ui internals to new resource implementation 2/3 (ref-point migration 5/10)

### DIFF
--- a/eclipse/src/saros/ui/command_handlers/SessionAddProjectsHandler.java
+++ b/eclipse/src/saros/ui/command_handlers/SessionAddProjectsHandler.java
@@ -11,6 +11,9 @@ import saros.ui.wizards.AddResourcesToSessionWizard;
 /**
  * Handles the addition of {@link IResource}s that must explicitly be selected in the opening {@link
  * AddResourcesToSessionWizard} to the running {@link ISarosSession}.
+ *
+ * <p>This class is used to define the behavior of the saros menu entry to add reference points to a
+ * running session.
  */
 public class SessionAddProjectsHandler extends AbstractHandler {
 

--- a/eclipse/src/saros/ui/command_handlers/SessionAddSelectedProjectsHandler.java
+++ b/eclipse/src/saros/ui/command_handlers/SessionAddSelectedProjectsHandler.java
@@ -1,15 +1,24 @@
 package saros.ui.command_handlers;
 
+import java.util.HashSet;
 import java.util.List;
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.resources.IResource;
 import saros.session.ISarosSession;
-import saros.ui.util.CollaborationUtils;
+import saros.ui.util.WizardUtils;
 import saros.ui.util.selection.retriever.SelectionRetrieverFactory;
 
-/** Handles the addition of selected {@link IResource}s to the running {@link ISarosSession}. */
+/**
+ * Handles the addition of selected {@link IResource}s to the running {@link ISarosSession}.
+ *
+ * <p>An {@link saros.ui.wizards.AddResourcesToSessionWizard} is opened for this purpose with the
+ * currently selected resources preselected.
+ *
+ * <p>This class is used to define the behavior of the project view context menu entry to add
+ * reference points to a running session.
+ */
 public class SessionAddSelectedProjectsHandler extends AbstractHandler {
 
   @Override
@@ -18,7 +27,8 @@ public class SessionAddSelectedProjectsHandler extends AbstractHandler {
     List<IResource> selectedResources =
         SelectionRetrieverFactory.getSelectionRetriever(IResource.class).getSelection();
 
-    CollaborationUtils.addResourcesToSession(selectedResources);
+    WizardUtils.openAddResourcesToSessionWizard(new HashSet<>(selectedResources));
+
     return null;
   }
 }

--- a/eclipse/src/saros/ui/menu_contributions/StartSessionWithProjects.java
+++ b/eclipse/src/saros/ui/menu_contributions/StartSessionWithProjects.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.jface.action.ContributionItem;
@@ -93,8 +92,7 @@ public class StartSessionWithProjects extends ContributionItem {
         new SelectionAdapter() {
           @Override
           public void widgetSelected(SelectionEvent e) {
-            CollaborationUtils.startSession(
-                Collections.<IResource>singletonList(project), contacts);
+            CollaborationUtils.startSession(Collections.singleton(project), contacts);
           }
         });
 

--- a/eclipse/src/saros/ui/wizards/AddResourcesToSessionWizard.java
+++ b/eclipse/src/saros/ui/wizards/AddResourcesToSessionWizard.java
@@ -1,7 +1,7 @@
 package saros.ui.wizards;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IResource;
@@ -43,7 +43,6 @@ public class AddResourcesToSessionWizard extends Wizard {
     addPage(resourceSelectionWizardPage);
   }
 
-  // TODO adjust once CollaborationUtils has been migrated
   @Override
   public boolean performFinish() {
     List<IContainer> selectedResources = resourceSelectionWizardPage.getSelectedResources();
@@ -54,7 +53,7 @@ public class AddResourcesToSessionWizard extends Wizard {
 
     SarosView.clearNotifications();
 
-    CollaborationUtils.addResourcesToSession(new ArrayList<>(selectedResources));
+    CollaborationUtils.addReferencePointsToSession(new HashSet<>(selectedResources));
 
     return true;
   }

--- a/eclipse/src/saros/ui/wizards/StartSessionWizard.java
+++ b/eclipse/src/saros/ui/wizards/StartSessionWizard.java
@@ -1,7 +1,7 @@
 package saros.ui.wizards;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IResource;
@@ -66,7 +66,6 @@ public class StartSessionWizard extends Wizard {
    *
    * <p>The chosen resources are put into collections to be sent to the chosen contacts.
    */
-  // TODO adjust once CollaborationUtils has been migrated
   @Override
   public boolean performFinish() {
 
@@ -82,7 +81,7 @@ public class StartSessionWizard extends Wizard {
 
     SarosView.clearNotifications();
 
-    CollaborationUtils.startSession(new ArrayList<>(selectedResources), selectedContacts);
+    CollaborationUtils.startSession(new HashSet<>(selectedResources), selectedContacts);
 
     return true;
   }


### PR DESCRIPTION
Migrates parts of the internal UI logic of Saros/E to use the new resource model introduced in #1023. Outdated javadoc and method names that are not directly related to the changed logic will be updated in a separate clean-up PR at the end.

This is the second part of the internal UI migration.

### Reviewing this PR

I would suggest reviewing this PR commit by commit.

### Commits

<details><summary><b>[INTERNAL][E] Migrate CollaborationUtils.startSession(...)</b></summary>
<br>

Migrates CollaborationUtils.startSession(...) to work on a set of
reference points. Adjusts the usages of the method to correctly supply a
set of reference points.

</details>

<details><summary><b>[INTERNAL][E] Migrate CollaborationUtils.addResoucesToSession(...)</b></summary>
<br>

Renames the method to addReferencePointsToSession(...) to make it more
clear what the method actually does.

Adjusts the method to get passed the set of reference points to add.

Adjusts the usage of the method to match the new implementation.

Uses WizardUtils.openAddResourcesToSessionWizard(...) instead of calling
addReferencePointsToSession(...) directly in
SessionAddSelectedProjectsHandler. This was done to avoid having to add
additional logic to filter the resource selection and determine the
minimal set of base resources to actually use as the reference points.
As this logic is already present in the wizard, using it was the easiest
workaround. Furthermore, with the new behavior, the option fits much
better into the rest of the usage flow of the UI as all other option to
add reference points to the session go through the wizard.

</details>