### PR TITLE
[FIX][I] Correctly tear down BackgroundEditorPool for closing project

### DIFF
--- a/intellij/src/saros/intellij/editor/ProjectAPI.java
+++ b/intellij/src/saros/intellij/editor/ProjectAPI.java
@@ -187,11 +187,14 @@ public class ProjectAPI {
    * boolean)} instead.
    *
    * @param document the document to open a background editor for
+   * @param project the project to associate the editor with
    * @return a background editor for the given document
    */
   @NotNull
-  public static Editor createBackgroundEditor(@NotNull Document document) {
-    return EDTExecutor.invokeAndWait(() -> editorFactory.createEditor(document));
+  public static Editor createBackgroundEditor(
+      @NotNull Document document, @NotNull Project project) {
+
+    return EDTExecutor.invokeAndWait(() -> editorFactory.createEditor(document, project));
   }
 
   /**
@@ -199,7 +202,7 @@ public class ProjectAPI {
    * needed/will no longer be used to dispose it correctly.
    *
    * <p><b>NOTE:</b> This method must only be called for background editors that were obtained using
-   * {@link #createBackgroundEditor(Document)}.
+   * {@link #createBackgroundEditor(Document, Project)}.
    *
    * @param editor the background editor to release
    * @see EditorFactory#releaseEditor(Editor)


### PR DESCRIPTION
Adjusts the BackgroundEditorPool to correctly drop all background
editors associated with the closing project. This is necessary as they
will otherwise be detected as a memory leak.

This case should normally be handled as part of the session teardown
triggered by ProjectClosedHandler. But the session teardown is executed
asynchronously on a different thread, meaning it only takes effect after
the internal memory leak check of IntelliJ has already run.

Adjusts the method creating the background editors offered by ProjectAPI
to also accept a project parameter to associate with the editor. This is
necessary to request the corresponding project from the editor. Even if
the editor is not explicitly associated with the project, it is still
connected to it and must be torn down as part of the project disposal.
Explicitly associating it with the project makes this process easier.