### PR TITLE
Move XMPP Exception Parsing into Core

### DIFF
--- a/core/src/saros/communication/connection/IConnectionStateListener.java
+++ b/core/src/saros/communication/connection/IConnectionStateListener.java
@@ -6,12 +6,21 @@ import saros.net.ConnectionState;
 @FunctionalInterface
 public interface IConnectionStateListener {
 
+  /** List of possible error types. TODO add cases for connect failures */
+  enum ErrorType {
+    /** A previously available connection was unexpectedly disconnected */
+    CONNECTION_LOST,
+    /** Another client logged on with the same resource */
+    RESOURCE_CONFLICT
+  }
+
   /**
    * Is fired when the state of the connection changes.
    *
    * @param state the current state of the connection
-   * @param error the error that occurred when the state is {@link ConnectionState#ERROR} or <code>
+   * @param errorType the error that occurred when the state is {@link ConnectionState#ERROR} or
+   *     <code>
    *     null</code> when the error is not available
    */
-  public void connectionStateChanged(ConnectionState state, Exception error);
+  public void connectionStateChanged(ConnectionState state, ErrorType errorType);
 }

--- a/eclipse/src/saros/service_providers/SarosSourceProvider.java
+++ b/eclipse/src/saros/service_providers/SarosSourceProvider.java
@@ -10,7 +10,6 @@ import saros.Saros;
 import saros.SarosPluginContext;
 import saros.communication.connection.ConnectionHandler;
 import saros.communication.connection.IConnectionStateListener;
-import saros.net.ConnectionState;
 import saros.repackaged.picocontainer.annotations.Inject;
 import saros.session.ISarosSession;
 import saros.session.ISarosSessionManager;
@@ -36,13 +35,7 @@ public class SarosSourceProvider extends AbstractSourceProvider {
 
   @Inject private ConnectionHandler connectionHandler;
 
-  private IConnectionStateListener connectionStateListener =
-      new IConnectionStateListener() {
-        @Override
-        public void connectionStateChanged(final ConnectionState state, final Exception error) {
-          connectionChanged();
-        }
-      };
+  private IConnectionStateListener connectionStateListener = (state, error) -> connectionChanged();
 
   private ISessionLifecycleListener sessionLifecycleListener =
       new ISessionLifecycleListener() {

--- a/eclipse/src/saros/ui/actions/ChangeXMPPAccountAction.java
+++ b/eclipse/src/saros/ui/actions/ChangeXMPPAccountAction.java
@@ -47,20 +47,7 @@ public class ChangeXMPPAccountAction extends Action implements IMenuCreator, Dis
   private boolean defaultAccountChanged;
 
   private final IConnectionStateListener connectionStateListener =
-      new IConnectionStateListener() {
-        @Override
-        public void connectionStateChanged(final ConnectionState state, final Exception error) {
-          SWTUtils.runSafeSWTAsync(
-              log,
-              new Runnable() {
-
-                @Override
-                public void run() {
-                  updateStatus(state);
-                }
-              });
-        }
-      };
+      (state, error) -> SWTUtils.runSafeSWTAsync(log, () -> updateStatus(state));
 
   private final IAccountStoreListener accountStoreListener =
       new IAccountStoreListener() {

--- a/eclipse/src/saros/ui/widgets/ConnectionStateComposite.java
+++ b/eclipse/src/saros/ui/widgets/ConnectionStateComposite.java
@@ -7,15 +7,13 @@ import org.eclipse.swt.custom.CLabel;
 import org.eclipse.swt.events.DisposeEvent;
 import org.eclipse.swt.events.DisposeListener;
 import org.eclipse.swt.widgets.Composite;
-import org.jivesoftware.smack.XMPPException;
-import org.jivesoftware.smack.packet.StreamError;
-import org.jivesoftware.smack.packet.XMPPError;
 import saros.SarosPluginContext;
 import saros.account.IAccountStoreListener;
 import saros.account.XMPPAccount;
 import saros.account.XMPPAccountStore;
 import saros.communication.connection.ConnectionHandler;
 import saros.communication.connection.IConnectionStateListener;
+import saros.communication.connection.IConnectionStateListener.ErrorType;
 import saros.context.IContextKeyBindings.SarosVersion;
 import saros.net.ConnectionState;
 import saros.repackaged.picocontainer.annotations.Inject;
@@ -49,7 +47,7 @@ public class ConnectionStateComposite extends Composite {
   private final CLabel stateLabel;
 
   private ConnectionState lastConnectionState;
-  private Exception lastError;
+  private ErrorType lastError;
 
   private final IAccountStoreListener accountStoreListener =
       new IAccountStoreListener() {
@@ -102,8 +100,8 @@ public class ConnectionStateComposite extends Composite {
    * @param state the current connection state or <code>null</code>
    * @param error additional error information or <code>null</code>
    */
-  private void updateLabel(ConnectionState state, Exception error) {
-    if (ConnectionStateComposite.this.isDisposed()) return;
+  private void updateLabel(ConnectionState state, ErrorType error) {
+    if (isDisposed()) return;
 
     // do not hide the latest error
     if (lastConnectionState == ConnectionState.ERROR && state == ConnectionState.NOT_CONNECTED)
@@ -137,7 +135,7 @@ public class ConnectionStateComposite extends Composite {
    * Returns a nice string description of the given state, which can be used to be shown in labels
    * (e.g. CONNECTING becomes "Connecting...").
    */
-  private String getDescription(ConnectionState state, Exception error) {
+  private String getDescription(ConnectionState state, ErrorType error) {
 
     switch (state) {
       case NOT_CONNECTED:
@@ -154,38 +152,25 @@ public class ConnectionStateComposite extends Composite {
          */
         if (id == null) return Messages.ConnectionStateComposite_error_unknown;
 
-        String displayText = id + Messages.ConnectionStateComposite_connected;
-        return displayText;
+        return id + Messages.ConnectionStateComposite_connected;
       case DISCONNECTING:
         return Messages.ConnectionStateComposite_disconnecting;
       case ERROR:
-        if (!(error instanceof XMPPException)
-            || !(lastConnectionState == ConnectionState.CONNECTED
-                || lastConnectionState == ConnectionState.CONNECTING))
-          return Messages.ConnectionStateComposite_error_connection_lost;
+        switch (error) {
+          case CONNECTION_LOST:
+            return Messages.ConnectionStateComposite_error_connection_lost;
+          case RESOURCE_CONFLICT:
+            if (lastConnectionState == ConnectionState.CONNECTING) {
+              SarosView.showNotification("XMPP Connection lost", "You are already logged in.");
+            } else {
+              SarosView.showNotification(
+                  "XMPP Connection lost", Messages.ConnectionStateComposite_remote_login_warning);
+            }
 
-        XMPPError xmppError = ((XMPPException) error).getXMPPError();
-
-        StreamError streamError = ((XMPPException) error).getStreamError();
-
-        // see http://xmpp.org/rfcs/rfc3921.html chapter 3
-
-        if (lastConnectionState == ConnectionState.CONNECTED
-            && (streamError == null || !"conflict".equalsIgnoreCase(streamError.getCode())))
-          return Messages.ConnectionStateComposite_error_connection_lost;
-
-        if (lastConnectionState == ConnectionState.CONNECTING
-            && (xmppError == null || xmppError.getCode() != 409))
-          return Messages.ConnectionStateComposite_error_connection_lost;
-
-        if (lastConnectionState == ConnectionState.CONNECTING) {
-          SarosView.showNotification("XMPP Connection lost", "You are already logged in.");
-        } else {
-          SarosView.showNotification(
-              "XMPP Connection lost", Messages.ConnectionStateComposite_remote_login_warning);
+            return Messages.ConnectionStateComposite_error_resource_conflict;
+          default:
         }
-
-        return Messages.ConnectionStateComposite_error_resource_conflict;
+        // $FALL-THROUGH$
       default:
         return Messages.ConnectionStateComposite_error_unknown;
     }

--- a/eclipse/src/saros/ui/widgets/ConnectionStateComposite.java
+++ b/eclipse/src/saros/ui/widgets/ConnectionStateComposite.java
@@ -49,38 +49,18 @@ public class ConnectionStateComposite extends Composite {
   private final CLabel stateLabel;
 
   private ConnectionState lastConnectionState;
-
   private Exception lastError;
 
   private final IAccountStoreListener accountStoreListener =
       new IAccountStoreListener() {
         @Override
         public void accountsChanged(List<XMPPAccount> currentAccounts) {
-          SWTUtils.runSafeSWTAsync(
-              log,
-              () -> {
-                if (!ConnectionStateComposite.this.isDisposed()) updateLabel(null, null);
-              });
+          SWTUtils.runSafeSWTAsync(log, () -> updateLabel(null, null));
         }
       };
 
   private final IConnectionStateListener connectionListener =
-      new IConnectionStateListener() {
-        @Override
-        public void connectionStateChanged(final ConnectionState state, final Exception error) {
-
-          SWTUtils.runSafeSWTAsync(
-              log,
-              new Runnable() {
-                @Override
-                public void run() {
-                  if (ConnectionStateComposite.this.isDisposed()) return;
-
-                  updateLabel(state, error);
-                }
-              });
-        }
-      };
+      (state, error) -> SWTUtils.runSafeSWTAsync(log, () -> updateLabel(state, error));
 
   public ConnectionStateComposite(Composite parent, int style) {
     super(parent, style);
@@ -123,6 +103,7 @@ public class ConnectionStateComposite extends Composite {
    * @param error additional error information or <code>null</code>
    */
   private void updateLabel(ConnectionState state, Exception error) {
+    if (ConnectionStateComposite.this.isDisposed()) return;
 
     // do not hide the latest error
     if (lastConnectionState == ConnectionState.ERROR && state == ConnectionState.NOT_CONNECTED)

--- a/eclipse/src/saros/ui/widgets/chat/ChatRoomsComposite.java
+++ b/eclipse/src/saros/ui/widgets/chat/ChatRoomsComposite.java
@@ -34,7 +34,6 @@ import saros.communication.chat.single.SingleUserChatService;
 import saros.communication.connection.ConnectionHandler;
 import saros.communication.connection.IConnectionStateListener;
 import saros.editor.EditorManager;
-import saros.net.ConnectionState;
 import saros.net.util.XMPPUtils;
 import saros.net.xmpp.JID;
 import saros.net.xmpp.contact.IContactsUpdate;
@@ -162,23 +161,14 @@ public class ChatRoomsComposite extends ListExplanatoryComposite {
       };
 
   private final IConnectionStateListener connectionStateListener =
-      new IConnectionStateListener() {
-
-        @Override
-        public void connectionStateChanged(ConnectionState state, Exception error) {
+      (state, error) ->
           SWTUtils.runSafeSWTAsync(
               log,
-              new Runnable() {
+              () -> {
+                if (ChatRoomsComposite.this.isDisposed()) return;
 
-                @Override
-                public void run() {
-                  if (ChatRoomsComposite.this.isDisposed()) return;
-
-                  updateExplanation();
-                }
+                updateExplanation();
               });
-        }
-      };
 
   protected ISessionLifecycleListener sessionLifecycleListener =
       new ISessionLifecycleListener() {


### PR DESCRIPTION
Moves XMPP exception parsing into Core and `IConnectionStateListener` now returns an `ErrorType` enum instead of an `Exception`.

