### PR TITLE
Workaround for compiling Saros/E with Java 8

### DIFF
--- a/eclipse/build.gradle.kts
+++ b/eclipse/build.gradle.kts
@@ -42,6 +42,9 @@ dependencies {
     implementation(project(":saros.core"))
     // This is a workaround for https://github.com/saros-project/saros/issues/1086
     implementation("org.eclipse.platform:org.eclipse.urischeme:1.1.0")
+    // This is a workaround for https://github.com/saros-project/saros/issues/1114
+    implementation("org.eclipse.platform:org.eclipse.ui.ide:3.17.200")
+    implementation("org.eclipse.platform:org.eclipse.ui.workbench:3.120.0")
     testImplementation(project(path = ":saros.core", configuration = "testing"))
 }
 

--- a/stf/build.gradle.kts
+++ b/stf/build.gradle.kts
@@ -28,9 +28,11 @@ dependencies {
     }
     compile(project(":saros.core"))
     compile(project(":saros.eclipse"))
-      // This is a workaround for https://github.com/saros-project/saros/issues/1086
+    // This is a workaround for https://github.com/saros-project/saros/issues/1086
     implementation("org.eclipse.platform:org.eclipse.urischeme:1.1.0")
-
+    // This is a workaround for https://github.com/saros-project/saros/issues/1114
+    implementation("org.eclipse.platform:org.eclipse.ui.ide:3.17.200")
+    implementation("org.eclipse.platform:org.eclipse.ui.workbench:3.120.0")
     compile(project(path = ":saros.eclipse", configuration = "testing"))
 
     releaseDep(fileTree("libs"))


### PR DESCRIPTION
This is a temporary fix for #1114, which can be used to compile Saros/E with JDK version 8.

This is not a proposed solution and the workaround will need to be updated for every `org.eclipse.platform`, that we use and gets an update at this point. Actually discussion about long-term fixes should be done in #1114.