### PR TITLE
[BUILD] Replace set-env in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         short_sha=$(git rev-parse --short=10 $GITHUB_SHA)
         echo "::set-output name=short_sha::$short_sha"
-        echo "::set-env name=SHORT_SHA::$short_sha"
+        echo "SHORT_SHA=$short_sha" >> $GITHUB_ENV
       shell: 'bash'
 
     # Build


### PR DESCRIPTION
Replaces the "set-env" call in the build workflow with writing the
parameter to the GITHUB_ENV file. The old way of setting environment
variables is deprecated and will be removed in the future.