### PR TITLE
[BUILD] Workaround for build fail

### DIFF
--- a/eclipse/build.gradle.kts
+++ b/eclipse/build.gradle.kts
@@ -42,6 +42,8 @@ dependencies {
     implementation(project(":saros.core"))
     // This is a workaround for https://github.com/saros-project/saros/issues/1086
     implementation("org.eclipse.platform:org.eclipse.urischeme:1.1.0")
+    // This is a workaround for https://github.com/saros-project/saros/issues/1138
+    implementation("org.eclipse.platform:org.eclipse.e4.core.di:1.7.600")
     // This is a workaround for https://github.com/saros-project/saros/issues/1114
     implementation("org.eclipse.platform:org.eclipse.ui.ide:3.17.200")
     implementation("org.eclipse.platform:org.eclipse.ui.workbench:3.120.0")

--- a/stf/build.gradle.kts
+++ b/stf/build.gradle.kts
@@ -30,6 +30,8 @@ dependencies {
     compile(project(":saros.eclipse"))
     // This is a workaround for https://github.com/saros-project/saros/issues/1086
     implementation("org.eclipse.platform:org.eclipse.urischeme:1.1.0")
+    // This is a workaround for https://github.com/saros-project/saros/issues/1138
+    implementation("org.eclipse.platform:org.eclipse.e4.core.di:1.7.600")
     // This is a workaround for https://github.com/saros-project/saros/issues/1114
     implementation("org.eclipse.platform:org.eclipse.ui.ide:3.17.200")
     implementation("org.eclipse.platform:org.eclipse.ui.workbench:3.120.0")


### PR DESCRIPTION
This is a temporary fix for #1138.

This is not a proposed solution and the workaround will most probably need to be updated for coming versions of `org.eclipse.platform:org.eclipse.ui.ide` (the version of which is also part of another workaround, see [here](https://github.com/saros-project/saros/pull/1115)). Actually discussion about long-term fixes should be done in #1138.