### PR TITLE
[UI][E] Menu Migration from Eclipse3 to Eclipse4

### DIFF
--- a/eclipse/META-INF/MANIFEST.MF
+++ b/eclipse/META-INF/MANIFEST.MF
@@ -20,7 +20,18 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.equinox.security,
  org.junit;resolution:=optional,
  org.eclipse.jdt.launching;resolution:=optional,
- saros.core
+ org.eclipse.e4.ui.model.workbench,
+ org.eclipse.e4.ui.di,
+ org.eclipse.osgi,
+ org.eclipse.e4.ui.services,
+ org.eclipse.e4.core.di.annotations,
+ saros.core,
+ org.eclipse.osgi.services,
+ org.eclipse.e4.ui.workbench,
+ org.eclipse.equinox.ds,
+ org.eclipse.equinox.event,
+ org.eclipse.equinox.util,
+ org.eclipse.e4.ui.workbench.addons.swt
 Bundle-ActivationPolicy: lazy
 Export-Package: saros;
   uses:="org.eclipse.core.runtime,
@@ -129,4 +140,6 @@ Export-Package: saros;
  saros.util;uses:="org.eclipse.core.resources,org.jivesoftware.smack.packet"
 Bundle-Vendor: Saros Project
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Import-Package: org.eclipse.core.filesystem
+Import-Package: javax.annotation;version="1.2.0",
+ javax.inject,
+ org.eclipse.core.filesystem

--- a/eclipse/build.gradle.kts
+++ b/eclipse/build.gradle.kts
@@ -45,6 +45,9 @@ dependencies {
     // This is a workaround for https://github.com/saros-project/saros/issues/1114
     implementation("org.eclipse.platform:org.eclipse.ui.ide:3.17.200")
     implementation("org.eclipse.platform:org.eclipse.ui.workbench:3.120.0")
+	// This is a workaround for an Issues, same as https://github.com/saros-project/saros/issues/1114
+	implementation("org.eclipse.platform:org.eclipse.e4.ui.services:1.3.700")
+	implementation("javax.inject:javax.inject:1")
     testImplementation(project(path = ":saros.core", configuration = "testing"))
 }
 

--- a/eclipse/fragment.e4xmi
+++ b/eclipse/fragment.e4xmi
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="ASCII"?>
+<fragment:ModelFragments xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:application="http://www.eclipse.org/ui/2010/UIModel/application" xmlns:commands="http://www.eclipse.org/ui/2010/UIModel/application/commands" xmlns:fragment="http://www.eclipse.org/ui/2010/UIModel/fragment" xmlns:menu="http://www.eclipse.org/ui/2010/UIModel/application/ui/menu" xmlns:ui="http://www.eclipse.org/ui/2010/UIModel/application/ui" xmi:id="_9R0kQDYLEeuIF8EFjFT7JQ">
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_AA2WUDYMEeuIF8EFjFT7JQ" featurename="commands" parentElementId="xpath:/">
+    <elements xsi:type="commands:Command" xmi:id="_FiO7QDYMEeuIF8EFjFT7JQ" elementId="saros.ui.commands.Empty" commandName="EMPTY COMMAND"/>
+    <elements xsi:type="commands:Command" xmi:id="_Ye-coDYNEeuIF8EFjFT7JQ" elementId="saros.ui.commands.GettingStarted" commandName="Getting Started..."/>
+    <elements xsi:type="commands:Command" xmi:id="_hvu2UDYNEeuIF8EFjFT7JQ" elementId="saros.ui.commands.StartSarosConfiguration" commandName="Start Saros Configuration..."/>
+    <elements xsi:type="commands:Command" xmi:id="_VbGKADYPEeuIF8EFjFT7JQ" elementId="saros.ui.commands.CreateXMPPAccount" commandName="Create Account..."/>
+    <elements xsi:type="commands:Command" xmi:id="_Y_2DIDYPEeuIF8EFjFT7JQ" elementId="saros.ui.commands.AddContact" commandName="Add Contact..."/>
+    <elements xsi:type="commands:Command" xmi:id="_h9fTkDYPEeuIF8EFjFT7JQ" elementId="saros.ui.commands.OpenSarosPreferences" commandName="Preferences..."/>
+    <elements xsi:type="commands:Command" xmi:id="_ji39ADYPEeuIF8EFjFT7JQ" elementId="saros.ui.commands.AddXMPPAccount" commandName="Add Account..."/>
+    <elements xsi:type="commands:Command" xmi:id="_pZa5oDYPEeuIF8EFjFT7JQ" elementId="saros.ui.commands.ShareResource" commandName="Share Resource(s)..."/>
+    <elements xsi:type="commands:Command" xmi:id="_rsWlkDYPEeuIF8EFjFT7JQ" elementId="saros.ui.commands.SessionLeave" commandName="Leave Session..."/>
+    <elements xsi:type="commands:Command" xmi:id="_wvkAwDYPEeuIF8EFjFT7JQ" elementId="saros.ui.commands.SessionAddResources" commandName="Add Resource(s)..."/>
+    <elements xsi:type="commands:Command" xmi:id="_0XH9UDYPEeuIF8EFjFT7JQ" elementId="saros.ui.commands.SessionAddContacts" commandName="Add Contacts..."/>
+    <elements xsi:type="commands:Command" xmi:id="_6kVtgDYPEeuIF8EFjFT7JQ" elementId="saros.ui.commands.SessionAddSelectedResources" commandName="Add to Saros Session"/>
+    <elements xsi:type="commands:Command" xmi:id="_8TldkDYPEeuIF8EFjFT7JQ" elementId="saros.ui.commands.SessionAddSelectedContacts" commandName="Add to Saros Session"/>
+  </fragments>
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_B_wWMDYQEeuIF8EFjFT7JQ" featurename="handlers" parentElementId="xpath:/">
+    <elements xsi:type="commands:Handler" xmi:id="_Fft18DYQEeuIF8EFjFT7JQ" elementId="saros.eclipse.handler.0" contributionURI="bundleclass://saros.eclipse/saros.ui.command_handlers.GettingStartedHandler" command="_Ye-coDYNEeuIF8EFjFT7JQ"/>
+    <elements xsi:type="commands:Handler" xmi:id="_ymPZEDYQEeuIF8EFjFT7JQ" elementId="saros.eclipse.handler.1" contributionURI="bundleclass://saros.eclipse/saros.ui.command_handlers.StartSarosConfigurationHandler" command="_hvu2UDYNEeuIF8EFjFT7JQ"/>
+    <elements xsi:type="commands:Handler" xmi:id="_AIKtADYREeuIF8EFjFT7JQ" elementId="saros.eclipse.handler.2" contributionURI="bundleclass://saros.eclipse/saros.ui.command_handlers.CreateXMPPAccountHandler" command="_VbGKADYPEeuIF8EFjFT7JQ"/>
+    <elements xsi:type="commands:Handler" xmi:id="_J9snsDYREeuIF8EFjFT7JQ" elementId="saros.eclipse.handler.3" contributionURI="bundleclass://saros.eclipse/saros.ui.command_handlers.AddXMPPAccountHandler" command="_ji39ADYPEeuIF8EFjFT7JQ"/>
+    <elements xsi:type="commands:Handler" xmi:id="_YHVb4DYREeuIF8EFjFT7JQ" elementId="saros.eclipse.handler.4" contributionURI="bundleclass://saros.eclipse/saros.ui.command_handlers.AddContactHandler" command="_Y_2DIDYPEeuIF8EFjFT7JQ"/>
+    <elements xsi:type="commands:Handler" xmi:id="_k056sDYREeuIF8EFjFT7JQ" elementId="saros.eclipse.handler.5" contributionURI="bundleclass://saros.eclipse/saros.ui.command_handlers.OpenSarosPreferencesHandler" command="_h9fTkDYPEeuIF8EFjFT7JQ"/>
+    <elements xsi:type="commands:Handler" xmi:id="_qIwZ8DYREeuIF8EFjFT7JQ" elementId="saros.eclipse.handler.6" contributionURI="bundleclass://saros.eclipse/saros.ui.command_handlers.ShareResourcesHandler" command="_pZa5oDYPEeuIF8EFjFT7JQ"/>
+    <elements xsi:type="commands:Handler" xmi:id="_6dvEUDYREeuIF8EFjFT7JQ" elementId="saros.eclipse.handler.7" contributionURI="bundleclass://saros.eclipse/saros.ui.command_handlers.SessionLeaveHandler" command="_rsWlkDYPEeuIF8EFjFT7JQ"/>
+    <elements xsi:type="commands:Handler" xmi:id="_FYilADYSEeuIF8EFjFT7JQ" elementId="saros.eclipse.handler.8" contributionURI="bundleclass://saros.eclipse/saros.ui.command_handlers.SessionAddResourcesHandler" command="_wvkAwDYPEeuIF8EFjFT7JQ"/>
+    <elements xsi:type="commands:Handler" xmi:id="_NFBIgDYSEeuIF8EFjFT7JQ" elementId="saros.eclipse.handler.9" contributionURI="bundleclass://saros.eclipse/saros.ui.command_handlers.SessionAddContactsHandler" command="_0XH9UDYPEeuIF8EFjFT7JQ"/>
+    <elements xsi:type="commands:Handler" xmi:id="_TUQR8DYSEeuIF8EFjFT7JQ" elementId="saros.eclipse.handler.10" contributionURI="bundleclass://saros.eclipse/saros.ui.command_handlers.SessionAddSelectedResourcesHandler" command="_6kVtgDYPEeuIF8EFjFT7JQ"/>
+    <elements xsi:type="commands:Handler" xmi:id="_gPUaMDYSEeuIF8EFjFT7JQ" elementId="saros.eclipse.handler.11" contributionURI="bundleclass://saros.eclipse/saros.ui.command_handlers.SessionAddSelectedContactsHandler" command="_8TldkDYPEeuIF8EFjFT7JQ"/>
+  </fragments>
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_w8wA0DYSEeuIF8EFjFT7JQ" featurename="menuContributions" parentElementId="xpath:/">
+    <elements xsi:type="menu:MenuContribution" xmi:id="_D-FjwDYTEeuIF8EFjFT7JQ" elementId="saros.eclipse.menucontribution.0" positionInParent="after=additions" parentId="org.eclipse.ui.main.menu">
+      <children xsi:type="menu:Menu" xmi:id="_Q9ag8DYTEeuIF8EFjFT7JQ" elementId="saros.ui.main.menu.e4" label="Saros">
+        <children xsi:type="menu:MenuSeparator" xmi:id="_bEDZwDYTEeuIF8EFjFT7JQ" elementId="saros.eclipse.menuseparator.DeveloperStart" accessibilityPhrase="DeveloperStart"/>
+        <children xsi:type="menu:MenuSeparator" xmi:id="_g7egIDYTEeuIF8EFjFT7JQ" elementId="saros.eclipse.menuseparator.DeveloperEnd" accessibilityPhrase="DeveloperEnd"/>
+        <children xsi:type="menu:HandledMenuItem" xmi:id="_nW5rcDYTEeuIF8EFjFT7JQ" elementId="saros.eclipse.handledmenuitem.0" iconURI="platform:/plugin/saros.eclipse/icons/view16/saros_misc.png" command="_Ye-coDYNEeuIF8EFjFT7JQ"/>
+        <children xsi:type="menu:HandledMenuItem" xmi:id="_wzI8YDYTEeuIF8EFjFT7JQ" elementId="saros.eclipse.handledmenuitem.1" iconURI="platform:/plugin/saros.eclipse/icons/view16/saros_misc.png" command="_hvu2UDYNEeuIF8EFjFT7JQ"/>
+        <children xsi:type="menu:MenuSeparator" xmi:id="_6GglMDYTEeuIF8EFjFT7JQ" elementId="saros.eclipse.menuseparator.RosterStart" accessibilityPhrase="RosterStart"/>
+        <children xsi:type="menu:HandledMenuItem" xmi:id="__T3a4DYTEeuIF8EFjFT7JQ" elementId="saros.eclipse.handledmenuitem.2" iconURI="platform:/plugin/saros.eclipse/icons/dlcl16/xmpp_create_account_tsk.png" command="_VbGKADYPEeuIF8EFjFT7JQ">
+          <visibleWhen xsi:type="ui:CoreExpression" xmi:id="_R2iE0DYUEeuIF8EFjFT7JQ" coreExpressionId="saros.ui.definitions.isCreateXMPPAccountEnabled"/>
+        </children>
+        <children xsi:type="menu:HandledMenuItem" xmi:id="_0jwR0DYUEeuIF8EFjFT7JQ" elementId="saros.eclipse.handledmenuitem.3" iconURI="platform:/plugin/saros.eclipse/icons/elcl16/xmpp_create_account_tsk.png" command="_ji39ADYPEeuIF8EFjFT7JQ"/>
+        <children xsi:type="menu:HandledMenuItem" xmi:id="_DNLZUDYVEeuIF8EFjFT7JQ" elementId="saros.eclipse.handledmenuitem.4" iconURI="platform:/plugin/saros.eclipse/icons/elcl16/session_add_contacts_tsk.png" command="_Y_2DIDYPEeuIF8EFjFT7JQ"/>
+        <children xsi:type="menu:MenuSeparator" xmi:id="_RkmK0DYVEeuIF8EFjFT7JQ" elementId="saros.eclipse.menuseparator.RosterEnd" accessibilityPhrase="RosterEnd"/>
+        <children xsi:type="menu:MenuSeparator" xmi:id="_2St4kDYVEeuIF8EFjFT7JQ" elementId="saros.eclipse.menuseparator.CollaborationStart" accessibilityPhrase="CollaborationStart"/>
+        <children xsi:type="menu:HandledMenuItem" xmi:id="_6984oDYVEeuIF8EFjFT7JQ" elementId="saros.eclipse.handledmenuitem.5" iconURI="platform:/plugin/saros.eclipse/icons/elcl16/session_tsk.png" command="_pZa5oDYPEeuIF8EFjFT7JQ">
+          <visibleWhen xsi:type="ui:CoreExpression" xmi:id="_N9R-gDYYEeuIF8EFjFT7JQ" coreExpressionId="saros.ui.definitions.notIsSarosSessionRunning"/>
+        </children>
+        <children xsi:type="menu:HandledMenuItem" xmi:id="_GqGWsDYWEeuIF8EFjFT7JQ" elementId="saros.eclipse.handledmenuitem.6" iconURI="platform:/plugin/saros.eclipse/icons/elcl16/session_add_reference_points_tsk.png" command="_wvkAwDYPEeuIF8EFjFT7JQ">
+          <visibleWhen xsi:type="ui:CoreExpression" xmi:id="_AHvngDYXEeuIF8EFjFT7JQ" coreExpressionId="saros.ui.definitions.isConnectedAndSarosSessionRunning"/>
+        </children>
+        <children xsi:type="menu:HandledMenuItem" xmi:id="_VjNOEDYYEeuIF8EFjFT7JQ" elementId="saros.eclipse.handledmenuitem.7" iconURI="platform:/plugin/saros.eclipse/icons/elcl16/session_add_contacts_tsk.png" command="_0XH9UDYPEeuIF8EFjFT7JQ">
+          <visibleWhen xsi:type="ui:CoreExpression" xmi:id="_GKb30DYZEeuIF8EFjFT7JQ" coreExpressionId="saros.ui.definitions.isConnectedAndSarosSessionRunningAndSarosSessionHost"/>
+        </children>
+        <children xsi:type="menu:HandledMenuItem" xmi:id="_NrpKADYaEeuIF8EFjFT7JQ" elementId="saros.eclipse.handledmenuitem.leavesession" label="Leave Session..." iconURI="platform:/plugin/saros.eclipse/icons/elcl16/session_leave_tsk.png" command="_rsWlkDYPEeuIF8EFjFT7JQ">
+          <visibleWhen xsi:type="ui:CoreExpression" xmi:id="_PlJCQDYaEeuIF8EFjFT7JQ" coreExpressionId="saros.ui.definitions.isConnectedAndSarosSessionRunningAndNotSarosSessionHost"/>
+        </children>
+        <children xsi:type="menu:HandledMenuItem" xmi:id="_dQsMQDYaEeuIF8EFjFT7JQ" elementId="saros.eclipse.handledmenuitem.stopsession" label="Stop Session..." iconURI="platform:/plugin/saros.eclipse/icons/elcl16/session_terminate_tsk.png" command="_rsWlkDYPEeuIF8EFjFT7JQ">
+          <visibleWhen xsi:type="ui:CoreExpression" xmi:id="_i3eOkDYaEeuIF8EFjFT7JQ" coreExpressionId="saros.ui.definitions.isConnectedAndSarosSessionRunningAndSarosSessionHost"/>
+        </children>
+        <children xsi:type="menu:MenuSeparator" xmi:id="_VZsCgD1nEeuEmIEsBAz29g" elementId="saros.eclipse.menuseparator.CollaborationEnd" accessibilityPhrase="CollaborationEnd"/>
+        <children xsi:type="menu:MenuSeparator" xmi:id="_Vi-hYD1nEeuEmIEsBAz29g" elementId="saros.eclipse.menuseparator.OtherStart" accessibilityPhrase="OtherStart"/>
+        <children xsi:type="menu:MenuSeparator" xmi:id="_Voc3QD1nEeuEmIEsBAz29g" elementId="saros.eclipse.menuseparator.OtherEnd" accessibilityPhrase="OtherEnd"/>
+        <children xsi:type="menu:MenuSeparator" xmi:id="_Vs2PED1nEeuEmIEsBAz29g" elementId="saros.eclipse.menuseparator.additions" visible="false" accessibilityPhrase="additions"/>
+        <children xsi:type="menu:HandledMenuItem" xmi:id="_migkoD1nEeuEmIEsBAz29g" elementId="saros.eclipse.handledmenuitem.8" iconURI="platform:/plugin/saros.eclipse/icons/elcl16/preferences_open_tsk.png" command="_h9fTkDYPEeuIF8EFjFT7JQ"/>
+      </children>
+    </elements>
+  </fragments>
+  <fragments xsi:type="fragment:StringModelFragment" xmi:id="_Gf3wkFNKEeu08YCit0yDew" featurename="addons" parentElementId="xpath:/">
+    <elements xsi:type="application:Addon" xmi:id="_HnzB8FNKEeu08YCit0yDew" elementId="saros.eclipse.addon.lifecycle" contributionURI="bundleclass://saros.eclipse/saros.Saros"/>
+  </fragments>
+</fragment:ModelFragments>

--- a/eclipse/plugin.xml
+++ b/eclipse/plugin.xml
@@ -2,6 +2,12 @@
 <?eclipse version="4.6"?>
 
 <plugin>
+	<extension point="org.eclipse.e4.workbench.model" id="test_id_e4">
+		<fragment
+            apply="initial"
+            uri="fragment.e4xmi">
+      </fragment>
+	</extension>
     <extension
          point="org.eclipse.ui.views">
       <category
@@ -476,394 +482,7 @@
       </startup>
    </extension>
    <extension
-         point="org.eclipse.ui.commands">
-      <command
-            id="saros.ui.commands.Empty"
-            name="EMPTY COMMAND">
-      </command>
-      <command
-            categoryId="org.eclipse.ui.category.project"
-            id="saros.ui.commands.GettingStarted"
-            name="Getting Started...">
-      </command>
-      <command
-            categoryId="org.eclipse.ui.category.project"
-            id="saros.ui.commands.StartSarosConfiguration"
-            name="Start Saros Configuration...">
-      </command>
-      <command
-            categoryId="org.eclipse.ui.category.project"
-            id="saros.ui.commands.CreateXMPPAccount"
-            name="Create Account...">
-      </command>
-      <command
-            categoryId="org.eclipse.ui.category.project"
-            id="saros.ui.commands.AddContact"
-            name="Add Contact...">
-      </command>
-      <command
-            categoryId="org.eclipse.ui.category.project"
-            id="saros.ui.commands.OpenSarosPreferences"
-            name="Preferences...">
-      </command>
-            <command
-            categoryId="org.eclipse.ui.category.project"
-            id="saros.ui.commands.AddXMPPAccount"
-            name="Add Account...">
-      </command>
-      <command
-            categoryId="org.eclipse.ui.category.project"
-            id="saros.ui.commands.ShareResource"
-            name="Share Resource(s)...">
-      </command>
-      <command
-            categoryId="org.eclipse.ui.category.project"
-            id="saros.ui.commands.SessionLeave"
-            name="Leave Session...">
-      </command>
-      <command
-            categoryId="org.eclipse.ui.category.project"
-            id="saros.ui.commands.SessionAddResources"
-            name="Add Resource(s)...">
-      </command>
-      <command
-            categoryId="org.eclipse.ui.category.project"
-            id="saros.ui.commands.SessionAddContacts"
-            name="Add Contacts...">
-      </command>
-      <command
-            categoryId="org.eclipse.ui.category.project"
-            id="saros.ui.commands.SessionAddSelectedResources"
-            name="Add to Saros Session">
-      </command>
-      <command
-            categoryId="org.eclipse.ui.category.project"
-            id="saros.ui.commands.SessionAddSelectedContacts"
-            name="Add to Saros Session">
-      </command>
-   </extension>
-   <extension
-         point="org.eclipse.ui.handlers">
-      <handler
-            class="saros.ui.command_handlers.GettingStartedHandler"
-            commandId="saros.ui.commands.GettingStarted">
-      </handler>
-      <handler
-            class="saros.ui.command_handlers.StartSarosConfigurationHandler"
-            commandId="saros.ui.commands.StartSarosConfiguration">
-      </handler>
-      <handler
-            class="saros.ui.command_handlers.CreateXMPPAccountHandler"
-            commandId="saros.ui.commands.CreateXMPPAccount">
-      </handler>
-      <handler
-            class="saros.ui.command_handlers.AddXMPPAccountHandler"
-            commandId="saros.ui.commands.AddXMPPAccount">
-      </handler>
-      <handler
-            class="saros.ui.command_handlers.AddContactHandler"
-            commandId="saros.ui.commands.AddContact">
-         <enabledWhen>
-             <reference definitionId="saros.ui.definitions.isConnected" />
-         </enabledWhen>
-      </handler>
-      <handler
-            class="saros.ui.command_handlers.OpenSarosPreferencesHandler"
-            commandId="saros.ui.commands.OpenSarosPreferences">
-      </handler>
-      <handler
-      class="saros.ui.command_handlers.ShareResourcesHandler"
-            commandId="saros.ui.commands.ShareResource">
-         <enabledWhen>
-            <and>
-               <reference
-                     definitionId="saros.ui.definitions.isConnected">
-               </reference>
-               <not>
-                  <reference
-                        definitionId="saros.ui.definitions.isSarosSessionRunning">
-                  </reference>
-               </not>
-            </and>
-         </enabledWhen>
-      </handler>
-      <handler
-            class="saros.ui.command_handlers.SessionLeaveHandler"
-            commandId="saros.ui.commands.SessionLeave">
-         <activeWhen>
-            <and>
-               <reference
-                     definitionId="saros.ui.definitions.isConnected">
-               </reference>
-               <reference
-                     definitionId="saros.ui.definitions.isSarosSessionRunning">
-               </reference>
-            </and>
-         </activeWhen>
-      </handler>
-      <handler
-            class="saros.ui.command_handlers.SessionAddResourcesHandler"
-            commandId="saros.ui.commands.SessionAddResources">
-         <activeWhen>
-            <and>
-               <reference
-                     definitionId="saros.ui.definitions.isConnected">
-               </reference>
-               <reference
-                     definitionId="saros.ui.definitions.isSarosSessionRunning">
-               </reference>
-            </and>
-         </activeWhen>
-         <enabledWhen>
-            <reference
-                  definitionId="saros.ui.definitions.hasWriteAccess">
-            </reference>
-         </enabledWhen>
-      </handler>
-      <handler
-            class="saros.ui.command_handlers.SessionAddContactsHandler"
-            commandId="saros.ui.commands.SessionAddContacts">
-         <activeWhen>
-            <and>
-               <reference
-                     definitionId="saros.ui.definitions.isConnected">
-               </reference>
-               <reference
-                     definitionId="saros.ui.definitions.isSarosSessionRunning">
-               </reference>
-            </and>
-         </activeWhen>
-      </handler>
-      <handler
-            class="saros.ui.command_handlers.SessionAddSelectedResourcesHandler"
-            commandId="saros.ui.commands.SessionAddSelectedResources">
-         <activeWhen>
-            <and>
-               <reference
-                     definitionId="saros.ui.definitions.isConnected">
-               </reference>
-               <reference
-                     definitionId="saros.ui.definitions.isSarosSessionRunning">
-               </reference>
-               <reference
-                     definitionId="saros.ui.definitions.resourcesSelected">
-               </reference>
-               <not>
-                  <reference
-                        definitionId="saros.ui.definitions.resourcesSelectedInSarosSession">
-                  </reference>
-               </not>
-            </and>
-         </activeWhen>
-         <enabledWhen>
-            <reference
-                  definitionId="saros.ui.definitions.hasWriteAccess">
-            </reference>
-         </enabledWhen>
-      </handler>
-      <handler
-            class="saros.ui.command_handlers.SessionAddSelectedContactsHandler"
-            commandId="saros.ui.commands.SessionAddSelectedContacts">
-         <activeWhen>
-            <and>
-               <reference
-                     definitionId="saros.ui.definitions.isConnected">
-               </reference>
-               <reference
-                     definitionId="saros.ui.definitions.isSarosSessionRunning">
-               </reference>
-               <reference
-                     definitionId="saros.ui.definitions.contactsSelected">
-               </reference>
-               <not>
-                  <reference
-                        definitionId="saros.ui.definitions.contactsSelectedInSarosSession">
-                  </reference>
-               </not>
-            </and>
-         </activeWhen>
-      </handler>
-   </extension>
-   <extension
          point="org.eclipse.ui.menus">
-      <menuContribution
-            allPopups="false"
-            locationURI="menu:org.eclipse.ui.main.menu?after=additions">
-         <menu
-               id="saros.ui.main.menu"
-               label="Saros">
-            <visibleWhen
-                  checkEnabled="false">
-            </visibleWhen>
-            <separator
-                  name="DeveloperStart"
-                  visible="true">
-            </separator>
-            <separator
-                  name="DeveloperEnd"
-                  visible="true">
-            </separator>
-            <command
-                  commandId="saros.ui.commands.GettingStarted"
-                  icon="icons/view16/saros_misc.png"
-                  style="push">
-            </command>
-            <command
-                  commandId="saros.ui.commands.StartSarosConfiguration"
-                  icon="icons/view16/saros_misc.png"
-                  style="push">
-            </command>
-            <separator
-                  name="RosterStart"
-                  visible="true">
-            </separator>
-            <command
-                  commandId="saros.ui.commands.CreateXMPPAccount"
-                  icon="icons/elcl16/xmpp_create_account_tsk.png"
-                  style="push">
-               <visibleWhen
-                     checkEnabled="false">
-                  <reference
-                        definitionId="saros.ui.definitions.isCreateXMPPAccountEnabled">
-                  </reference>
-               </visibleWhen>
-            </command>
-            <command
-                  commandId="saros.ui.commands.AddXMPPAccount"
-                  icon="icons/elcl16/xmpp_create_account_tsk.png"
-                  style="push">
-            </command>
-            <command
-                  commandId="saros.ui.commands.AddContact"
-                  disabledIcon="icons/dlcl16/contact_add_tsk.png"
-                  icon="icons/elcl16/contact_add_tsk.png"
-                  style="push">
-            </command>
-            <separator
-                  name="RosterEnd"
-                  visible="true">
-            </separator>
-            <separator
-                  name="CollaborationStart"
-                  visible="true">
-            </separator>
-            <command
-                  commandId="saros.ui.commands.ShareResource"
-                  disabledIcon="icons/dlcl16/spacer.png"
-                  icon="icons/elcl16/session_tsk.png"
-                  style="push">
-               <visibleWhen
-                     checkEnabled="false">
-                      <not>
-                        <reference
-                              definitionId="saros.ui.definitions.isSarosSessionRunning">
-                        </reference>
-                     </not>
-               </visibleWhen>
-            </command>
-           <command
-                  commandId="saros.ui.commands.SessionAddResources"
-                  disabledIcon="icons/dlcl16/session_add_reference_points_tsk.png"
-                  icon="icons/elcl16/session_add_reference_points_tsk.png"
-                  style="push">
-               <visibleWhen
-                     checkEnabled="false">
-                  <and>
-                     <reference
-                           definitionId="saros.ui.definitions.isConnected">
-                     </reference>
-                     <reference
-                           definitionId="saros.ui.definitions.isSarosSessionRunning">
-                     </reference>
-                  </and>
-               </visibleWhen>
-            </command>
-            <command
-                  commandId="saros.ui.commands.SessionAddContacts"
-                  disabledIcon="icons/dlcl16/session_add_contacts_tsk.png"
-                  icon="icons/elcl16/session_add_contacts_tsk.png"
-                  style="push">
-               <visibleWhen
-                     checkEnabled="false">
-                  <and>
-                     <reference
-                           definitionId="saros.ui.definitions.isConnected">
-                     </reference>
-                     <reference
-                           definitionId="saros.ui.definitions.isSarosSessionRunning">
-                     </reference>
-                     <reference
-                           definitionId="saros.ui.definitions.isSarosSessionHost">
-                     </reference>
-                  </and>
-               </visibleWhen>
-            </command>
-            <command
-                  commandId="saros.ui.commands.SessionLeave"
-                  disabledIcon="icons/dlcl16/session_leave_tsk.png"
-                  icon="icons/elcl16/session_leave_tsk.png"
-                  label="Leave Session..."
-                  style="push">
-               <visibleWhen
-                     checkEnabled="false">
-                  <and>
-                     <reference
-                           definitionId="saros.ui.definitions.isConnected">
-                     </reference>
-                     <reference
-                           definitionId="saros.ui.definitions.isSarosSessionRunning">
-                     </reference>
-                     <not>
-                        <reference
-                              definitionId="saros.ui.definitions.isSarosSessionHost">
-                        </reference>
-                     </not>
-                  </and>
-               </visibleWhen>
-            </command>
-            <command
-                  commandId="saros.ui.commands.SessionLeave"
-                  disabledIcon="icons/dlcl16/session_terminate_tsk.png"
-                  icon="icons/elcl16/session_terminate_tsk.png"
-                  label="Stop Session..."
-                  style="push">
-               <visibleWhen
-                     checkEnabled="false">
-                  <and>
-                     <reference
-                           definitionId="saros.ui.definitions.isConnected">
-                     </reference>
-                     <reference
-                           definitionId="saros.ui.definitions.isSarosSessionRunning">
-                     </reference>
-                     <reference
-                           definitionId="saros.ui.definitions.isSarosSessionHost">
-                     </reference>
-                  </and>
-               </visibleWhen>
-            </command>
-            <separator
-                  name="CollaborationEnd"
-                  visible="true">
-            </separator>
-            <separator
-                  name="OtherStart"
-                  visible="true">
-            </separator>
-            <separator
-                  name="OtherEnd"
-                  visible="true">
-            </separator>
-            <separator
-                  name="additions">
-            </separator>
-            <command
-                  commandId="saros.ui.commands.OpenSarosPreferences"
-                  icon="icons/elcl16/preferences_open_tsk.png"
-                  style="push">
-            </command>
-         </menu>
-      </menuContribution>
       <menuContribution
             allPopups="false"
             locationURI="popup:saros.ui.views.SarosView?before=menustart">
@@ -1088,6 +707,20 @@
             </instanceof>
          </with>
       </definition>
+      <definition id="saros.ui.definitions.notIsSarosSessionRunning">
+      	<not>
+      		<reference definitionId="saros.ui.definitions.isSarosSessionRunning">
+        	</reference>
+      	</not>
+      </definition>
+      <definition id="saros.ui.definitions.isConnectedAndSarosSessionRunning">
+      	<and>
+      		<reference definitionId="saros.ui.definitions.isConnected">
+        	</reference>
+        	<reference definitionId="saros.ui.definitions.isSarosSessionRunning">
+        	</reference>
+      	</and>
+      </definition>      
       <definition
             id="saros.ui.definitions.isSarosSessionHost">
          <with
@@ -1096,6 +729,28 @@
                   property="saros.isHost">
             </test>
          </with>
+      </definition>
+      <definition id="saros.ui.definitions.isConnectedAndSarosSessionRunningAndSarosSessionHost">
+      	<and>
+      		<reference definitionId="saros.ui.definitions.isConnected">
+        	</reference>
+        	<reference definitionId="saros.ui.definitions.isSarosSessionRunning">
+        	</reference>
+        	<reference definitionId="saros.ui.definitions.isSarosSessionHost">
+        	</reference>
+      	</and>
+      </definition>
+      <definition id="saros.ui.definitions.isConnectedAndSarosSessionRunningAndNotSarosSessionHost">
+      	<and>
+      		<reference definitionId="saros.ui.definitions.isConnected">
+        	</reference>
+        	<reference definitionId="saros.ui.definitions.isSarosSessionRunning">
+        	</reference>
+        	<not>
+	        	<reference definitionId="saros.ui.definitions.isSarosSessionHost">
+	        	</reference>
+	        </not>
+      	</and>
       </definition>
       <definition
             id="saros.ui.definitions.isInSarosSession">

--- a/eclipse/src/saros/Saros.java
+++ b/eclipse/src/saros/Saros.java
@@ -3,6 +3,7 @@ package saros;
 import java.io.File;
 import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.inject.Inject;
 import org.apache.log4j.Logger;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
@@ -11,12 +12,16 @@ import org.apache.logging.log4j.core.lookup.MainMapLookup;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.ConfigurationScope;
+import org.eclipse.e4.core.di.annotations.Optional;
+import org.eclipse.e4.ui.di.UIEventTopic;
+import org.eclipse.e4.ui.workbench.UIEvents;
 import org.eclipse.swt.SWTException;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchListener;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
+import org.osgi.service.event.Event;
 import org.osgi.service.prefs.BackingStoreException;
 import org.osgi.service.prefs.Preferences;
 import saros.annotations.Component;
@@ -130,8 +135,15 @@ public class Saros extends AbstractUIPlugin {
 
     isLifecycleStarted = true;
 
-    getWorkbench().addWorkbenchListener(workbenchShutdownListener);
     isInitialized = true;
+  }
+
+  @Inject
+  @Optional
+  public void applicationStarted(
+      @UIEventTopic(UIEvents.UILifeCycle.APP_STARTUP_COMPLETE) Event event, Saros saros) {
+
+    saros.getWorkbench().addWorkbenchListener(saros.workbenchShutdownListener);
   }
 
   @Override

--- a/eclipse/src/saros/ui/command_handlers/AddContactHandler.java
+++ b/eclipse/src/saros/ui/command_handlers/AddContactHandler.java
@@ -1,15 +1,27 @@
 package saros.ui.command_handlers;
 
-import org.eclipse.core.commands.AbstractHandler;
-import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.e4.core.di.annotations.CanExecute;
+import org.eclipse.e4.core.di.annotations.Execute;
+import saros.SarosPluginContext;
+import saros.communication.connection.ConnectionHandler;
+import saros.repackaged.picocontainer.annotations.Inject;
 import saros.ui.util.WizardUtils;
 
-public class AddContactHandler extends AbstractHandler {
+public class AddContactHandler {
+  @Inject private ConnectionHandler connectionHandler;
 
-  @Override
-  public Object execute(ExecutionEvent event) throws ExecutionException {
+  public AddContactHandler() {
+    SarosPluginContext.initComponent(this);
+  }
+
+  @Execute
+  public Object execute() {
     WizardUtils.openAddContactWizard();
     return null;
+  }
+
+  @CanExecute
+  public boolean canExecute() {
+    return connectionHandler != null && connectionHandler.isConnected();
   }
 }

--- a/eclipse/src/saros/ui/command_handlers/AddXMPPAccountHandler.java
+++ b/eclipse/src/saros/ui/command_handlers/AddXMPPAccountHandler.java
@@ -1,14 +1,12 @@
 package saros.ui.command_handlers;
 
-import org.eclipse.core.commands.AbstractHandler;
-import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.e4.core.di.annotations.Execute;
 import saros.ui.util.WizardUtils;
 
-public class AddXMPPAccountHandler extends AbstractHandler {
+public class AddXMPPAccountHandler {
 
-  @Override
-  public Object execute(ExecutionEvent event) throws ExecutionException {
+  @Execute
+  public Object execute() {
     WizardUtils.openAddXMPPAccountWizard();
     return null;
   }

--- a/eclipse/src/saros/ui/command_handlers/CreateXMPPAccountHandler.java
+++ b/eclipse/src/saros/ui/command_handlers/CreateXMPPAccountHandler.java
@@ -1,14 +1,12 @@
 package saros.ui.command_handlers;
 
-import org.eclipse.core.commands.AbstractHandler;
-import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.e4.core.di.annotations.Execute;
 import saros.ui.util.WizardUtils;
 
-public class CreateXMPPAccountHandler extends AbstractHandler {
+public class CreateXMPPAccountHandler {
 
-  @Override
-  public Object execute(ExecutionEvent event) throws ExecutionException {
+  @Execute
+  public Object execute() {
 
     WizardUtils.openCreateXMPPAccountWizard(true);
 

--- a/eclipse/src/saros/ui/command_handlers/GettingStartedHandler.java
+++ b/eclipse/src/saros/ui/command_handlers/GettingStartedHandler.java
@@ -1,18 +1,14 @@
 package saros.ui.command_handlers;
 
-import org.eclipse.core.commands.AbstractHandler;
-import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.e4.core.di.annotations.Execute;
 import saros.ui.util.SWTUtils;
 
-public class GettingStartedHandler extends AbstractHandler {
+public class GettingStartedHandler {
 
-  @Override
-  public Object execute(ExecutionEvent event) throws ExecutionException {
+  @Execute
+  public void execute() {
 
     SWTUtils.openInternalBrowser(
         "https://www.saros-project.org/documentation/getting-started.html", "Welcome to Saros");
-
-    return null;
   }
 }

--- a/eclipse/src/saros/ui/command_handlers/OpenSarosPreferencesHandler.java
+++ b/eclipse/src/saros/ui/command_handlers/OpenSarosPreferencesHandler.java
@@ -1,19 +1,16 @@
 package saros.ui.command_handlers;
 
-import org.eclipse.core.commands.AbstractHandler;
-import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.jface.preference.PreferenceDialog;
 import org.eclipse.ui.dialogs.PreferencesUtil;
 
-public class OpenSarosPreferencesHandler extends AbstractHandler {
+public class OpenSarosPreferencesHandler {
 
-  @Override
-  public Object execute(ExecutionEvent event) throws ExecutionException {
+  @Execute
+  public Object execute() {
     PreferenceDialog pref =
         PreferencesUtil.createPreferenceDialogOn(null, "saros.preferences", null, null);
     if (pref != null) pref.open();
-
     return null;
   }
 }

--- a/eclipse/src/saros/ui/command_handlers/SessionAddContactsHandler.java
+++ b/eclipse/src/saros/ui/command_handlers/SessionAddContactsHandler.java
@@ -1,10 +1,13 @@
 package saros.ui.command_handlers;
 
-import org.eclipse.core.commands.AbstractHandler;
-import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.e4.core.di.annotations.CanExecute;
+import org.eclipse.e4.core.di.annotations.Execute;
+import saros.SarosPluginContext;
+import saros.communication.connection.ConnectionHandler;
 import saros.net.xmpp.JID;
+import saros.repackaged.picocontainer.annotations.Inject;
 import saros.session.ISarosSession;
+import saros.session.ISarosSessionManager;
 import saros.ui.util.WizardUtils;
 import saros.ui.wizards.AddResourcesToSessionWizard;
 
@@ -12,11 +15,25 @@ import saros.ui.wizards.AddResourcesToSessionWizard;
  * Handles the addition of {@link JID}s that must explicitly be selected in the opening {@link
  * AddResourcesToSessionWizard} to the running {@link ISarosSession}.
  */
-public class SessionAddContactsHandler extends AbstractHandler {
+public class SessionAddContactsHandler {
+  @Inject private ConnectionHandler connectionHandler;
+  @Inject private ISarosSessionManager sessionManager;
 
-  @Override
-  public Object execute(ExecutionEvent event) throws ExecutionException {
+  public SessionAddContactsHandler() {
+    SarosPluginContext.initComponent(this);
+  }
+
+  @Execute
+  public Object execute() {
     WizardUtils.openAddContactsToSessionWizard();
     return null;
+  }
+
+  @CanExecute
+  public boolean canExecute() {
+    return connectionHandler != null
+        && connectionHandler.isConnected()
+        && sessionManager != null
+        && sessionManager.getSession() != null;
   }
 }

--- a/eclipse/src/saros/ui/command_handlers/SessionAddResourcesHandler.java
+++ b/eclipse/src/saros/ui/command_handlers/SessionAddResourcesHandler.java
@@ -1,10 +1,13 @@
 package saros.ui.command_handlers;
 
-import org.eclipse.core.commands.AbstractHandler;
-import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.e4.core.di.annotations.CanExecute;
+import org.eclipse.e4.core.di.annotations.Execute;
+import saros.SarosPluginContext;
+import saros.communication.connection.ConnectionHandler;
+import saros.repackaged.picocontainer.annotations.Inject;
 import saros.session.ISarosSession;
+import saros.session.ISarosSessionManager;
 import saros.ui.util.WizardUtils;
 import saros.ui.wizards.AddResourcesToSessionWizard;
 
@@ -15,11 +18,26 @@ import saros.ui.wizards.AddResourcesToSessionWizard;
  * <p>This class is used to define the behavior of the saros menu entry to add reference points to a
  * running session.
  */
-public class SessionAddResourcesHandler extends AbstractHandler {
+public class SessionAddResourcesHandler {
+  @Inject private ConnectionHandler connectionHandler;
+  @Inject private ISarosSessionManager sessionManager;
 
-  @Override
-  public Object execute(ExecutionEvent event) throws ExecutionException {
+  public SessionAddResourcesHandler() {
+    SarosPluginContext.initComponent(this);
+  }
+
+  @Execute
+  public Object execute() {
     WizardUtils.openAddResourcesToSessionWizard(null);
     return null;
+  }
+
+  @CanExecute
+  public boolean canExecute() {
+    return connectionHandler != null
+        && connectionHandler.isConnected()
+        && sessionManager != null
+        && sessionManager.getSession() != null
+        && sessionManager.getSession().hasWriteAccess();
   }
 }

--- a/eclipse/src/saros/ui/command_handlers/SessionAddSelectedContactsHandler.java
+++ b/eclipse/src/saros/ui/command_handlers/SessionAddSelectedContactsHandler.java
@@ -1,23 +1,49 @@
 package saros.ui.command_handlers;
 
 import java.util.List;
-import org.eclipse.core.commands.AbstractHandler;
-import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
+import javax.inject.Named;
+import org.eclipse.e4.core.di.annotations.CanExecute;
+import org.eclipse.e4.core.di.annotations.Execute;
+import org.eclipse.e4.core.di.annotations.Optional;
+import org.eclipse.e4.ui.services.IServiceConstants;
+import saros.SarosPluginContext;
+import saros.communication.connection.ConnectionHandler;
 import saros.net.xmpp.JID;
+import saros.net.xmpp.contact.XMPPContactsService;
+import saros.repackaged.picocontainer.annotations.Inject;
 import saros.session.ISarosSession;
+import saros.session.ISarosSessionManager;
 import saros.ui.util.CollaborationUtils;
 import saros.ui.util.selection.retriever.SelectionRetrieverFactory;
 
 /** Handles the addition of selected {@link JID}s to the running {@link ISarosSession}. */
-public class SessionAddSelectedContactsHandler extends AbstractHandler {
+public class SessionAddSelectedContactsHandler {
 
-  @Override
-  public Object execute(ExecutionEvent event) throws ExecutionException {
+  @Inject private ConnectionHandler connectionHandler;
+  @Inject private ISarosSessionManager sessionManager;
+  @Inject private XMPPContactsService contactsService;
+
+  public SessionAddSelectedContactsHandler() {
+    SarosPluginContext.initComponent(this);
+  }
+
+  @Execute
+  public Object execute() {
 
     List<JID> jids = SelectionRetrieverFactory.getSelectionRetriever(JID.class).getSelection();
 
     CollaborationUtils.addContactsToSession(jids);
     return null;
+  }
+
+  @CanExecute
+  public boolean canExecute(@Named(IServiceConstants.ACTIVE_SELECTION) @Optional JID contact) {
+    final JID jid = contact;
+    return (connectionHandler != null
+        && connectionHandler.isConnected()
+        && sessionManager != null
+        && sessionManager.getSession() != null
+        && sessionManager.getSession().hasWriteAccess()
+        && !sessionManager.getSession().getUsers().stream().anyMatch(u -> u.getJID().equals(jid)));
   }
 }

--- a/eclipse/src/saros/ui/command_handlers/SessionAddSelectedResourcesHandler.java
+++ b/eclipse/src/saros/ui/command_handlers/SessionAddSelectedResourcesHandler.java
@@ -2,11 +2,21 @@ package saros.ui.command_handlers;
 
 import java.util.HashSet;
 import java.util.List;
-import org.eclipse.core.commands.AbstractHandler;
-import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
+import java.util.Set;
+import javax.inject.Named;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.e4.core.di.annotations.CanExecute;
+import org.eclipse.e4.core.di.annotations.Execute;
+import org.eclipse.e4.core.di.annotations.Optional;
+import org.eclipse.e4.ui.services.IServiceConstants;
+import saros.SarosPluginContext;
+import saros.communication.connection.ConnectionHandler;
+import saros.filesystem.IReferencePoint;
+import saros.filesystem.ResourceConverter;
+import saros.repackaged.picocontainer.annotations.Inject;
 import saros.session.ISarosSession;
+import saros.session.ISarosSessionManager;
+import saros.ui.expressions.ResourcePropertyTester;
 import saros.ui.util.WizardUtils;
 import saros.ui.util.selection.retriever.SelectionRetrieverFactory;
 
@@ -19,10 +29,17 @@ import saros.ui.util.selection.retriever.SelectionRetrieverFactory;
  * <p>This class is used to define the behavior of the package explorer context menu entry to add
  * reference points to a running session.
  */
-public class SessionAddSelectedResourcesHandler extends AbstractHandler {
+public class SessionAddSelectedResourcesHandler {
+  @Inject private ConnectionHandler connectionHandler;
+  @Inject private ISarosSessionManager sessionManager;
+  @Inject private ResourcePropertyTester resourcePropertyTester;
 
-  @Override
-  public Object execute(ExecutionEvent event) throws ExecutionException {
+  public SessionAddSelectedResourcesHandler() {
+    SarosPluginContext.initComponent(this);
+  }
+
+  @Execute
+  public Object execute() {
 
     List<IResource> selectedResources =
         SelectionRetrieverFactory.getSelectionRetriever(IResource.class).getSelection();
@@ -30,5 +47,22 @@ public class SessionAddSelectedResourcesHandler extends AbstractHandler {
     WizardUtils.openAddResourcesToSessionWizard(new HashSet<>(selectedResources));
 
     return null;
+  }
+
+  @CanExecute
+  public boolean canExecute(
+      @Named(IServiceConstants.ACTIVE_SELECTION) @Optional IResource resource) {
+    if (!(connectionHandler != null
+        && connectionHandler.isConnected()
+        && sessionManager != null
+        && sessionManager.getSession() != null
+        && sessionManager.getSession().hasWriteAccess())) {
+      return false;
+    }
+    final ISarosSession session = sessionManager.getSession();
+    Set<IReferencePoint> sharedReferencePoints = session.getReferencePoints();
+    saros.filesystem.IResource wrappedResource =
+        ResourceConverter.convertToResource(sharedReferencePoints, resource);
+    return !session.isShared(wrappedResource);
   }
 }

--- a/eclipse/src/saros/ui/command_handlers/SessionLeaveHandler.java
+++ b/eclipse/src/saros/ui/command_handlers/SessionLeaveHandler.java
@@ -1,15 +1,32 @@
 package saros.ui.command_handlers;
 
-import org.eclipse.core.commands.AbstractHandler;
-import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.e4.core.di.annotations.CanExecute;
+import org.eclipse.e4.core.di.annotations.Execute;
+import saros.SarosPluginContext;
+import saros.communication.connection.ConnectionHandler;
+import saros.repackaged.picocontainer.annotations.Inject;
+import saros.session.ISarosSessionManager;
 import saros.ui.util.CollaborationUtils;
 
-public class SessionLeaveHandler extends AbstractHandler {
+public class SessionLeaveHandler {
+  @Inject private ConnectionHandler connectionHandler;
+  @Inject private ISarosSessionManager sessionManager;
 
-  @Override
-  public Object execute(ExecutionEvent event) throws ExecutionException {
+  public SessionLeaveHandler() {
+    SarosPluginContext.initComponent(this);
+  }
+
+  @Execute
+  public Object execute() {
     CollaborationUtils.leaveSession();
     return null;
+  }
+
+  @CanExecute
+  public boolean canExecute() {
+    return connectionHandler != null
+        && connectionHandler.isConnected()
+        && sessionManager != null
+        && sessionManager.getSession() != null;
   }
 }

--- a/eclipse/src/saros/ui/command_handlers/ShareResourcesHandler.java
+++ b/eclipse/src/saros/ui/command_handlers/ShareResourcesHandler.java
@@ -1,9 +1,12 @@
 package saros.ui.command_handlers;
 
-import org.eclipse.core.commands.AbstractHandler;
-import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.e4.core.di.annotations.CanExecute;
+import org.eclipse.e4.core.di.annotations.Execute;
+import saros.SarosPluginContext;
+import saros.communication.connection.ConnectionHandler;
+import saros.repackaged.picocontainer.annotations.Inject;
+import saros.session.ISarosSessionManager;
 import saros.ui.menu_contributions.StartSessionWithProjects;
 import saros.ui.util.WizardUtils;
 import saros.ui.util.selection.retriever.SelectionRetrieverFactory;
@@ -35,12 +38,27 @@ import saros.ui.util.selection.retriever.SelectionRetrieverFactory;
  *
  * <p>Notice that this is done via the {@link saros.ui.wizards.StartSessionWizard}.
  */
-public class ShareResourcesHandler extends AbstractHandler {
+public class ShareResourcesHandler {
 
-  @Override
-  public Object execute(ExecutionEvent event) throws ExecutionException {
+  @Inject private ConnectionHandler connectionHandler;
+  @Inject private ISarosSessionManager sessionManager;
+
+  public ShareResourcesHandler() {
+    SarosPluginContext.initComponent(this);
+  }
+
+  @Execute
+  public Object execute() {
     WizardUtils.openStartSessionWizard(
         SelectionRetrieverFactory.getSelectionRetriever(IResource.class).getSelection());
     return null;
+  }
+
+  @CanExecute
+  public boolean canExecute() {
+    return connectionHandler != null
+        && connectionHandler.isConnected()
+        && sessionManager != null
+        && sessionManager.getSession() == null;
   }
 }

--- a/eclipse/src/saros/ui/command_handlers/StartSarosConfigurationHandler.java
+++ b/eclipse/src/saros/ui/command_handlers/StartSarosConfigurationHandler.java
@@ -1,14 +1,12 @@
 package saros.ui.command_handlers;
 
-import org.eclipse.core.commands.AbstractHandler;
-import org.eclipse.core.commands.ExecutionEvent;
-import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.e4.core.di.annotations.Execute;
 import saros.ui.util.WizardUtils;
 
-public class StartSarosConfigurationHandler extends AbstractHandler {
+public class StartSarosConfigurationHandler {
 
-  @Override
-  public Object execute(ExecutionEvent event) throws ExecutionException {
+  @Execute
+  public Object execute() {
     WizardUtils.openSarosConfigurationWizard();
     return null;
   }

--- a/eclipse/src/saros/ui/util/SWTUtils.java
+++ b/eclipse/src/saros/ui/util/SWTUtils.java
@@ -187,7 +187,12 @@ public class SWTUtils {
    * @return the display of the current workbench
    */
   public static Display getDisplay() {
-    return PlatformUI.getWorkbench().getDisplay();
+    // return PlatformUI.getWorkbench().getDisplay();
+    Display display = Display.getCurrent();
+    if (display == null) {
+      display = Display.getDefault();
+    }
+    return display;
   }
 
   /**

--- a/stf/build.gradle.kts
+++ b/stf/build.gradle.kts
@@ -33,6 +33,9 @@ dependencies {
     // This is a workaround for https://github.com/saros-project/saros/issues/1114
     implementation("org.eclipse.platform:org.eclipse.ui.ide:3.17.200")
     implementation("org.eclipse.platform:org.eclipse.ui.workbench:3.120.0")
+	// This is a workaround for an Issues, same as https://github.com/saros-project/saros/issues/1114
+	implementation("org.eclipse.platform:org.eclipse.e4.ui.services:1.3.700")
+	implementation("javax.inject:javax.inject:1")
     compile(project(path = ":saros.eclipse", configuration = "testing"))
 
     releaseDep(fileTree("libs"))


### PR DESCRIPTION
Migration of the Main-Menu, as well as all Commands and Handlers to the E4 Platform.

Explanation:
Since 2012 Saros/E uses the compatibility layer provided by Eclipse for the UI to function.
To drop the need for the compatibility layer all UI Elements have to be migrated and all references to org.eclipse.ui have to be removed.
Also described [here](https://git.imp.fu-berlin.de/vbrekenfeld/swp-large-codebase/-/wikis/Themensammlung#e4-migration).
