### PR TITLE
Improve action run conditions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ name: Build
 
 on:
   push:
+    branches:
+    - 'master'
     paths-ignore:
     - 'docs/**'
   pull_request:

--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -3,6 +3,8 @@ name: Build
 
 on:
   push:
+    branches:
+    - 'master'
     paths:
     - 'docs/**'
   pull_request:

--- a/.github/workflows/build_pmd.yml
+++ b/.github/workflows/build_pmd.yml
@@ -3,6 +3,8 @@ name: Build
 
 on:
   push:
+    branches:
+      - 'master'
     paths:
       - 'ruleset.xml'
   pull_request:

--- a/.github/workflows/stf.yml
+++ b/.github/workflows/stf.yml
@@ -6,6 +6,13 @@ on:
       - 'pr/stf/**'
       - 'master'
 
+  pull_request:
+    paths:
+      - 'core/**'
+      - 'eclipse/**'
+      - 'stf/**'
+      - 'stf.test/**'
+
   workflow_dispatch:
     inputs:
       arguments:


### PR DESCRIPTION
Improves the run conditions for the existing GitHub actions.

#### [BUILD] Avoid running GitHub actions twice on PRs

Adjusts the GitHub action configuration to only run on Pull Requests and
on pushes to the 'master' branch. This avoids the actions always running
twice for PRs, once for the PR and once for the push to the branch.

#### [BUILD] Run STF GitHub action on PRs modifying related resources

Adjusts the STF GitHub action to run on any PR that modifies resources
in the 'core', 'eclipse', 'stf', or 'stf.test' directory. This should
ensure that the action is run for any PR that modifies resources that
could influence the result of the STF.