### PR TITLE
[DOC] Add info where to get a JDK8

### DIFF
--- a/docs/contribute/development-environment.md
+++ b/docs/contribute/development-environment.md
@@ -8,7 +8,7 @@ If you want to execute the STF tests it is recommended to use Eclipse. Otherwise
 ## Common
 
 * You have to [clone](https://help.github.com/articles/cloning-a-repository/) the Saros repository with [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
-* You need a **Java 8 JDK**.
+* You need a **Java 8 JDK** (e.g. from [AdoptOpenJDK](https://adoptopenjdk.net/?variant=openjdk8&jvmVariant=hotspot) or using [SDKMAN](https://sdkman.io/install) to manage [multiple JDKs](https://sdkman.io/jdks)).
 * *Optional:* You can use a local **IntelliJ IDEA** installation (version `2019.2.3` or newer) for dependency resolution by setting the **system-wide environment variable `INTELLIJ_HOME`** to the IntelliJ installation directory that contains the directory `lib`.
 If the `INTELLIJ_HOME` variable is not set, the intellij-gradle-plugin will download and use the IntelliJ version specified in the `build.gradle` file of the 'intellij' project.
 * *Optional:* You can also set the **system-wide environment variable `SAROS_INTELLIJ_SANDBOX`** to specify the base directory in which the IntelliJ sandboxes will be created. Otherwise, the directory `intellij/build` in the repository will be used by default.


### PR DESCRIPTION
Oracle does not provide a public JDK 8 version.
Therefore, we provide a link to alternative sources.
