### PR TITLE
[FIX][I] #1050 Correctly initialize Saros view

### DIFF
--- a/intellij/src/saros/intellij/ui/tree/ContactTreeRootNode.java
+++ b/intellij/src/saros/intellij/ui/tree/ContactTreeRootNode.java
@@ -75,6 +75,14 @@ public class ContactTreeRootNode extends DefaultMutableTreeNode implements Dispo
     contactsService.addListener(contactsUpdate);
   }
 
+  /**
+   * Adds all contacts of the currently connected XMPP account to the contacts list. Covers cases
+   * where the component is initialized when there is already a connected account.
+   */
+  void setInitialState() {
+    contactsService.getAllContacts().forEach(this::addContact);
+  }
+
   @Override
   public void dispose() {
     contactsService.removeListener(contactsUpdate);

--- a/intellij/src/saros/intellij/ui/tree/SessionAndContactsTreeView.java
+++ b/intellij/src/saros/intellij/ui/tree/SessionAndContactsTreeView.java
@@ -119,8 +119,10 @@ public class SessionAndContactsTreeView extends JTree implements Disposable {
     connectionHandler.addConnectionStateListener(connectionStateListener);
     xmppContactsService.addListener(contactsUpdateListener);
 
-    // show correct initial state
+    /* show correct initial state */
     renderConnectionState(connectionHandler.getConnectionState());
+    // contact tree must be set up first as it is adjusted as part of session tree setup
+    contactTreeRootNode.setInitialState();
     sessionTreeRootNode.setInitialState();
   }
 

--- a/intellij/src/saros/intellij/ui/tree/SessionTreeRootNode.java
+++ b/intellij/src/saros/intellij/ui/tree/SessionTreeRootNode.java
@@ -126,12 +126,28 @@ public class SessionTreeRootNode extends DefaultMutableTreeNode implements Dispo
     }
   }
 
+  /** Sets up the view in cases where there already is a running session when it is initialized. */
   void setInitialState() {
     ISarosSession session = sessionManager.getSession();
 
     if (session != null) {
       sessionStarted(session);
+      populateInitialState();
     }
+  }
+
+  /** Adds components to session node that would otherwise be added by the state listeners. */
+  private void populateInitialState() {
+    session.getReferencePoints().forEach(this::addReferencePointNode);
+
+    User host = session.getHost();
+    User localUser = session.getLocalUser();
+
+    session
+        .getUsers()
+        .stream()
+        .filter(user -> !user.equals(host) && !user.equals(localUser))
+        .forEach(this::addUserNode);
   }
 
   private void sessionStarted(final ISarosSession newSarosSession) {


### PR DESCRIPTION
Adjusts the Saros view to correctly display the initial state at the
point it was initialized. This is necessary as the view relies on
listeners to correctly update the state. As a result, it will not be
able to reflect changes that were made before it was initialized.

To avoid this issue, the components are manually initialized with the
initial state.

This is more of a quick fix than an actual solution. The whole Saros
view logic needs an overhaul as the state handling is spread across
multiple classes, making it very hard to track.

Resolves #1050.
