### PR TITLE
Add sanity check to prevent nested reference points

### DIFF
--- a/core/src/saros/filesystem/IReferencePoint.java
+++ b/core/src/saros/filesystem/IReferencePoint.java
@@ -20,6 +20,17 @@ public interface IReferencePoint extends IContainer {
   IPath getReferencePointRelativePath();
 
   /**
+   * Returns whether this reference point in combination with the other reference point represents a
+   * nested configuration, either because this reference point is contained in the other reference
+   * point or the other reference point is contained in this reference point.
+   *
+   * @param otherReferencePoint the other reference point with which to check
+   * @return whether this reference point in combination with the other reference point represents a
+   *     nested configuration
+   */
+  boolean isNested(IReferencePoint otherReferencePoint);
+
+  /**
    * Always throws an IO exception.
    *
    * <p>Deleting a reference point resource is not supported.

--- a/core/src/saros/session/internal/SharedReferencePointMapper.java
+++ b/core/src/saros/session/internal/SharedReferencePointMapper.java
@@ -83,10 +83,32 @@ class SharedReferencePointMapper {
               + currentReferencePoin);
     }
 
+    checkForNestedReferencePoints(referencePoint);
+
     idToReferencePointMapping.put(id, referencePoint);
     referencePointToIDMapping.put(referencePoint, id);
 
     log.debug("added reference point " + referencePoint + " with ID " + id);
+  }
+
+  /**
+   * Checks whether adding the given reference point to the mapping would create shared nested
+   * reference points.
+   *
+   * @param addedReferencePoint the reference point to add to the mapping
+   * @throws IllegalStateException if nested reference points are detected
+   */
+  private void checkForNestedReferencePoints(IReferencePoint addedReferencePoint) {
+    for (IReferencePoint sharedReferencePoint : idToReferencePointMapping.values()) {
+      if (addedReferencePoint.isNested(sharedReferencePoint)) {
+        throw new IllegalStateException(
+            "Reference point "
+                + addedReferencePoint
+                + " can not be added to the mapping as this would create nested reference points "
+                + "in combination with the already shared reference point "
+                + sharedReferencePoint);
+      }
+    }
   }
 
   /**

--- a/core/src/saros/session/internal/SharedReferencePointMapper.java
+++ b/core/src/saros/session/internal/SharedReferencePointMapper.java
@@ -27,19 +27,23 @@ class SharedReferencePointMapper {
   private static final Logger log = Logger.getLogger(SharedReferencePointMapper.class);
 
   /** Mapping from reference point IDs to currently registered shared reference points. */
-  private final Map<String, IReferencePoint> idToReferencePointMapping =
-      new HashMap<String, IReferencePoint>();
+  private final Map<String, IReferencePoint> idToReferencePointMapping;
 
   /** Mapping from currently registered shared reference points to their id's. */
-  private final Map<IReferencePoint, String> referencePointToIDMapping =
-      new HashMap<IReferencePoint, String>();
+  private final Map<IReferencePoint, String> referencePointToIDMapping;
 
   /**
    * Map for storing which clients have which reference points. Used by the host to determine who
    * can currently process an activity related to a particular reference point. (Non-hosts don't
    * maintain this map.)
    */
-  private final Map<User, List<String>> referencePointsOfUsers = new HashMap<User, List<String>>();
+  private final Map<User, List<String>> referencePointsOfUsers;
+
+  SharedReferencePointMapper() {
+    this.idToReferencePointMapping = new HashMap<>();
+    this.referencePointToIDMapping = new HashMap<>();
+    this.referencePointsOfUsers = new HashMap<>();
+  }
 
   /**
    * Adds a reference point to the set of currently shared reference points.
@@ -162,8 +166,10 @@ class SharedReferencePointMapper {
   public synchronized boolean isShared(IResource resource) {
     if (resource == null) return false;
 
-    if (resource.getType() == REFERENCE_POINT)
-      return idToReferencePointMapping.containsValue(resource);
+    if (resource.getType() == REFERENCE_POINT) {
+      IReferencePoint referencePoint = (IReferencePoint) resource;
+      return idToReferencePointMapping.containsValue(referencePoint);
+    }
 
     IReferencePoint referencePoint = resource.getReferencePoint();
 
@@ -178,7 +184,7 @@ class SharedReferencePointMapper {
    * @return a newly created {@link Set} with the shared reference points
    */
   public synchronized Set<IReferencePoint> getReferencePoints() {
-    return new HashSet<IReferencePoint>(idToReferencePointMapping.values());
+    return new HashSet<>(idToReferencePointMapping.values());
   }
 
   /**
@@ -217,10 +223,7 @@ class SharedReferencePointMapper {
    * @see #userHasReferencePoint(User, IReferencePoint)
    */
   public synchronized void addMissingReferencePointsToUser(User user) {
-    List<String> referencePointIds = new ArrayList<String>();
-    for (String referencePointId : idToReferencePointMapping.keySet()) {
-      referencePointIds.add(referencePointId);
-    }
+    List<String> referencePointIds = new ArrayList<>(idToReferencePointMapping.keySet());
 
     this.referencePointsOfUsers.put(user, referencePointIds);
   }

--- a/eclipse/src/saros/filesystem/EclipseReferencePoint.java
+++ b/eclipse/src/saros/filesystem/EclipseReferencePoint.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import org.apache.log4j.Logger;
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.runtime.CoreException;
 
 /** Eclipse implementation of the Saros reference point interface. */
@@ -43,6 +44,16 @@ public class EclipseReferencePoint implements IReferencePoint {
   @Override
   public EclipsePathImpl getReferencePointRelativePath() {
     return new EclipsePathImpl(org.eclipse.core.runtime.Path.EMPTY);
+  }
+
+  @Override
+  public boolean isNested(IReferencePoint otherReferencePoint) {
+    org.eclipse.core.runtime.IPath p1 = delegate.getFullPath();
+
+    IContainer d2 = ResourceConverter.getDelegate(otherReferencePoint);
+    org.eclipse.core.runtime.IPath p2 = d2.getFullPath();
+
+    return p1.equals(p2) || p1.isPrefixOf(p2) || p2.isPrefixOf(p1);
   }
 
   @Override

--- a/intellij/src/saros/intellij/filesystem/IntellijReferencePoint.java
+++ b/intellij/src/saros/intellij/filesystem/IntellijReferencePoint.java
@@ -110,6 +110,16 @@ public class IntellijReferencePoint implements IReferencePoint {
     return IntellijPath.EMPTY;
   }
 
+  @Override
+  public boolean isNested(IReferencePoint otherReferencePoint) {
+    Path p1 = Paths.get(virtualFile.getPath());
+
+    IntellijReferencePoint i2 = (IntellijReferencePoint) otherReferencePoint;
+    Path p2 = Paths.get(i2.getVirtualFile().getPath());
+
+    return p1.equals(p2) || p1.startsWith(p2) || p2.startsWith(p1);
+  }
+
   /**
    * Returns the path to the given file relative to the virtual file represented by this reference
    * point.

--- a/server/src/saros/server/filesystem/ServerProjectImpl.java
+++ b/server/src/saros/server/filesystem/ServerProjectImpl.java
@@ -4,6 +4,8 @@ import static saros.filesystem.IResource.Type.REFERENCE_POINT;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import saros.filesystem.IReferencePoint;
 
 /** Server implementation of the {@link IReferencePoint} interface. */
@@ -16,6 +18,16 @@ public class ServerProjectImpl extends ServerContainerImpl implements IReference
    */
   public ServerProjectImpl(ServerWorkspaceImpl workspace, String name) {
     super(workspace, ServerPathImpl.fromString(name));
+  }
+
+  @Override
+  public boolean isNested(IReferencePoint otherReferencePoint) {
+    Path p1 = Paths.get(getLocation().toString());
+
+    ServerProjectImpl s2 = (ServerProjectImpl) otherReferencePoint;
+    Path p2 = Paths.get(s2.getLocation().toString());
+
+    return p1.equals(p2) || p1.startsWith(p2) || p2.startsWith(p1);
   }
 
   @Override


### PR DESCRIPTION
Adds a sanity check ensuring the no nested reference points can be created. As this is only a sanity check, it does not provide the best user experience. Nested reference points should be prevented by the IDE-specific UI not allowing such resource choices when starting or receiving resource negotiations.

### Reviewing this PR

I would suggest reviewing this PR commit by commit.

### Commits

<details><summary><b>[INTERNAL] Add method to check for nested reference points</b></summary>
<br>

Adds IReferencePoint.isNested(IReferencePoint), providing the logic to
check whether the given reference point would create a nested
configuration with the called-on reference point.

Adds the IDE implementations for the new method.

</details>

<details><summary><b>[INTERNAL][CORE] Add sanity check preventing nested reference points</b></summary>
<br>

Adds a sanity check to the logic adding reference points to the
SharedReferencePointMapper to prevent nested reference points from being
created. If adding a reference point would create such nested reference
points, an IllegalStateException is thrown instead.

This is only meant as a sanity. Normally, this should already be
prevented by the IDE-specific UI implementation.

</details>

<details><summary><b>[REFACTOR][CORE] Clean up SharedReferencePointMapper</b></summary>
<br>

Removes unnecessary explicit type arguments.

Moves the instantiation of the contained maps to the constructor.

Replaces an explicit addition of a range of elements to a newly created
list with using the corresponding ArrayList constructor.

Casts a resource object to IReferencePoint before checking whether it is
contained in the mapping to ensure type safety.

</details>