### PR TITLE
[INTERNAL][CORE] Remove annotation injection from SarosSession

### DIFF
--- a/core/src/saros/session/SarosSessionManager.java
+++ b/core/src/saros/session/SarosSessionManager.java
@@ -251,6 +251,8 @@ public class SarosSessionManager implements ISarosSessionManager {
 
       negotiationPacketLister.setRejectSessionNegotiationRequests(true);
 
+      JID localUserJID = connectionHandler.getLocalJID();
+
       IPreferenceStore hostProperties = new PreferenceStore();
       if (hookManager != null) {
         for (ISessionNegotiationHook hook : hookManager.getHooks()) {
@@ -258,7 +260,7 @@ public class SarosSessionManager implements ISarosSessionManager {
         }
       }
 
-      session = new SarosSession(sessionID, hostProperties, context);
+      session = new SarosSession(sessionID, localUserJID, hostProperties, context);
 
       sessionStarting(session);
       session.start();
@@ -284,7 +286,9 @@ public class SarosSessionManager implements ISarosSessionManager {
 
     assert session == null;
 
-    session = new SarosSession(id, host, localProperties, hostProperties, context);
+    JID localUserJID = connectionHandler.getLocalJID();
+
+    session = new SarosSession(id, localUserJID, host, localProperties, hostProperties, context);
 
     log.info("joined uninitialized Saros session");
 

--- a/core/src/saros/session/internal/SarosSession.java
+++ b/core/src/saros/session/internal/SarosSession.java
@@ -45,7 +45,7 @@ import saros.net.xmpp.JID;
 import saros.net.xmpp.XMPPConnectionService;
 import saros.preferences.IPreferenceStore;
 import saros.repackaged.picocontainer.MutablePicoContainer;
-import saros.repackaged.picocontainer.annotations.Inject;
+import saros.repackaged.picocontainer.PicoContainer;
 import saros.session.IActivityConsumer;
 import saros.session.IActivityConsumer.Priority;
 import saros.session.IActivityHandlerCallback;
@@ -70,15 +70,17 @@ public final class SarosSession implements ISarosSession {
 
   private static final Logger log = Logger.getLogger(SarosSession.class);
 
-  @Inject private UISynchronizer synchronizer;
+  /* Application Context Dependencies Start*/
 
-  /* Dependencies */
+  private final UISynchronizer synchronizer;
 
-  @Inject private ITransmitter transmitter;
+  private final ITransmitter transmitter;
 
-  @Inject private XMPPConnectionService connectionService;
+  private final XMPPConnectionService connectionService;
 
-  @Inject private IConnectionManager connectionManager;
+  private final IConnectionManager connectionManager;
+
+  /* Application Context Dependencies End*/
 
   private final IContainerContext containerContext;
 
@@ -93,6 +95,7 @@ public final class SarosSession implements ISarosSession {
 
   private final List<IActivityConsumer> activeActivityConsumers =
       new CopyOnWriteArrayList<IActivityConsumer>();
+
   private final List<IActivityConsumer> passiveActivityConsumers =
       new CopyOnWriteArrayList<IActivityConsumer>();
 
@@ -787,7 +790,7 @@ public final class SarosSession implements ISarosSession {
       JID host,
       IPreferenceStore hostProperties) {
 
-    context.initComponent(this);
+    connectionService = getComponent(context, XMPPConnectionService.class);
 
     this.sessionID = id;
     this.referencePointMapper = new SharedReferencePointMapper();
@@ -816,25 +819,29 @@ public final class SarosSession implements ISarosSession {
     sessionContainer.addComponent(ISarosSession.class, this);
     sessionContainer.addComponent(IActivityHandlerCallback.class, activityCallback);
 
-    ISarosSessionContextFactory factory = context.getComponent(ISarosSessionContextFactory.class);
+    ISarosSessionContextFactory factory =
+        getComponent(sessionContainer, ISarosSessionContextFactory.class);
+
     factory.createComponents(this, sessionContainer);
 
     // Force the creation of the components added to the session container.
     sessionContainer.getComponents();
 
-    concurrentDocumentClient = sessionContainer.getComponent(ConcurrentDocumentClient.class);
+    // Obtained from Application context START
+    synchronizer = getComponent(sessionContainer, UISynchronizer.class);
+    transmitter = getComponent(sessionContainer, ITransmitter.class);
+    connectionManager = getComponent(sessionContainer, IConnectionManager.class);
+    // Obtained from Application context END
 
-    activityHandler = sessionContainer.getComponent(ActivityHandler.class);
-
-    stopManager = sessionContainer.getComponent(StopManager.class);
-
-    changeColorManager = sessionContainer.getComponent(ChangeColorManager.class);
-
-    permissionManager = sessionContainer.getComponent(PermissionManager.class);
-
-    activitySequencer = sessionContainer.getComponent(ActivitySequencer.class);
-
-    userListHandler = sessionContainer.getComponent(UserInformationHandler.class);
+    // Obtained from Session context START
+    concurrentDocumentClient = getComponent(sessionContainer, ConcurrentDocumentClient.class);
+    activityHandler = getComponent(sessionContainer, ActivityHandler.class);
+    stopManager = getComponent(sessionContainer, StopManager.class);
+    changeColorManager = getComponent(sessionContainer, ChangeColorManager.class);
+    permissionManager = getComponent(sessionContainer, PermissionManager.class);
+    activitySequencer = getComponent(sessionContainer, ActivitySequencer.class);
+    userListHandler = getComponent(sessionContainer, UserInformationHandler.class);
+    // Obtained from Session context END
 
     // ensure that the container uses caching
     assert sessionContainer.getComponent(ActivityHandler.class)
@@ -860,5 +867,31 @@ public final class SarosSession implements ISarosSession {
    */
   boolean hasActivityConsumers() {
     return !activeActivityConsumers.isEmpty() || !passiveActivityConsumers.isEmpty();
+  }
+
+  // remove this method
+  @Deprecated
+  private static <T> T getComponent(final IContainerContext context, final Class<T> componentType) {
+    final T result = context.getComponent(componentType);
+
+    if (result == null)
+      throw new IllegalStateException(
+          "component of class type "
+              + componentType.getName()
+              + " could not be found in the current global application context but is required for operation");
+
+    return result;
+  }
+
+  private static <T> T getComponent(final PicoContainer container, final Class<T> componentType) {
+    final T result = container.getComponent(componentType);
+
+    if (result == null)
+      throw new IllegalStateException(
+          "component of class type "
+              + componentType.getName()
+              + " could not be found in the current session context or application context but is required for operation");
+
+    return result;
   }
 }

--- a/core/test/junit/saros/session/SarosSessionManagerTest.java
+++ b/core/test/junit/saros/session/SarosSessionManagerTest.java
@@ -17,6 +17,7 @@ import saros.communication.connection.ConnectionHandler;
 import saros.context.IContainerContext;
 import saros.net.IReceiver;
 import saros.net.ITransmitter;
+import saros.net.xmpp.JID;
 import saros.preferences.IPreferenceStore;
 import saros.session.internal.SarosSession;
 
@@ -97,6 +98,7 @@ public class SarosSessionManagerTest {
     PowerMock.expectNew(
             SarosSession.class,
             EasyMock.anyObject(String.class),
+            EasyMock.anyObject(JID.class),
             EasyMock.anyObject(IPreferenceStore.class),
             EasyMock.anyObject(IContainerContext.class))
         .andStubReturn(session);

--- a/eclipse/test/junit/saros/session/internal/SarosSessionTest.java
+++ b/eclipse/test/junit/saros/session/internal/SarosSessionTest.java
@@ -58,7 +58,6 @@ import saros.repackaged.picocontainer.PicoContainer;
 import saros.repackaged.picocontainer.injectors.AnnotatedFieldInjection;
 import saros.repackaged.picocontainer.injectors.CompositeInjection;
 import saros.repackaged.picocontainer.injectors.ConstructorInjection;
-import saros.repackaged.picocontainer.injectors.Reinjector;
 import saros.session.ISarosSessionContextFactory;
 import saros.session.ISarosSessionManager;
 import saros.session.SessionEndReason;
@@ -123,25 +122,6 @@ public class SarosSessionTest {
   private static IContainerContext createContextMock(final MutablePicoContainer container) {
 
     final IContainerContext context = createMock(IContainerContext.class);
-
-    context.initComponent(isA(Object.class));
-
-    expectLastCall()
-        .andAnswer(
-            new IAnswer<Object>() {
-
-              @Override
-              public Object answer() throws Throwable {
-                Object session = getCurrentArguments()[0];
-                MutablePicoContainer dummyContainer = container.makeChildContainer();
-                dummyContainer.addComponent(session.getClass(), session);
-                new Reinjector(dummyContainer)
-                    .reinject(session.getClass(), new AnnotatedFieldInjection());
-                container.removeChildContainer(dummyContainer);
-                return null;
-              }
-            })
-        .times(2);
 
     expect(context.getComponent(isA(Class.class)))
         .andStubAnswer(

--- a/eclipse/test/junit/saros/session/internal/SarosSessionTest.java
+++ b/eclipse/test/junit/saros/session/internal/SarosSessionTest.java
@@ -73,6 +73,8 @@ public class SarosSessionTest {
 
   private static final String SAROS_SESSION_ID = "SAROS_SESSION_TEST";
 
+  private static final JID LOCAL_USER_JID = new JID("alice");
+
   private static class CountingReceiver implements IReceiver {
 
     private int currentListeners;
@@ -100,23 +102,6 @@ public class SarosSessionTest {
     public synchronized int getCurrentPacketListenersCount() {
       return currentListeners;
     }
-  }
-
-  private static XMPPConnectionService createConnectionServiceMock() {
-    XMPPConnectionService srv = createNiceMock(XMPPConnectionService.class);
-
-    expect(srv.getJID())
-        .andStubAnswer(
-            new IAnswer<JID>() {
-
-              @Override
-              public JID answer() throws Throwable {
-                return new JID("alice");
-              }
-            });
-
-    replay(srv);
-    return srv;
   }
 
   private static IContainerContext createContextMock(final MutablePicoContainer container) {
@@ -262,7 +247,7 @@ public class SarosSessionTest {
      * Replacements
      */
     container.removeComponent(XMPPConnectionService.class);
-    container.addComponent(XMPPConnectionService.class, createConnectionServiceMock());
+    container.addComponent(XMPPConnectionService.class);
 
     container.removeComponent(IConnectionManager.class);
     addMockedComponent(IConnectionManager.class);
@@ -301,7 +286,8 @@ public class SarosSessionTest {
     final IContainerContext context = createContextMock(container);
 
     // Test creating, starting and stopping the session.
-    SarosSession session = new SarosSession(SAROS_SESSION_ID, new PreferenceStore(), context);
+    SarosSession session =
+        new SarosSession(SAROS_SESSION_ID, LOCAL_USER_JID, new PreferenceStore(), context);
 
     assertFalse(session.hasActivityConsumers());
     assertFalse(session.hasActivityProducers());


### PR DESCRIPTION
The desired effect can be done without annotations and IIRC in former times fields could be null instead of throwing an exception. As this is up to the implementation do it the correct way.