### PR TITLE
Fix version numbers

### DIFF
--- a/eclipse/META-INF/MANIFEST.MF
+++ b/eclipse/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Saros Plug-in
 Bundle-SymbolicName: saros.eclipse;singleton:=true
-Bundle-Version: 16.0.0
+Bundle-Version: 16.0.1
 Bundle-Activator: saros.Saros
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui,

--- a/eclipse/feature/feature.xml
+++ b/eclipse/feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="saros.feature"
       label="Saros"
-      version="16.0.0">
+      version="16.0.1">
 
    <description>
       Distributed Party Programming for Eclipse.
@@ -370,7 +370,7 @@ Public License instead of this License.
          id="saros.eclipse"
          download-size="0"
          install-size="0"
-         version="16.0.0"
+         version="16.0.1"
          unpack="false"/>
 
    <plugin

--- a/eclipse/update/site.xml
+++ b/eclipse/update/site.xml
@@ -5,7 +5,7 @@
    </description>
    <!-- The "url" attribute is used to fulfill the requirements of the Eclipse PDE tooling,
         but is unused (and therefore empty).-->
-   <feature url="" id="saros.feature" version="16.0.0">
+   <feature url="" id="saros.feature" version="16.0.1">
       <category name="DPP"/>
    </feature>
    <category-def name="DPP" label="DPP"/>

--- a/server/src/saros/server/SarosServer.java
+++ b/server/src/saros/server/SarosServer.java
@@ -13,7 +13,7 @@ public class SarosServer {
   /** The Saros version which is impersonated by the current server version. */
   // FIXME create a version handling that allows a separate server versioning
   // the current handling is tied to the current Saros/E versioning
-  public static final String SAROS_VERSION = "15.0.0";
+  public static final String SAROS_VERSION = "16.0.1";
 
   /** Initializes and starts a Saros server. */
   public SarosServer() {


### PR DESCRIPTION
#### [BUILD][E] Increase Saros/E version to 16.0.1 to match current release

Increases the Saros/E version to 16.0.1 to match the current release.
This change was probably never merged back into the master when the
release was created.

#### [BUILD][SERVER] Adjust version number of Saros Server

Adjusts the version number of the Saros Server to match the current
Saros/E release number.

This should have been done when the release was published but was
forgotten.