### PR TITLE
Switch to google format 1 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
         fetch-depth: 1
     - uses: m273d15/java-format-action@v1.1
       with:
-        version: '1.6'
+        version: '1.10.0'
 
   build:
     runs-on: ubuntu-latest

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -90,7 +90,6 @@
     </TypeScriptCodeStyleSettings>
     <XML>
       <option name="XML_ALIGN_ATTRIBUTES" value="false" />
-      <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>
     <codeStyleSettings language="CSS">
       <indentOptions>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -11,7 +11,7 @@
       <entry name="!?*.kt" />
       <entry name="!?*.clj" />
     </wildcardResourcePatterns>
-    <bytecodeTargetLevel>
+    <bytecodeTargetLevel target="1.8">
       <module name="saros.core_main" target="1.8" />
       <module name="saros.core_test" target="1.8" />
       <module name="saros.eclipse_main" target="1.8" />

--- a/.idea/libraries-with-intellij-classes.xml
+++ b/.idea/libraries-with-intellij-classes.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="libraries-with-intellij-classes">
+    <option name="intellijApiContainingLibraries">
+      <list>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="ideaIU" />
+          <option name="groupId" value="com.jetbrains.intellij.idea" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="ideaIU" />
+          <option name="groupId" value="com.jetbrains" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="ideaIC" />
+          <option name="groupId" value="com.jetbrains.intellij.idea" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="ideaIC" />
+          <option name="groupId" value="com.jetbrains" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="pycharmPY" />
+          <option name="groupId" value="com.jetbrains.intellij.pycharm" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="pycharmPY" />
+          <option name="groupId" value="com.jetbrains" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="pycharmPC" />
+          <option name="groupId" value="com.jetbrains.intellij.pycharm" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="pycharmPC" />
+          <option name="groupId" value="com.jetbrains" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="clion" />
+          <option name="groupId" value="com.jetbrains.intellij.clion" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="clion" />
+          <option name="groupId" value="com.jetbrains" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="riderRD" />
+          <option name="groupId" value="com.jetbrains.intellij.rider" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="riderRD" />
+          <option name="groupId" value="com.jetbrains" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="goland" />
+          <option name="groupId" value="com.jetbrains.intellij.goland" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="goland" />
+          <option name="groupId" value="com.jetbrains" />
+        </LibraryCoordinatesState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,7 @@
       <writeAnnotation name="saros.repackaged.picocontainer.annotations.Inject" />
     </writeAnnotations>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/buildSrc/src/main/java/saros/gradle/eclipse/configurator/OsgiBundleVersionConfigurator.java
+++ b/buildSrc/src/main/java/saros/gradle/eclipse/configurator/OsgiBundleVersionConfigurator.java
@@ -38,8 +38,7 @@ public class OsgiBundleVersionConfigurator {
       Charset charset = StandardCharsets.UTF_8;
       List<String> oldContentLines = Files.readAllLines(path, charset);
       String newContent =
-          oldContentLines
-              .stream()
+          oldContentLines.stream()
               .map(line -> line.replaceAll(regex, replacement))
               .collect(Collectors.joining("\n"));
       Files.write(path, newContent.getBytes(charset));

--- a/buildSrc/src/main/java/saros/gradle/eclipse/configurator/OsgiDependencyConfigurator.java
+++ b/buildSrc/src/main/java/saros/gradle/eclipse/configurator/OsgiDependencyConfigurator.java
@@ -42,7 +42,8 @@ public class OsgiDependencyConfigurator {
     String requireBundleValue = getRequireBundleValue(manifestFile);
     if (requireBundleValue == null) {
       throw new GradleException(
-          "Unable to add dependencies, because the 'Require-Bundle' entry is missing in the manifest file: "
+          "Unable to add dependencies, because the 'Require-Bundle' entry is missing in the"
+              + " manifest file: "
               + manifestFile.getAbsolutePath());
     }
     String[] bundles = parseRequireBundleValue(requireBundleValue, excludeManifestDependencies);

--- a/buildSrc/src/main/java/saros/gradle/intellij/IntellijConfigurator.java
+++ b/buildSrc/src/main/java/saros/gradle/intellij/IntellijConfigurator.java
@@ -13,10 +13,11 @@ class IntellijConfigurator {
   private static final String LOCKFILE_NAME = "saros_sandbox.lock";
   private static final String SANDBOX_DIR_PREFIX = "idea-sandbox-";
   private static final String RACE_CONDITION_WARNING =
-      "\nThis issue might be caused by a race condition between two or more 'runIde'"
-          + "calls. In order to avoid that race condition: Call 'runIde' and wait until the IntelliJ instance started"
-          + "before starting the next instance with 'runIde'."
-          + "See issue #724 for the corresponding discussion.";
+      "\n"
+          + "This issue might be caused by a race condition between two or more 'runIde'calls. In"
+          + " order to avoid that race condition: Call 'runIde' and wait until the IntelliJ"
+          + " instance startedbefore starting the next instance with 'runIde'.See issue #724 for"
+          + " the corresponding discussion.";
 
   private Project project;
 

--- a/core/src/saros/account/XMPPAccountStore.java
+++ b/core/src/saros/account/XMPPAccountStore.java
@@ -243,8 +243,7 @@ public final class XMPPAccountStore {
    * @return
    */
   public synchronized List<XMPPAccount> getAllAccounts() {
-    return accounts
-        .stream()
+    return accounts.stream()
         .sorted(XMPPAccountStore::compare)
         .collect(Collectors.toCollection(ArrayList::new));
   }
@@ -540,8 +539,7 @@ public final class XMPPAccountStore {
    */
   public synchronized boolean existsAccount(
       String username, String domain, String server, int port) {
-    return getAllAccounts()
-        .stream()
+    return getAllAccounts().stream()
         .anyMatch(a -> matchesAccount(a, username, domain, server, port));
   }
 
@@ -556,8 +554,7 @@ public final class XMPPAccountStore {
    * @return the account or <code>null</code> if the account does not exist
    */
   public XMPPAccount getAccount(final String username, final String domain) {
-    return getAllAccounts()
-        .stream()
+    return getAllAccounts().stream()
         .filter(a -> matchesAnyServer(a, username, domain))
         .findFirst()
         .orElse(null);
@@ -574,8 +571,7 @@ public final class XMPPAccountStore {
    */
   public XMPPAccount getAccount(
       final String username, final String domain, final String server, final int port) {
-    return getAllAccounts()
-        .stream()
+    return getAllAccounts().stream()
         .filter(a -> matchesAccount(a, username, domain, server, port))
         .findFirst()
         .orElse(null);

--- a/core/src/saros/concurrent/jupiter/internal/Jupiter.java
+++ b/core/src/saros/concurrent/jupiter/internal/Jupiter.java
@@ -267,7 +267,8 @@ public class Jupiter implements Algorithm {
       throw new TransformationException("Precondition #1 violated.");
     } else if (time.getRemoteOperationCount() > this.vectorTime.getLocalOperationCount()) {
       throw new TransformationException(
-          "precondition #2 violated (Remote vector time is greater than local vector time) - remote time: "
+          "precondition #2 violated (Remote vector time is greater than local vector time) - remote"
+              + " time: "
               + time
               + " ,local time: "
               + vectorTime);

--- a/core/src/saros/concurrent/management/TransformationResult.java
+++ b/core/src/saros/concurrent/management/TransformationResult.java
@@ -38,7 +38,8 @@ public class TransformationResult {
   public void addAll(TransformationResult other) {
     if (!Objects.equals(other.localUser, this.localUser)) {
       throw new IllegalArgumentException(
-          "can only merge two transformation result objects if they are managing the same local user");
+          "can only merge two transformation result objects if they are managing the same local"
+              + " user");
     }
     this.executeLocally.addAll(other.executeLocally);
     this.sendToPeers.addAll(other.sendToPeers);

--- a/core/src/saros/negotiation/AdditionalResourceDataFactory.java
+++ b/core/src/saros/negotiation/AdditionalResourceDataFactory.java
@@ -69,7 +69,8 @@ public class AdditionalResourceDataFactory {
 
       if (!Collections.disjoint(additionalResourceData.keySet(), providerData.keySet())) {
         log.warn(
-            "Key sets used by additional resource data providers are not disjoint! Noticed while processing "
+            "Key sets used by additional resource data providers are not disjoint! Noticed while"
+                + " processing "
                 + additionalResourceDataProvider.getClass().getSimpleName());
       }
 

--- a/core/src/saros/negotiation/additional_resource_data/AbstractPossibleRepresentationProvider.java
+++ b/core/src/saros/negotiation/additional_resource_data/AbstractPossibleRepresentationProvider.java
@@ -67,8 +67,7 @@ public abstract class AbstractPossibleRepresentationProvider
         computePossibleRepresentations(referencePoint);
 
     String flattenedPossibleRepresentations =
-        possibleRepresentations
-            .stream()
+        possibleRepresentations.stream()
             .map(
                 pair ->
                     ESCAPE_INNER.escape(pair.getLeft())

--- a/core/src/saros/net/stream/Socks5StreamService.java
+++ b/core/src/saros/net/stream/Socks5StreamService.java
@@ -232,7 +232,8 @@ public class Socks5StreamService implements IStreamService, BytestreamListener {
 
     log.debug(
         msg
-            + "and the server does not allow bidirectional connections. Wrapped session established.");
+            + "and the server does not allow bidirectional connections. Wrapped session"
+            + " established.");
 
     return new WrappedBidirectionalSocks5BytestreamSession(inSession, outSession);
   }
@@ -519,7 +520,8 @@ public class Socks5StreamService implements IStreamService, BytestreamListener {
 
         log.debug(
             prefix()
-                + "connection/session is mediated, performing additional connection optimization...");
+                + "connection/session is mediated, performing additional connection"
+                + " optimization...");
 
       } catch (IOException e) {
         exception = e;

--- a/core/src/saros/net/stun/internal/StunServiceImpl.java
+++ b/core/src/saros/net/stun/internal/StunServiceImpl.java
@@ -429,43 +429,43 @@ public final class StunServiceImpl implements IStunService {
 
         case 401:
           log.error(
-              "401 (Unauthorized): The Binding Request did not contain a MESSAGE-INTEGRITY attribute."
-                  + " ["
+              "401 (Unauthorized): The Binding Request did not contain a MESSAGE-INTEGRITY"
+                  + " attribute. ["
                   + message
                   + "]");
           return false;
         case 420:
           log.error(
-              "420 (Unknown Attribute): The server did not understand a mandatory attribute in the request."
-                  + " ["
+              "420 (Unknown Attribute): The server did not understand a mandatory attribute in the"
+                  + " request. ["
                   + message
                   + "]");
           return false;
         case 430:
           log.error(
-              "430 (Stale Credentials): The Binding Request did contain a MESSAGE-INTEGRITY attribute, but it used a shared secret that has expired."
-                  + " ["
+              "430 (Stale Credentials): The Binding Request did contain a MESSAGE-INTEGRITY"
+                  + " attribute, but it used a shared secret that has expired. ["
                   + message
                   + "]");
           return false;
         case 431:
           log.error(
-              "431 (Integrity Check Failure): The Binding Request contained a MESSAGE-INTEGRITY attribute, but the HMAC failed verification."
-                  + " ["
+              "431 (Integrity Check Failure): The Binding Request contained a MESSAGE-INTEGRITY"
+                  + " attribute, but the HMAC failed verification. ["
                   + message
                   + "]");
           return false;
         case 432:
           log.error(
-              "432 (Missing Username): The Binding Request contained a MESSAGE-INTEGRITY attribute, but not a USERNAME attribute."
-                  + " ["
+              "432 (Missing Username): The Binding Request contained a MESSAGE-INTEGRITY attribute,"
+                  + " but not a USERNAME attribute. ["
                   + message
                   + "]");
           return false;
         case 433:
           log.error(
-              "433 (Use TLS): The Shared Secret request has to be sent over TLS, but was not received over TLS."
-                  + " ["
+              "433 (Use TLS): The Shared Secret request has to be sent over TLS, but was not"
+                  + " received over TLS. ["
                   + message
                   + "]");
           return false;

--- a/core/src/saros/net/upnp/internal/UPnPServiceImpl.java
+++ b/core/src/saros/net/upnp/internal/UPnPServiceImpl.java
@@ -197,8 +197,7 @@ public final class UPnPServiceImpl implements IUPnPService, Disposable {
     log.debug(deviceName + " - deleting port mapping... - port=" + port + ", protocol=" + protocol);
 
     final PortMappingRefreshTask task =
-        portMappingRefreshTasks
-            .stream()
+        portMappingRefreshTasks.stream()
             .filter(t -> t.device.equals(device) && t.protocol.equals(protocol) && t.port == port)
             .findFirst()
             .orElse(null);

--- a/core/src/saros/net/xmpp/contact/AddContactUtility.java
+++ b/core/src/saros/net/xmpp/contact/AddContactUtility.java
@@ -85,7 +85,8 @@ class AddContactUtility {
         throw new OperationCanceledException(dialogContent.invocationTargetExceptionMessage);
 
       log.warn(
-          "Problem while adding a contact.CancellationException User decided to add contact anyway. Problem: "
+          "Problem while adding a contact.CancellationException User decided to add contact anyway."
+              + " Problem: "
               + e.getMessage());
     }
 

--- a/core/src/saros/net/xmpp/contact/ContactStore.java
+++ b/core/src/saros/net/xmpp/contact/ContactStore.java
@@ -62,9 +62,7 @@ class ContactStore {
    * @return list of all known {@link XMPPContact XMPPContacts}
    */
   List<XMPPContact> getAll() {
-    return contactsGrouped
-        .values()
-        .stream()
+    return contactsGrouped.values().stream()
         .flatMap(map -> map.values().stream())
         .distinct()
         .collect(Collectors.toList());
@@ -76,9 +74,7 @@ class ContactStore {
    * @return list of all groups as {@link XMPPContactGroup}
    */
   List<XMPPContactGroup> getGroupsList() {
-    return contactsGrouped
-        .entrySet()
-        .stream()
+    return contactsGrouped.entrySet().stream()
         .filter(group -> !group.getKey().equals(NO_GROUP))
         .map(group -> new XMPPContactGroup(group.getKey(), group.getValue().values()))
         .collect(Collectors.toList());
@@ -183,9 +179,7 @@ class ContactStore {
     String jid = GET_BAREJID_STRING.apply(contact);
 
     long removed =
-        contactsGrouped
-            .entrySet()
-            .stream()
+        contactsGrouped.entrySet().stream()
             .filter(entry -> !exclude.contains(entry.getKey()))
             .map(entry -> Optional.ofNullable(entry.getValue().remove(jid)))
             .filter(Optional::isPresent)

--- a/core/src/saros/session/SarosSessionManager.java
+++ b/core/src/saros/session/SarosSessionManager.java
@@ -196,7 +196,8 @@ public class SarosSessionManager implements ISarosSessionManager {
     try {
       if (!startStopSessionLock.tryLock(LOCK_TIMEOUT, TimeUnit.MILLISECONDS)) {
         log.warn(
-            "could not start a new session because another operation still tries to start or stop a session");
+            "could not start a new session because another operation still tries to start or stop a"
+                + " session");
         return;
       }
     } catch (InterruptedException e) {
@@ -208,7 +209,8 @@ public class SarosSessionManager implements ISarosSessionManager {
 
       if (sessionShutdown)
         throw new IllegalStateException(
-            "cannot start the session from the same thread context that is currently about to stop the session: "
+            "cannot start the session from the same thread context that is currently about to stop"
+                + " the session: "
                 + Thread.currentThread().getName());
 
       if (sessionStartup) {
@@ -287,7 +289,8 @@ public class SarosSessionManager implements ISarosSessionManager {
     try {
       if (!startStopSessionLock.tryLock(LOCK_TIMEOUT, TimeUnit.MILLISECONDS)) {
         log.warn(
-            "could not stop the current session because another operation still tries to start or stop a session");
+            "could not stop the current session because another operation still tries to start or"
+                + " stop a session");
         return;
       }
     } catch (InterruptedException e) {
@@ -299,7 +302,8 @@ public class SarosSessionManager implements ISarosSessionManager {
 
       if (sessionStartup)
         throw new IllegalStateException(
-            "cannot stop the session from the same thread context that is currently about to start the session: "
+            "cannot stop the session from the same thread context that is currently about to start"
+                + " the session: "
                 + Thread.currentThread().getName());
 
       if (sessionShutdown) {
@@ -602,7 +606,8 @@ public class SarosSessionManager implements ISarosSessionManager {
 
     if (referencePointsToShare.isEmpty()) {
       log.warn(
-          "skipping resource negotiation because no new reference points were added to the current session");
+          "skipping resource negotiation because no new reference points were added to the current"
+              + " session");
       return;
     }
 

--- a/core/src/saros/session/internal/ChangeColorManager.java
+++ b/core/src/saros/session/internal/ChangeColorManager.java
@@ -319,7 +319,8 @@ public class ChangeColorManager extends AbstractActivityProducer implements Star
           if (favoriteUserColors.containsValue(UserColorID.UNKNOWN)
               && isValidColorAssignment(assignedColors)) {
             log.debug(
-                "color conflict resolve result = FAVORITE COLORS UNKNOWN, USING PREVIOUS COLOR ASSIGNMENT");
+                "color conflict resolve result = FAVORITE COLORS UNKNOWN, USING PREVIOUS COLOR"
+                    + " ASSIGNMENT");
             break resolveColorConflicts;
           }
 

--- a/core/src/saros/session/internal/SarosSession.java
+++ b/core/src/saros/session/internal/SarosSession.java
@@ -803,7 +803,8 @@ public final class SarosSession implements ISarosSession {
       throw new IllegalStateException(
           "component of class type "
               + ISarosSessionContextFactory.class.getName()
-              + " could not be found in the current global application context but is required for operation");
+              + " could not be found in the current global application context but is required for"
+              + " operation");
     }
 
     factory.createComponents(this, sessionContainer);
@@ -860,7 +861,8 @@ public final class SarosSession implements ISarosSession {
       throw new IllegalStateException(
           "component of class type "
               + componentType.getName()
-              + " could not be found in the current session context or application context but is required for operation");
+              + " could not be found in the current session context or application context but is"
+              + " required for operation");
 
     return result;
   }

--- a/core/test/junit/saros/net/internal/DataTransferManagerTest.java
+++ b/core/test/junit/saros/net/internal/DataTransferManagerTest.java
@@ -493,7 +493,8 @@ public class DataTransferManagerTest {
     dtm.connect(new JID("fallback@emergency"));
 
     assertEquals(
-        "established an outgoing connection also the remote side is already connected to the local side",
+        "established an outgoing connection also the remote side is already connected to the local"
+            + " side",
         1,
         mainTransport.getEstablishedConnections().size());
   }

--- a/docs/contribute/development-environment.md
+++ b/docs/contribute/development-environment.md
@@ -20,7 +20,7 @@ This is checked on our build server, so please make sure to format your code wit
 For ease of use, the formatter can also be integrated into the default formatting logic of Eclipse and IntelliJ through a plugin.
 Installation instructions are given in the IDE specific sections on the topic ([Eclipse](#install-and-enable-google-java-formatter), [IntelliJ](#install-and-enable-google-java-formatter-1)).
 
-**Important:** We still use [**google java format 1.6**](https://github.com/google/google-java-format/releases/tag/google-java-format-1.6) as the maintainers of the tool have not provided an official build of the corresponding Eclipse plugin for later versions.
+**Important:** We still use [**google java format 1.10**](https://github.com/google/google-java-format/releases/tag/v1.10.0).
 
 
 
@@ -45,7 +45,7 @@ If you develop on Eclipse you should have already installed the Eclipse version 
 
 #### Install and Enable Google Java Formatter
 
-* Install the [Eclipse Google Java Formatter](https://github.com/google/google-java-format#eclipse) **version 1.6**, which is available as a Drop-In in the [GitHub Releases](https://github.com/google/google-java-format/releases/tag/google-java-format-1.6).
+* Install the [Eclipse Google Java Formatter](https://github.com/google/google-java-format#eclipse), which is available as a Drop-In in the [GitHub Releases](https://github.com/google/google-java-format/releases).
 * Enable the formatter by choosing `google-java-format` in `Window > Preferences > Java > Code Style > Formatter > Formatter Implementation`
 
 ### Import the Saros Project
@@ -65,12 +65,7 @@ See [the Saros testing framework documentation](saros-testing-framework.md) for 
 
 #### Install and Enable Google Java Formatter
 
-* Install the [IntelliJ Google Java Formatter](https://plugins.jetbrains.com/plugin/8527-google-java-format) **version 1.6** which is available in the IntelliJ plugin repository (search for `google-java-format`) or in the [GitHub Releases](https://github.com/google/google-java-format/releases/tag/google-java-format-1.6).
-
-**Important:** If you are using an IntelliJ version newer than 2018.2, the official 1.6 release will not work for you as it's configured to be incompatible with newer IntelliJ releases.
-These compatibility settings were adjusted for later versions of the plugin, but such changes are not available for the 1.6 release.
-
-To avoid the issue, you can have a look at the discussion on the [PR #395](https://github.com/saros-project/saros/pull/395), where we provide a modified plugin zip and reference the adjusted version of the source code if you prefer to build the plugin yourself instead.
+* Install the [IntelliJ Google Java Formatter](https://plugins.jetbrains.com/plugin/8527-google-java-format) which is available in the IntelliJ plugin repository (search for `google-java-format`).
 
 #### Delegate IDE Action
 
@@ -108,7 +103,7 @@ The final build results are copied into the directory `<repository root>/build/d
 
 ### Formatting via Standalone Google Java Formatter
 
-* Download the **release 1.6** of the [Google Java Formatter](https://github.com/google/google-java-format/releases/tag/google-java-format-1.6) `google-java-format-<version>-all-deps.jar`
+* Download [Google Java Formatter](https://github.com/google/google-java-format/releases/) `google-java-format-<version>-all-deps.jar`
 * Call `java -jar google-java-format-<version>-all-deps.jar --dry-run --set-exit-if-changed **/*.java` in a shell with enabled globstar (`shopt -s globstar`) to **check the formatting**
   and add the option `--replace` and remove the option `--dry-run` if you want to **trigger automated formatting**.
 
@@ -133,7 +128,7 @@ Example hook that checks only java files that are staged.
   # download stand-alone formatter
   function download_formatter() {
     local jar_path=$1
-    local url="https://repo.maven.apache.org/maven2/com/google/googlejavaformat/google-java-format/1.6/google-java-format-1.6-all-deps.jar"
+    local url="https://repo.maven.apache.org/maven2/com/google/googlejavaformat/google-java-format/1.10.0/google-java-format-1.10.0-all-deps.jar"
     set -e
     curl -Lo $jar_path "$url" > /dev/null
     set +e

--- a/eclipse/src/saros/editor/EditorPool.java
+++ b/eclipse/src/saros/editor/EditorPool.java
@@ -344,7 +344,8 @@ final class EditorPool {
               + defaultDocumentProvider
               + " for editor with title '"
               + editorPart.getTitle()
-              + "' might not support shared access. It is likely that the editor content is not properly synchronized!");
+              + "' might not support shared access. It is likely that the editor content is not"
+              + " properly synchronized!");
 
       return;
     }
@@ -361,7 +362,8 @@ final class EditorPool {
               + editorDocumentProvider
               + " for editor with title '"
               + editorPart.getTitle()
-              + "' might not support shared access. It is likely that the editor content is not properly synchronized!");
+              + "' might not support shared access. It is likely that the editor content is not"
+              + " properly synchronized!");
     }
   }
 }

--- a/eclipse/src/saros/filesystem/EclipseReferencePoint.java
+++ b/eclipse/src/saros/filesystem/EclipseReferencePoint.java
@@ -213,7 +213,8 @@ public class EclipseReferencePoint implements IReferencePoint {
 
     } else {
       log.debug(
-          "Given resource delegate is not a file or a folder; can't be non-reference-point resource; found type: "
+          "Given resource delegate is not a file or a folder; can't be non-reference-point"
+              + " resource; found type: "
               + delegate.getType()
               + " - "
               + delegate);

--- a/eclipse/src/saros/session/resources/validation/ResourceChangeValidator.java
+++ b/eclipse/src/saros/session/resources/validation/ResourceChangeValidator.java
@@ -81,7 +81,8 @@ public class ResourceChangeValidator extends ModelProvider {
         referencePointDelta.accept(visitor);
       } catch (CoreException e) {
         log.warn(
-            "error occurred during delta visitation, some resources might have not been checked", //$NON-NLS-1$
+            "error occurred during delta visitation, some resources might have not"
+                + " been checked", //$NON-NLS-1$
             e);
       }
 

--- a/eclipse/src/saros/ui/actions/ConsistencyAction.java
+++ b/eclipse/src/saros/ui/actions/ConsistencyAction.java
@@ -267,8 +267,9 @@ public class ConsistencyAction extends Action implements Disposable {
         new MultiStatus(
             pluginID,
             0,
-            "The recovery process will perform changes to files and folders of the currently shared resources. "
-                + "The affected files and folders may be either modified, created, or deleted.\n\n"
+            "The recovery process will perform changes to files and folders of the currently shared"
+                + " resources. The affected files and folders may be either modified, created, or"
+                + " deleted.\n\n"
                 + "Press 'Details' for the affected files and folders.",
             null);
 

--- a/eclipse/src/saros/ui/preference_pages/NetworkPreferencePage.java
+++ b/eclipse/src/saros/ui/preference_pages/NetworkPreferencePage.java
@@ -425,7 +425,9 @@ public final class NetworkPreferencePage extends PreferencePage
     Label socks5CandidatesLabel = new Label(group, SWT.CENTER);
     socks5CandidatesLabel.setText("Socks5 candidates:");
     socks5CandidatesLabel.setToolTipText(
-        "Comma separated list of Socks5 candidates (IP addresses or host names) that should be used during Socks5 connection establishment.\nLeave blank to use all local available IP addresses as candidates.");
+        "Comma separated list of Socks5 candidates (IP addresses or host names) that should be used"
+            + " during Socks5 connection establishment.\n"
+            + "Leave blank to use all local available IP addresses as candidates.");
 
     socks5CandidatesLabel.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false));
 
@@ -469,7 +471,8 @@ public final class NetworkPreferencePage extends PreferencePage
     buttonIncludeUPNPGatewayAddress.setText("Include external IP address of UPNP gateway(s)");
 
     buttonIncludeUPNPGatewayAddress.setToolTipText(
-        "If checked the external IP address of the selected UPNP gateways(s) will be included in the Socks5 candidate list");
+        "If checked the external IP address of the selected UPNP gateways(s) will be included in"
+            + " the Socks5 candidate list");
 
     GridData data = new GridData(SWT.BEGINNING, SWT.CENTER, false, false);
 

--- a/eclipse/src/saros/ui/util/CollaborationUtils.java
+++ b/eclipse/src/saros/ui/util/CollaborationUtils.java
@@ -239,8 +239,7 @@ public class CollaborationUtils {
    * @return the reference point objects representing the given container objects
    */
   private static Set<IReferencePoint> getReferencePoints(Set<IContainer> referencePointContainers) {
-    return referencePointContainers
-        .stream()
+    return referencePointContainers.stream()
         .map(EclipseReferencePoint::new)
         .collect(Collectors.toSet());
   }
@@ -252,8 +251,7 @@ public class CollaborationUtils {
    * @return all projects that contain at least one of the given reference points
    */
   private static Set<IProject> getProjects(Set<IReferencePoint> referencePoints) {
-    return referencePoints
-        .stream()
+    return referencePoints.stream()
         .map(referencePoint -> ResourceConverter.getDelegate(referencePoint).getProject())
         .collect(Collectors.toSet());
   }

--- a/eclipse/src/saros/ui/util/XMPPConnectionSupport.java
+++ b/eclipse/src/saros/ui/util/XMPPConnectionSupport.java
@@ -125,7 +125,8 @@ public class XMPPConnectionSupport {
           MessageDialog.openQuestion(
               SWTUtils.getShell(),
               "Disconnecting from the current Saros Session",
-              "Connecting with a different account will disconnect you from your current Saros session. Do you wish to continue ?");
+              "Connecting with a different account will disconnect you from your current Saros"
+                  + " session. Do you wish to continue ?");
 
       if (!disconnectFromSession) {
         isConnecting = false;
@@ -160,7 +161,8 @@ public class XMPPConnectionSupport {
 
     if (accountToConnect == null) {
       log.warn(
-          "unable to establish a connection - no account was provided and no default account could be found");
+          "unable to establish a connection - no account was provided and no default account could"
+              + " be found");
 
       isConnecting = false;
       return;

--- a/eclipse/src/saros/ui/widgets/viewer/resources/BaseResourceSelectionComposite.java
+++ b/eclipse/src/saros/ui/widgets/viewer/resources/BaseResourceSelectionComposite.java
@@ -706,8 +706,7 @@ public abstract class BaseResourceSelectionComposite extends ViewerComposite<Che
 
     for (IContainer container : containers) {
       boolean isChild =
-          baseContainers
-              .stream()
+          baseContainers.stream()
               .anyMatch((baseContainer) -> isChildResource(baseContainer, container));
 
       if (!isChild) {

--- a/eclipse/src/saros/ui/widgets/viewer/resources/ResourceSelectionComposite.java
+++ b/eclipse/src/saros/ui/widgets/viewer/resources/ResourceSelectionComposite.java
@@ -219,7 +219,8 @@ public class ResourceSelectionComposite extends BaseResourceSelectionComposite {
                       } else {
                         SarosView.showNotification(
                             "Error while restoring a selection",
-                            "Could not restore a selection because there is none with the name you entered.",
+                            "Could not restore a selection because there is none with the name you"
+                                + " entered.",
                             savedSelectionPresetsCombo);
                       }
 

--- a/eclipse/src/saros/ui/widgets/wizard/ReferencePointOptionResult.java
+++ b/eclipse/src/saros/ui/widgets/wizard/ReferencePointOptionResult.java
@@ -47,11 +47,13 @@ public class ReferencePointOptionResult {
       case NEW_DIRECTORY:
         Objects.requireNonNull(
             newDirectoryName,
-            "The new directory name must not be null if the option to create a new directory is chosen");
+            "The new directory name must not be null if the option to create a new directory is"
+                + " chosen");
 
         Objects.requireNonNull(
             newDirectoryBase,
-            "The new directory base path must not be null if the option to create a new directory is chosen");
+            "The new directory base path must not be null if the option to create a new directory"
+                + " is chosen");
 
         break;
 

--- a/intellij/src/saros/intellij/editor/EditorManager.java
+++ b/intellij/src/saros/intellij/editor/EditorManager.java
@@ -492,7 +492,8 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
     if (fileForEditor == null) {
       log.warn(
-          "Encountered editor without valid virtual file representation - file held in editor pool: "
+          "Encountered editor without valid virtual file representation - file held in editor pool:"
+              + " "
               + file);
 
       return;
@@ -502,7 +503,8 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
       log.debug(
           "Ignoring "
               + file
-              + " while sending viewport awareness information as the editor is not currently visible.");
+              + " while sending viewport awareness information as the editor is not currently"
+              + " visible.");
 
       return;
     }
@@ -686,7 +688,8 @@ public class EditorManager extends AbstractActivityProducer implements IEditorMa
 
           if (!backgroundEditorPool.isEmpty()) {
             log.warn(
-                "BackgroundEditorPool already contains entries at session start! Possible memory leak.");
+                "BackgroundEditorPool already contains entries at session start! Possible memory"
+                    + " leak.");
           }
 
           session.getStopManager().addBlockable(stopManagerListener);

--- a/intellij/src/saros/intellij/editor/colorstorage/ColorManager.java
+++ b/intellij/src/saros/intellij/editor/colorstorage/ColorManager.java
@@ -69,8 +69,7 @@ public final class ColorManager {
    */
   @NotNull
   public static ColorKeys getColorKeys(final int colorId) {
-    return COLOR_KEYS
-        .stream()
+    return COLOR_KEYS.stream()
         .filter(x -> x.getId() == colorId)
         .findFirst()
         .map(ColorKeys.class::cast)

--- a/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
+++ b/intellij/src/saros/intellij/eventhandler/filesystem/LocalFilesystemModificationHandler.java
@@ -343,7 +343,8 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
     VirtualFile copy = virtualFileCopyEvent.getFile();
 
     assert !copy.isDirectory()
-        : "Unexpected copying event for directory. This should have been handled by the creation listener.";
+        : "Unexpected copying event for directory. This should have been handled by the creation"
+            + " listener.";
 
     if (log.isTraceEnabled()) {
       log.trace(
@@ -971,7 +972,8 @@ public class LocalFilesystemModificationHandler extends AbstractActivityProducer
               log.error(
                   "Renamed resource "
                       + resource
-                      + " is a root directory but not a reference point. This should not be possible.");
+                      + " is a root directory but not a reference point. This should not be"
+                      + " possible.");
             }
           }
 

--- a/intellij/src/saros/intellij/ui/tree/SessionTreeRootNode.java
+++ b/intellij/src/saros/intellij/ui/tree/SessionTreeRootNode.java
@@ -146,9 +146,7 @@ public class SessionTreeRootNode extends DefaultMutableTreeNode implements Dispo
     User host = session.getHost();
     User localUser = session.getLocalUser();
 
-    session
-        .getUsers()
-        .stream()
+    session.getUsers().stream()
         .filter(user -> !user.equals(host) && !user.equals(localUser))
         .forEach(this::addUserNode);
   }

--- a/intellij/src/saros/intellij/ui/wizards/AddReferencePointToSessionWizard.java
+++ b/intellij/src/saros/intellij/ui/wizards/AddReferencePointToSessionWizard.java
@@ -127,7 +127,8 @@ public class AddReferencePointToSessionWizard extends Wizard {
 
           if (referencePointSelectionResult == null) {
             noisyCancel(
-                "Could not find a local representation selection result for the shared root directory "
+                "Could not find a local representation selection result for the shared root"
+                    + " directory "
                     + remoteReferencePointName,
                 null);
 

--- a/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
+++ b/intellij/test/junit/saros/intellij/editor/annotations/AnnotationManagerTest.java
@@ -1638,8 +1638,7 @@ public class AnnotationManagerTest {
      * position for all subsequent calls.
      */
     List<Pair<Pair<Integer, Integer>, RangeHighlighter>> selectionRangePairs =
-        startSelectionRanges
-            .stream()
+        startSelectionRanges.stream()
             .map(
                 range -> {
                   int rangeStart = range.getLeft();
@@ -1664,8 +1663,7 @@ public class AnnotationManagerTest {
             .collect(Collectors.toList());
 
     List<Pair<Pair<Integer, Integer>, RangeHighlighter>> contributionRangePairs =
-        startContributionRanges
-            .stream()
+        startContributionRanges.stream()
             .map(
                 range -> {
                   int rangeStart = range.getLeft();
@@ -1740,8 +1738,7 @@ public class AnnotationManagerTest {
      *  for all subsequent calls.
      */
     List<Pair<Pair<Integer, Integer>, RangeHighlighter>> selectionRangePairs =
-        startSelectionRanges
-            .stream()
+        startSelectionRanges.stream()
             .map(
                 range -> {
                   int rangeStart = range.getLeft();
@@ -1763,8 +1760,7 @@ public class AnnotationManagerTest {
             .collect(Collectors.toList());
 
     List<Pair<Pair<Integer, Integer>, RangeHighlighter>> contributionRangePairs =
-        startContributionRanges
-            .stream()
+        startContributionRanges.stream()
             .map(
                 range -> {
                   int rangeStart = range.getLeft();

--- a/stf.test/test/saros/stf/test/editing/ConcurrentEditingInsert100CharactersTest.java
+++ b/stf.test/test/saros/stf/test/editing/ConcurrentEditingInsert100CharactersTest.java
@@ -70,7 +70,13 @@ public class ConcurrentEditingInsert100CharactersTest extends StfTestCase {
     Util.setUpSessionWithProjectAndFile(
         "foo",
         "readme.txt",
-        "package test;\n\npublic class paulaBean {\n\n\tprivate String paula = \"Brillant\";\n\n\tpublic String getPaula() {\n\t\treturn paula;\n\t}\n}",
+        "package test;\n\n"
+            + "public class paulaBean {\n\n"
+            + "\tprivate String paula = \"Brillant\";\n\n"
+            + "\tpublic String getPaula() {\n"
+            + "\t\treturn paula;\n"
+            + "\t}\n"
+            + "}",
         CONCURRENTLY,
         ALICE,
         BOB,

--- a/stf.test/test/saros/stf/test/encoding/ChangeShareFilesEncodingTest.java
+++ b/stf.test/test/saros/stf/test/encoding/ChangeShareFilesEncodingTest.java
@@ -15,7 +15,42 @@ import saros.stf.shared.Constants.TypeOfCreateProject;
 public class ChangeShareFilesEncodingTest extends StfTestCase {
 
   private static String CONTENT =
-      "Bittida en morgon, innan solen upprann,\nInnan foglarna började sjunga,\nBergatrollet friade till fager ungersven.\nHon hade en falskeliger tunga:\nHerr Mannelig, herr Mannelig, trolofven I mig.\nFör det jag bjuder så gerna;\nI kunnen väl svara endast ja eller nej.\nOm i viljen eller ej.\nEder vill jag gifva de gångare tolf,\nSom gå uti rosendelunden;\nAldrig har det varit någon sadel uppå dem,\nEj heller betsel uti munnen.\nEder vill jag gifva de qvarnarna tolf,\nSom stå mellan Tillö och Ternö;\nStenarna de äro af rödaste gull,\nOch hjulen silfverbeslagna.\nEder vill jag gifva ett förgyllande svärd,\nSom klingar utaf femton guldringar;\nOch strida huru I strida vill,\nStridsplatsen skolen i väl vinna.\nEder vill jag gifva en skjorta så ny,\nDen bästa I lysten att slita;\nInte är hon sömmad av nål eller trå,\nMen virkad af silket det hvita.\nSådana gåfvor jag toge väl emot,\nOm du vore kristelig qvinna,\nMen nu så är du det värsta bergatroll\nAf Neckens och djefvulens stämma.\nBergatrollet ut på dörren sprang,\nHon rister och jämrar sig svåra:\nHade jag fått den fager ungersven,\nSå hade jag mistat min plåga.\nHerr Mannelig herr Mannelig trolofven I mig.\nFör det jag bjuder så gerna;\nI kunnen väl svara endast ja eller nej,\nOm i viljen eller ej.";
+      "Bittida en morgon, innan solen upprann,\n"
+          + "Innan foglarna började sjunga,\n"
+          + "Bergatrollet friade till fager ungersven.\n"
+          + "Hon hade en falskeliger tunga:\n"
+          + "Herr Mannelig, herr Mannelig, trolofven I mig.\n"
+          + "För det jag bjuder så gerna;\n"
+          + "I kunnen väl svara endast ja eller nej.\n"
+          + "Om i viljen eller ej.\n"
+          + "Eder vill jag gifva de gångare tolf,\n"
+          + "Som gå uti rosendelunden;\n"
+          + "Aldrig har det varit någon sadel uppå dem,\n"
+          + "Ej heller betsel uti munnen.\n"
+          + "Eder vill jag gifva de qvarnarna tolf,\n"
+          + "Som stå mellan Tillö och Ternö;\n"
+          + "Stenarna de äro af rödaste gull,\n"
+          + "Och hjulen silfverbeslagna.\n"
+          + "Eder vill jag gifva ett förgyllande svärd,\n"
+          + "Som klingar utaf femton guldringar;\n"
+          + "Och strida huru I strida vill,\n"
+          + "Stridsplatsen skolen i väl vinna.\n"
+          + "Eder vill jag gifva en skjorta så ny,\n"
+          + "Den bästa I lysten att slita;\n"
+          + "Inte är hon sömmad av nål eller trå,\n"
+          + "Men virkad af silket det hvita.\n"
+          + "Sådana gåfvor jag toge väl emot,\n"
+          + "Om du vore kristelig qvinna,\n"
+          + "Men nu så är du det värsta bergatroll\n"
+          + "Af Neckens och djefvulens stämma.\n"
+          + "Bergatrollet ut på dörren sprang,\n"
+          + "Hon rister och jämrar sig svåra:\n"
+          + "Hade jag fått den fager ungersven,\n"
+          + "Så hade jag mistat min plåga.\n"
+          + "Herr Mannelig herr Mannelig trolofven I mig.\n"
+          + "För det jag bjuder så gerna;\n"
+          + "I kunnen väl svara endast ja eller nej,\n"
+          + "Om i viljen eller ej.";
 
   @BeforeClass
   public static void selectTesters() throws Exception {

--- a/stf.test/test/saros/stf/test/followmode/RefactorInFollowModeTest.java
+++ b/stf.test/test/saros/stf/test/followmode/RefactorInFollowModeTest.java
@@ -39,7 +39,8 @@ public class RefactorInFollowModeTest extends StfTestCase {
           .append("()\n{myfoobar = ")
           .append(i)
           .append(
-              ";\n}\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
+              ";\n"
+                  + "}\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
 
     builder.append("}");
 

--- a/stf.test/test/saros/stf/test/followmode/SimpleFollowModeIITest.java
+++ b/stf.test/test/saros/stf/test/followmode/SimpleFollowModeIITest.java
@@ -20,7 +20,16 @@ import saros.stf.test.categories.FlakyTests;
 public class SimpleFollowModeIITest extends StfTestCase {
 
   private final String fileContent =
-      "1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n";
+      "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n"
+          + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n"
+          + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n"
+          + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n"
+          + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n"
+          + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n"
+          + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n"
+          + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n"
+          + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n"
+          + "1\n" + "1\n";
 
   @BeforeClass
   public static void selectTesters() throws Exception {

--- a/stf.test/test/saros/stf/test/followmode/SimpleFollowModeITest.java
+++ b/stf.test/test/saros/stf/test/followmode/SimpleFollowModeITest.java
@@ -19,7 +19,16 @@ import saros.stf.test.categories.FlakyTests;
 public class SimpleFollowModeITest extends StfTestCase {
 
   private final String fileContent =
-      "1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n";
+      "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n"
+          + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n"
+          + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n"
+          + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n"
+          + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n"
+          + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n"
+          + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n"
+          + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n"
+          + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n" + "1\n"
+          + "1\n" + "1\n";
 
   @BeforeClass
   public static void selectTesters() throws Exception {

--- a/stf.test/test/saros/stf/test/session/CreatingNewFileTest.java
+++ b/stf.test/test/saros/stf/test/session/CreatingNewFileTest.java
@@ -61,7 +61,8 @@ public class CreatingNewFileTest extends StfTestCase {
         .remoteBot()
         .editor("readme.txt")
         .typeText(
-            "eene meene miste es rappelt in der kiste, eene meene meck und du bist weck ! weck bist du noch lange nicht ...");
+            "eene meene miste es rappelt in der kiste, eene meene meck und du bist weck ! weck bist"
+                + " du noch lange nicht ...");
 
     assertFalse("Carls editor must not be opened", CARL.remoteBot().isEditorOpen("readme.txt"));
     assertFalse("Bobs editor must not be opened", BOB.remoteBot().isEditorOpen("readme.txt"));

--- a/stf/src/saros/stf/server/rmi/superbot/component/view/eclipse/impl/PackageExplorerView.java
+++ b/stf/src/saros/stf/server/rmi/superbot/component/view/eclipse/impl/PackageExplorerView.java
@@ -213,7 +213,8 @@ public final class PackageExplorerView extends StfRemoteObject implements IPacka
       throw new RuntimeException(
           "the passed parameter '"
               + pkg
-              + "' is not valid, the package name should corresponds to the pattern [\\w\\.]*\\w+ e.g. PKG1.PKG2.PKG3");
+              + "' is not valid, the package name should corresponds to the pattern [\\w\\.]*\\w+"
+              + " e.g. PKG1.PKG2.PKG3");
     }
   }
 
@@ -226,7 +227,8 @@ public final class PackageExplorerView extends StfRemoteObject implements IPacka
       throw new RuntimeException(
           "the passed parameter '"
               + pkg
-              + "' is not valid, the package name should corresponds to the pattern [\\w\\.]*\\w+ e.g. PKG1.PKG2.PKG3");
+              + "' is not valid, the package name should corresponds to the pattern [\\w\\.]*\\w+"
+              + " e.g. PKG1.PKG2.PKG3");
     }
   }
 


### PR DESCRIPTION
As they now finally released a new official version of the Eclipse
plugin, we can update to the newest version of GJF. The Eclipse plugin
is only available for version 1.11. But, as the IntelliJ plugin for 1.11
has not been released yet (and I use the plugin to format the code), I
only updated to version 1.10. The update to 1.11 will follow as soon as
the IntelliJ plugin is released.

Updates the GJF version used in the CI.

Reformats the code using GJF 1.10.

Resolves #389.
Closes #395.