### PR TITLE
Fixes issues with the paths used in the context of the local Saros instance

### DIFF
--- a/eclipse/src/saros/resource_change_handlers/ToStringResourceDeltaVisitor.java
+++ b/eclipse/src/saros/resource_change_handlers/ToStringResourceDeltaVisitor.java
@@ -73,7 +73,7 @@ public class ToStringResourceDeltaVisitor implements IResourceDeltaVisitor {
 
       if (resource.isHidden()) sb.append("H ");
 
-      sb.append(resource.getFullPath().toPortableString());
+      sb.append(resource.getFullPath().toOSString());
     } else {
       sb.append("No resource");
     }

--- a/eclipse/src/saros/ui/widgets/wizard/ReferencePointOptionComposite.java
+++ b/eclipse/src/saros/ui/widgets/wizard/ReferencePointOptionComposite.java
@@ -463,8 +463,8 @@ public class ReferencePointOptionComposite extends Composite {
 
     if (result == null || result.length == 0) return null;
 
-    // TODO don't use portable string? drop leading delimiter?
-    return ((Path) result[0]).toPortableString();
+    // TODO drop leading delimiter?
+    return ((Path) result[0]).toOSString();
   }
 
   /**

--- a/eclipse/src/saros/ui/widgets/wizard/ReferencePointOptionResult.java
+++ b/eclipse/src/saros/ui/widgets/wizard/ReferencePointOptionResult.java
@@ -293,7 +293,7 @@ public class ReferencePointOptionResult {
       throw new IllegalInputException(
           MessageFormat.format(
               Messages.ReferencePointOptionResult_error_new_directory_already_exists,
-              containerToCreate));
+              containerToCreate.getFullPath().toOSString()));
     }
 
     return containerToCreate;

--- a/eclipse/src/saros/ui/wizards/AddReferencePointsToSessionWizard.java
+++ b/eclipse/src/saros/ui/wizards/AddReferencePointsToSessionWizard.java
@@ -797,7 +797,7 @@ public class AddReferencePointsToSessionWizard extends Wizard {
     for (Entry<String, IContainer> entry : referencePointContainers.entrySet()) {
       String referencePointId = entry.getKey();
 
-      String referencePointPath = entry.getValue().getFullPath().toPortableString();
+      String referencePointPath = entry.getValue().getFullPath().toOSString();
       String referencePointName =
           negotiation.getResourceNegotiationData(referencePointId).getReferencePointName();
 

--- a/eclipse/src/saros/ui/wizards/pages/LocalRepresentationSelectionPage.java
+++ b/eclipse/src/saros/ui/wizards/pages/LocalRepresentationSelectionPage.java
@@ -283,14 +283,14 @@ public class LocalRepresentationSelectionPage extends WizardPage {
       if (selectedPath.equals(otherReferencePointPath)) {
         return MessageFormat.format(
             Messages.LocalRepresentationSelectionPage_error_reference_point_path_clash,
-            selectedPath.toPortableString(),
+            selectedPath.toOSString(),
             referencePointName,
             otherReferencePointName);
 
       } else if (otherReferencePointPath.isPrefixOf(selectedPath)) {
         return MessageFormat.format(
             Messages.LocalRepresentationSelectionPage_error_nested_selected_reference_point_paths,
-            selectedPath.toPortableString(),
+            selectedPath.toOSString(),
             referencePointName,
             otherReferencePointName);
       }
@@ -304,21 +304,21 @@ public class LocalRepresentationSelectionPage extends WizardPage {
       if (referencePointPath.equals(selectedPath)) {
         return MessageFormat.format(
             Messages.LocalRepresentationSelectionPage_error_existing_reference_point_path_clash,
-            selectedPath.toPortableString(),
+            selectedPath.toOSString(),
             referencePointName,
             sharedReferencePoint.getName());
 
       } else if (referencePointPath.isPrefixOf(selectedPath)) {
         return MessageFormat.format(
             Messages.LocalRepresentationSelectionPage_error_child_of_existing_reference_point,
-            selectedPath.toPortableString(),
+            selectedPath.toOSString(),
             referencePointName,
             sharedReferencePoint.getName());
 
       } else if (selectedPath.isPrefixOf(referencePointPath)) {
         return MessageFormat.format(
             Messages.LocalRepresentationSelectionPage_error_parent_of_existing_reference_point,
-            selectedPath.toPortableString(),
+            selectedPath.toOSString(),
             referencePointName,
             sharedReferencePoint.getName());
       }
@@ -514,7 +514,7 @@ public class LocalRepresentationSelectionPage extends WizardPage {
             ReferencePointOptionResult.getContainerForPath(previousReferencePointPath);
 
         if (desiredContainer != null && desiredContainer.exists()) {
-          String existingDirectoryPath = desiredContainer.getFullPath().toPortableString();
+          String existingDirectoryPath = desiredContainer.getFullPath().toOSString();
 
           referencePointOptionComposite.setExistingDirectoryOptionSelected(existingDirectoryPath);
         }
@@ -535,7 +535,7 @@ public class LocalRepresentationSelectionPage extends WizardPage {
 
           if (projectRelativePath.isEmpty()) {
             referencePointOptionComposite.setExistingDirectoryOptionSelected(
-                project.getFullPath().toPortableString());
+                project.getFullPath().toOSString());
 
             break;
           }
@@ -544,7 +544,7 @@ public class LocalRepresentationSelectionPage extends WizardPage {
 
           if (container.exists()) {
             referencePointOptionComposite.setExistingDirectoryOptionSelected(
-                container.getFullPath().toPortableString());
+                container.getFullPath().toOSString());
 
             break;
           }


### PR DESCRIPTION
Fixes issues with the paths used in the context of the local Saros instance.

#### Commits

<details><summary><b>[FIX][E] #1093 Correctly display path of existing resource for error</b></summary>
<br>

Adjusts the error message displayed in cases where the user chooses the
option to create a new directory as part of the resource negotiation
using values pointing to an already existing directory. The message used
the `toString()` of the `IContainer` object which included a resource type
designation at the start of the path. To avoid confusion, the
OS-specific path of the resource is used instead.

Resolves #1093.

</details>

<details><summary><b>[INTERNAL][E] Use OS path when exclusively working in the local context</b></summary>
<br>

Replaces usages of `IPath.toPortableString()` with `IPath.toOSString()` in
cases where the logic is only working in the local context, i.e. when
displaying information to the user or setting values in a local dialog.

This was done to make it as easy as possible to recognize the path in
the local system. Making the path portable could be confusing for the
user as it no longer matches the representation in the local filesystem.

</details>