### PR TITLE
[FIX][I] #962 Adjust Saros annotation highlighter layer

### DIFF
--- a/intellij/src/saros/intellij/editor/annotations/AbstractEditorAnnotation.java
+++ b/intellij/src/saros/intellij/editor/annotations/AbstractEditorAnnotation.java
@@ -2,7 +2,6 @@ package saros.intellij.editor.annotations;
 
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.editor.markup.HighlighterLayer;
 import com.intellij.openapi.editor.markup.HighlighterTargetArea;
 import com.intellij.openapi.editor.markup.RangeHighlighter;
 import com.intellij.openapi.editor.markup.TextAttributes;
@@ -28,6 +27,9 @@ import saros.session.User;
  * currently open, the annotations also holds the current {@link Editor} representing the file. The
  * held <code>IFile</code> is used to determine the file the annotation belongs to, even when there
  * is currently no editor available for the file.
+ *
+ * <p>The different annotation layers used by Saros are declared in {@link
+ * AnnotationHighlighterLayers}.
  *
  * @see AnnotationRange
  */
@@ -393,6 +395,8 @@ abstract class AbstractEditorAnnotation {
    * @param start the start of the highlighted area
    * @param end the end of the highlighted area
    * @param editor the editor to create the highlighter for
+   * @param textAttributes the text attributes defining the look of the range highlighter
+   * @param highlighterLayer the highlighter layer of the range highlighter
    * @param file the file for the editor
    * @return a RangeHighlighter with the given parameters or <code>null</code> if the given end
    *     position is located after the document end
@@ -403,6 +407,7 @@ abstract class AbstractEditorAnnotation {
       int end,
       @NotNull Editor editor,
       @NotNull TextAttributes textAttributes,
+      int highlighterLayer,
       @NotNull IFile file) {
 
     int documentLength = editor.getDocument().getTextLength();
@@ -434,7 +439,7 @@ abstract class AbstractEditorAnnotation {
                     .addRangeHighlighter(
                         start,
                         end,
-                        HighlighterLayer.LAST,
+                        highlighterLayer,
                         textAttributes,
                         HighlighterTargetArea.EXACT_RANGE),
         ModalityState.defaultModalityState());

--- a/intellij/src/saros/intellij/editor/annotations/AnnotationHighlighterLayers.java
+++ b/intellij/src/saros/intellij/editor/annotations/AnnotationHighlighterLayers.java
@@ -1,0 +1,45 @@
+package saros.intellij.editor.annotations;
+
+import com.intellij.openapi.editor.markup.HighlighterLayer;
+
+/**
+ * Constants defining the different highlighter layers used by Saros editor annotations.
+ *
+ * <p>Annotations on a layer with a higher number overshadow annotations on a layer with a lower
+ * number.
+ *
+ * @see HighlighterLayer
+ */
+class AnnotationHighlighterLayers {
+
+  private AnnotationHighlighterLayers() {}
+
+  /**
+   * Base highlighter layer used for Saros editor annotations. All Saros annotations must be
+   * displayed on or below this highlighter layer.
+   *
+   * @see HighlighterLayer
+   */
+  private static final int SAROS_BASE_HIGHLIGHTER_LAYER = HighlighterLayer.CARET_ROW - 1;
+
+  /**
+   * Highlighter layer for the caret annotations displayed as part of the selection annotations.
+   *
+   * @see SelectionAnnotation
+   */
+  static final int CARET_HIGHLIGHTER_LAYER = SAROS_BASE_HIGHLIGHTER_LAYER - 1;
+
+  /**
+   * Highlighter layer for the selection annotations.
+   *
+   * @see SelectionAnnotation
+   */
+  static final int SELECTION_HIGHLIGHTER_LAYER = SAROS_BASE_HIGHLIGHTER_LAYER - 2;
+
+  /**
+   * Highlighter layer for the contribution annotations.
+   *
+   * @see ContributionAnnotation
+   */
+  static final int CONTRIBUTION_HIGHLIGHTER_LAYER = SAROS_BASE_HIGHLIGHTER_LAYER - 3;
+}

--- a/intellij/src/saros/intellij/editor/annotations/ContributionAnnotation.java
+++ b/intellij/src/saros/intellij/editor/annotations/ContributionAnnotation.java
@@ -1,5 +1,7 @@
 package saros.intellij.editor.annotations;
 
+import static saros.intellij.editor.annotations.AnnotationHighlighterLayers.CONTRIBUTION_HIGHLIGHTER_LAYER;
+
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.colors.TextAttributesKey;
 import com.intellij.openapi.editor.markup.RangeHighlighter;
@@ -76,7 +78,13 @@ class ContributionAnnotation extends AbstractEditorAnnotation {
       AnnotationRange annotationRange;
       if (editor != null) {
         RangeHighlighter rangeHighlighter =
-            addRangeHighlighter(currentStart, currentEnd, editor, contributionTextAttributes, file);
+            addRangeHighlighter(
+                currentStart,
+                currentEnd,
+                editor,
+                contributionTextAttributes,
+                CONTRIBUTION_HIGHLIGHTER_LAYER,
+                file);
 
         if (rangeHighlighter == null) {
           throw new IllegalStateException(
@@ -117,7 +125,8 @@ class ContributionAnnotation extends AbstractEditorAnnotation {
       int end = annotationRange.getEnd();
 
       RangeHighlighter rangeHighlighter =
-          AbstractEditorAnnotation.addRangeHighlighter(start, end, editor, textAttributes, file);
+          AbstractEditorAnnotation.addRangeHighlighter(
+              start, end, editor, textAttributes, CONTRIBUTION_HIGHLIGHTER_LAYER, file);
 
       if (rangeHighlighter != null) {
         annotationRange.addRangeHighlighter(rangeHighlighter);

--- a/intellij/src/saros/intellij/editor/annotations/SelectionAnnotation.java
+++ b/intellij/src/saros/intellij/editor/annotations/SelectionAnnotation.java
@@ -1,6 +1,8 @@
 package saros.intellij.editor.annotations;
 
 import static com.intellij.openapi.editor.colors.EditorColors.CARET_COLOR;
+import static saros.intellij.editor.annotations.AnnotationHighlighterLayers.CARET_HIGHLIGHTER_LAYER;
+import static saros.intellij.editor.annotations.AnnotationHighlighterLayers.SELECTION_HIGHLIGHTER_LAYER;
 
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.colors.TextAttributesKey;
@@ -98,7 +100,8 @@ class SelectionAnnotation extends AbstractEditorAnnotation {
       TextAttributes selectionTextAttributes = getSelectionTextAttributes(editor, user);
 
       RangeHighlighter rangeHighlighter =
-          addRangeHighlighter(start, end, editor, selectionTextAttributes, file);
+          addRangeHighlighter(
+              start, end, editor, selectionTextAttributes, SELECTION_HIGHLIGHTER_LAYER, file);
 
       if (rangeHighlighter == null) {
         throw new IllegalStateException(
@@ -148,7 +151,8 @@ class SelectionAnnotation extends AbstractEditorAnnotation {
     int end = annotationRange.getEnd();
 
     RangeHighlighter rangeHighlighter =
-        AbstractEditorAnnotation.addRangeHighlighter(start, end, editor, textAttributes, file);
+        AbstractEditorAnnotation.addRangeHighlighter(
+            start, end, editor, textAttributes, SELECTION_HIGHLIGHTER_LAYER, file);
 
     if (rangeHighlighter != null) {
       annotationRange.addRangeHighlighter(rangeHighlighter);
@@ -190,7 +194,12 @@ class SelectionAnnotation extends AbstractEditorAnnotation {
 
     caretHighlighter =
         AbstractEditorAnnotation.addRangeHighlighter(
-            caretPosition, caretPosition, editor, caretTextAttributes, file);
+            caretPosition,
+            caretPosition,
+            editor,
+            caretTextAttributes,
+            CARET_HIGHLIGHTER_LAYER,
+            file);
 
     if (caretHighlighter == null) {
       log.warn("Could not create caret highlighter for position " + caretPosition + " for " + this);


### PR DESCRIPTION
Adjusts the Saros editor annotation highlighter layer. The annotations
are now displayed at a very low level, meaning they will be overshadowed
by almost all other IDE highlighters. This will ensure that the user
will still be able to develop normally using the default IDE features
while in a Saros session.

Separates the different annotations onto different highlighter layers to
create the correct hierarchy. This ensures that selection annotations
overshadow contribution annotations to match the behavior of Saros/E.

It looks a bit weird that the line selection highlighter now also
overshadows Saros annotations. But it provides an important visual aid
to keep track of the current caret position, so I wanted to avoid
overshadowing it. But this is something that can easily be fixed if user
feedback suggests something different.

Resolves #962.