### PR TITLE
Replace option to create projects as part of resource negotiation

### DIFF
--- a/eclipse/src/saros/ui/Messages.java
+++ b/eclipse/src/saros/ui/Messages.java
@@ -172,22 +172,17 @@ public class Messages extends NLS {
   public static String LocalRepresentationSelectionPage_saros_url;
   public static String LocalRepresentationSelectionPage_title;
   public static String LocalRepresentationSelectionPage_unknown_transport_method;
-  public static String LocalRepresentationSelectionPage_warning_project_artifacts_found;
   public static String LocalRepresentationSelectionPage_warning_unsupported_encoding_found;
 
-  public static String ReferencePointOptionComposite_create_new_project;
   public static String ReferencePointOptionComposite_create_new_directory;
   public static String ReferencePointOptionComposite_directory_name;
   public static String ReferencePointOptionComposite_directory_base_path;
   public static String ReferencePointOptionComposite_existing_directory_path;
-  public static String ReferencePointOptionComposite_project_name;
   public static String ReferencePointOptionComposite_select_base_directory;
   public static String ReferencePointOptionComposite_select_existing_directory;
   public static String ReferencePointOptionComposite_tooltip_browse_button;
   public static String ReferencePointOptionComposite_tooltip_existing_directory;
   public static String ReferencePointOptionComposite_tooltip_existing_directory_path;
-  public static String ReferencePointOptionComposite_tooltip_new_project;
-  public static String ReferencePointOptionComposite_tooltip_new_project_name;
   public static String ReferencePointOptionComposite_tooltip_new_directory;
   public static String ReferencePointOptionComposite_tooltip_new_directory_name;
   public static String ReferencePointOptionComposite_tooltip_new_directory_base_path;
@@ -201,9 +196,6 @@ public class Messages extends NLS {
   public static String ReferencePointOptionResult_error_new_directory_base_does_not_exist;
   public static String ReferencePointOptionResult_error_new_directory_invalid_name;
   public static String ReferencePointOptionResult_error_new_directory_no_name_or_path;
-  public static String ReferencePointOptionResult_error_new_project_already_exists;
-  public static String ReferencePointOptionResult_error_new_project_invalid_name;
-  public static String ReferencePointOptionResult_error_new_project_no_name;
 
   public static String GeneralPreferencePage_ACCOUNT_GROUP_TITLE;
   public static String GeneralPreferencePage_ACTIVATE_BTN_TEXT;

--- a/eclipse/src/saros/ui/Messages.java
+++ b/eclipse/src/saros/ui/Messages.java
@@ -173,6 +173,7 @@ public class Messages extends NLS {
   public static String LocalRepresentationSelectionPage_title;
   public static String LocalRepresentationSelectionPage_unknown_transport_method;
   public static String LocalRepresentationSelectionPage_warning_unsupported_encoding_found;
+  public static String LocalRepresentationSelectionPage_new_project_button;
 
   public static String ReferencePointOptionComposite_create_new_directory;
   public static String ReferencePointOptionComposite_directory_name;

--- a/eclipse/src/saros/ui/messages.properties
+++ b/eclipse/src/saros/ui/messages.properties
@@ -270,6 +270,7 @@ LocalRepresentationSelectionPage_saros_url=https://www.saros-project.org/documen
 LocalRepresentationSelectionPage_title=Select local representation for the shared resource roots.
 LocalRepresentationSelectionPage_unknown_transport_method=Warning: Unknown transport method established.
 LocalRepresentationSelectionPage_warning_unsupported_encoding_found=At least one remote reference point contains files with a character encoding that is not available on the local Java platform. Working on such reference points may result in data loss or corruption.\nThe following character encodings are not available: {0}
+LocalRepresentationSelectionPage_new_project_button=New Project...
 
 ReferencePointOptionComposite_create_new_directory=Create new directory
 ReferencePointOptionComposite_directory_name=Directory name

--- a/eclipse/src/saros/ui/messages.properties
+++ b/eclipse/src/saros/ui/messages.properties
@@ -269,22 +269,17 @@ LocalRepresentationSelectionPage_page_name=referencePointRepresentationPage
 LocalRepresentationSelectionPage_saros_url=https://www.saros-project.org/documentation/faq.html
 LocalRepresentationSelectionPage_title=Select local representation for the shared resource roots.
 LocalRepresentationSelectionPage_unknown_transport_method=Warning: Unknown transport method established.
-LocalRepresentationSelectionPage_warning_project_artifacts_found=The following project(s) will overwrite or delete existing data in the file system: {0}
 LocalRepresentationSelectionPage_warning_unsupported_encoding_found=At least one remote reference point contains files with a character encoding that is not available on the local Java platform. Working on such reference points may result in data loss or corruption.\nThe following character encodings are not available: {0}
 
-ReferencePointOptionComposite_create_new_project=Create new project
 ReferencePointOptionComposite_create_new_directory=Create new directory
 ReferencePointOptionComposite_directory_name=Directory name
 ReferencePointOptionComposite_directory_base_path=Base path
 ReferencePointOptionComposite_existing_directory_path=Directory path
-ReferencePointOptionComposite_project_name=Project name
 ReferencePointOptionComposite_select_base_directory=Select an existing base directory to create the new directory in.
 ReferencePointOptionComposite_select_existing_directory=Select an existing directory to represent the shared resource root.
 ReferencePointOptionComposite_tooltip_browse_button=Browse the workspace to select an existing directory.
 ReferencePointOptionComposite_tooltip_existing_directory=Use an existing directory to represent the shared resource root. Project directories can be used as well.
 ReferencePointOptionComposite_tooltip_existing_directory_path=The path of the existing directory to use.
-ReferencePointOptionComposite_tooltip_new_project=Create a new project to represent the shared resource root.
-ReferencePointOptionComposite_tooltip_new_project_name=The name of the new project to create.
 ReferencePointOptionComposite_tooltip_new_directory=Create a new directory to represent the shared resource root.
 ReferencePointOptionComposite_tooltip_new_directory_name=The name of the new directory to create.
 ReferencePointOptionComposite_tooltip_new_directory_base_path=The base path of the new directory to create.
@@ -298,9 +293,6 @@ ReferencePointOptionResult_error_new_directory_already_exists_as_file=The chosen
 ReferencePointOptionResult_error_new_directory_base_does_not_exist=The chosen new directory base path for the shared root "{0}" is not valid or does not exist.
 ReferencePointOptionResult_error_new_directory_invalid_name=The chosen new directory name for the shared root "{0}" is not valid: {1}
 ReferencePointOptionResult_error_new_directory_no_name_or_path=Please enter a new directory name and base path for the shared root "{0}".
-ReferencePointOptionResult_error_new_project_already_exists=The chosen new project name for the shared root "{0}" is not valid: A project with the name "{1}" already exists.
-ReferencePointOptionResult_error_new_project_invalid_name=The chosen new project name for the shared root "{0}" is not valid: {1}
-ReferencePointOptionResult_error_new_project_no_name=Please enter a new project name for the shared root "{0}".
 
 SessionAddContactsWizard_title=Add Contact(s) to Session
 

--- a/eclipse/src/saros/ui/widgets/wizard/ReferencePointOptionComposite.java
+++ b/eclipse/src/saros/ui/widgets/wizard/ReferencePointOptionComposite.java
@@ -29,7 +29,6 @@ public class ReferencePointOptionComposite extends Composite {
 
   /** The possible ways to represent the shared reference point that can be chosen by the user. */
   public enum LocalRepresentationOption {
-    NEW_PROJECT,
     NEW_DIRECTORY,
     EXISTING_DIRECTORY
   }
@@ -40,12 +39,6 @@ public class ReferencePointOptionComposite extends Composite {
   private final List<ReferencePointOptionListener> listeners = new ArrayList<>();
 
   private final String remoteReferencePointId;
-
-  /*
-   * Fields for the option to create a new project to represent the reference point.
-   */
-  private Button newProjectRadioButton;
-  private Text newProjectNameText;
 
   /*
    * Fields for the option to create a new directory to represent the reference point.
@@ -63,8 +56,8 @@ public class ReferencePointOptionComposite extends Composite {
   private Button existingDirectoryBrowseButton;
 
   /**
-   * Instantiates a new reference point option composite. Selects the option to create a new project
-   * by default.
+   * Instantiates a new reference point option composite. Selects the option to create a new
+   * directory by default.
    *
    * @param parent the parent composite
    * @param remoteReferencePointId the ID of the reference point for which this composite chooses a
@@ -80,13 +73,12 @@ public class ReferencePointOptionComposite extends Composite {
     layout.numColumns = 3;
     super.setLayout(layout);
 
-    createNewProjectGroup();
     createNewDirectoryGroup();
     createExistingDirectoryGroup();
 
     addDisposeListener(e -> listeners.clear());
 
-    setRadioButtonSelection(LocalRepresentationOption.NEW_PROJECT);
+    setRadioButtonSelection(LocalRepresentationOption.NEW_DIRECTORY);
   }
 
   @Override
@@ -121,10 +113,6 @@ public class ReferencePointOptionComposite extends Composite {
    * @see #getResult()
    */
   private LocalRepresentationOption getSelectedOption() {
-    if (newProjectRadioButton.getSelection()) {
-      return LocalRepresentationOption.NEW_PROJECT;
-    }
-
     if (newDirectoryRadioButton.getSelection()) {
       return LocalRepresentationOption.NEW_DIRECTORY;
     }
@@ -146,17 +134,11 @@ public class ReferencePointOptionComposite extends Composite {
   public ReferencePointOptionResult getResult() {
     LocalRepresentationOption localRepresentationOption = getSelectedOption();
 
-    String newProjectName = null;
     String newDirectoryName = null;
     String newDirectoryBase = null;
     String existingDirectory = null;
 
     switch (localRepresentationOption) {
-      case NEW_PROJECT:
-        newProjectName = newProjectNameText.getText();
-
-        break;
-
       case NEW_DIRECTORY:
         newDirectoryName = newDirectoryNameText.getText();
         newDirectoryBase = newDirectoryBasePathText.getText();
@@ -174,28 +156,7 @@ public class ReferencePointOptionComposite extends Composite {
     }
 
     return new ReferencePointOptionResult(
-        localRepresentationOption,
-        newProjectName,
-        newDirectoryName,
-        newDirectoryBase,
-        existingDirectory);
-  }
-
-  /**
-   * Sets the option to create a new project to represent the reference point as selected.
-   *
-   * <p>If a project name is given, it is set as the new value of the new project name field.
-   *
-   * @param projectName the value to set in the project name text field or <code>null</code>
-   */
-  public void setNewProjectOptionSelected(String projectName) {
-    setRadioButtonSelection(LocalRepresentationOption.NEW_PROJECT);
-
-    newProjectNameText.setFocus();
-
-    if (projectName != null) {
-      newProjectNameText.setText(projectName);
-    }
+        localRepresentationOption, newDirectoryName, newDirectoryBase, existingDirectory);
   }
 
   /**
@@ -238,56 +199,6 @@ public class ReferencePointOptionComposite extends Composite {
     if (directoryPath != null) {
       existingDirectoryPathText.setText(directoryPath);
     }
-  }
-
-  /** Create components for the option to create a new project to represent the reference point. */
-  private void createNewProjectGroup() {
-    GridData gridData;
-
-    /* Radio button */
-    newProjectRadioButton = new Button(this, SWT.RADIO);
-    newProjectRadioButton.setText(Messages.ReferencePointOptionComposite_create_new_project);
-    newProjectRadioButton.setToolTipText(
-        Messages.ReferencePointOptionComposite_tooltip_new_project);
-    newProjectRadioButton.setSelection(false);
-
-    gridData = new GridData();
-    gridData.horizontalSpan = 3;
-
-    newProjectRadioButton.setLayoutData(gridData);
-    newProjectRadioButton.addSelectionListener(
-        new SelectionListener() {
-          @Override
-          public void widgetSelected(SelectionEvent e) {
-            updateEnablement(LocalRepresentationOption.NEW_PROJECT);
-            newProjectNameText.setFocus();
-            fireValueChanged();
-            fireSelectedOptionChanged();
-          }
-
-          @Override
-          public void widgetDefaultSelected(SelectionEvent e) {
-            widgetSelected(e);
-          }
-        });
-
-    /* Label */
-    Label newProjectNameLabel = new Label(this, SWT.RIGHT);
-    newProjectNameLabel.setText(Messages.ReferencePointOptionComposite_project_name);
-    newProjectNameLabel.setToolTipText(
-        Messages.ReferencePointOptionComposite_tooltip_new_project_name);
-    newProjectNameLabel.setLayoutData(new GridData(SWT.BEGINNING, SWT.BEGINNING, false, false));
-
-    /* Text box */
-    newProjectNameText = new Text(this, SWT.BORDER);
-    newProjectNameText.setToolTipText(
-        Messages.ReferencePointOptionComposite_tooltip_new_project_name);
-
-    gridData = new GridData(SWT.FILL, SWT.BEGINNING, true, false);
-    gridData.horizontalSpan = 2;
-
-    newProjectNameText.setLayoutData(gridData);
-    newProjectNameText.addModifyListener(e -> fireValueChanged());
   }
 
   /**
@@ -472,20 +383,14 @@ public class ReferencePointOptionComposite extends Composite {
    * radio buttons and disables all other fields.
    *
    * @param selectedOption the selected option
-   * @see #setNewProjectFieldsEnabled(boolean)
    * @see #setNewDirectoryFieldsEnabled(boolean)
    * @see #setExistingDirectoryFieldsEnabled(boolean)
    */
   private void setRadioButtonSelection(LocalRepresentationOption selectedOption) {
-    boolean newProjectOptionsSelected = false;
     boolean newDirectoryOptionsSelected = false;
     boolean existingDirectoryOptionsSelected = false;
 
     switch (selectedOption) {
-      case NEW_PROJECT:
-        newProjectOptionsSelected = true;
-        break;
-
       case NEW_DIRECTORY:
         newDirectoryOptionsSelected = true;
         break;
@@ -499,11 +404,9 @@ public class ReferencePointOptionComposite extends Composite {
             "Encountered unsupported selection option " + selectedOption);
     }
 
-    newProjectRadioButton.setSelection(newProjectOptionsSelected);
     newDirectoryRadioButton.setSelection(newDirectoryOptionsSelected);
     existingDirectoryRadioButton.setSelection(existingDirectoryOptionsSelected);
 
-    setNewProjectFieldsEnabled(newProjectOptionsSelected);
     setNewDirectoryFieldsEnabled(newDirectoryOptionsSelected);
     setExistingDirectoryFieldsEnabled(existingDirectoryOptionsSelected);
   }
@@ -516,20 +419,14 @@ public class ReferencePointOptionComposite extends Composite {
    * use {@link #setRadioButtonSelection(LocalRepresentationOption)}.
    *
    * @param selectedOption the selected option
-   * @see #setNewProjectFieldsEnabled(boolean)
    * @see #setNewDirectoryFieldsEnabled(boolean)
    * @see #setExistingDirectoryFieldsEnabled(boolean)
    */
   private void updateEnablement(LocalRepresentationOption selectedOption) {
-    boolean newProjectOptionsEnabled = false;
     boolean newDirectoryOptionsEnabled = false;
     boolean existingDirectoryOptionsEnabled = false;
 
     switch (selectedOption) {
-      case NEW_PROJECT:
-        newProjectOptionsEnabled = true;
-        break;
-
       case NEW_DIRECTORY:
         newDirectoryOptionsEnabled = true;
         break;
@@ -543,19 +440,8 @@ public class ReferencePointOptionComposite extends Composite {
             "Encountered unsupported selection option " + selectedOption);
     }
 
-    setNewProjectFieldsEnabled(newProjectOptionsEnabled);
     setNewDirectoryFieldsEnabled(newDirectoryOptionsEnabled);
     setExistingDirectoryFieldsEnabled(existingDirectoryOptionsEnabled);
-  }
-
-  /**
-   * Sets the enabled state of all fields of the option to create a new project to represent the
-   * reference point to the given value.
-   *
-   * @param enabled whether to enable the fields
-   */
-  private void setNewProjectFieldsEnabled(boolean enabled) {
-    newProjectNameText.setEnabled(enabled);
   }
 
   /**

--- a/eclipse/src/saros/ui/widgets/wizard/ReferencePointOptionResult.java
+++ b/eclipse/src/saros/ui/widgets/wizard/ReferencePointOptionResult.java
@@ -2,7 +2,6 @@ package saros.ui.widgets.wizard;
 
 import static saros.ui.widgets.wizard.ReferencePointOptionComposite.LocalRepresentationOption.EXISTING_DIRECTORY;
 import static saros.ui.widgets.wizard.ReferencePointOptionComposite.LocalRepresentationOption.NEW_DIRECTORY;
-import static saros.ui.widgets.wizard.ReferencePointOptionComposite.LocalRepresentationOption.NEW_PROJECT;
 
 import java.text.MessageFormat;
 import java.util.Objects;
@@ -20,7 +19,6 @@ import saros.ui.widgets.wizard.ReferencePointOptionComposite.LocalRepresentation
 /** Data holder class for the result of a {@link ReferencePointOptionComposite}. */
 public class ReferencePointOptionResult {
   private final LocalRepresentationOption localRepresentationOption;
-  private final String newProjectName;
   private final String newDirectoryName;
   private final String newDirectoryBase;
   private final String existingDirectory;
@@ -32,14 +30,12 @@ public class ReferencePointOptionResult {
    * <code>null</code>
    *
    * @param localRepresentationOption the representation option that was chosen
-   * @param newProjectName the name of the new project to create
    * @param newDirectoryName the name of the new directory to create
    * @param newDirectoryBase the bas path of the new directory to create
    * @param existingDirectory the existing directory to use
    */
   public ReferencePointOptionResult(
       LocalRepresentationOption localRepresentationOption,
-      String newProjectName,
       String newDirectoryName,
       String newDirectoryBase,
       String existingDirectory) {
@@ -48,13 +44,6 @@ public class ReferencePointOptionResult {
         localRepresentationOption, "The given representation option must not be null");
 
     switch (localRepresentationOption) {
-      case NEW_PROJECT:
-        Objects.requireNonNull(
-            newProjectName,
-            "The new project name must not be null if the option to create a new project is chosen");
-
-        break;
-
       case NEW_DIRECTORY:
         Objects.requireNonNull(
             newDirectoryName,
@@ -79,7 +68,6 @@ public class ReferencePointOptionResult {
     }
 
     this.localRepresentationOption = localRepresentationOption;
-    this.newProjectName = newProjectName;
     this.newDirectoryName = newDirectoryName;
     this.newDirectoryBase = newDirectoryBase;
     this.existingDirectory = existingDirectory;
@@ -92,20 +80,6 @@ public class ReferencePointOptionResult {
    */
   public LocalRepresentationOption getLocalRepresentationOption() {
     return localRepresentationOption;
-  }
-
-  /**
-   * Returns the name of the new project to create as part of the resource negotiation to represent
-   * the reference point.
-   *
-   * <p>The return value is undefined if the selected local representation option is not {@link
-   * LocalRepresentationOption#NEW_PROJECT}.
-   *
-   * @return the name of the new project to create as part of the resource negotiation to represent
-   *     the reference point
-   */
-  public String getNewProjectName() {
-    return newProjectName;
   }
 
   /**
@@ -156,7 +130,6 @@ public class ReferencePointOptionResult {
    * @param referencePointName the name of the reference point the result is belongs to
    * @return the container selected in this reference point option result
    * @throws IllegalInputException if the input contained in this result is not valid
-   * @see #getNewProjectHandle(String, String)
    * @see #getNewDirectoryHandle(String, String, String)
    * @see #getExistingDirectoryHandle(String, String)
    */
@@ -165,12 +138,7 @@ public class ReferencePointOptionResult {
 
     LocalRepresentationOption localRepresentationOption = getLocalRepresentationOption();
 
-    if (localRepresentationOption == NEW_PROJECT) {
-      String newProjectName = getNewProjectName().trim();
-
-      return getNewProjectHandle(newProjectName, referencePointName);
-
-    } else if (localRepresentationOption == NEW_DIRECTORY) {
+    if (localRepresentationOption == NEW_DIRECTORY) {
       String newDirectoryName = getNewDirectoryName().trim();
       String newDirectoryBasePath = getNewDirectoryBase().trim();
 
@@ -188,47 +156,6 @@ public class ReferencePointOptionResult {
               + "': "
               + localRepresentationOption);
     }
-  }
-
-  /**
-   * Returns a handle for the new project for the given name.
-   *
-   * @param newProjectName the name for the new project
-   * @param referencePointName the name of the reference point the result is belongs to
-   * @return a handle for the new project for the given name
-   * @throws IllegalInputException if the given project name is not valid or a project with the
-   *     given name already exists
-   */
-  private IContainer getNewProjectHandle(String newProjectName, String referencePointName)
-      throws IllegalInputException {
-
-    if (newProjectName == null || newProjectName.isEmpty()) {
-      throw new IllegalInputException(
-          MessageFormat.format(
-              Messages.ReferencePointOptionResult_error_new_project_no_name, referencePointName));
-    }
-
-    IStatus status = ResourcesPlugin.getWorkspace().validateName(newProjectName, IResource.PROJECT);
-
-    if (!status.isOK()) {
-      throw new IllegalInputException(
-          MessageFormat.format(
-              Messages.ReferencePointOptionResult_error_new_project_invalid_name,
-              referencePointName,
-              status.getMessage()));
-    }
-
-    IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(newProjectName);
-
-    if (project.exists()) {
-      throw new IllegalInputException(
-          MessageFormat.format(
-              Messages.ReferencePointOptionResult_error_new_project_already_exists,
-              referencePointName,
-              newProjectName));
-    }
-
-    return project;
   }
 
   /**

--- a/eclipse/src/saros/ui/wizards/AddReferencePointsToSessionWizard.java
+++ b/eclipse/src/saros/ui/wizards/AddReferencePointsToSessionWizard.java
@@ -531,10 +531,7 @@ public class AddReferencePointsToSessionWizard extends Wizard {
                     if (!existingReferencePointContainers.containsValue(container)) {
 
                       if (!container.exists()) {
-                        if (container instanceof IProject) {
-                          ((IProject) container).create(null);
-
-                        } else if (container instanceof IFolder) {
+                        if (container instanceof IFolder) {
                           ((IFolder) container).create(true, true, null);
 
                         } else {

--- a/eclipse/src/saros/ui/wizards/pages/LocalRepresentationSelectionPage.java
+++ b/eclipse/src/saros/ui/wizards/pages/LocalRepresentationSelectionPage.java
@@ -1,11 +1,7 @@
 package saros.ui.wizards.pages;
 
-import static saros.ui.widgets.wizard.ReferencePointOptionComposite.LocalRepresentationOption.NEW_PROJECT;
-
-import java.io.File;
 import java.nio.charset.Charset;
 import java.text.MessageFormat;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -353,19 +349,16 @@ public class LocalRepresentationSelectionPage extends WizardPage {
 
     setErrorMessage(null);
 
-    String warningMessage = findAndReportClashingProjectArtifacts();
+    String warningMessage;
 
     if (!unsupportedCharsets.isEmpty()) {
-      if (warningMessage == null) {
-        warningMessage = "";
-      } else {
-        warningMessage += "\n";
-      }
-
-      warningMessage +=
+      warningMessage =
           MessageFormat.format(
               Messages.LocalRepresentationSelectionPage_warning_unsupported_encoding_found,
               StringUtils.join(unsupportedCharsets, ", "));
+
+    } else {
+      warningMessage = null;
     }
 
     setMessage(warningMessage, WARNING);
@@ -430,53 +423,6 @@ public class LocalRepresentationSelectionPage extends WizardPage {
     } else {
       currentErrors.remove(referencePointID);
     }
-  }
-
-  /**
-   * Scans the current Eclipse Workspace for existing project artifacts that would clash with the
-   * projects created as part of the resource negotiation with the current selections.
-   *
-   * @return a warning message if such artifacts are found, or <code>null</code> otherwise
-   */
-  private String findAndReportClashingProjectArtifacts() {
-    IPath workspacePath = ResourcesPlugin.getWorkspace().getRoot().getLocation();
-
-    if (workspacePath == null) {
-      return null;
-    }
-
-    File workspaceDirectory = workspacePath.toFile();
-
-    List<String> dirtyProjectNames = new ArrayList<>();
-
-    for (ReferencePointOptionComposite composite : referencePointOptionComposites.values()) {
-      ReferencePointOptionResult referencePointOptionResult = composite.getResult();
-
-      if (referencePointOptionResult.getLocalRepresentationOption() != NEW_PROJECT) {
-        continue;
-      }
-
-      String projectName = referencePointOptionResult.getNewProjectName();
-
-      if (projectName == null || projectName.isEmpty()) {
-        continue;
-      }
-
-      if (new File(workspaceDirectory, projectName).exists()) {
-        dirtyProjectNames.add(projectName);
-      }
-    }
-
-    String warningMessage = null;
-
-    if (!dirtyProjectNames.isEmpty()) {
-      warningMessage =
-          MessageFormat.format(
-              Messages.LocalRepresentationSelectionPage_warning_project_artifacts_found,
-              StringUtils.join(dirtyProjectNames, ", "));
-    }
-
-    return warningMessage;
   }
 
   /**
@@ -557,10 +503,8 @@ public class LocalRepresentationSelectionPage extends WizardPage {
   }
 
   /**
-   * Sets the reference point name as the value in the fields for the new project name and new
-   * directory name in the given reference point option composite.
-   *
-   * <p>Leaves the option to create a new project with the given reference point name as selected.
+   * Sets the reference point name as the value in the fields for the new directory name in the
+   * given reference point option composite.
    *
    * @param referencePointOptionComposite the reference point option composite to update
    * @param referencePointName the name to set in the name fields
@@ -569,7 +513,6 @@ public class LocalRepresentationSelectionPage extends WizardPage {
       ReferencePointOptionComposite referencePointOptionComposite, String referencePointName) {
 
     referencePointOptionComposite.setNewDirectoryOptionSelected(referencePointName, null);
-    referencePointOptionComposite.setNewProjectOptionSelected(referencePointName);
   }
 
   /**

--- a/eclipse/src/saros/ui/wizards/pages/LocalRepresentationSelectionPage.java
+++ b/eclipse/src/saros/ui/wizards/pages/LocalRepresentationSelectionPage.java
@@ -20,11 +20,14 @@ import org.eclipse.jface.dialogs.IDialogPage;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
-import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
@@ -42,6 +45,7 @@ import saros.session.ISarosSession;
 import saros.ui.ImageManager;
 import saros.ui.Messages;
 import saros.ui.util.SWTUtils;
+import saros.ui.util.WizardUtils;
 import saros.ui.widgets.wizard.ReferencePointOptionComposite;
 import saros.ui.widgets.wizard.ReferencePointOptionResult;
 import saros.ui.widgets.wizard.events.ReferencePointOptionListener;
@@ -164,9 +168,10 @@ public class LocalRepresentationSelectionPage extends WizardPage {
 
     setControl(composite);
 
-    composite.setLayout(new FillLayout());
+    composite.setLayout(new GridLayout());
 
     TabFolder tabFolder = new TabFolder(composite, SWT.TOP);
+    tabFolder.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
 
     for (String referencePointID : remoteReferencePointIdToNameMapping.keySet()) {
       TabItem tabItem = new TabItem(tabFolder, SWT.NONE);
@@ -212,6 +217,18 @@ public class LocalRepresentationSelectionPage extends WizardPage {
                 return;
               }
             }
+          }
+        });
+
+    Button newProjectButton = new Button(composite, SWT.PUSH);
+    newProjectButton.setImage(ImageManager.ETOOL_NEW_PROJECT);
+    newProjectButton.setLayoutData(new GridData(SWT.END, SWT.FILL, false, false));
+    newProjectButton.setText(Messages.LocalRepresentationSelectionPage_new_project_button);
+    newProjectButton.addSelectionListener(
+        new SelectionAdapter() {
+          @Override
+          public void widgetSelected(SelectionEvent e) {
+            WizardUtils.openNewProjectWizard();
           }
         });
 

--- a/stf.test/test/saros/stf/test/consistency/AddMultipleFilesTest.java
+++ b/stf.test/test/saros/stf/test/consistency/AddMultipleFilesTest.java
@@ -3,6 +3,7 @@ package saros.stf.test.consistency;
 import static org.junit.Assert.assertTrue;
 import static saros.stf.client.tester.SarosTester.ALICE;
 import static saros.stf.client.tester.SarosTester.BOB;
+import static saros.stf.shared.Constants.SessionInvitationModality.CONCURRENTLY;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -35,7 +36,7 @@ public class AddMultipleFilesTest extends StfTestCase {
   @Category(FlakyTests.class)
   @Test
   public void testAddMultipleFilesSimultaneouslyTest() throws Exception {
-    Util.setUpSessionWithProjectAndFile("foo", "main", "main", ALICE, BOB);
+    Util.setUpSessionWithProjectAndFile("foo", "main", "main", CONCURRENTLY, ALICE, BOB);
 
     BOB.superBot().views().packageExplorerView().waitUntilResourceIsShared("foo/main");
 

--- a/stf.test/test/saros/stf/test/consistency/CreateSameFileAtOnceTest.java
+++ b/stf.test/test/saros/stf/test/consistency/CreateSameFileAtOnceTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.fail;
 import static saros.stf.client.tester.SarosTester.ALICE;
 import static saros.stf.client.tester.SarosTester.BOB;
 import static saros.stf.client.tester.SarosTester.CARL;
+import static saros.stf.shared.Constants.SessionInvitationModality.SEQUENTIALLY;
 
 import org.junit.After;
 import org.junit.BeforeClass;
@@ -13,7 +14,6 @@ import saros.stf.annotation.TestLink;
 import saros.stf.client.StfTestCase;
 import saros.stf.client.tester.AbstractTester;
 import saros.stf.client.util.Util;
-import saros.stf.shared.Constants.TypeOfCreateProject;
 
 @TestLink(id = "Saros-131_create_same_file_at_once")
 public class CreateSameFileAtOnceTest extends StfTestCase {
@@ -31,10 +31,8 @@ public class CreateSameFileAtOnceTest extends StfTestCase {
 
   @Test
   public void testCreateSameFileAtOnce() throws Exception {
-    ALICE.superBot().internal().createProject("foo");
-    ALICE.superBot().internal().createFile("foo", "sync.dummy", "dummy");
-
-    Util.buildSessionSequentially("foo", TypeOfCreateProject.NEW_PROJECT, ALICE, BOB, CARL);
+    Util.setUpSessionWithProjectAndFile(
+        "foo", "sync.dummy", "dummy", SEQUENTIALLY, ALICE, BOB, CARL);
 
     BOB.superBot().views().packageExplorerView().waitUntilResourceIsShared("foo/sync.dummy");
     CARL.superBot().views().packageExplorerView().waitUntilResourceIsShared("foo/sync.dummy");

--- a/stf.test/test/saros/stf/test/consistency/EditDuringNonHostAddsProjectTest.java
+++ b/stf.test/test/saros/stf/test/consistency/EditDuringNonHostAddsProjectTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static saros.stf.client.tester.SarosTester.ALICE;
 import static saros.stf.client.tester.SarosTester.BOB;
 import static saros.stf.client.tester.SarosTester.CARL;
+import static saros.stf.shared.Constants.SessionInvitationModality.CONCURRENTLY;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -25,7 +26,8 @@ public class EditDuringNonHostAddsProjectTest extends StfTestCase {
   public void testNonHostAddsProject() throws Exception {
 
     // Initial session setup
-    Util.setUpSessionWithProjectAndFile("foo", "text.txt", "Hello World", ALICE, BOB, CARL);
+    Util.setUpSessionWithProjectAndFile(
+        "foo", "text.txt", "Hello World", CONCURRENTLY, ALICE, BOB, CARL);
     BOB.superBot().views().packageExplorerView().waitUntilResourceIsShared("foo/text.txt");
     CARL.superBot().views().packageExplorerView().waitUntilResourceIsShared("foo/text.txt");
 

--- a/stf.test/test/saros/stf/test/consistency/EditDuringNonHostAddsProjectTest.java
+++ b/stf.test/test/saros/stf/test/consistency/EditDuringNonHostAddsProjectTest.java
@@ -66,14 +66,16 @@ public class EditDuringNonHostAddsProjectTest extends StfTestCase {
             });
 
     // Alice receives the project and also starts typing
-    ALICE.superBot().confirmShellAddProjectWithNewProject("bar");
+    ALICE.superBot().internal().createProject("bar");
+    ALICE.superBot().confirmShellAddProjectUsingExistProject("bar");
     ALICE.superBot().views().packageExplorerView().waitUntilResourceIsShared("bar/text.txt");
     ALICE.superBot().views().packageExplorerView().selectFile("bar", "text.txt").open();
     ALICE.remoteBot().editor("text.txt").waitUntilIsActive();
     aliceIsWriting.start();
 
     // Carl receives the project and also adds some text
-    CARL.superBot().confirmShellAddProjectWithNewProject("bar");
+    CARL.superBot().internal().createProject("bar");
+    CARL.superBot().confirmShellAddProjectUsingExistProject("bar");
     CARL.superBot().views().packageExplorerView().waitUntilResourceIsShared("bar/text.txt");
     CARL.superBot().views().packageExplorerView().selectFile("bar", "text.txt").open();
     CARL.remoteBot().editor("text.txt").waitUntilIsActive();

--- a/stf.test/test/saros/stf/test/consistency/ModifyFileWithoutEditorTest.java
+++ b/stf.test/test/saros/stf/test/consistency/ModifyFileWithoutEditorTest.java
@@ -3,6 +3,7 @@ package saros.stf.test.consistency;
 import static org.junit.Assert.assertEquals;
 import static saros.stf.client.tester.SarosTester.ALICE;
 import static saros.stf.client.tester.SarosTester.BOB;
+import static saros.stf.shared.Constants.SessionInvitationModality.CONCURRENTLY;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -20,7 +21,8 @@ public class ModifyFileWithoutEditorTest extends StfTestCase {
 
   @Test
   public void testCreateSameFileAtOnce() throws Exception {
-    Util.setUpSessionWithProjectAndFile("foo", "readme.txt", "Chuck Norris", ALICE, BOB);
+    Util.setUpSessionWithProjectAndFile(
+        "foo", "readme.txt", "Chuck Norris", CONCURRENTLY, ALICE, BOB);
 
     BOB.superBot().views().packageExplorerView().waitUntilResourceIsShared("foo/readme.txt");
 

--- a/stf.test/test/saros/stf/test/consistency/RecoveryWhileTypingTest.java
+++ b/stf.test/test/saros/stf/test/consistency/RecoveryWhileTypingTest.java
@@ -3,6 +3,7 @@ package saros.stf.test.consistency;
 import static org.junit.Assert.assertEquals;
 import static saros.stf.client.tester.SarosTester.ALICE;
 import static saros.stf.client.tester.SarosTester.BOB;
+import static saros.stf.shared.Constants.SessionInvitationModality.CONCURRENTLY;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -24,7 +25,7 @@ public class RecoveryWhileTypingTest extends StfTestCase {
   @Test
   public void testRecoveryWhileTyping() throws Exception {
     Util.setUpSessionWithProjectAndFile(
-        "foo", "readme.txt", "Harry Potter und der geheime Pornokeller", ALICE, BOB);
+        "foo", "readme.txt", "Harry Potter und der geheime Pornokeller", CONCURRENTLY, ALICE, BOB);
 
     BOB.superBot().views().packageExplorerView().waitUntilResourceIsShared("foo/readme.txt");
 

--- a/stf.test/test/saros/stf/test/editing/ConcurrentEditingInsert100CharactersTest.java
+++ b/stf.test/test/saros/stf/test/editing/ConcurrentEditingInsert100CharactersTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static saros.stf.client.tester.SarosTester.ALICE;
 import static saros.stf.client.tester.SarosTester.BOB;
 import static saros.stf.client.tester.SarosTester.CARL;
+import static saros.stf.shared.Constants.SessionInvitationModality.CONCURRENTLY;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -11,7 +12,6 @@ import saros.stf.client.StfTestCase;
 import saros.stf.client.tester.AbstractTester;
 import saros.stf.client.util.EclipseTestThread;
 import saros.stf.client.util.Util;
-import saros.stf.shared.Constants.TypeOfCreateProject;
 
 public class ConcurrentEditingInsert100CharactersTest extends StfTestCase {
 
@@ -67,17 +67,14 @@ public class ConcurrentEditingInsert100CharactersTest extends StfTestCase {
 
   @Test
   public void testInsertCharactersOnTheSameLine() throws Exception {
-
-    ALICE.superBot().internal().createProject("foo");
-    ALICE
-        .superBot()
-        .internal()
-        .createFile(
-            "foo",
-            "readme.txt",
-            "package test;\n\npublic class paulaBean {\n\n\tprivate String paula = \"Brillant\";\n\n\tpublic String getPaula() {\n\t\treturn paula;\n\t}\n}");
-
-    Util.buildSessionConcurrently("foo", TypeOfCreateProject.NEW_PROJECT, ALICE, BOB, CARL);
+    Util.setUpSessionWithProjectAndFile(
+        "foo",
+        "readme.txt",
+        "package test;\n\npublic class paulaBean {\n\n\tprivate String paula = \"Brillant\";\n\n\tpublic String getPaula() {\n\t\treturn paula;\n\t}\n}",
+        CONCURRENTLY,
+        ALICE,
+        BOB,
+        CARL);
 
     BOB.superBot().views().packageExplorerView().waitUntilResourceIsShared("foo/readme.txt");
 

--- a/stf.test/test/saros/stf/test/editing/ConcurrentEditingTest.java
+++ b/stf.test/test/saros/stf/test/editing/ConcurrentEditingTest.java
@@ -44,7 +44,10 @@ public class ConcurrentEditingTest extends StfTestCase {
     ALICE.remoteBot().editor(FILE).setTextFromFile("test/resources/lorem.txt");
     ALICE.remoteBot().editor(FILE).navigateTo(0, 6);
 
-    Util.buildSessionSequentially(Constants.PROJECT1, TypeOfCreateProject.NEW_PROJECT, ALICE, BOB);
+    BOB.superBot().internal().createProject(Constants.PROJECT1);
+    Util.buildSessionSequentially(
+        Constants.PROJECT1, TypeOfCreateProject.EXIST_PROJECT, ALICE, BOB);
+
     BOB.superBot()
         .views()
         .packageExplorerView()

--- a/stf.test/test/saros/stf/test/editing/ConcurrentEditingWith3UsersTest.java
+++ b/stf.test/test/saros/stf/test/editing/ConcurrentEditingWith3UsersTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static saros.stf.client.tester.SarosTester.ALICE;
 import static saros.stf.client.tester.SarosTester.BOB;
 import static saros.stf.client.tester.SarosTester.CARL;
+import static saros.stf.shared.Constants.SessionInvitationModality.CONCURRENTLY;
 
 import org.junit.After;
 import org.junit.Before;
@@ -52,6 +53,7 @@ public class ConcurrentEditingWith3UsersTest extends StfTestCase {
         "foo",
         "readme.txt",
         "\nVerbesserung des algorithmischen Kerns, Gleichzeitiges Editieren\n",
+        CONCURRENTLY,
         ALICE,
         CARL,
         BOB);
@@ -194,6 +196,7 @@ public class ConcurrentEditingWith3UsersTest extends StfTestCase {
         "foo",
         "readme.txt",
         "\nVerbesserung des algorithmischen Kerns, Gleichzeitiges Editieren\n",
+        CONCURRENTLY,
         ALICE,
         CARL,
         BOB);

--- a/stf.test/test/saros/stf/test/filefolderoperations/FolderOperationsTest.java
+++ b/stf.test/test/saros/stf/test/filefolderoperations/FolderOperationsTest.java
@@ -31,7 +31,8 @@ public class FolderOperationsTest extends StfTestCase {
                                                                        * MByte
                                                                        */ 1024 * 1024 * 100, false);
 
-    Util.buildSessionSequentially("foo", TypeOfCreateProject.NEW_PROJECT, ALICE, BOB);
+    BOB.superBot().internal().createProject("foo");
+    Util.buildSessionSequentially("foo", TypeOfCreateProject.EXIST_PROJECT, ALICE, BOB);
 
     BOB.superBot().views().packageExplorerView().waitUntilResourceIsShared("foo/test/foo.txt");
 

--- a/stf.test/test/saros/stf/test/followmode/FollowModeDisabledInNewSessionTest.java
+++ b/stf.test/test/saros/stf/test/followmode/FollowModeDisabledInNewSessionTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static saros.stf.client.tester.SarosTester.ALICE;
 import static saros.stf.client.tester.SarosTester.BOB;
+import static saros.stf.shared.Constants.SessionInvitationModality.CONCURRENTLY;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -20,7 +21,8 @@ public class FollowModeDisabledInNewSessionTest extends StfTestCase {
 
   @Test
   public void testFollowModeDisabledInNewSession() throws Exception {
-    Util.setUpSessionWithProjectAndFile("foo", "readme.txt", "bla bla bla", ALICE, BOB);
+    Util.setUpSessionWithProjectAndFile(
+        "foo", "readme.txt", "bla bla bla", CONCURRENTLY, ALICE, BOB);
 
     BOB.superBot().views().packageExplorerView().waitUntilResourceIsShared("foo/readme.txt");
 

--- a/stf.test/test/saros/stf/test/followmode/SimpleFollowModeIITest.java
+++ b/stf.test/test/saros/stf/test/followmode/SimpleFollowModeIITest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static saros.stf.client.tester.SarosTester.ALICE;
 import static saros.stf.client.tester.SarosTester.BOB;
+import static saros.stf.shared.Constants.SessionInvitationModality.CONCURRENTLY;
 
 import java.util.List;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
@@ -29,7 +30,7 @@ public class SimpleFollowModeIITest extends StfTestCase {
   @Category(FlakyTests.class)
   @Test
   public void testSimpleFollowMode() throws Exception {
-    Util.setUpSessionWithProjectAndFile("foo", "readme.txt", fileContent, ALICE, BOB);
+    Util.setUpSessionWithProjectAndFile("foo", "readme.txt", fileContent, CONCURRENTLY, ALICE, BOB);
 
     BOB.superBot().views().packageExplorerView().waitUntilResourceIsShared("foo/readme.txt");
 

--- a/stf.test/test/saros/stf/test/followmode/SimpleFollowModeITest.java
+++ b/stf.test/test/saros/stf/test/followmode/SimpleFollowModeITest.java
@@ -3,6 +3,7 @@ package saros.stf.test.followmode;
 import static org.junit.Assert.assertEquals;
 import static saros.stf.client.tester.SarosTester.ALICE;
 import static saros.stf.client.tester.SarosTester.BOB;
+import static saros.stf.shared.Constants.SessionInvitationModality.CONCURRENTLY;
 
 import java.util.List;
 import org.eclipse.jface.bindings.keys.IKeyLookup;
@@ -28,7 +29,7 @@ public class SimpleFollowModeITest extends StfTestCase {
   @Category(FlakyTests.class)
   @Test
   public void testSimpleFollowMode() throws Exception {
-    Util.setUpSessionWithProjectAndFile("foo", "readme.txt", fileContent, ALICE, BOB);
+    Util.setUpSessionWithProjectAndFile("foo", "readme.txt", fileContent, CONCURRENTLY, ALICE, BOB);
 
     BOB.superBot().views().packageExplorerView().waitUntilResourceIsShared("foo/readme.txt");
 

--- a/stf.test/test/saros/stf/test/invitation/InviteAndLeaveStressTest.java
+++ b/stf.test/test/saros/stf/test/invitation/InviteAndLeaveStressTest.java
@@ -25,10 +25,13 @@ public class InviteAndLeaveStressTest extends StfTestCase {
     for (int i = 0; i < MAX_PROJECTS; i++) {
       ALICE.superBot().internal().createProject("foo" + i);
       ALICE.superBot().internal().createFile("foo" + i, "foo.txt", "foo");
+
+      BOB.superBot().internal().createProject("foo" + i);
+      CARL.superBot().internal().createProject("foo" + i);
     }
 
     for (int i = 0; i < MAX_PROJECTS; i++) {
-      Util.buildSessionConcurrently("foo" + i, TypeOfCreateProject.NEW_PROJECT, ALICE, BOB, CARL);
+      Util.buildSessionConcurrently("foo" + i, TypeOfCreateProject.EXIST_PROJECT, ALICE, BOB, CARL);
 
       leaveSessionHostFirst(ALICE);
     }

--- a/stf.test/test/saros/stf/test/invitation/ShareProjectUsingExistingProjectTest.java
+++ b/stf.test/test/saros/stf/test/invitation/ShareProjectUsingExistingProjectTest.java
@@ -10,7 +10,6 @@ import java.util.regex.Pattern;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import saros.stf.client.StfTestCase;
 import saros.stf.client.util.Util;
@@ -87,36 +86,5 @@ public class ShareProjectUsingExistingProjectTest extends StfTestCase {
             .packageExplorerView()
             .selectPkg(Constants.PROJECT1, Constants.PKG1)
             .existsWithRegex(Pattern.quote(Constants.CLS2) + ".*"));
-  }
-
-  @Test
-  @Ignore("The feature is currently disabled because it is not working as expected")
-  public void testShareProjectUsingExistingProjectWithCopy() throws Exception {
-    Util.buildSessionSequentially(
-        Constants.PROJECT1, TypeOfCreateProject.EXIST_PROJECT_WITH_COPY, ALICE, BOB);
-    assertTrue(
-        BOB.superBot()
-            .views()
-            .packageExplorerView()
-            .tree()
-            .existsWithRegex(Pattern.quote(Constants.PROJECT1) + ".*"));
-    assertTrue(
-        BOB.superBot()
-            .views()
-            .packageExplorerView()
-            .selectPkg(Constants.PROJECT1, Constants.PKG1)
-            .existsWithRegex(Pattern.quote(Constants.CLS2) + ".*"));
-    assertTrue(
-        BOB.superBot()
-            .views()
-            .packageExplorerView()
-            .tree()
-            .existsWithRegex(Pattern.quote(Constants.PROJECT1_COPY) + ".*"));
-    assertTrue(
-        BOB.superBot()
-            .views()
-            .packageExplorerView()
-            .selectPkg(Constants.PROJECT1_COPY, Constants.PKG1)
-            .existsWithRegex(Pattern.quote(Constants.CLS1) + ".*"));
   }
 }

--- a/stf.test/test/saros/stf/test/invitation/UserDeclinesInvitationToCurrentSessionTest.java
+++ b/stf.test/test/saros/stf/test/invitation/UserDeclinesInvitationToCurrentSessionTest.java
@@ -6,6 +6,7 @@ import static saros.stf.client.tester.SarosTester.BOB;
 import static saros.stf.client.tester.SarosTester.CARL;
 import static saros.stf.shared.Constants.CANCEL;
 import static saros.stf.shared.Constants.SHELL_SESSION_INVITATION;
+import static saros.stf.shared.Constants.SessionInvitationModality.CONCURRENTLY;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -24,7 +25,8 @@ public class UserDeclinesInvitationToCurrentSessionTest extends StfTestCase {
 
   @Test
   public void testUserDeclinesInvitationToCurrentSession() throws Exception {
-    Util.setUpSessionWithProjectAndFile("foo", "readme.txt", "1234/1234=1", ALICE, BOB);
+    Util.setUpSessionWithProjectAndFile(
+        "foo", "readme.txt", "1234/1234=1", CONCURRENTLY, ALICE, BOB);
 
     BOB.superBot().views().packageExplorerView().waitUntilResourceIsShared("foo");
 

--- a/stf.test/test/saros/stf/test/session/CreatingNewFileTest.java
+++ b/stf.test/test/saros/stf/test/session/CreatingNewFileTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.fail;
 import static saros.stf.client.tester.SarosTester.ALICE;
 import static saros.stf.client.tester.SarosTester.BOB;
 import static saros.stf.client.tester.SarosTester.CARL;
+import static saros.stf.shared.Constants.SessionInvitationModality.CONCURRENTLY;
 
 import org.eclipse.swtbot.swt.finder.widgets.TimeoutException;
 import org.junit.BeforeClass;
@@ -14,7 +15,6 @@ import org.junit.Test;
 import saros.stf.annotation.TestLink;
 import saros.stf.client.StfTestCase;
 import saros.stf.client.util.Util;
-import saros.stf.shared.Constants.TypeOfCreateProject;
 
 @TestLink(id = "Saros-18_creating_new_files")
 public class CreatingNewFileTest extends StfTestCase {
@@ -26,10 +26,7 @@ public class CreatingNewFileTest extends StfTestCase {
 
   @Test
   public void testCreatingNewFileTest() throws Exception {
-
-    CARL.superBot().internal().createProject("foo");
-
-    Util.buildSessionConcurrently("foo", TypeOfCreateProject.NEW_PROJECT, CARL, ALICE, BOB);
+    Util.setUpSessionWithProject("foo", CONCURRENTLY, CARL, ALICE, BOB);
 
     ALICE.superBot().views().packageExplorerView().waitUntilResourceIsShared("foo");
     BOB.superBot().views().packageExplorerView().waitUntilResourceIsShared("foo");

--- a/stf.test/test/saros/stf/test/session/EditFileThatIsNotOpenOnRemoteSideTest.java
+++ b/stf.test/test/saros/stf/test/session/EditFileThatIsNotOpenOnRemoteSideTest.java
@@ -3,6 +3,7 @@ package saros.stf.test.session;
 import static org.junit.Assert.assertTrue;
 import static saros.stf.client.tester.SarosTester.ALICE;
 import static saros.stf.client.tester.SarosTester.BOB;
+import static saros.stf.shared.Constants.SessionInvitationModality.CONCURRENTLY;
 
 import java.util.regex.Pattern;
 import org.junit.BeforeClass;
@@ -10,7 +11,6 @@ import org.junit.Test;
 import saros.stf.client.StfTestCase;
 import saros.stf.client.util.Util;
 import saros.stf.server.rmi.remotebot.widget.IRemoteBotEditor;
-import saros.stf.shared.Constants.TypeOfCreateProject;
 
 public class EditFileThatIsNotOpenOnRemoteSideTest extends StfTestCase {
 
@@ -51,10 +51,7 @@ public class EditFileThatIsNotOpenOnRemoteSideTest extends StfTestCase {
 
     content = builder.toString();
 
-    ALICE.superBot().internal().createProject("foo");
-    ALICE.superBot().internal().createFile("foo", "text.txt", content);
-
-    Util.buildSessionConcurrently("foo", TypeOfCreateProject.NEW_PROJECT, ALICE, BOB);
+    Util.setUpSessionWithProjectAndFile("foo", "text.txt", content, CONCURRENTLY, ALICE, BOB);
 
     BOB.superBot().views().packageExplorerView().waitUntilResourceIsShared("foo/text.txt");
 

--- a/stf.test/test/saros/stf/test/session/EstablishSessionWithDifferentTransportModesTest.java
+++ b/stf.test/test/saros/stf/test/session/EstablishSessionWithDifferentTransportModesTest.java
@@ -13,6 +13,7 @@ import static saros.stf.shared.Constants.PREF_NODE_SAROS_NETWORK_TRANSPORT_MODE_
 import static saros.stf.shared.Constants.PREF_NODE_SAROS_NETWORK_TRANSPORT_MODE_SOCKS5_MEDIATED_CHECKBOX;
 import static saros.stf.shared.Constants.RESTORE_DEFAULTS;
 import static saros.stf.shared.Constants.SHELL_PREFERNCES;
+import static saros.stf.shared.Constants.SessionInvitationModality.SEQUENTIALLY;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -24,7 +25,6 @@ import saros.stf.client.StfTestCase;
 import saros.stf.client.tester.AbstractTester;
 import saros.stf.client.util.Util;
 import saros.stf.server.rmi.remotebot.widget.IRemoteBotShell;
-import saros.stf.shared.Constants.TypeOfCreateProject;
 
 /**
  * This test class ensures that it is possible to establish and running sessions with different
@@ -78,11 +78,8 @@ public class EstablishSessionWithDifferentTransportModesTest extends StfTestCase
   }
 
   private void simulateSession() throws Exception {
+    Util.setUpSessionWithProjectAndFile("foo", "bar.txt", "bar", SEQUENTIALLY, ALICE, BOB);
 
-    ALICE.superBot().internal().createProject("foo");
-    ALICE.superBot().internal().createFile("foo", "bar.txt", "bar");
-
-    Util.buildSessionSequentially("foo", TypeOfCreateProject.NEW_PROJECT, ALICE, BOB);
     BOB.superBot().views().packageExplorerView().waitUntilResourceIsShared("foo/bar.txt");
     BOB.superBot().views().packageExplorerView().selectFile("foo", "bar.txt").open();
     BOB.remoteBot().editor("bar.txt").typeText("foo");

--- a/stf/src/saros/stf/client/util/Util.java
+++ b/stf/src/saros/stf/client/util/Util.java
@@ -270,49 +270,6 @@ public class Util {
    * Adds a project to the current session. This is done sequentially, so the project is send to the
    * invitees one after another.
    *
-   * <p><b>Note:</b> The creation type {@link TypeOfCreateProject#NEW_PROJECT} does not enforce that
-   * the project nature on the inviter's side is correctly applied on the invitee's side. As a
-   * result, it is only supported for cases where the project nature is not of interest. In cases
-   * where the same project nature is necessary on all sides (e.g. if Java language support is
-   * needed), please use {@link TypeOfCreateProject#EXIST_PROJECT}. For Java projects, the utility
-   * method {@link #addJavaProjectToSessionSequentially(String, AbstractTester, AbstractTester...)}
-   * can be used for this purpose.
-   *
-   * <p><b>Note:</b> Adding a project that is already shared or does not exist results in unexpected
-   * behavior.
-   *
-   * <p><b>Note:</b> There is no guarantee that the project and its files are already shared after
-   * this method returns.
-   *
-   * @param projectName the name of the project
-   * @param projectType the type of project that should be used on the invitee side e.g new, use
-   *     existing ...
-   * @param inviter the inviting test user, e.g. ALICE
-   * @param invitees the invited test user(s), e.g. BOB, CARL
-   * @throws IllegalStateException if the inviter or one of the invitee is not connected or is not
-   *     in a session
-   * @throws Exception for any other (internal) failure
-   */
-  public static void addProjectToSessionSequentially(
-      String projectName,
-      TypeOfCreateProject projectType,
-      AbstractTester inviter,
-      AbstractTester... invitees)
-      throws Exception {
-
-    assertStates(true, true, inviter, invitees);
-
-    inviter.superBot().menuBar().saros().addProjects(projectName);
-
-    for (AbstractTester invitee : invitees) {
-      invitee.superBot().confirmShellAddProjectUsingWhichProject(projectName, projectType);
-    }
-  }
-
-  /**
-   * Adds a project to the current session. This is done sequentially, so the project is send to the
-   * invitees one after another.
-   *
    * <p>The projects to add is created on the invitee's side as part of this process. It <b>must
    * not</b> already exist on the invitee's side. Adding a project that already exists on the
    * invitee's side or is already shared results in unexpected behavior.
@@ -347,14 +304,6 @@ public class Util {
 
   /**
    * Establish a Saros session with the given invitees. Every invitee is invited one bye one.
-   *
-   * <p><b>Note:</b> The creation type {@link TypeOfCreateProject#NEW_PROJECT} does not enforce that
-   * the project nature on the inviter's side is correctly applied on the invitee's side. As a
-   * result, it is only supported for cases where the project nature is not of interest. In cases
-   * where the same project nature is necessary on all sides (e.g. if Java language support is
-   * needed), please use {@link TypeOfCreateProject#EXIST_PROJECT}. For Java projects, the utility
-   * method {@link #setUpSessionWithJavaProject(String, SessionInvitationModality, AbstractTester,
-   * AbstractTester...)} can be used for this purpose.
    *
    * <p><b>Note:</b> Establishing session with a project that is already shared or does not exist
    * results in unexpected behavior.
@@ -392,14 +341,6 @@ public class Util {
 
   /**
    * Establish a Saros session with the given invitees. All invitees are invited simultaneously.
-   *
-   * <p><b>Note:</b> The creation type {@link TypeOfCreateProject#NEW_PROJECT} does not enforce that
-   * the project nature on the inviter's side is correctly applied on the invitee's side. As a
-   * result, it is only supported for cases where the project nature is not of interest. In cases
-   * where the same project nature is necessary on all sides (e.g. if Java language support is
-   * needed), please use {@link TypeOfCreateProject#EXIST_PROJECT}. For Java projects, the utility
-   * method {@link #setUpSessionWithJavaProject(String, SessionInvitationModality, AbstractTester,
-   * AbstractTester...)} can be used for this purpose.
    *
    * <p><b>Note:</b> Establishing session with a project that is already shared or does not exist
    * results in unexpected behavior.
@@ -543,12 +484,6 @@ public class Util {
 
   /**
    * Adds testers to the current session.
-   *
-   * <p><b>Note:</b> The creation type {@link TypeOfCreateProject#NEW_PROJECT} does not enforce that
-   * the project nature on the inviter's side is correctly applied on the invitee's side. As a
-   * result, it is only supported for cases where the project nature is not of interest. In cases
-   * where the same project nature is necessary on all sides (e.g. if Java language support is
-   * needed), please use {@link TypeOfCreateProject#EXIST_PROJECT}.
    *
    * <p><b>Note:</b> There is no guarantee that the project and its files are already shared after
    * this method returns.

--- a/stf/src/saros/stf/client/util/Util.java
+++ b/stf/src/saros/stf/client/util/Util.java
@@ -59,8 +59,8 @@ public class Util {
 
   /**
    * A convenient function to quickly build a session with a project and a file. The project is
-   * created by this method so it <b>must not</b> exist before. The invitees are invited
-   * concurrently.
+   * created by this method so it <b>must not</b> exist before. The invitees are invited using the
+   * given modality.
    *
    * <p><b>Note:</b> This method does not enforce that the project nature on the inviter's side is
    * correctly applied on the invitee's side. As a result, it is only supported for cases where the
@@ -75,6 +75,7 @@ public class Util {
    * @param projectName the name of the project
    * @param path the path of the file, e.g. foo/bar/readme.txt
    * @param content the content of the file
+   * @param sessionInvitationModality the session invitation modality to use
    * @param inviter the inviting test user, e.g. ALICE
    * @param invitees the invited test user(s), e.g. BOB, CARL
    * @throws IllegalStateException if the inviter or one of the invitee is not connected or is
@@ -85,6 +86,7 @@ public class Util {
       String projectName,
       String path,
       String content,
+      SessionInvitationModality sessionInvitationModality,
       AbstractTester inviter,
       AbstractTester... invitees)
       throws Exception {
@@ -93,7 +95,20 @@ public class Util {
 
     inviter.superBot().internal().createProject(projectName);
     inviter.superBot().internal().createFile(projectName, path, content);
-    buildSessionConcurrently(projectName, TypeOfCreateProject.NEW_PROJECT, inviter, invitees);
+
+    switch (sessionInvitationModality) {
+      case CONCURRENTLY:
+        buildSessionConcurrently(projectName, TypeOfCreateProject.NEW_PROJECT, inviter, invitees);
+        break;
+
+      case SEQUENTIALLY:
+        buildSessionSequentially(projectName, TypeOfCreateProject.NEW_PROJECT, inviter, invitees);
+        break;
+
+      default:
+        throw new IllegalArgumentException(
+            "Encountered unhandled session invitation modality " + sessionInvitationModality);
+    }
   }
 
   /**

--- a/stf/src/saros/stf/server/rmi/superbot/ISuperBot.java
+++ b/stf/src/saros/stf/server/rmi/superbot/ISuperBot.java
@@ -37,20 +37,6 @@ public interface ISuperBot extends Remote {
 
   /**
    * The shell with the title {@link StfRemoteObject#SHELL_ADD_RESOURCES} should be appeared by the
-   * invitees' side during sharing session. This method confirm the shell using a new project.
-   *
-   * <p><b>Note:</b> This method does not enforce that the project nature on the inviter's side is
-   * correctly applied on the invitee's side. As a result, it is only supported for cases where the
-   * project nature is not of interest. In cases where the same project nature is required on all
-   * sides (e.g. if Java language support is needed), please use {@link
-   * #confirmShellAddProjectUsingExistProject(String)} instead.
-   *
-   * @throws RemoteException
-   */
-  public void confirmShellAddProjectWithNewProject(String projectName) throws RemoteException;
-
-  /**
-   * The shell with the title {@link StfRemoteObject#SHELL_ADD_RESOURCES} should be appeared by the
    * invitees' side during sharing session. This method confirm the shell using an existed project.
    *
    * @throws RemoteException
@@ -71,12 +57,6 @@ public interface ISuperBot extends Remote {
    * The shell with the title {@link StfRemoteObject#SHELL_ADD_RESOURCES} should be appeared by the
    * invitees' side during sharing session. This method confirm the shell. with the passed parameter
    * "usingWhichProject" to decide using which project.
-   *
-   * <p><b>Note:</b> The type {@link TypeOfCreateProject#NEW_PROJECT} does not enforce that the
-   * project nature on the inviter's side is correctly applied on the invitee's side. As a result,
-   * it is only supported for cases where the project nature is not of interest. In cases where the
-   * same project nature is necessary on all sides (e.g. if Java language support is needed), please
-   * use {@link TypeOfCreateProject#EXIST_PROJECT}.
    *
    * @throws RemoteException
    */
@@ -168,12 +148,6 @@ public interface ISuperBot extends Remote {
   /**
    * confirm the shell with title {@link StfRemoteObject#SHELL_SESSION_INVITATION} and also the
    * following shell with title {@link StfRemoteObject#SHELL_ADD_RESOURCES}
-   *
-   * <p><b>Note:</b> The type {@link TypeOfCreateProject#NEW_PROJECT} does not enforce that the
-   * project nature on the inviter's side is correctly applied on the invitee's side. As a result,
-   * it is only supported for cases where the project nature is not of interest. In cases where the
-   * same project nature is necessary on all sides (e.g. if Java language support is needed), please
-   * use {@link TypeOfCreateProject#EXIST_PROJECT}.
    *
    * @param projectName the name of shared project
    * @param usingWhichProject if invitee has same project locally, he can decide use new or existed

--- a/stf/src/saros/stf/server/rmi/superbot/ISuperBot.java
+++ b/stf/src/saros/stf/server/rmi/superbot/ISuperBot.java
@@ -45,16 +45,6 @@ public interface ISuperBot extends Remote {
 
   /**
    * The shell with the title {@link StfRemoteObject#SHELL_ADD_RESOURCES} should be appeared by the
-   * invitees' side during sharing session. This method confirm the shell using an existed project
-   * with copy.
-   *
-   * @throws RemoteException
-   */
-  public void confirmShellAddProjectUsingExistProjectWithCopy(String projectName)
-      throws RemoteException;
-
-  /**
-   * The shell with the title {@link StfRemoteObject#SHELL_ADD_RESOURCES} should be appeared by the
    * invitees' side during sharing session. This method confirm the shell. with the passed parameter
    * "usingWhichProject" to decide using which project.
    *

--- a/stf/src/saros/stf/server/rmi/superbot/impl/SuperBot.java
+++ b/stf/src/saros/stf/server/rmi/superbot/impl/SuperBot.java
@@ -56,22 +56,6 @@ public final class SuperBot extends StfRemoteObject implements ISuperBot {
   }
 
   @Override
-  public void confirmShellAddProjectWithNewProject(String projectName) throws RemoteException {
-
-    SWTBot bot = new SWTBot();
-    bot.waitUntil(
-        Conditions.shellIsActive(SHELL_ADD_RESOURCES), SarosSWTBotPreferences.SAROS_LONG_TIMEOUT);
-
-    SWTBotShell shell = bot.shell(SHELL_ADD_RESOURCES);
-    shell.activate();
-
-    shell.bot().radio(RADIO_CREATE_NEW_PROJECT).click();
-    shell.bot().textWithLabel(LABEL_NEW_PROJECT_NAME, 0).setText(projectName);
-    shell.bot().button(FINISH).click();
-    shell.bot().waitUntil(Conditions.shellCloses(shell));
-  }
-
-  @Override
   public void confirmShellAddProjectUsingExistProject(String projectName) throws RemoteException {
     SWTBot bot = new SWTBot();
     bot.waitUntil(
@@ -142,9 +126,6 @@ public final class SuperBot extends StfRemoteObject implements ISuperBot {
     shell.activate();
 
     switch (usingWhichProject) {
-      case NEW_PROJECT:
-        confirmShellAddProjectWithNewProject(projectName);
-        break;
       case EXIST_PROJECT:
         confirmShellAddProjectUsingExistProject(projectName);
         break;

--- a/stf/src/saros/stf/server/rmi/superbot/impl/SuperBot.java
+++ b/stf/src/saros/stf/server/rmi/superbot/impl/SuperBot.java
@@ -99,23 +99,6 @@ public final class SuperBot extends StfRemoteObject implements ISuperBot {
   }
 
   @Override
-  public void confirmShellAddProjectUsingExistProjectWithCopy(String projectName)
-      throws RemoteException {
-
-    SWTBot bot = new SWTBot();
-    bot.waitUntil(
-        Conditions.shellIsActive(SHELL_ADD_RESOURCES), SarosSWTBotPreferences.SAROS_LONG_TIMEOUT);
-
-    SWTBotShell shell = bot.shell(SHELL_ADD_RESOURCES);
-    shell.activate();
-
-    shell.bot().radio("Use existing project").click();
-    shell.bot().checkBox("Create copy for working distributed. New project name:").click();
-    shell.bot().button(FINISH).click();
-    shell.bot().waitUntil(Conditions.shellCloses(shell));
-  }
-
-  @Override
   public void confirmShellAddProjectUsingWhichProject(
       String projectName, TypeOfCreateProject usingWhichProject) throws RemoteException {
     SWTBot bot = new SWTBot();
@@ -129,9 +112,9 @@ public final class SuperBot extends StfRemoteObject implements ISuperBot {
       case EXIST_PROJECT:
         confirmShellAddProjectUsingExistProject(projectName);
         break;
-      case EXIST_PROJECT_WITH_COPY:
-        confirmShellAddProjectUsingExistProjectWithCopy(projectName);
-        break;
+      default:
+        throw new IllegalStateException(
+            "Encountered unhandled project creation type " + usingWhichProject);
     }
   }
 

--- a/stf/src/saros/stf/shared/Constants.java
+++ b/stf/src/saros/stf/shared/Constants.java
@@ -10,17 +10,8 @@ public interface Constants {
     CONCURRENTLY
   }
 
-  /**
-   * Defines how the shared project is represented on the invitee's side.
-   *
-   * <p><b>Note:</b> Using creation type {@link TypeOfCreateProject#NEW_PROJECT} does not enforce
-   * that the project nature on the inviter's side is correctly applied on the invitee's side. As a
-   * result, it is only supported for cases where the project nature is not of interest. In cases
-   * where the same project nature is necessary on all sides (e.g. if Java language support is
-   * needed), please use {@link TypeOfCreateProject#EXIST_PROJECT} instead.
-   */
+  /** Defines how the shared project is represented on the invitee's side. */
   enum TypeOfCreateProject {
-    NEW_PROJECT,
     EXIST_PROJECT,
     EXIST_PROJECT_WITH_COPY
   }
@@ -384,7 +375,6 @@ public interface Constants {
    * ********************************************
    */
 
-  int CREATE_NEW_PROJECT = 1;
   int USE_EXISTING_PROJECT = 2;
   int USE_EXISTING_PROJECT_WITH_CANCEL_LOCAL_CHANGE = 3;
   int USE_EXISTING_PROJECT_WITH_COPY = 4;
@@ -411,8 +401,6 @@ public interface Constants {
    * second page of the wizard "Session invitation"
    */
   String RADIO_USING_EXISTING_DIRECTORY = get("radio_use_existing_directory");
-  String RADIO_CREATE_NEW_PROJECT = get("radio_create_new_project");
-  String LABEL_NEW_PROJECT_NAME = get("label_new_project_name");
   String LABEL_EXISTING_DIRECTORY_PATH = get("label_existing_directory_path");
 
   /* *********************************************

--- a/stf/src/saros/stf/shared/Constants.java
+++ b/stf/src/saros/stf/shared/Constants.java
@@ -12,8 +12,7 @@ public interface Constants {
 
   /** Defines how the shared project is represented on the invitee's side. */
   enum TypeOfCreateProject {
-    EXIST_PROJECT,
-    EXIST_PROJECT_WITH_COPY
+    EXIST_PROJECT
   }
 
   enum TypeOfShareProject {

--- a/stf/src/saros/stf/shared/configuration.properties
+++ b/stf/src/saros/stf/shared/configuration.properties
@@ -137,8 +137,6 @@ cm_add_to_saros_session = Add to Saros Session
 cm_multiple_contacts = Multiple Contacts...
 
 radio_use_existing_directory = Use existing directory
-radio_create_new_project = Create new project
-label_new_project_name = Project name
 label_existing_directory_path = Directory path
 
 ########################################################

--- a/stf/test/saros/stf/test/stf/Constants.java
+++ b/stf/test/saros/stf/test/stf/Constants.java
@@ -33,7 +33,6 @@ public interface Constants {
   public static String NO_MATCHED_REPEAT_PASSWORD = "dddfffggggg";
   /* Project name */
   public static final String PROJECT1 = "Foo1_Saros";
-  public static final String PROJECT1_COPY = "Foo1_Saros-copy";
 
   public static final String PROJECT1_NEXT = "Foo1_1_Saros";
   public static final String PROJECT2 = "Foo2_Saros";

--- a/stf/test/saros/stf/test/stf/contextmenu/ContextMenuShareWithTest.java
+++ b/stf/test/saros/stf/test/stf/contextmenu/ContextMenuShareWithTest.java
@@ -38,9 +38,11 @@ public class ContextMenuShareWithTest extends StfTestCase {
         .selectJavaProject(Constants.PROJECT1)
         .shareWith()
         .contact(BOB.getJID());
+
+    BOB.superBot().internal().createJavaProject(Constants.PROJECT1);
     BOB.superBot()
         .confirmShellSessionInvitationAndShellAddProject(
-            Constants.PROJECT1, TypeOfCreateProject.NEW_PROJECT);
+            Constants.PROJECT1, TypeOfCreateProject.EXIST_PROJECT);
 
     BOB.superBot().views().sarosView().waitUntilIsInSession();
 

--- a/stf/test/saros/stf/test/stf/controlbot/manipulation/NetworkManipulatorTest.java
+++ b/stf/test/saros/stf/test/stf/controlbot/manipulation/NetworkManipulatorTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static saros.stf.client.tester.SarosTester.ALICE;
 import static saros.stf.client.tester.SarosTester.BOB;
+import static saros.stf.shared.Constants.SessionInvitationModality.CONCURRENTLY;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -34,7 +35,7 @@ public class NetworkManipulatorTest extends StfTestCase {
 
   @Before
   public void createProjectandOpenFiles() throws Exception {
-    Util.setUpSessionWithProjectAndFile("foo", "bar.txt", "bla", ALICE, BOB);
+    Util.setUpSessionWithProjectAndFile("foo", "bar.txt", "bla", CONCURRENTLY, ALICE, BOB);
     BOB.superBot().views().packageExplorerView().waitUntilResourceIsShared("foo/bar.txt");
 
     ALICE.superBot().views().packageExplorerView().selectFile("foo", "bar.txt").open();

--- a/stf/test/saros/stf/test/stf/menubar/MenuSarosByAliceBobCarlTest.java
+++ b/stf/test/saros/stf/test/stf/menubar/MenuSarosByAliceBobCarlTest.java
@@ -25,7 +25,9 @@ public class MenuSarosByAliceBobCarlTest extends StfTestCase {
     Util.setUpSessionWithJavaProjectAndClass(
         Constants.PROJECT1, Constants.PKG1, Constants.CLS1, ALICE, BOB);
     assertFalse(CARL.superBot().views().sarosView().isInSession());
-    Util.addTestersToSession(Constants.PROJECT1, TypeOfCreateProject.NEW_PROJECT, ALICE, CARL);
+
+    CARL.superBot().internal().createJavaProject(Constants.PROJECT1);
+    Util.addTestersToSession(Constants.PROJECT1, TypeOfCreateProject.EXIST_PROJECT, ALICE, CARL);
 
     CARL.superBot().views().packageExplorerView().waitUntilResourceIsShared(Constants.PROJECT1);
     assertTrue(CARL.superBot().views().sarosView().isInSession());

--- a/stf/test/saros/stf/test/stf/menubar/MenuSarosByAliceBobTest.java
+++ b/stf/test/saros/stf/test/stf/menubar/MenuSarosByAliceBobTest.java
@@ -72,6 +72,8 @@ public class MenuSarosByAliceBobTest extends StfTestCase {
     shell.bot().tree().selectTreeItemWithRegex(Pattern.quote(BOB.getBaseJid()) + ".*").check();
     shell.bot().button(FINISH).click();
 
+    BOB.superBot().internal().createJavaProject(Constants.PROJECT1);
+
     BOB.remoteBot().waitUntilShellIsOpen(SHELL_SESSION_INVITATION);
     IRemoteBotShell shell2 = BOB.remoteBot().shell(SHELL_SESSION_INVITATION);
     shell2.activate();
@@ -79,7 +81,7 @@ public class MenuSarosByAliceBobTest extends StfTestCase {
 
     BOB.superBot()
         .confirmShellAddProjectUsingWhichProject(
-            Constants.PROJECT1, TypeOfCreateProject.NEW_PROJECT);
+            Constants.PROJECT1, TypeOfCreateProject.EXIST_PROJECT);
     BOB.superBot().views().sarosView().waitUntilIsInSession();
     BOB.superBot()
         .views()
@@ -102,9 +104,11 @@ public class MenuSarosByAliceBobTest extends StfTestCase {
 
     ALICE.superBot().menuBar().saros().shareProjects(Constants.PROJECT1, BOB.getJID());
 
+    BOB.superBot().internal().createJavaProject(Constants.PROJECT1);
+
     BOB.superBot()
         .confirmShellSessionInvitationAndShellAddProject(
-            Constants.PROJECT1, TypeOfCreateProject.NEW_PROJECT);
+            Constants.PROJECT1, TypeOfCreateProject.EXIST_PROJECT);
 
     BOB.superBot().views().sarosView().waitUntilIsInSession();
 
@@ -144,9 +148,11 @@ public class MenuSarosByAliceBobTest extends StfTestCase {
         .javaProjectWithClasses(Constants.PROJECT2, Constants.PKG1, Constants.CLS1);
 
     ALICE.superBot().menuBar().saros().addProjects(Constants.PROJECT2);
+
+    BOB.superBot().internal().createJavaProject(Constants.PROJECT2);
     BOB.superBot()
         .confirmShellAddProjectUsingWhichProject(
-            Constants.PROJECT2, TypeOfCreateProject.NEW_PROJECT);
+            Constants.PROJECT2, TypeOfCreateProject.EXIST_PROJECT);
 
     BOB.superBot()
         .views()

--- a/stf/test/saros/stf/test/stf/view/explorer/PackageExplorerViewDecoratorTest.java
+++ b/stf/test/saros/stf/test/stf/view/explorer/PackageExplorerViewDecoratorTest.java
@@ -3,6 +3,7 @@ package saros.stf.test.stf.view.explorer;
 import static org.junit.Assert.assertTrue;
 import static saros.stf.client.tester.SarosTester.ALICE;
 import static saros.stf.client.tester.SarosTester.BOB;
+import static saros.stf.shared.Constants.SessionInvitationModality.CONCURRENTLY;
 
 import org.junit.After;
 import org.junit.Before;
@@ -89,7 +90,8 @@ public class PackageExplorerViewDecoratorTest extends StfTestCase {
 
   @Test
   public void testPackageExplorerViewMethodsWithFullSharedProject() throws Exception {
-    Util.setUpSessionWithProjectAndFile(PROJECT, FOLDER + "/" + FILE_1, "", ALICE, BOB);
+    Util.setUpSessionWithProjectAndFile(
+        PROJECT, FOLDER + "/" + FILE_1, "", CONCURRENTLY, ALICE, BOB);
 
     BOB.superBot().views().packageExplorerView().waitUntilResourceIsShared(PROJECT);
 

--- a/stf/test/saros/stf/test/stf/view/sarosview/content/ContactsByAliceBobTest.java
+++ b/stf/test/saros/stf/test/stf/view/sarosview/content/ContactsByAliceBobTest.java
@@ -161,9 +161,10 @@ public class ContactsByAliceBobTest extends StfTestCase {
         .workTogetherOn()
         .multipleProjects("Foo", BOB.getJID());
 
+    BOB.superBot().internal().createJavaProject(Constants.PROJECT1);
     BOB.superBot()
         .confirmShellSessionInvitationAndShellAddProject(
-            Constants.PROJECT1, TypeOfCreateProject.NEW_PROJECT);
+            Constants.PROJECT1, TypeOfCreateProject.EXIST_PROJECT);
 
     ALICE.superBot().views().sarosView().leaveSession();
     ALICE.superBot().views().sarosView().waitUntilIsNotInSession();

--- a/stf/test/saros/stf/test/stf/view/sarosview/content/InviteContactsByAliceBobCarlTest.java
+++ b/stf/test/saros/stf/test/stf/view/sarosview/content/InviteContactsByAliceBobCarlTest.java
@@ -46,9 +46,10 @@ public class InviteContactsByAliceBobCarlTest extends StfTestCase {
 
     ALICE.superBot().views().sarosView().selectContact(CARL.getJID()).addToSarosSession();
 
+    CARL.superBot().internal().createJavaProject(Constants.PROJECT1);
     CARL.superBot()
         .confirmShellSessionInvitationAndShellAddProject(
-            Constants.PROJECT1, TypeOfCreateProject.NEW_PROJECT);
+            Constants.PROJECT1, TypeOfCreateProject.EXIST_PROJECT);
 
     CARL.superBot().views().sarosView().waitUntilIsInSession();
 

--- a/stf/test/saros/stf/test/stf/view/sarosview/content/SessionAliceBobTest.java
+++ b/stf/test/saros/stf/test/stf/view/sarosview/content/SessionAliceBobTest.java
@@ -257,9 +257,11 @@ public class SessionAliceBobTest extends StfTestCase {
   public void addProjects() throws Exception {
     ALICE.superBot().views().packageExplorerView().tree().newC().javaProject(Constants.PROJECT2);
     ALICE.superBot().views().sarosView().selectSession().addProjects(Constants.PROJECT2);
+
+    BOB.superBot().internal().createJavaProject(Constants.PROJECT2);
     BOB.superBot()
         .confirmShellAddProjectUsingWhichProject(
-            Constants.PROJECT2, TypeOfCreateProject.NEW_PROJECT);
+            Constants.PROJECT2, TypeOfCreateProject.EXIST_PROJECT);
 
     // TODO remove this, we have to wait for project arrival
     // or next test cases will fail because of an uncloseable window


### PR DESCRIPTION
Removes the option to create a project to use for the incoming resource negotiation to represent the shared reference point. Instead adds a button to the wizard allowing the user to manually create and configure a new project. This guarantees that the wizard is still completable, even if the workspace is initially empty.

Adjusts the STF to match these changes. Adds new utility methods to set up sessions by creating stub projects on the receiving side. This matches the behavior for the setups providing projects with language support. Subsequently adjusts the existing tests still using the option `NEW_PROJECT`. Removes all methods and constants corresponding to this option.

Also removes the option `EXISTING_PROJECT_WITH_COPY` from the STF methods. It was only used in ignored tests and is no longer supported by the Saros/E UI. Removes the ignored tests as well.

Resolves #1094.

#### Reviewing This PR

I would suggest reviewing this PR commit by commit.

#### Commits

<details><summary><b>[UI][E] Remove option to create project as part of resource negotiation</b></summary>
<br>

Removes the option to create a project as part of the incoming resource
negotiation. This option will be replaced with a button offering the
user the functionality to manually create a new project that can then be
used for the incoming resource negotiation.

This avoids potential issues caused by incorrectly set up projects as
part of the negotiation. Since Saros no longer supports correctly
configuring the project, it is best to completely avoid creating it and
rather pass this responsibility to the user.

</details>

<details><summary><b>[UI][E] Add project creation button to resource negotiation wizard</b></summary>
<br>

Adds a button to create a new project to the wizard used to accept
incoming resource negotiations. This button can be used by the user to
create and configure new projects that can then subsequently be used to
represent the shared reference points in the local workspace.

This option is necessary to ensure that the wizard is always
completable, even in cases where the workspace is empty when the wizard
is started.

As the button is part of the external wizard and not the selection tab
itself, creating a new project through the button does not update the
currently selected tab. This has to be done manually by the user.

</details>

<details><summary><b>[STF] Add modality option to Util.setUpSessionWithProjectAndFile()</b></summary>
<br>

Adds the option to pass the used session invitation modality state to
`Util.setUpSessionWithProjectAndFile(...)`. This was done in preparation
for an upcoming change adding more usages of the method requiring
different modality states.

All existing usages of the method were adjusted to use the "concurrent"
session invitation modality. This was the previous default for the
method.

</details>

<details><summary><b>[STF] Add utility methods for setups using existing non-java projects</b></summary>
<br>

Adds `Util.setUpSessionWithProject(...)`, providing the functionality to
set up a session without Java language support with the given project.
Project stubs are created on the receiving side, allowing the
negotiation to use `EXISTING_PROJECTS`.

This method was added to replace the usage of the mode `NEW_PROJECT`,
which is no longer available.

Amends `Util.setUpSessionWithProjectAndFile(...)` to also create and use
project stubs on the receiving side.

</details>

<details><summary><b>[STF] Adjust tests to no longer use option "NEW_PROJECT"</b></summary>
<br>

Adjusts the existing STF tests relying on the resource negotiation to
create the shared projects. This option was removed from the UI.

Instead, such tests now create a stub project on the receiving side and
use the option `EXISTING_PROJECT` instead.

Adjusted some test setups to use the available utility methods to
simplify the session setup if possible.

</details>

<details><summary><b>[STF] Remove methods supporting "NEW_PROJECT" negotiation mode</b></summary>
<br>

Removes the methods providing access to the resource negotiation mode
creating a new project on the receiving side as this mode is no longer
available.

Subsequently removes constants only necessary for these methods.

</details>

<details><summary><b>[STF] Remove methods supporting "EXISTING_PROJECT_WITH_COPY" mode</b></summary>
<br>

Removes methods supporting the creation of a project copy on the
receiving side as part of the resource negotiation as it is no longer
available.

Removes the tests for this mode. All of them were ignored anyway.

Removes the constants only used in the removed methods.

</details>