### PR TITLE
Check for qualifier as part of version compatibility check

### DIFF
--- a/core/src/saros/versioning/Compatibility.java
+++ b/core/src/saros/versioning/Compatibility.java
@@ -9,7 +9,7 @@ public enum Compatibility {
   /**
    * The local version is (probably) too old to work with the remote version.
    *
-   * <p>The user should be told to upgrade
+   * <p>The user should be told to upgrade.
    */
   OLDER,
 
@@ -20,12 +20,12 @@ public enum Compatibility {
    */
   NEWER,
 
-  /** The compatibility could not be determined. */
-  UNKNOWN,
-
   /**
-   * At least one of the versions contains a qualifiers and the complete version string does not
+   * At least one of the versions contains a qualifier and the complete version string does not
    * match.
    */
-  QUALIFIER_MISMATCH
+  QUALIFIER_MISMATCH,
+
+  /** The compatibility could not be determined. */
+  UNKNOWN
 }

--- a/core/src/saros/versioning/Compatibility.java
+++ b/core/src/saros/versioning/Compatibility.java
@@ -4,76 +4,28 @@ package saros.versioning;
 public enum Compatibility {
 
   /** Versions are (probably) compatible */
-  OK(0) {
-    @Override
-    public Compatibility invert() {
-      return OK;
-    }
-  },
+  OK,
+
   /**
    * The local version is (probably) too old to work with the remote version.
    *
    * <p>The user should be told to upgrade
    */
-  OLDER(1) {
-    @Override
-    public Compatibility invert() {
-      return NEWER;
-    }
-  },
+  OLDER,
+
   /**
    * The local version is (probably) too new to work with the remote version.
    *
    * <p>The user should be told to tell the peer to update.
    */
-  NEWER(2) {
-    @Override
-    public Compatibility invert() {
-      return OLDER;
-    }
-  },
+  NEWER,
 
   /** The compatibility could not be determined. */
-  UNKNOWN(3) {
-    @Override
-    public Compatibility invert() {
-      return UNKNOWN;
-    }
-  },
+  UNKNOWN,
 
   /**
    * At least one of the versions contains a qualifiers and the complete version string does not
    * match.
    */
-  QUALIFIER_MISMATCH(4) {
-    @Override
-    public Compatibility invert() {
-      return QUALIFIER_MISMATCH;
-    }
-  };
-
-  private final int code;
-
-  Compatibility(final int code) {
-    this.code = code;
-  }
-
-  /**
-   * @return <code>TOO_OLD</code> if the initial compatibility was <code>TOO_NEW</code>, <code>
-   *     TOO_NEW</code> if the initial compatibility was <code>TOO_OLD</code>, <code>OK</code>
-   *     otherwise
-   */
-  public abstract Compatibility invert();
-
-  public int getCode() {
-    return code;
-  }
-
-  public static Compatibility fromCode(int code) {
-    for (Compatibility compatibility : Compatibility.values()) {
-      if (compatibility.getCode() == code) return compatibility;
-    }
-
-    return UNKNOWN;
-  }
+  QUALIFIER_MISMATCH
 }

--- a/core/src/saros/versioning/Compatibility.java
+++ b/core/src/saros/versioning/Compatibility.java
@@ -41,6 +41,17 @@ public enum Compatibility {
     public Compatibility invert() {
       return UNKNOWN;
     }
+  },
+
+  /**
+   * At least one of the versions contains a qualifiers and the complete version string does not
+   * match.
+   */
+  QUALIFIER_MISMATCH(4) {
+    @Override
+    public Compatibility invert() {
+      return QUALIFIER_MISMATCH;
+    }
   };
 
   private final int code;

--- a/core/src/saros/versioning/Compatibility.java
+++ b/core/src/saros/versioning/Compatibility.java
@@ -1,7 +1,5 @@
 package saros.versioning;
 
-import java.util.Comparator;
-
 /** Enumeration to describe whether a local version is compatible with a remote one. */
 public enum Compatibility {
 
@@ -77,21 +75,5 @@ public enum Compatibility {
     }
 
     return UNKNOWN;
-  }
-
-  /**
-   * Given a result from {@link Comparator#compare(Object, Object)} will return the associated
-   * Compatibility object
-   */
-  public static Compatibility valueOf(int comparison) {
-    switch (Integer.signum(comparison)) {
-      case -1:
-        return OLDER;
-      case 0:
-        return OK;
-      case 1:
-      default:
-        return NEWER;
-    }
   }
 }

--- a/core/src/saros/versioning/VersionCompatibilityResult.java
+++ b/core/src/saros/versioning/VersionCompatibilityResult.java
@@ -17,7 +17,7 @@ public class VersionCompatibilityResult {
   /**
    * Returns the {@link Compatibility compatibility} of the negotiation result.
    *
-   * @return
+   * @return the {@link Compatibility compatibility} of the negotiation result
    */
   public Compatibility getCompatibility() {
     return compatibility;
@@ -26,7 +26,7 @@ public class VersionCompatibilityResult {
   /**
    * Returns the local version that was used for during the negotiation.
    *
-   * @return
+   * @return the local version that was used for during the negotiation
    */
   public Version getLocalVersion() {
     return localVersion;
@@ -35,7 +35,7 @@ public class VersionCompatibilityResult {
   /**
    * Returns the remote version that was used for during the negotiation.
    *
-   * @return
+   * @return the remote version that was used for during the negotiation
    */
   public Version getRemoteVersion() {
     return remoteVersion;

--- a/core/src/saros/versioning/VersionManager.java
+++ b/core/src/saros/versioning/VersionManager.java
@@ -55,17 +55,7 @@ public class VersionManager {
       log.warn("contact: " + contact + ", remote version string is invalid: " + versionString);
     }
 
-    Compatibility compatibility = determineCompatibility(localVersion, remoteVersion);
+    Compatibility compatibility = localVersion.determineCompatibilityWith(remoteVersion);
     return new VersionCompatibilityResult(compatibility, localVersion, remoteVersion);
-  }
-
-  /**
-   * Compares the two given versions for compatibility. The result indicates whether the local
-   * version is compatible with the remote version.
-   */
-  private Compatibility determineCompatibility(Version localVersion, Version remoteVersion) {
-    Compatibility compatibility = Compatibility.valueOf(localVersion.compareTo(remoteVersion));
-
-    return compatibility;
   }
 }

--- a/core/src/saros/versioning/VersionManager.java
+++ b/core/src/saros/versioning/VersionManager.java
@@ -10,7 +10,7 @@ import saros.net.xmpp.contact.XMPPContact;
 /**
  * Component for figuring out whether two Saros plug-in instances with known Version are compatible.
  *
- * <p>This class compares if local and remote version (not checking qualifier) are the same.
+ * @see Version#determineCompatibilityWith(Version)
  */
 @Component(module = "core")
 public class VersionManager {
@@ -28,8 +28,10 @@ public class VersionManager {
 
   public VersionManager(@SarosVersion String version, InfoManager infoManager) {
     this.localVersion = Version.parseVersion(version);
-    if (this.localVersion == Version.INVALID)
+
+    if (this.localVersion == Version.INVALID) {
       throw new IllegalArgumentException("version string is malformed: " + version);
+    }
 
     this.infoManager = infoManager;
     infoManager.setLocalInfo(VERSION_KEY, localVersion.toString());
@@ -45,12 +47,14 @@ public class VersionManager {
     Objects.requireNonNull(contact, "contact is needed");
 
     String versionString = infoManager.getRemoteInfo(contact, VERSION_KEY).orElse(null);
+
     if (versionString == null) {
       log.warn("remote version not found for: " + contact);
       return new VersionCompatibilityResult(Compatibility.UNKNOWN, localVersion, Version.INVALID);
     }
 
     Version remoteVersion = Version.parseVersion(versionString);
+
     if (remoteVersion == Version.INVALID) {
       log.warn("contact: " + contact + ", remote version string is invalid: " + versionString);
     }

--- a/core/test/junit/saros/versioning/VersionManagerTest.java
+++ b/core/test/junit/saros/versioning/VersionManagerTest.java
@@ -58,6 +58,98 @@ public class VersionManagerTest {
   @Test
   public void testVersionsSame() {
 
+    Version local = Version.parseVersion("1.1.1");
+    Version remote = Version.parseVersion("1.1.1");
+
+    init(local, remote);
+
+    VersionCompatibilityResult result =
+        versionManagerLocal.determineVersionCompatibility(bobContact);
+
+    assertEquals(Compatibility.OK, result.getCompatibility());
+  }
+
+  @Test
+  public void testLocalMajorVersionOlder() {
+    Version local = Version.parseVersion("1.1.1");
+    Version remote = Version.parseVersion("2.1.1");
+
+    init(local, remote);
+
+    VersionCompatibilityResult result =
+        versionManagerLocal.determineVersionCompatibility(bobContact);
+
+    assertEquals(Compatibility.OLDER, result.getCompatibility());
+  }
+
+  @Test
+  public void testLocalMinorVersionOlder() {
+    Version local = Version.parseVersion("1.1.1");
+    Version remote = Version.parseVersion("1.2.1");
+
+    init(local, remote);
+
+    VersionCompatibilityResult result =
+        versionManagerLocal.determineVersionCompatibility(bobContact);
+
+    assertEquals(Compatibility.OLDER, result.getCompatibility());
+  }
+
+  @Test
+  public void testLocalMajorVersionNewer() {
+    Version local = Version.parseVersion("2.1.1");
+    Version remote = Version.parseVersion("1.1.1");
+
+    init(local, remote);
+
+    VersionCompatibilityResult result =
+        versionManagerLocal.determineVersionCompatibility(bobContact);
+
+    assertEquals(Compatibility.NEWER, result.getCompatibility());
+  }
+
+  @Test
+  public void testLocalMinorVersionNewer() {
+    Version local = Version.parseVersion("1.2.1");
+    Version remote = Version.parseVersion("1.1.1");
+
+    init(local, remote);
+
+    VersionCompatibilityResult result =
+        versionManagerLocal.determineVersionCompatibility(bobContact);
+
+    assertEquals(Compatibility.NEWER, result.getCompatibility());
+  }
+
+  @Test
+  public void testLocalMicroVersionNewer() {
+    Version local = Version.parseVersion("1.1.2");
+    Version remote = Version.parseVersion("1.1.1");
+
+    init(local, remote);
+
+    VersionCompatibilityResult result =
+        versionManagerLocal.determineVersionCompatibility(bobContact);
+
+    assertEquals(Compatibility.OK, result.getCompatibility());
+  }
+
+  @Test
+  public void testLocalMicroVersionOlder() {
+    Version local = Version.parseVersion("1.1.1");
+    Version remote = Version.parseVersion("1.1.2");
+
+    init(local, remote);
+
+    VersionCompatibilityResult result =
+        versionManagerLocal.determineVersionCompatibility(bobContact);
+
+    assertEquals(Compatibility.OK, result.getCompatibility());
+  }
+
+  @Test
+  public void testVersionsSameIncludingQualifier() {
+
     Version local = Version.parseVersion("1.1.1.r1");
     Version remote = Version.parseVersion("1.1.1.r1");
 
@@ -79,45 +171,19 @@ public class VersionManagerTest {
     VersionCompatibilityResult result =
         versionManagerLocal.determineVersionCompatibility(bobContact);
 
-    assertEquals(Compatibility.OK, result.getCompatibility());
+    assertEquals(Compatibility.QUALIFIER_MISMATCH, result.getCompatibility());
   }
 
   @Test
-  public void testlocalVersionOlder() {
+  public void testVersionsDifferentMicroWithSameQualifier() {
     Version local = Version.parseVersion("1.1.1.r1");
-    Version remote = Version.parseVersion("1.2.1.r1");
+    Version remote = Version.parseVersion("1.1.2.r1");
 
     init(local, remote);
 
     VersionCompatibilityResult result =
         versionManagerLocal.determineVersionCompatibility(bobContact);
 
-    assertEquals(Compatibility.OLDER, result.getCompatibility());
-  }
-
-  @Test
-  public void testlocalVersionNewer() {
-    Version local = Version.parseVersion("1.2.1.r1");
-    Version remote = Version.parseVersion("1.1.1.r1");
-
-    init(local, remote);
-
-    VersionCompatibilityResult result =
-        versionManagerLocal.determineVersionCompatibility(bobContact);
-
-    assertEquals(Compatibility.NEWER, result.getCompatibility());
-  }
-
-  @Test
-  public void testlocalVersionNewerMicro() {
-    Version local = Version.parseVersion("1.1.2.r1");
-    Version remote = Version.parseVersion("1.1.1.r1");
-
-    init(local, remote);
-
-    VersionCompatibilityResult result =
-        versionManagerLocal.determineVersionCompatibility(bobContact);
-
-    assertEquals(Compatibility.OK, result.getCompatibility());
+    assertEquals(Compatibility.QUALIFIER_MISMATCH, result.getCompatibility());
   }
 }

--- a/docs/_data/documentation/sidebar.yml
+++ b/docs/_data/documentation/sidebar.yml
@@ -31,5 +31,8 @@
 - title: Features
   url: /documentation/features.html
 
+- title: Compatibility
+  url: /documentation/compatibility.html
+
 - title: FAQ
   url: /documentation/faq.html

--- a/docs/documentation/compatibility.md
+++ b/docs/documentation/compatibility.md
@@ -1,0 +1,23 @@
+---
+title: Saros Version Compatibility
+---
+
+Before inviting another user to join the session, Saros checks whether the plugin version of the invited user is compatible with the local version (i.e. the version of the session host).
+If the remote version is detected as incompatible with the local version, the invitation process is aborted.
+
+The Saros plugin version is specified using the format `MAJOR.MINOR.MICRO`.
+**For two Saros versions to be compatible, they have to have the same `MAJOR` and `MINOR` version number.**
+The `MICRO` version number is ignored for compatibility checks.
+
+
+## Development Builds
+
+For [development builds](../releases/#development-builds) of Saros, the version string is extended to include a qualifier: `MAJOR.MINOR.MICRO.QUALIFIER`.
+This qualifier contains a shortened version of the hash for the commit the build was created on.
+
+**When using such development builds (or any Saros version containing a `QUALIFIER` element), the complete version strings have to match (including `MICRO` and `QUALIFIER`) to be seen as compatible.**
+
+
+## IDE Cross-Compatibility
+
+Currently, the Saros versions for Eclipse (Saros/E) and IntelliJ IDEA (Saros/I) are not compatible with each other.

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -22,6 +22,20 @@ Find latest release in [GitHub](https://github.com/saros-project/saros/releases)
 
 You can install the plugin through the JetBrains plugin repository. This requires the `alpha` release channel. More information can be found [here](../documentation/installation.html?tab=intellij#from-the-plugin-repository).
 
-## IntelliJ (and [IntelliJ platform based IDEs](https://www.jetbrains.org/intellij/sdk/docs/intro/intellij_platform.html#ides-based-on-the-intellij-platform)) Zip
+## IntelliJ (and [IntelliJ-platform-based IDEs](https://www.jetbrains.org/intellij/sdk/docs/intro/intellij_platform.html#ides-based-on-the-intellij-platform)) Zip
 
 Find latest release in [GitHub](https://github.com/saros-project/saros/releases)
+
+
+## Development Builds
+
+For every push to the `master` branch, a development build is created and released as part of a [GitHub action](https://github.com/saros-project/saros/actions?query=workflow%3ABuild+branch%3Amaster+is%3Asuccess+event%3Apush).
+These development builds are kept for 90 days after the action was run.
+
+{% alert warning %}
+
+### Note
+
+There is no guarantee that such development builds are stable or function correctly.
+
+{% endalert %}


### PR DESCRIPTION
Adjusts the Saros version compatibility logic. Adds a separate check ensuring that the entire version string matches (including micro and qualifier) when a qualifier is given as part of the version. This ensures that users can't start a session between different development builds. Subsequently cleans up the version compatibility logic.

Adds a specific page describing the Saros version compatibility to the homepage. Also adds a section mentioning the development builds to the releases page.


### Commits

<details><summary><b>[INTERNAL][CORE] Add compatibility result for differing dev builds</b></summary>
<br>

Adds a compatibility result indicating that at least one of the compared
versions contained a qualifier and the version strings did not match
exactly. As the qualifier is the indicator that a development build is
used, this result can be used to ensures that only matching development
builds are compatible.

</details>

<details><summary><b>[INTERNAL][CORE] Include qualifier in compatibility check</b></summary>
<br>

Adds a separate case to the compatibility check, ensuring that the
entire version string matches in case one of the compared versions
contains a qualifier. This check ensures that clients running a
development build can only start a session with clients running the same
development build. This should avoid issues where users download
different, potentially incompatible development builds and start a
session with them.

Simplifies the logic comparing two versions.

Adjusts Version.equals(...) to include the micro version and qualifier
in the check.

Extends VersionManagerTest to cover all possible comparison cases.

</details>

<details><summary><b>[NOP][CORE] Remove unused capabilities of Compatibility enum</b></summary>
<br>

Removes the additional capabilities of the Compatibility enum (like
specifying the integer represented by an entry and inverting an entry).
They were no longer being used.

</details>

<b>[REFACTOR][CORE] Clean up version compatibility logic</b>

<details><summary><b>[DOC] Add page for Saros version compatibility</b></summary>
<br>

Adds a dedicated page to the user documentation explaining the Saros
version compatibility. Also explains the special case when using a Saros
version containing the 'qualifier' element (e.g. development builds).

Adds the new compatibility page to the user documentation sidebar. As
this is kind of fringe knowledge, I added as the second-to-last entry
(only followed by the FAQ). Adding this information to the FAQ instead
of a separate section seemed too inaccessible/hard to find to me.

Adds a section on development builds to the release page. Explicitly
mentions that such builds may be unstable.

</details>