### PR TITLE
[FEATURE] #563 Add implementation identifier to compatibility check

### DIFF
--- a/core/src/saros/context/IContextKeyBindings.java
+++ b/core/src/saros/context/IContextKeyBindings.java
@@ -32,6 +32,7 @@ public interface IContextKeyBindings {
     // marker interface
   }
 
+  /** The version number of the local Saros instance. */
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ElementType.FIELD, ElementType.PARAMETER})
   @Bind
@@ -39,6 +40,15 @@ public interface IContextKeyBindings {
     // marker interface
   }
 
+  /** The qualifier used to identify the IDE-specific Saros implementation. */
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.FIELD, ElementType.PARAMETER})
+  @Bind
+  public @interface SarosImplementation {
+    // marker interface
+  }
+
+  /** The version number of the IDE Saros is running in. */
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ElementType.FIELD, ElementType.PARAMETER})
   @Bind

--- a/core/src/saros/versioning/Compatibility.java
+++ b/core/src/saros/versioning/Compatibility.java
@@ -26,6 +26,9 @@ public enum Compatibility {
    */
   QUALIFIER_MISMATCH,
 
+  /** The two versions specified different, incompatible Saros implementations. */
+  INCOMPATIBLE_IMPLEMENTATIONS,
+
   /** The compatibility could not be determined. */
   UNKNOWN
 }

--- a/core/src/saros/versioning/VersionManager.java
+++ b/core/src/saros/versioning/VersionManager.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import org.apache.log4j.Logger;
 import saros.annotations.Component;
 import saros.communication.InfoManager;
+import saros.context.IContextKeyBindings.SarosImplementation;
 import saros.context.IContextKeyBindings.SarosVersion;
 import saros.net.xmpp.contact.XMPPContact;
 
@@ -26,8 +27,12 @@ public class VersionManager {
   private final Version localVersion;
   private final InfoManager infoManager;
 
-  public VersionManager(@SarosVersion String version, InfoManager infoManager) {
-    this.localVersion = Version.parseVersion(version);
+  public VersionManager(
+      @SarosImplementation String implementation,
+      @SarosVersion String version,
+      InfoManager infoManager) {
+
+    this.localVersion = Version.parseVersion(implementation, version);
 
     if (this.localVersion == Version.INVALID) {
       throw new IllegalArgumentException("version string is malformed: " + version);

--- a/core/test/junit/saros/SarosCoreContextFactoryTest.java
+++ b/core/test/junit/saros/SarosCoreContextFactoryTest.java
@@ -39,6 +39,8 @@ public class SarosCoreContextFactoryTest {
 
     // nice mocks aren't clever enough here
     container.addComponent(
+        BindKey.bindKey(String.class, IContextKeyBindings.SarosImplementation.class), "DUMMY");
+    container.addComponent(
         BindKey.bindKey(String.class, IContextKeyBindings.SarosVersion.class), "1.0.0.dummy");
 
     // nice mocks aren't clever enough here

--- a/eclipse/src/saros/context/SarosEclipseContextFactory.java
+++ b/eclipse/src/saros/context/SarosEclipseContextFactory.java
@@ -33,6 +33,8 @@ import saros.ui.util.XMPPConnectionSupport;
 /** Factory used for creating the Saros context when running as Eclipse plugin. */
 public class SarosEclipseContextFactory extends AbstractContextFactory {
 
+  private static final String IMPLEMENTATION_IDENTIFIER = "E";
+
   private final Saros saros;
 
   /**
@@ -91,6 +93,10 @@ public class SarosEclipseContextFactory extends AbstractContextFactory {
     container.addComponent(
         BindKey.bindKey(String.class, IContextKeyBindings.SarosVersion.class),
         saros.getBundle().getVersion().toString());
+
+    container.addComponent(
+        BindKey.bindKey(String.class, IContextKeyBindings.SarosImplementation.class),
+        IMPLEMENTATION_IDENTIFIER);
 
     container.addComponent(
         BindKey.bindKey(String.class, IContextKeyBindings.PlatformVersion.class),

--- a/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
+++ b/intellij/src/saros/intellij/context/SarosIntellijContextFactory.java
@@ -26,6 +26,8 @@ import saros.synchronize.UISynchronizer;
 /** Intellij related context */
 public class SarosIntellijContextFactory extends AbstractContextFactory {
 
+  private static final String IMPLEMENTATION_IDENTIFIER = "I";
+
   /**
    * Must not be static in order to avoid heavy work during class initialization
    *
@@ -68,6 +70,10 @@ public class SarosIntellijContextFactory extends AbstractContextFactory {
     container.addComponent(
         BindKey.bindKey(String.class, IContextKeyBindings.SarosVersion.class),
         IntellijVersionProvider.getPluginVersion());
+
+    container.addComponent(
+        BindKey.bindKey(String.class, IContextKeyBindings.SarosImplementation.class),
+        IMPLEMENTATION_IDENTIFIER);
 
     container.addComponent(
         BindKey.bindKey(String.class, IContextKeyBindings.PlatformVersion.class),

--- a/server/src/saros/server/ServerContextFactory.java
+++ b/server/src/saros/server/ServerContextFactory.java
@@ -39,6 +39,8 @@ public class ServerContextFactory extends AbstractContextFactory {
 
   private static final Logger log = Logger.getLogger(ServerContextFactory.class);
 
+  private static final String IMPLEMENTATION_IDENTIFIER = "S";
+
   @Override
   public void createComponents(MutablePicoContainer c) {
     addVersionString(c);
@@ -50,6 +52,10 @@ public class ServerContextFactory extends AbstractContextFactory {
     c.addComponent(
         BindKey.bindKey(String.class, IContextKeyBindings.SarosVersion.class),
         SarosServer.SAROS_VERSION);
+
+    c.addComponent(
+        BindKey.bindKey(String.class, IContextKeyBindings.SarosImplementation.class),
+        IMPLEMENTATION_IDENTIFIER);
   }
 
   private void addCoreInterfaceImplementations(MutablePicoContainer c) {


### PR DESCRIPTION
Adds the implementation identifier as a field to the Saros version
transferred and checked before the session negotiation. This identifier
can be used to check whether the IDE the Saros instance is running on
matches to prohibit cross-IDE sessions, even if the version number
matches.

This logic will have to be adjusted once IDE cross-compatibility has
been added. At that point, it would probably be best to create a static
list of known compatible Saros implementations.

Adds the new Saros plugin context value 'SarosImplementation'. It is
expected to be injected by IDE-specific implementations, providing the
corresponding implementation identifier. Subsequently adjusted the
Eclipse and IntelliJ IDEA implementation as well as the Saros Server to
inject such an identifier.

Adjusted the version compatibility test to include cases for differing
implementation identifiers. Also adjusted the existing tests to use the
new version format.

Resolves #563.
