### PR TITLE
Move minimal compatibility to 2020.1

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 
 dependencies {
     compile("com.diffplug.gradle:goomph:3.24.0")
-    compile("gradle.plugin.org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.4.21")
+    compile("org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.6.3")
 }
 
 gradlePlugin {

--- a/intellij/build.gradle.kts
+++ b/intellij/build.gradle.kts
@@ -39,7 +39,7 @@ sourceSets {
 sarosIntellij {
     sandboxBaseDir = if (intellijSandboxDir.isNullOrBlank()) null else file(intellijSandboxDir!!)
     localIntellijHome = if (intellijHome.isNullOrBlank()) null else file(intellijHome!!)
-    intellijVersion = "IC-2019.3.4"
+    intellijVersion = "IC-2020.1.3"
 }
 
 tasks {

--- a/intellij/resources/META-INF/plugin.xml
+++ b/intellij/resources/META-INF/plugin.xml
@@ -35,7 +35,7 @@
   </vendor>
 
   <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-  <idea-version since-build="192.6817.14"/>
+  <idea-version since-build="201.8538.31"/>
 
   <!-- please see https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html on how to target different products -->
   <depends>com.intellij.modules.platform</depends>

--- a/intellij/src/saros/intellij/context/IntellijVersionProvider.java
+++ b/intellij/src/saros/intellij/context/IntellijVersionProvider.java
@@ -1,7 +1,7 @@
 package saros.intellij.context;
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManager;
+import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.extensions.PluginId;
 import saros.intellij.SarosComponent;
@@ -22,7 +22,7 @@ public class IntellijVersionProvider {
    */
   public static String getPluginVersion() {
     IdeaPluginDescriptor sarosPluginDescriptor =
-        PluginManager.getPlugin(PluginId.getId(SarosComponent.PLUGIN_ID));
+        PluginManagerCore.getPlugin(PluginId.getId(SarosComponent.PLUGIN_ID));
 
     if (sarosPluginDescriptor == null) {
       throw new IllegalStateException(

--- a/intellij/src/saros/intellij/eventhandler/ProjectEventHandlersFactory.java
+++ b/intellij/src/saros/intellij/eventhandler/ProjectEventHandlersFactory.java
@@ -100,7 +100,7 @@ public class ProjectEventHandlersFactory {
     /*
      * editor viewport change handlers
      */
-    projectEventHandlers.add(new LocalViewPortChangeHandler(editorManager));
+    projectEventHandlers.add(new LocalViewPortChangeHandler(project, editorManager));
 
     return new ProjectEventHandlers(projectEventHandlers);
   }

--- a/intellij/src/saros/intellij/eventhandler/editor/viewport/LocalViewPortChangeHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/editor/viewport/LocalViewPortChangeHandler.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.editor.LogicalPosition;
 import com.intellij.openapi.editor.event.VisibleAreaEvent;
 import com.intellij.openapi.editor.event.VisibleAreaListener;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import java.awt.Rectangle;
 import org.apache.log4j.Logger;
@@ -20,6 +21,7 @@ import saros.intellij.eventhandler.IProjectEventHandler;
 public class LocalViewPortChangeHandler implements IProjectEventHandler {
   private static final Logger log = Logger.getLogger(LocalViewPortChangeHandler.class);
 
+  private final Project project;
   private final EditorManager editorManager;
 
   private final VisibleAreaListener visibleAreaListener = this::generateViewportActivity;
@@ -34,7 +36,8 @@ public class LocalViewPortChangeHandler implements IProjectEventHandler {
    *
    * @param editorManager the EditorManager instance
    */
-  public LocalViewPortChangeHandler(EditorManager editorManager) {
+  public LocalViewPortChangeHandler(Project project, EditorManager editorManager) {
+    this.project = project;
     this.editorManager = editorManager;
 
     this.enabled = false;
@@ -130,8 +133,9 @@ public class LocalViewPortChangeHandler implements IProjectEventHandler {
       this.enabled = false;
 
     } else if (!this.enabled && enabled) {
-      // TODO add project as disposable parent once compatibility is set to above 2019.3
-      EditorFactory.getInstance().getEventMulticaster().addVisibleAreaListener(visibleAreaListener);
+      EditorFactory.getInstance()
+          .getEventMulticaster()
+          .addVisibleAreaListener(visibleAreaListener, project);
 
       this.enabled = true;
     }

--- a/intellij/src/saros/intellij/ui/SarosToolWindowFactory.java
+++ b/intellij/src/saros/intellij/ui/SarosToolWindowFactory.java
@@ -1,6 +1,7 @@
 package saros.intellij.ui;
 
-import com.intellij.ide.plugins.PluginManager;
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
@@ -17,14 +18,19 @@ public class SarosToolWindowFactory implements ToolWindowFactory {
   public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
     SarosMainPanelView sarosMainPanelView = new SarosMainPanelView(project);
 
+    IdeaPluginDescriptor sarosPluginDescriptor =
+        PluginManagerCore.getPlugin(PluginId.getId(SarosComponent.PLUGIN_ID));
+
+    if (sarosPluginDescriptor == null) {
+      throw new IllegalStateException(
+          "Could not find Saros plugin using ID " + SarosComponent.PLUGIN_ID);
+    }
+
     Content content =
         toolWindow
             .getContentManager()
             .getFactory()
-            .createContent(
-                sarosMainPanelView,
-                PluginManager.getPlugin(PluginId.getId(SarosComponent.PLUGIN_ID)).getName(),
-                false);
+            .createContent(sarosMainPanelView, sarosPluginDescriptor.getName(), false);
     toolWindow.getContentManager().addContent(content);
   }
 }


### PR DESCRIPTION
Sets the minimal compatibility of the plugin to IntelliJ 2020.1.3.

### Commits

#### [I] Increase minimal supported IntelliJ version to 2020.1.3

Increases the minimal supported IntelliJ version to 2020.1.3 (build ID
201.8538.31).

Adjusts the build setup to use this version when starting IntelliJ
instances for local test builds.

#### [INTERNAL][I] Correct deprecated API usages for IntelliJ 2020.1

Corrects the usages of deprecated APIs now possible with the minimal
supported IntelliJ version 2020.1.

Replaces the usage of `PluginManager.getPlugin(...)` with
`PluginManagerCore.getPlugin(...)`.

Adds the project the handler belongs to as the disposable parent for
`LocalViewPortChangeHandler`.

#### [BUILD][I] Update gradle-intellij-plugin to 0.6.3