### PR TITLE
[UI][I] Add border to selection and contribution annotations

### DIFF
--- a/intellij/resources/colorSchemes/SarosDarcula.xml
+++ b/intellij/resources/colorSchemes/SarosDarcula.xml
@@ -3,61 +3,85 @@
   <option name="SAROS_DEFAULT_TEXT_SELECTION">
     <value>
       <option name="BACKGROUND" value="494949"/>
+      <option name="EFFECT_COLOR" value="494949"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_DEFAULT_TEXT_CONTRIBUTION">
     <value>
       <option name="BACKGROUND" value="505050"/>
+      <option name="EFFECT_COLOR" value="505050"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_TEXT_SELECTION_0">
     <value>
       <option name="BACKGROUND" value="0F3D43"/>
+      <option name="EFFECT_COLOR" value="0F3D43"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_TEXT_CONTRIBUTION_0">
     <value>
       <option name="BACKGROUND" value="1A6D77"/>
+      <option name="EFFECT_COLOR" value="1A6D77"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_TEXT_SELECTION_1">
     <value>
       <option name="BACKGROUND" value="4D4317"/>
+      <option name="EFFECT_COLOR" value="4D4317"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_TEXT_CONTRIBUTION_1">
     <value>
       <option name="BACKGROUND" value="635912"/>
+      <option name="EFFECT_COLOR" value="635912"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_TEXT_SELECTION_2">
     <value>
       <option name="BACKGROUND" value="264309"/>
+      <option name="EFFECT_COLOR" value="264309"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_TEXT_CONTRIBUTION_2">
     <value>
       <option name="BACKGROUND" value="3C5D0C"/>
+      <option name="EFFECT_COLOR" value="3C5D0C"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_TEXT_SELECTION_3">
     <value>
       <option name="BACKGROUND" value="491411"/>
+      <option name="EFFECT_COLOR" value="491411"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_TEXT_CONTRIBUTION_3">
     <value>
       <option name="BACKGROUND" value="7A1713"/>
+      <option name="EFFECT_COLOR" value="7A1713"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_TEXT_SELECTION_4">
     <value>
       <option name="BACKGROUND" value="192749"/>
+      <option name="EFFECT_COLOR" value="192749"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_TEXT_CONTRIBUTION_4">
     <value>
       <option name="BACKGROUND" value="282488"/>
+      <option name="EFFECT_COLOR" value="282488"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
 </list>

--- a/intellij/resources/colorSchemes/SarosDefault.xml
+++ b/intellij/resources/colorSchemes/SarosDefault.xml
@@ -3,61 +3,85 @@
   <option name="SAROS_DEFAULT_TEXT_SELECTION">
     <value>
       <option name="BACKGROUND" value="CFCFCF"/>
+      <option name="EFFECT_COLOR" value="CFCFCF"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_DEFAULT_TEXT_CONTRIBUTION">
     <value>
       <option name="BACKGROUND" value="A7A7A7"/>
+      <option name="EFFECT_COLOR" value="A7A7A7"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_TEXT_SELECTION_0">
     <value>
       <option name="BACKGROUND" value="B7E0F0"/>
+      <option name="EFFECT_COLOR" value="B7E0F0"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_TEXT_CONTRIBUTION_0">
     <value>
       <option name="BACKGROUND" value="8DCEE7"/>
+      <option name="EFFECT_COLOR" value="8DCEE7"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_TEXT_SELECTION_1">
     <value>
       <option name="BACKGROUND" value="D0CDA4"/>
+      <option name="EFFECT_COLOR" value="D0CDA4"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_TEXT_CONTRIBUTION_1">
     <value>
       <option name="BACKGROUND" value="BFBB82"/>
+      <option name="EFFECT_COLOR" value="BFBB82"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_TEXT_SELECTION_2">
     <value>
       <option name="BACKGROUND" value="DCEDA6"/>
+      <option name="EFFECT_COLOR" value="DCEDA6"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_TEXT_CONTRIBUTION_2">
     <value>
       <option name="BACKGROUND" value="BADC51"/>
+      <option name="EFFECT_COLOR" value="BADC51"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_TEXT_SELECTION_3">
     <value>
       <option name="BACKGROUND" value="F6F6D3"/>
+      <option name="EFFECT_COLOR" value="F6F6D3"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_TEXT_CONTRIBUTION_3">
     <value>
       <option name="BACKGROUND" value="EDEDA9"/>
+      <option name="EFFECT_COLOR" value="EDEDA9"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_TEXT_SELECTION_4">
     <value>
       <option name="BACKGROUND" value="B8D2D1"/>
+      <option name="EFFECT_COLOR" value="B8D2D1"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
   <option name="SAROS_TEXT_CONTRIBUTION_4">
     <value>
       <option name="BACKGROUND" value="89B4B2"/>
+      <option name="EFFECT_COLOR" value="89B4B2"/>
+      <option name="EFFECT_TYPE" value="0"/>
     </value>
   </option>
 </list>


### PR DESCRIPTION
Adds a border to selection and contribution annotations by default. This
border will be visible even when the rest of the annotation is
overshadowed by other IDE range highlighters most of the time (as
bordered highlighters are rare as far as I can tell).

Contribution annotations look a bit weird with the borders as they show
that each added character is its own range highlighter and therefore
will be displayed as its own border "box". This, however, will only be
visible when the main annotation (the background color) is overshadowed
(or if the user changes the border color).

This border can be disabled by the user in the editor color scheme
settings for Saros if they don't like it.

### Visual Comparison

#### Without Borders

Default contribution & selection annotations:
![annotation](https://user-images.githubusercontent.com/12495415/109168844-83293580-777f-11eb-829b-8fad3d999074.png)

Annotation on active line (i.e. the line in which the local caret it located):
![annotation-active-line](https://user-images.githubusercontent.com/12495415/109169004-a9e76c00-777f-11eb-871a-010eeed43409.png)

Annotation under selection:
![annotation-selected](https://user-images.githubusercontent.com/12495415/109169080-bd92d280-777f-11eb-8ad8-82913548e235.png)

#### With Borders

Default contribution & selection annotations:
![annotation-with-blocks](https://user-images.githubusercontent.com/12495415/109169135-cd121b80-777f-11eb-995a-f49c5e90bb04.png)

Annotations on active line:
![annotation-with-blocks-active-line](https://user-images.githubusercontent.com/12495415/109169176-d3a09300-777f-11eb-873b-b693d39c4f51.png)

Annotation under selection:
![annotation-with-blocks-selected](https://user-images.githubusercontent.com/12495415/109169196-db603780-777f-11eb-90d4-2f4faa85a9fd.png)

### Note Regarding the Active Line Highlighter

To explain the behavior on the active line in more details: IntelliJ IDEA highlights the line the local caret currently resides in. This helps figuring out where you are currently typing at a glance. As I find this feature helpful, I did not want Saros overshadowing it. Therefore, I put Saros annotations below the layer the active line is highlighted in with #1126. As a result, the default Saros contribution and selection annotations (displayed by a colored background) are overshadowed by the active line highlighter.
