### PR TITLE
[INTERNAL][CORE] Pass JID of local user to session CTOR

### DIFF
--- a/core/src/saros/session/SarosSessionManager.java
+++ b/core/src/saros/session/SarosSessionManager.java
@@ -251,6 +251,8 @@ public class SarosSessionManager implements ISarosSessionManager {
 
       negotiationPacketLister.setRejectSessionNegotiationRequests(true);
 
+      JID localUserJID = connectionHandler.getLocalJID();
+
       IPreferenceStore hostProperties = new PreferenceStore();
       if (hookManager != null) {
         for (ISessionNegotiationHook hook : hookManager.getHooks()) {
@@ -258,7 +260,7 @@ public class SarosSessionManager implements ISarosSessionManager {
         }
       }
 
-      session = new SarosSession(sessionID, hostProperties, context);
+      session = new SarosSession(sessionID, localUserJID, hostProperties, context);
 
       sessionStarting(session);
       session.start();
@@ -284,7 +286,9 @@ public class SarosSessionManager implements ISarosSessionManager {
 
     assert session == null;
 
-    session = new SarosSession(id, host, localProperties, hostProperties, context);
+    JID localUserJID = connectionHandler.getLocalJID();
+
+    session = new SarosSession(id, localUserJID, host, localProperties, hostProperties, context);
 
     log.info("joined uninitialized Saros session");
 

--- a/core/test/junit/saros/session/SarosSessionManagerTest.java
+++ b/core/test/junit/saros/session/SarosSessionManagerTest.java
@@ -17,6 +17,7 @@ import saros.communication.connection.ConnectionHandler;
 import saros.context.IContainerContext;
 import saros.net.IReceiver;
 import saros.net.ITransmitter;
+import saros.net.xmpp.JID;
 import saros.preferences.IPreferenceStore;
 import saros.session.internal.SarosSession;
 
@@ -97,6 +98,7 @@ public class SarosSessionManagerTest {
     PowerMock.expectNew(
             SarosSession.class,
             EasyMock.anyObject(String.class),
+            EasyMock.anyObject(JID.class),
             EasyMock.anyObject(IPreferenceStore.class),
             EasyMock.anyObject(IContainerContext.class))
         .andStubReturn(session);

--- a/eclipse/test/junit/saros/session/internal/SarosSessionTest.java
+++ b/eclipse/test/junit/saros/session/internal/SarosSessionTest.java
@@ -73,6 +73,8 @@ public class SarosSessionTest {
 
   private static final String SAROS_SESSION_ID = "SAROS_SESSION_TEST";
 
+  private static final JID LOCAL_USER_JID = new JID("alice");
+
   private static class CountingReceiver implements IReceiver {
 
     private int currentListeners;
@@ -100,23 +102,6 @@ public class SarosSessionTest {
     public synchronized int getCurrentPacketListenersCount() {
       return currentListeners;
     }
-  }
-
-  private static XMPPConnectionService createConnectionServiceMock() {
-    XMPPConnectionService srv = createNiceMock(XMPPConnectionService.class);
-
-    expect(srv.getJID())
-        .andStubAnswer(
-            new IAnswer<JID>() {
-
-              @Override
-              public JID answer() throws Throwable {
-                return new JID("alice");
-              }
-            });
-
-    replay(srv);
-    return srv;
   }
 
   private static IContainerContext createContextMock(final MutablePicoContainer container) {
@@ -262,7 +247,7 @@ public class SarosSessionTest {
      * Replacements
      */
     container.removeComponent(XMPPConnectionService.class);
-    container.addComponent(XMPPConnectionService.class, createConnectionServiceMock());
+    container.addComponent(XMPPConnectionService.class);
 
     container.removeComponent(IConnectionManager.class);
     addMockedComponent(IConnectionManager.class);
@@ -301,7 +286,8 @@ public class SarosSessionTest {
     final IContainerContext context = createContextMock(container);
 
     // Test creating, starting and stopping the session.
-    SarosSession session = new SarosSession(SAROS_SESSION_ID, new PreferenceStore(), context);
+    SarosSession session =
+        new SarosSession(SAROS_SESSION_ID, LOCAL_USER_JID, new PreferenceStore(), context);
 
     assertFalse(session.hasActivityConsumers());
     assertFalse(session.hasActivityProducers());


### PR DESCRIPTION
Avoids the dependency on the connection service to initialize the
session context by passing the JID of the local user to the session
constructor.

Removes the method to resolve plugin context dependencies from
SarosSession as it was no longer necessary. Moved the error handling
in-line for the last usage.

Updates the session tests for the new CTOR argument.