### PR TITLE
[BUILD][STF] Use new docker images

### DIFF
--- a/travis/script/stf/coordinator_setup_utils.sh
+++ b/travis/script/stf/coordinator_setup_utils.sh
@@ -17,8 +17,6 @@ function start_container_coordinator()
 
 function setup_container_coordinator()
 {
-  # Workaround: Package installation has to be moved into a Dockerfile
-  docker exec -t "$stf_coordinator_name" /bin/sh -c "apk --update add --no-cache gtk+3.0"
   echo "Build testees"
   docker exec -t "$stf_coordinator_name" "$SCRIPT_DIR_CONTAINER/stf/coordinator/build_testee.sh"
   echo "Executing setup_stf_ws.sh on $stf_coordinator_name"

--- a/travis/script/stf/shared_vars.sh
+++ b/travis/script/stf/shared_vars.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
-stf_coordinator_image="openjdk:8-jdk-alpine3.8"
-stf_worker_image="saros/stf_test_slave:0.6"
-stf_xmpp_image="saros/stf_xmpp_server:0.6"
+stf_coordinator_image="saros/stf_test_coordinator:0.8"
+stf_worker_image="saros/stf_test_worker:0.8"
+stf_xmpp_image="saros/stf_xmpp_server:0.8"
 
 stf_coordinator_name="stf_coordinator"
 stf_network_name="stf_test_network"


### PR DESCRIPTION
Use the new images (tag 0.8) containing a GTK3
installation and remove the workaround introduce with #1047.
