### PR TITLE
[BUILD] Workaround failing STF Tests

### DIFF
--- a/travis/script/stf/master_setup_utils.sh
+++ b/travis/script/stf/master_setup_utils.sh
@@ -17,6 +17,8 @@ function start_container_master()
 
 function setup_container_master()
 {
+  # Workaround: Package installation has to be moved into a Dockerfile
+  docker exec -t "$stf_master_name" /bin/sh -c "apk --update add --no-cache gtk+3.0"
   echo "Build testees"
   docker exec -t "$stf_master_name" "$SCRIPT_DIR_CONTAINER/stf/master/build_testee.sh"
   echo "Executing setup_stf_ws.sh on $stf_master_name"


### PR DESCRIPTION
Eclipse dropped the GTK2 support [with 4.10](https://www.eclipse.org/eclipse/news/4.10/platform.php#gtk2-removal).
Our build process uses the latest compatible
bundle version (and the corresponding [new jar](https://mvnrepository.com/artifact/org.eclipse.platform/org.eclipse.swt/3.114.100) was released at 17.06.20).
Therefore, the new bundle version is used and we have to install GTK3.

However, this installation has to be moved into
a Dockerfile file in the corresponding repository.
I will open a follow-up PR.


