### PR TITLE
Sort contact names

### DIFF
--- a/intellij/src/saros/intellij/ui/menu/SarosResourceShareGroup.java
+++ b/intellij/src/saros/intellij/ui/menu/SarosResourceShareGroup.java
@@ -6,6 +6,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.vfs.VirtualFile;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -46,9 +47,12 @@ public class SarosResourceShareGroup extends ActionGroup {
       return new AnAction[0];
     }
 
+    List<XMPPContact> contacts = new ArrayList<>(contactsService.getAllContacts());
+    contacts.sort(Comparator.comparing(contact -> contact.getBareJid().toString()));
+
     int userCount = 1;
     List<AnAction> list = new ArrayList<>();
-    for (XMPPContact contact : contactsService.getAllContacts()) {
+    for (XMPPContact contact : contacts) {
       if (contact.getStatus().isOnline()) {
         list.add(new ShareWithUserAction(contact.getBareJid(), userCount));
         userCount++;

--- a/intellij/src/saros/intellij/ui/tree/ContactTreeRootNode.java
+++ b/intellij/src/saros/intellij/ui/tree/ContactTreeRootNode.java
@@ -3,9 +3,11 @@ package saros.intellij.ui.tree;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.util.ui.UIUtil;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Vector;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreePath;
@@ -104,11 +106,29 @@ public class ContactTreeRootNode extends DefaultMutableTreeNode implements Dispo
 
     add(new DefaultMutableTreeNode(contactInfo));
 
+    sortEntries();
+
     treeView.reloadModelNode(this);
 
     if (noContactsToDisplayBefore) {
       treeView.expandPath(new TreePath(getPath()));
     }
+  }
+
+  /** Sorts the nodes displayed in the contacts view alphabetically. */
+  private void sortEntries() {
+    ((Vector<?>) this.children)
+        .sort(
+            (Comparator<Object>)
+                (o1, o2) -> {
+                  DefaultMutableTreeNode n1 = (DefaultMutableTreeNode) o1;
+                  DefaultMutableTreeNode n2 = (DefaultMutableTreeNode) o2;
+
+                  ContactInfo c1 = (ContactInfo) n1.getUserObject();
+                  ContactInfo c2 = (ContactInfo) n2.getUserObject();
+
+                  return c1.title.compareTo(c2.title);
+                });
   }
 
   private ContactInfo getContact(XMPPContact contact) {

--- a/intellij/src/saros/intellij/ui/tree/SessionTreeRootNode.java
+++ b/intellij/src/saros/intellij/ui/tree/SessionTreeRootNode.java
@@ -304,18 +304,33 @@ public class SessionTreeRootNode extends DefaultMutableTreeNode implements Dispo
     }
   }
 
-  protected class UserInfo extends LeafInfo {
+  protected static class UserInfo extends LeafInfo {
     private final User user;
 
     public UserInfo(User user) {
-      super(
-          (user.isHost() ? "Host " : "") + CoreUtils.determineUserDisplayName(user),
-          IconManager.CONTACT_ONLINE_ICON);
+      super(getUserNodeLabel(user), IconManager.CONTACT_ONLINE_ICON);
       this.user = user;
     }
 
     public User getUser() {
       return user;
+    }
+
+    /**
+     * Returns the label to use for the node of the given user.
+     *
+     * @param user the user whose node label to return
+     * @return the label to use for the node of the given user
+     */
+    private static String getUserNodeLabel(User user) {
+      String userName = CoreUtils.determineUserDisplayName(user);
+
+      if (!user.isHost()) {
+        return userName;
+
+      } else {
+        return "<html><i><b>Host</b></i> " + userName + "</html>";
+      }
     }
   }
 

--- a/intellij/src/saros/intellij/ui/views/buttons/FollowButton.java
+++ b/intellij/src/saros/intellij/ui/views/buttons/FollowButton.java
@@ -4,6 +4,9 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.JBMenuItem;
 import com.intellij.openapi.ui.JBPopupMenu;
 import com.intellij.util.ui.UIUtil;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import javax.swing.JButton;
 import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
@@ -130,10 +133,15 @@ public class FollowButton extends AbstractSessionToolbarButton {
       return;
     }
 
+    List<JMenuItem> followUserMenuItems = new ArrayList<>();
+
     for (User user : currentSession.getRemoteUsers()) {
-      JMenuItem menuItem = createItemForUser(user);
-      popupMenu.add(menuItem);
+      followUserMenuItems.add(createItemForUser(user));
     }
+
+    followUserMenuItems.sort(Comparator.comparing(JMenuItem::getText));
+
+    followUserMenuItems.forEach(popupMenu::add);
 
     popupMenu.addSeparator();
 


### PR DESCRIPTION
Adjusts different part of the Saros UI to always sort the displayed contacts alphabetically.

Also adjusts the display logic for the users of the current session in the Saros view to display the 'Host' label in bold and italics to better differentiate it from the user name.

#### [FIX][I] #610 Sort Saros contacts view alphabetically

Adds logic to sorts the contacts displayed in the contacts view
alphabetically.

Resolves #610.

#### [FIX][I] Sort user nodes in session view alphabetically

Sorts the user nodes displayed in the session view alphabetically. Also
ensures that the entry for the session host is always displayed as the
first user, independent of the user name.

#### [UI][I] Display 'Host' label in bold an italics in session view

Adjusts UserInfo to display the 'Host' label in bold and italics. This
should help user better differentiate between the label and the display
name of the user.

#### [FIX][I] Sort list of users in follow mode menu

#### [FIX][I] Sort list of users in 'Share with' project pop-up dialog