### PR TITLE
Fix Saros view update behavior

### DIFF
--- a/intellij/src/saros/intellij/ui/tree/ContactTreeRootNode.java
+++ b/intellij/src/saros/intellij/ui/tree/ContactTreeRootNode.java
@@ -97,12 +97,18 @@ public class ContactTreeRootNode extends DefaultMutableTreeNode implements Dispo
     ContactInfo contactInfo = getContact(contact);
     if (contactInfo != null) return;
 
+    boolean noContactsToDisplayBefore = visibleContactsMap.isEmpty();
+
     contactInfo = new ContactInfo(contact);
     visibleContactsMap.put(contact, contactInfo);
 
     add(new DefaultMutableTreeNode(contactInfo));
 
     treeView.reloadModelNode(this);
+
+    if (noContactsToDisplayBefore) {
+      treeView.expandPath(new TreePath(getPath()));
+    }
   }
 
   private ContactInfo getContact(XMPPContact contact) {

--- a/intellij/src/saros/intellij/ui/tree/ContactTreeRootNode.java
+++ b/intellij/src/saros/intellij/ui/tree/ContactTreeRootNode.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Optional;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreePath;
 import saros.SarosPluginContext;
 import saros.intellij.ui.util.IconManager;
 import saros.intellij.ui.views.SarosMainPanelView;
@@ -54,8 +55,8 @@ public class ContactTreeRootNode extends DefaultMutableTreeNode implements Dispo
                       .ifPresent(
                           info -> {
                             info.updateStatusIcon();
-                            treeView.collapseRow(2);
-                            treeView.expandRow(2);
+                            treeView.collapsePath(new TreePath(ContactTreeRootNode.this.getPath()));
+                            treeView.expandPath(new TreePath(ContactTreeRootNode.this.getPath()));
                           });
                 }
               });
@@ -100,6 +101,8 @@ public class ContactTreeRootNode extends DefaultMutableTreeNode implements Dispo
     visibleContactsMap.put(contact, contactInfo);
 
     add(new DefaultMutableTreeNode(contactInfo));
+
+    treeView.reloadModelNode(this);
   }
 
   private ContactInfo getContact(XMPPContact contact) {
@@ -137,6 +140,8 @@ public class ContactTreeRootNode extends DefaultMutableTreeNode implements Dispo
         break;
       }
     }
+
+    treeView.reloadModelNode(this);
   }
 
   /**

--- a/intellij/src/saros/intellij/ui/tree/SessionAndContactsTreeView.java
+++ b/intellij/src/saros/intellij/ui/tree/SessionAndContactsTreeView.java
@@ -5,6 +5,9 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.util.ui.UIUtil;
 import java.awt.Component;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
 import javax.swing.JTree;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeCellRenderer;
@@ -188,10 +191,9 @@ public class SessionAndContactsTreeView extends JTree implements Disposable {
   }
 
   private void updateTree() {
-    DefaultTreeModel model = (DefaultTreeModel) (getModel());
-    model.reload();
+    reloadModel();
 
-    expandRow(2);
+    expandPath(new TreePath(contactTreeRootNode.getPath()));
   }
 
   protected ContactTreeRootNode getContactTreeRootNode() {
@@ -200,5 +202,73 @@ public class SessionAndContactsTreeView extends JTree implements Disposable {
 
   private SarosTreeRootNode getSarosTreeRootNode() {
     return (SarosTreeRootNode) getModel().getRoot();
+  }
+
+  /** Reloads the entire tree model, trying to preserve the current tree expansion. */
+  void reloadModel() {
+    List<TreePath> paths = getExpandedPaths();
+
+    ((DefaultTreeModel) getModel()).reload();
+
+    expandPaths(paths);
+  }
+
+  /**
+   * Reloads the given tree node, trying to preserve the current tree expansion.
+   *
+   * @param node the tree node to reload
+   */
+  void reloadModelNode(DefaultMutableTreeNode node) {
+    List<TreePath> paths = getExpandedPaths(node);
+
+    ((DefaultTreeModel) getModel()).reload(node);
+
+    expandPaths(paths);
+  }
+
+  /**
+   * Returns the paths of all currently expanded elements of the tree.
+   *
+   * @return the paths of all currently expanded elements of the tree
+   */
+  private List<TreePath> getExpandedPaths() {
+    List<TreePath> expandedPaths = new ArrayList<>();
+
+    expandedPaths.addAll(getExpandedPaths(sessionTreeRootNode));
+    expandedPaths.addAll(getExpandedPaths(contactTreeRootNode));
+
+    return expandedPaths;
+  }
+
+  /**
+   * Returns the paths of all currently expanded elements under the given node.
+   *
+   * @param node the node whose expanded paths to return
+   * @return the paths of all currently expanded elements under the given node
+   */
+  private List<TreePath> getExpandedPaths(DefaultMutableTreeNode node) {
+    List<TreePath> expandedPaths = new ArrayList<>();
+
+    Enumeration<TreePath> expandedSessionPaths =
+        getExpandedDescendants(new TreePath(node.getPath()));
+
+    if (expandedSessionPaths != null) {
+      while (expandedSessionPaths.hasMoreElements()) {
+        expandedPaths.add(expandedSessionPaths.nextElement());
+      }
+    }
+
+    return expandedPaths;
+  }
+
+  /**
+   * Expands all given paths.
+   *
+   * @param pathsToExpand the paths to expand
+   */
+  private void expandPaths(List<TreePath> pathsToExpand) {
+    for (TreePath pathToExpand : pathsToExpand) {
+      expandPath(pathToExpand);
+    }
   }
 }

--- a/intellij/src/saros/intellij/ui/tree/SessionTreeRootNode.java
+++ b/intellij/src/saros/intellij/ui/tree/SessionTreeRootNode.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreePath;
 import saros.SarosPluginContext;
 import saros.filesystem.IReferencePoint;
 import saros.intellij.ui.util.IconManager;
@@ -168,7 +169,7 @@ public class SessionTreeRootNode extends DefaultMutableTreeNode implements Dispo
     sessionNodeList.put(newSarosSession, newSession);
 
     treeModel.insertNodeInto(newSession, this, getChildCount());
-    treeModel.reload(this);
+    treeView.reloadModelNode(this);
 
     add(newSession);
 
@@ -181,7 +182,8 @@ public class SessionTreeRootNode extends DefaultMutableTreeNode implements Dispo
 
     addUserNode(newSarosSession.getLocalUser());
 
-    treeView.expandRow(1);
+    treeView.expandPath(new TreePath(getPath()));
+    treeView.expandPath(new TreePath(newSession.getPath()));
   }
 
   private void removeSessionNode(ISarosSession oldSarosSession) {
@@ -197,8 +199,7 @@ public class SessionTreeRootNode extends DefaultMutableTreeNode implements Dispo
       setUserObject(TREE_TITLE_NO_SESSIONS);
     }
 
-    treeModel.reload(this);
-    treeView.expandRow(2);
+    treeView.reloadModelNode(this);
   }
 
   private void addReferencePointNode(IReferencePoint referencePoint) {
@@ -208,7 +209,7 @@ public class SessionTreeRootNode extends DefaultMutableTreeNode implements Dispo
       DefaultMutableTreeNode referencePointNode = new DefaultMutableTreeNode(referencePointInfo);
       treeModel.insertNodeInto(referencePointNode, sessionNode, sessionNode.getChildCount());
 
-      treeModel.reload(sessionNode);
+      treeView.reloadModelNode(sessionNode);
     }
   }
 
@@ -219,7 +220,7 @@ public class SessionTreeRootNode extends DefaultMutableTreeNode implements Dispo
 
     treeView.getContactTreeRootNode().hideContact(user.getJID());
 
-    treeModel.reload(this);
+    treeView.reloadModelNode(this);
   }
 
   private void removeUserNode(User user) {
@@ -229,7 +230,8 @@ public class SessionTreeRootNode extends DefaultMutableTreeNode implements Dispo
 
     remove(nUser);
     treeView.getContactTreeRootNode().showContact(user.getJID());
-    treeModel.reload();
+
+    treeView.reloadModelNode(this);
   }
 
   private void removeAllUserNodes() {


### PR DESCRIPTION
#### [FIX][I] #888 Fix Saros view tree model update behavior

Introduces new methods to reload the entire tree model or a specific
node while trying to retain the current tree expansion. To do so, the
model saves all expanded paths before the reload and restores them after
the reload.

Replaces all calls to reloading the model with calls to the new utility
methods to ensure that the expansion state is preserved as part of the
reload.

Moves the responsibility of reloading the contacts node for session
related events (e.g. when hiding a contact from the contacts list when
they join the current session) to the contacts node class.

Replaces calls to expanding specific rows of the tree with calls to
expanding the path of the element that is actually supposed to be
expanded. This removes the guesswork whether the given row actually
points to the correct element and ensures that the logic still works
when the tree layout is changed.

Resolves #888.

#### [UI][I] Expand contacts node when first contact is added

Adds new logic explicitly expanding the contacts view if the first
contact is added. This can be the case when there were no contacts
before or when all contacts were part of the session the user just
left. This ensures that the contact node is expanded in such cases.